### PR TITLE
機能: チャットセッションの分析フェーズとユーザーの進捗状況の追跡を追加

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -74,11 +74,13 @@ func main() {
 	chatMessageRepo := repositories.NewChatMessageRepository(db)
 	userWeightScoreRepo := repositories.NewUserWeightScoreRepository(db)
 	aiGeneratedQuestionRepo := repositories.NewAIGeneratedQuestionRepository(db)
+	phaseRepo := repositories.NewAnalysisPhaseRepository(db)
+	progressRepo := repositories.NewUserAnalysisProgressRepository(db)
 
 	// サービス層の初期化
 	authService := services.NewAuthService(userRepo)
 	oauthService := services.NewOAuthService(userRepo, oauthConfig)
-	chatService := services.NewChatService(aiClient, questionWeightRepo, chatMessageRepo, userWeightScoreRepo, aiGeneratedQuestionRepo, userRepo)
+	chatService := services.NewChatService(aiClient, questionWeightRepo, chatMessageRepo, userWeightScoreRepo, aiGeneratedQuestionRepo, userRepo, phaseRepo, progressRepo)
 	questionService := services.NewQuestionGeneratorService(aiClient, questionWeightRepo)
 
 	// コントローラー層の初期化

--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -36,6 +36,8 @@ func (c *ChatController) Chat(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := c.chatService.ProcessChat(r.Context(), req)
 	if err != nil {
+		// エラーログを詳細に出力
+		println("Error in ProcessChat:", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/Backend/internal/models/analysis_phase.go
+++ b/Backend/internal/models/analysis_phase.go
@@ -1,0 +1,42 @@
+package models
+
+import "time"
+
+// AnalysisPhase 分析フェーズの定義
+type AnalysisPhase struct {
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	PhaseName    string    `gorm:"size:50;not null;uniqueIndex" json:"phase_name"` // 職種分析、興味分析、適性分析、将来分析
+	DisplayName  string    `gorm:"size:100;not null" json:"display_name"`
+	PhaseOrder   int       `gorm:"not null" json:"phase_order"` // 実行順序
+	Description  string    `gorm:"type:text" json:"description"`
+	MinQuestions int       `gorm:"not null;default:3" json:"min_questions"` // 最小質問数
+	MaxQuestions int       `gorm:"not null;default:5" json:"max_questions"` // 最大質問数
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// UserAnalysisProgress ユーザーごとの分析進捗
+type UserAnalysisProgress struct {
+	ID              uint           `gorm:"primaryKey" json:"id"`
+	UserID          uint           `gorm:"not null;index:idx_user_session_phase" json:"user_id"`
+	SessionID       string         `gorm:"size:100;not null;index:idx_user_session_phase" json:"session_id"`
+	PhaseID         uint           `gorm:"not null;index:idx_user_session_phase" json:"phase_id"`
+	Phase           *AnalysisPhase `gorm:"foreignKey:PhaseID" json:"phase,omitempty"`
+	QuestionsAsked  int            `gorm:"not null;default:0" json:"questions_asked"`
+	ValidAnswers    int            `gorm:"not null;default:0" json:"valid_answers"`    // 有効な回答数
+	InvalidAnswers  int            `gorm:"not null;default:0" json:"invalid_answers"`  // 無効な回答数
+	CompletionScore float64        `gorm:"not null;default:0" json:"completion_score"` // 0-100のスコア
+	IsCompleted     bool           `gorm:"not null;default:false" json:"is_completed"`
+	CompletedAt     *time.Time     `json:"completed_at,omitempty"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+}
+
+// TableName overrides
+func (AnalysisPhase) TableName() string {
+	return "analysis_phases"
+}
+
+func (UserAnalysisProgress) TableName() string {
+	return "user_analysis_progress"
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -15,5 +15,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&QuestionWeight{},
 		&ChatMessage{},
 		&UserWeightScore{},
+		&AnalysisPhase{},
+		&UserAnalysisProgress{},
 	)
 }

--- a/Backend/internal/models/seed.go
+++ b/Backend/internal/models/seed.go
@@ -34,6 +34,11 @@ func SeedData(db *gorm.DB) error {
 		return err
 	}
 
+	// 分析フェーズデータ
+	if err := seedAnalysisPhases(db); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -478,4 +483,49 @@ func seedDetailedQuestions(db *gorm.DB) error {
 	}
 
 	return db.Create(&questions).Error
+}
+
+func seedAnalysisPhases(db *gorm.DB) error {
+	var count int64
+	db.Model(&AnalysisPhase{}).Count(&count)
+	if count > 0 {
+		return nil
+	}
+
+	phases := []AnalysisPhase{
+		{
+			PhaseName:    "job_analysis",
+			DisplayName:  "職種分析",
+			PhaseOrder:   1,
+			Description:  "ユーザーが興味を持つIT職種や分野を特定し、基本的な方向性を確認します。",
+			MinQuestions: 2,
+			MaxQuestions: 4,
+		},
+		{
+			PhaseName:    "interest_analysis",
+			DisplayName:  "興味分析",
+			PhaseOrder:   2,
+			Description:  "技術的な興味や学習スタイル、好きな作業内容などを深掘りします。",
+			MinQuestions: 3,
+			MaxQuestions: 5,
+		},
+		{
+			PhaseName:    "aptitude_analysis",
+			DisplayName:  "適性分析",
+			PhaseOrder:   3,
+			Description:  "コミュニケーション能力、チームワーク、問題解決力などの適性を評価します。",
+			MinQuestions: 3,
+			MaxQuestions: 5,
+		},
+		{
+			PhaseName:    "future_analysis",
+			DisplayName:  "将来分析",
+			PhaseOrder:   4,
+			Description:  "キャリアビジョンや将来の目標、働き方の希望などを確認します。",
+			MinQuestions: 2,
+			MaxQuestions: 4,
+		},
+	}
+
+	return db.Create(&phases).Error
 }

--- a/Backend/internal/openai/client.go
+++ b/Backend/internal/openai/client.go
@@ -48,7 +48,7 @@ func (cli *Client) Responses(ctx context.Context, input string, modelOverride ..
 
 	var lastErr error
 	for attempt := 1; attempt <= 3; attempt++ {
-		ctxReq, cancel := context.WithTimeout(ctx, 15*time.Second)
+		ctxReq, cancel := context.WithTimeout(ctx, 30*time.Second)
 
 		resp, err := cli.c.CreateChatCompletion(ctxReq, openai.ChatCompletionRequest{
 			Model: model,
@@ -70,6 +70,7 @@ func (cli *Client) Responses(ctx context.Context, input string, modelOverride ..
 		}
 
 		lastErr = err
+		println("OpenAI API error (attempt", attempt, "):", err.Error())
 		time.Sleep(time.Duration(attempt) * time.Second)
 	}
 

--- a/Backend/internal/repositories/analysis_phase_repository.go
+++ b/Backend/internal/repositories/analysis_phase_repository.go
@@ -1,0 +1,85 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"gorm.io/gorm"
+)
+
+type AnalysisPhaseRepository struct {
+	db *gorm.DB
+}
+
+func NewAnalysisPhaseRepository(db *gorm.DB) *AnalysisPhaseRepository {
+	return &AnalysisPhaseRepository{db: db}
+}
+
+// FindAll 全フェーズを順序順に取得
+func (r *AnalysisPhaseRepository) FindAll() ([]models.AnalysisPhase, error) {
+	var phases []models.AnalysisPhase
+	err := r.db.Order("phase_order ASC").Find(&phases).Error
+	return phases, err
+}
+
+// FindByID IDでフェーズを取得
+func (r *AnalysisPhaseRepository) FindByID(id uint) (*models.AnalysisPhase, error) {
+	var phase models.AnalysisPhase
+	err := r.db.First(&phase, id).Error
+	return &phase, err
+}
+
+// FindByName 名前でフェーズを取得
+func (r *AnalysisPhaseRepository) FindByName(name string) (*models.AnalysisPhase, error) {
+	var phase models.AnalysisPhase
+	err := r.db.Where("phase_name = ?", name).First(&phase).Error
+	return &phase, err
+}
+
+type UserAnalysisProgressRepository struct {
+	db *gorm.DB
+}
+
+func NewUserAnalysisProgressRepository(db *gorm.DB) *UserAnalysisProgressRepository {
+	return &UserAnalysisProgressRepository{db: db}
+}
+
+// FindByUserAndSession ユーザーとセッションで進捗を取得
+func (r *UserAnalysisProgressRepository) FindByUserAndSession(userID uint, sessionID string) ([]models.UserAnalysisProgress, error) {
+	var progress []models.UserAnalysisProgress
+	err := r.db.Preload("Phase").
+		Where("user_id = ? AND session_id = ?", userID, sessionID).
+		Order("phase_id ASC").
+		Find(&progress).Error
+	return progress, err
+}
+
+// FindOrCreate フェーズの進捗を取得または作成
+func (r *UserAnalysisProgressRepository) FindOrCreate(userID uint, sessionID string, phaseID uint) (*models.UserAnalysisProgress, error) {
+	var progress models.UserAnalysisProgress
+	err := r.db.Where("user_id = ? AND session_id = ? AND phase_id = ?", userID, sessionID, phaseID).
+		FirstOrCreate(&progress, models.UserAnalysisProgress{
+			UserID:    userID,
+			SessionID: sessionID,
+			PhaseID:   phaseID,
+		}).Error
+	if err != nil {
+		return nil, err
+	}
+	// Phaseをロード
+	r.db.Preload("Phase").First(&progress, progress.ID)
+	return &progress, nil
+}
+
+// Update 進捗を更新
+func (r *UserAnalysisProgressRepository) Update(progress *models.UserAnalysisProgress) error {
+	return r.db.Save(progress).Error
+}
+
+// GetCurrentPhase 現在進行中のフェーズを取得
+func (r *UserAnalysisProgressRepository) GetCurrentPhase(userID uint, sessionID string) (*models.UserAnalysisProgress, error) {
+	var progress models.UserAnalysisProgress
+	err := r.db.Preload("Phase").
+		Where("user_id = ? AND session_id = ? AND is_completed = ?", userID, sessionID, false).
+		Order("phase_id ASC").
+		First(&progress).Error
+	return &progress, err
+}

--- a/compose.yml
+++ b/compose.yml
@@ -47,15 +47,20 @@ services:
   frontend: # サービス名を追加
     build:
       context: ./frontend # ./frontend をルートとして使用（従来の構造を維持）
-      dockerfile: ${DOCKERFILE:-Dockerfile} # Dockerfile名もデフォルト設定を使用
+      dockerfile: Dockerfile
     container_name: soc-ai-agent-frontend
     restart: 'always'
-    # volumes:
-    #   - ./frontend:/app  # 本番ビルド時は不要（開発時のみ）
+    volumes:
+      # ホットリロード用にソースコードをマウント（本番ではコメントアウト）
+      - ./frontend:/app
+      - /app/node_modules  # node_modulesは除外
+      - /app/.next  # .nextディレクトリも除外（コンテナ内で生成）
     ports:
       - "3000:3000"
-    env_file:
-      - ${ENV_FILE:-./Backend/.env}
+    environment:
+      - NODE_ENV=${NODE_ENV:-development}
+      - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL:-http://localhost:8080}
+      - BACKEND_URL=${BACKEND_URL:-http://app:8080}
     depends_on:
       app:
         condition: service_started

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,23 @@
+# 依存関係
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Next.js
+.next
+out
+dist
+
+# 環境変数ファイル
+.env*.local
+
+# テスト
+coverage
+.nyc_output
+
+# その他
+.DS_Store
+*.pem
+.idea
+.vscode

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,50 +1,28 @@
-# ----------------------------------------------------------------------------
-# 1. ビルダー・ステージ
-# Next.jsアプリケーションのビルド（.nextディレクトリ生成）を担当
-# ----------------------------------------------------------------------------
-FROM node:20-alpine AS builder
+FROM node:20-alpine
 
 # 作業ディレクトリの設定
 WORKDIR /app
 
-# 依存関係ファイル (package.json, lockfile) のみ先にコピーしてキャッシュを活用
+# 依存関係ファイルのみをコピー
 COPY package*.json ./
+
+# 依存関係のインストール (開発に必要なもの全て)
+# ホットリロードのためのファイル監視ツール (chokidar など) もインストールされます
 RUN npm install
 
-# アプリケーションソースコード全体をコピー
-COPY . .
-
-# Next.jsのプロダクションビルドを実行
-# next.config.jsで standalone: true が設定されていることを前提とします
-RUN npm run build
-
 # ----------------------------------------------------------------------------
-# 2. プロダクション・ステージ
-# 実行に必要な最小限のファイルのみをコピーし、軽量でセキュアな環境を構築
+# 開発・実行ステージ
 # ----------------------------------------------------------------------------
-FROM node:20-alpine AS runner
 
-# プロダクション環境を指定
-ENV NODE_ENV production
-ENV NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
-WORKDIR /app
+# アプリケーションソースコードは Docker Volume でマウントすることを推奨
 
-# セキュリティ向上のため、非rootユーザーを使用（Next.jsの推奨設定）
-# UID 1001 の nodejs グループと nextjs ユーザーを作成
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001 -G nodejs
-USER nextjs
+# 開発環境を指定（デフォルトは development ですが、明示的に）
+ENV NODE_ENV development
 
-# Standaloneモードの成果物をコピー
-# これにはサーバー実行に必要なコードと依存関係が含まれます
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-
-# 静的アセットと public ディレクトリをコピー
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-
-# アプリケーションがリッスンするポート
+# Next.js のデフォルトポート
 EXPOSE 3000
 
-# Standaloneモードのサーバー起動
-CMD ["node", "server.js"]
+# 開発サーバー起動
+# このコマンドはファイル変更を監視し、ホットリロードを有効にします
+# ソースコードはホストマシンから volume mount されていることを前提とします
+CMD ["npm", "run", "dev"]

--- a/frontend/app/api/chat/history/route.ts
+++ b/frontend/app/api/chat/history/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:80'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
 export const dynamic = 'force-dynamic'
 

--- a/frontend/app/api/chat/recommendations/route.ts
+++ b/frontend/app/api/chat/recommendations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:80'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
 export const dynamic = 'force-dynamic'
 

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:80'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
 export async function POST(request: NextRequest) {
   try {

--- a/frontend/app/api/chat/scores/route.ts
+++ b/frontend/app/api/chat/scores/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:80'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
 export const dynamic = 'force-dynamic'
 

--- a/frontend/app/api/companies/[id]/route.ts
+++ b/frontend/app/api/companies/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:80'
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
 export const dynamic = 'force-dynamic'
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { LoginPage } from '@/components/login-page'
+import { authService, AuthResponse } from '@/lib/auth'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function Login() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const storedUser = authService.getStoredUser()
+    if (storedUser) {
+      router.replace('/')
+    }
+  }, [router])
+
+  const handleAuthSuccess = (authResponse: AuthResponse) => {
+    router.push('/')
+  }
+
+  return <LoginPage onAuthSuccess={handleAuthSuccess} />
+}
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,37 +1,35 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Box } from '@mui/material'
 import { AnalysisSidebar } from '@/components/analysis-sidebar'
 import { MuiChat } from '@/components/mui-chat'
-import { LoginPage } from '@/components/login-page'
-import { authService, User, AuthResponse } from '@/lib/auth'
+import { authService, User } from '@/lib/auth'
 
 export default function Home() {
+  const router = useRouter()
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const storedUser = authService.getStoredUser()
+    if (!storedUser) {
+      router.replace('/login')
+      return
+    }
     setUser(storedUser)
     setLoading(false)
-  }, [])
-
-  const handleAuthSuccess = (authResponse: AuthResponse) => {
-    setUser({ ...authResponse, user_id: Number(authResponse.user_id) })
-  }
+  }, [router])
 
   const handleLogout = () => {
     authService.logout()
     setUser(null)
+    router.push('/login')
   }
 
-  if (loading) {
+  if (loading || !user) {
     return null
-  }
-
-  if (!user) {
-    return <LoginPage onAuthSuccess={handleAuthSuccess} />
   }
 
   return (

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -32,11 +32,12 @@ export default function ProfilePage() {
 
   const fetchSessions = async (userId: number) => {
     try {
-      const response = await fetch(`http://localhost:80/api/chat/sessions?user_id=${userId}`)
+      const response = await fetch(`http://localhost:8080/api/chat/sessions?user_id=${userId}`)
       if (!response.ok) {
         throw new Error('Failed to fetch sessions')
       }
       const data = await response.json()
+      console.log('[Profile] Fetched sessions:', data)
       setSessions(data || [])
     } catch (error) {
       console.error('Error fetching sessions:', error)

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -87,12 +87,6 @@ export function AnalysisSidebar({ user, onLogout }: AnalysisSidebarProps) {
 
   const analysisSteps: AnalysisStep[] = [
     {
-      id: 'backend',
-      label: 'バックエンド連携',
-      icon: <Speed />,
-      completed: true,
-    },
-    {
       id: 'job',
       label: progress.job === 100 ? '職種分析完了' : '職種分析進行中',
       icon: <Work />,

--- a/frontend/components/job-agent-chat.tsx
+++ b/frontend/components/job-agent-chat.tsx
@@ -64,7 +64,7 @@ export function JobAgentChat() {
   const [isAnalyzing, setIsAnalyzing] = useState(false)
   const [isTyping, setIsTyping] = useState(false)
   const [userScores, setUserScores] = useState<UserScore[]>([])
-  const [progress, setProgress] = useState({ questions: 0, total: 20, categories: 0, totalCategories: 10 })
+  const [progress, setProgress] = useState({ questions: 0, total: 15, categories: 0, totalCategories: 10 })
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   // メッセージが更新されたらキャッシュに保存
@@ -127,7 +127,7 @@ export function JobAgentChat() {
             // 進捗状況を計算（スコアの数から）
             setProgress({
               questions: history.length,
-              total: 20,
+              total: 15,
               categories: scores.length,
               totalCategories: 10,
             })
@@ -136,9 +136,9 @@ export function JobAgentChat() {
           console.error("Failed to load scores:", error)
         }
         
-        // 完了状態をチェック
+        // 完了状態をチェック（診断完了の特別なメッセージのみ）
         const lastMessage = history[history.length - 1]
-        if (lastMessage.role === "assistant" && lastMessage.content.includes("完了")) {
+        if (lastMessage.role === "assistant" && lastMessage.content.includes("✅ 診断が完了しました")) {
           setIsComplete(true)
         }
       } else {
@@ -287,6 +287,17 @@ export function JobAgentChat() {
     window.location.reload()
   }
 
+  const handleEndChat = () => {
+    // セッションとキャッシュを完全にクリア
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(`chat_cache_${sessionId}`)
+      localStorage.removeItem('chat_session_id')
+    }
+    
+    // ページをリロードして新しいセッションを開始
+    window.location.reload()
+  }
+
   const handleAnalysisComplete = () => {
     setIsAnalyzing(false)
     setIsComplete(true)
@@ -319,26 +330,38 @@ export function JobAgentChat() {
                 </div>
               </div>
               
-              {/* 進捗状況表示 */}
-              {progress.categories > 0 && (
-                <div className="flex flex-col items-end gap-1.5 min-w-[200px]">
-                  <div className="flex items-center gap-2">
-                    <div className="text-sm font-semibold text-primary">
-                      診断進行度
+              <div className="flex items-center gap-3">
+                {/* 進捗状況表示 */}
+                {progress.categories > 0 && (
+                  <div className="flex flex-col items-end gap-1.5 min-w-[200px]">
+                    <div className="flex items-center gap-2">
+                      <div className="text-sm font-semibold text-primary">
+                        診断進行度
+                      </div>
+                      <div className="text-lg font-bold text-primary">
+                        {Math.round((progress.categories / progress.totalCategories) * 100)}%
+                      </div>
                     </div>
-                    <div className="text-lg font-bold text-primary">
-                      {Math.round((progress.categories / progress.totalCategories) * 100)}%
+                    <div className="text-xs text-muted-foreground text-right">
+                      {progress.categories}/{progress.totalCategories} カテゴリ評価済み
                     </div>
+                    <Progress 
+                      value={(progress.categories / progress.totalCategories) * 100} 
+                      className="w-full h-2.5"
+                    />
                   </div>
-                  <div className="text-xs text-muted-foreground text-right">
-                    {progress.categories}/{progress.totalCategories} カテゴリ評価済み
-                  </div>
-                  <Progress 
-                    value={(progress.categories / progress.totalCategories) * 100} 
-                    className="w-full h-2.5"
-                  />
-                </div>
-              )}
+                )}
+                
+                {/* チャットを終了ボタン */}
+                <Button 
+                  variant="outline" 
+                  size="sm"
+                  onClick={handleEndChat}
+                  className="text-sm"
+                >
+                  チャットを終了
+                </Button>
+              </div>
             </div>
           </div>
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,3 +1,5 @@
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080'
+
 export interface ChatRequest {
     user_id: number
     session_id: string
@@ -40,7 +42,7 @@ export interface ChatHistory {
 }
 
 export async function sendChatMessage(request: ChatRequest): Promise<ChatResponse> {
-    const response = await fetch('/api/chat', {
+    const response = await fetch(`${BACKEND_URL}/api/chat`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -49,14 +51,16 @@ export async function sendChatMessage(request: ChatRequest): Promise<ChatRespons
     })
 
     if (!response.ok) {
-        throw new Error(`Chat API error: ${response.statusText}`)
+        const errorText = await response.text().catch(() => response.statusText)
+        console.error('[API] Chat error:', response.status, errorText)
+        throw new Error(`Chat API error: ${errorText || response.statusText}`)
     }
 
     return response.json()
 }
 
 export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> {
-    const response = await fetch(`/api/chat/history?session_id=${sessionId}`)
+    const response = await fetch(`${BACKEND_URL}/api/chat/history?session_id=${sessionId}`)
 
     if (!response.ok) {
         throw new Error(`History API error: ${response.statusText}`)
@@ -66,7 +70,7 @@ export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> 
 }
 
 export async function getUserScores(userId: number, sessionId: string) {
-    const response = await fetch(`/api/chat/scores?user_id=${userId}&session_id=${sessionId}`)
+    const response = await fetch(`${BACKEND_URL}/api/chat/scores?user_id=${userId}&session_id=${sessionId}`)
 
     if (!response.ok) {
         throw new Error(`Scores API error: ${response.statusText}`)
@@ -77,7 +81,7 @@ export async function getUserScores(userId: number, sessionId: string) {
 
 export async function getRecommendations(userId: number, sessionId: string, limit = 5) {
     const response = await fetch(
-        `/api/chat/recommendations?user_id=${userId}&session_id=${sessionId}&limit=${limit}`,
+        `${BACKEND_URL}/api/chat/recommendations?user_id=${userId}&session_id=${sessionId}&limit=${limit}`,
     )
 
     if (!response.ok) {
@@ -108,7 +112,7 @@ export async function sendMessage(message: string): Promise<{ message: string }>
 }
 
 export async function getCompanyDetail(companyId: number) {
-    const response = await fetch(`/api/companies/${companyId}`)
+    const response = await fetch(`${BACKEND_URL}/api/companies/${companyId}`)
     
     if (!response.ok) {
         throw new Error(`Company API error: ${response.statusText}`)

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -123,7 +123,15 @@ export const authService = {
   },
 
   logout() {
+    // ユーザー情報とトークンを削除
     localStorage.removeItem('user')
     localStorage.removeItem('token')
+    
+    // チャットキャッシュを削除
+    const sessionId = localStorage.getItem('chat_session_id')
+    if (sessionId) {
+      localStorage.removeItem(`chat_cache_${sessionId}`)
+    }
+    localStorage.removeItem('chat_session_id')
   },
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
   reactStrictMode: true,
+  // Docker開発環境でのホットリロード設定（Turbopack対応）
+  turbopack: {
+    // Turbopackは自動的にファイル変更を検知するため、空オブジェクトで設定
+  },
+  // MUI emotion CSS-in-JS のSSR対応
+  compiler: {
+    emotion: true,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
# PR #10: 機能: チャットセッションの分析フェーズとユーザーの進捗状況の追跡を追加

## 要約（日本語）
このプルリクエストは、チャットセッションのライフサイクルに「分析フェーズ」を導入し、セッション内の会話を解析（例：要約、意図抽出、感情やキーワード抽出など）して、その解析結果とユーザーごとの進捗（達成度・ステータス）を記録・追跡できるようにする機能追加を目的としています。

## 想定される変更点
- セッションライフサイクルに新しいステージ（分析フェーズ）を追加
- チャット履歴を解析するロジック／サービスの追加（要約・意図推定・感情分析等）
- ユーザー進捗（ステータス、完了率、チェックポイント等）を保存するためのデータ構造／DBスキーマ変更
- 進捗情報を取得・更新するためのAPIエンドポイントやフロントエンド表示の追加・更新
- 単体テスト／統合テストの追加、ドキュメント（READMEやAPI仕様）の更新

## レビュー時に確認すると良いポイント
- 追加されたファイル差分（どのモジュール／コンポーネントが変わったか）
- DBスキーマやマイグレーションが含まれているか、互換性や既存データへの影響
- 解析フェーズの処理方式（同期処理か非同期処理か）、処理コスト、エラーハンドリング
- プライバシーや個人情報の扱い（会話データの保存・解析に関する方針）
- テストの有無（解析ロジックと進捗追跡の単体テスト・統合テスト）
- ドキュメントや利用方法の説明（開発者向けとエンドユーザー向け）

## PR メタ情報
- タイトル: 機能: チャットセッションの分析フェーズとユーザーの進捗状況の追跡を追加
- PR 番号: 10
- 作成者: oohasikazuyuki
- リポジトリ: ISCProduct/soc-ai-agent-mock
- 状態: open
- URL: https://github.com/ISCProduct/soc-ai-agent-mock/pull/10

## 次にできること（提案）
- 差分（Files changed）を取得して具体的な変更箇所を詳細にレビューする
- 解析処理のパフォーマンスや設計（キュー／バッチ／ストリーム処理など）について評価する
- DBマイグレーションの影響範囲を確認し、ロールバック手順を整備する
- テストを実行して解析結果や進捗更新の安定性を検証する
