### PR TITLE
fix: 新卒ユーザーの短文回答（「はい」等）が評価されない問題を修正

### DIFF
--- a/Backend/internal/services/answer_evaluator.go
+++ b/Backend/internal/services/answer_evaluator.go
@@ -294,24 +294,39 @@ func (e *AnswerEvaluator) precheckHuman(answer string, isChoice bool, jobRoleSet
 		return HumanScoreResult{Action: PrecheckScore}
 	}
 
-	if len([]rune(answerTrimmed)) < 5 {
+	// 新卒ユーザーの短文回答（「はい」「ある」等）を有効スコアとして扱うため、
+	// shortValidAnswers に該当する場合は文字数に関わらず最小スコアを付与する
+	shortValidAnswers := []string{
+		"はい", "いいえ", "yes", "no", "好き", "嫌い", "得意", "苦手",
+		"できる", "できない", "ある", "ない", "する", "しない",
+	}
+	normalizedAnswer := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(answerTrimmed), " ", ""), "　", "")
+	for _, valid := range shortValidAnswers {
+		if strings.Contains(normalizedAnswer, valid) {
+			return HumanScoreResult{Action: PrecheckScore}
+		}
+	}
+
+	// 完全に空または1文字以下は無視
+	if len([]rune(answerTrimmed)) < 2 {
 		return HumanScoreResult{Action: PrecheckIgnore, Reason: "too_short_ignore"}
 	}
 
 	skipPhrases := []string{
-		"わからない", "分からない", "わかりません", "特にない", "特になし", "なし", "ない",
+		"わからない", "分からない", "わかりません", "特にない", "特になし", "なし",
 	}
-	normalized := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(answerTrimmed), " ", ""), "　", "")
 	for _, phrase := range skipPhrases {
-		if strings.Contains(normalized, phrase) {
+		if strings.Contains(normalizedAnswer, phrase) {
 			return HumanScoreResult{Action: PrecheckSkip, Reason: "skip_phrase"}
 		}
 	}
 
-	if len([]rune(answerTrimmed)) < 10 {
-		return HumanScoreResult{Action: PrecheckNoScore, Reason: "too_short_no_score"}
+	// 5文字未満の短文は最小スコアを付与（PrecheckNoScoreから変更）
+	if len([]rune(answerTrimmed)) < 5 {
+		return HumanScoreResult{Action: PrecheckScore, Reason: "short_but_valid"}
 	}
 
+	// 10文字未満も評価対象とする（新卒の短答に対応）
 	return HumanScoreResult{Action: PrecheckScore}
 }
 

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -2403,7 +2403,20 @@ func isLikelyAnswer(answer, question string) bool {
 		return true
 	}
 
-	// 3文字未満は無効（ただし上で選択肢判定済み）
+	// 「はい」「いいえ」「好き」「嫌い」などの短い回答は文字数チェックより先に判定する
+	// （新卒ユーザーの短文回答を正しく有効扱いするため）
+	shortValidAnswers := []string{
+		"はい", "いいえ", "yes", "no", "好き", "嫌い", "得意", "苦手",
+		"できる", "できない", "ある", "ない", "する", "しない",
+	}
+	for _, valid := range shortValidAnswers {
+		if strings.Contains(strings.ToLower(a), valid) {
+			fmt.Printf("[Validation] Fallback: Valid short answer: %s\n", a)
+			return true
+		}
+	}
+
+	// 3文字未満は無効（選択肢記号・短答キーワードは上で判定済み）
 	if len([]rune(a)) < 3 {
 		fmt.Printf("[Validation] Fallback: Too short (< 3 chars): %s\n", a)
 		return false
@@ -2425,18 +2438,6 @@ func isLikelyAnswer(answer, question string) bool {
 		if answerLower == pattern || answerLower == pattern+"。" {
 			fmt.Printf("[Validation] Fallback: No-answer pattern detected: %s\n", a)
 			return false
-		}
-	}
-
-	// 「はい」「いいえ」「好き」「嫌い」などの短い回答も有効
-	shortValidAnswers := []string{
-		"はい", "いいえ", "yes", "no", "好き", "嫌い", "得意", "苦手",
-		"できる", "できない", "ある", "ない", "する", "しない",
-	}
-	for _, valid := range shortValidAnswers {
-		if strings.Contains(strings.ToLower(a), valid) {
-			fmt.Printf("[Validation] Fallback: Valid short answer: %s\n", a)
-			return true
 		}
 	}
 


### PR DESCRIPTION
## 関連Issue
Closes #21

## 変更概要

新卒ユーザーがチャットで短い回答（「はい」「ある」「好きです」など）を入力しても、評価・スコアが全く更新されない問題を修正。

## 根本原因と修正

### 1. `isLikelyAnswer` の判定順序バグ（chat_service.go）

**問題**: `shortValidAnswers`（「はい」等）のチェックが `< 3文字` チェックの**後**にあったため、「はい」(2文字) などが評価前に弾かれていた。

**修正**: `shortValidAnswers` チェックを文字数チェックより**前**に移動。

```go
// 修正前: 「はい」はここで return false され shortValidAnswers に到達しない
if len([]rune(a)) < 3 {
    return false
}
// shortValidAnswers チェック（到達しない）

// 修正後: shortValidAnswers を先にチェック
for _, valid := range shortValidAnswers {
    if strings.Contains(strings.ToLower(a), valid) {
        return true  // 「はい」もここで true
    }
}
if len([]rune(a)) < 3 {
    return false
}
```

### 2. `precheckHuman` の短文スコアゼロ問題（answer_evaluator.go）

**問題**: 5文字未満は `PrecheckIgnore`、10文字未満は `PrecheckNoScore` となり、有効な短答でもスコアが保存されなかった。

**修正**:
- `shortValidAnswers` に該当する場合は文字数に関わらず `PrecheckScore` を返す
- 2文字未満のみ `PrecheckIgnore`（完全空回答のみ）
- 10文字未満も `PrecheckScore` に変更

## 影響範囲

- `Backend/internal/services/chat_service.go` - `isLikelyAnswer` 関数
- `Backend/internal/services/answer_evaluator.go` - `precheckHuman` 関数

## テスト計画

- [ ] 「はい」「いいえ」の回答でサイドバーの評価が更新されること
- [ ] 「好き」「得意」などの短答が有効判定されること
- [ ] 「A」「B」などの選択肢記号が有効判定されること（既存動作維持）
- [ ] 完全な空回答・挨拶のみの無効判定は変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)