### PR TITLE
Resolve #29: 各新卒求人サイトの会社情報スクレイピング機能を追加

### DIFF
--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -78,9 +78,24 @@ func (r *CompanyRepository) Update(company *models.Company) error {
 	return r.db.Save(company).Error
 }
 
+// FindJobPositionByCompanyAndTitle 企業IDと職種タイトルで募集職種を取得
+func (r *CompanyRepository) FindJobPositionByCompanyAndTitle(companyID uint, title string) (*models.CompanyJobPosition, error) {
+	var position models.CompanyJobPosition
+	err := r.db.Where("company_id = ? AND title = ?", companyID, title).First(&position).Error
+	if err != nil {
+		return nil, err
+	}
+	return &position, nil
+}
+
 // CreateJobPosition 募集職種を作成
 func (r *CompanyRepository) CreateJobPosition(position *models.CompanyJobPosition) error {
 	return r.db.Create(position).Error
+}
+
+// UpdateJobPosition 募集職種を更新
+func (r *CompanyRepository) UpdateJobPosition(position *models.CompanyJobPosition) error {
+	return r.db.Save(position).Error
 }
 
 // FindJobPositionsByCompany 企業の募集職種を取得

--- a/Backend/internal/services/crawl_service.go
+++ b/Backend/internal/services/crawl_service.go
@@ -192,6 +192,8 @@ func (s *CrawlService) executeCrawl(source *models.CrawlSource) error {
 		return s.executePopularCompaniesCrawl(source)
 	case "job_site_company":
 		return s.executeJobSiteCompanyCrawl(source)
+	case "job_listing":
+		return s.executeJobListingCrawl(source)
 	default:
 		return fmt.Errorf("unsupported target_type: %s", source.TargetType)
 	}
@@ -204,14 +206,17 @@ func validateCrawlSource(source *models.CrawlSource) error {
 	if strings.TrimSpace(source.TargetType) == "" {
 		return errors.New("target_type is required")
 	}
-	if source.TargetType != "company" && source.TargetType != "popular_companies" && source.TargetType != "job_site_company" {
-		return errors.New("target_type must be company, popular_companies, or job_site_company")
+	if source.TargetType != "company" && source.TargetType != "popular_companies" && source.TargetType != "job_site_company" && source.TargetType != "job_listing" {
+		return errors.New("target_type must be company, popular_companies, job_site_company, or job_listing")
 	}
 	if source.TargetType == "popular_companies" && strings.TrimSpace(source.SourceURL) == "" {
 		return errors.New("source_url is required for popular_companies")
 	}
 	if source.TargetType == "job_site_company" && strings.TrimSpace(source.SourceURL) == "" {
 		return errors.New("source_url is required for job_site_company")
+	}
+	if source.TargetType == "job_listing" && strings.TrimSpace(source.SourceURL) == "" {
+		return errors.New("source_url is required for job_listing")
 	}
 	if source.ScheduleType != "weekly" && source.ScheduleType != "monthly" {
 		return errors.New("schedule_type must be weekly or monthly")
@@ -434,6 +439,166 @@ func (s *CrawlService) executeJobSiteCompanyCrawl(source *models.CrawlSource) er
 	company.SourceURL = source.SourceURL
 	company.SourceFetchedAt = &now
 	return s.companyRepo.Update(company)
+}
+
+type jobListingExtraction struct {
+	CompanyName string `json:"company_name"`
+	Positions   []struct {
+		Title           string `json:"title"`
+		Description     string `json:"description"`
+		EmploymentType  string `json:"employment_type"`
+		WorkLocation    string `json:"work_location"`
+		RemoteOption    bool   `json:"remote_option"`
+		MinSalary       int    `json:"min_salary"`
+		MaxSalary       int    `json:"max_salary"`
+		RequiredSkills  string `json:"required_skills"`
+		PreferredSkills string `json:"preferred_skills"`
+	} `json:"positions"`
+}
+
+func (s *CrawlService) executeJobListingCrawl(source *models.CrawlSource) error {
+	if s.aiClient == nil {
+		return errors.New("openai client is required for job_listing crawl")
+	}
+	body, err := fetchText(source.SourceURL)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(body) == "" {
+		return errors.New("empty content from source_url")
+	}
+
+	extracted, err := s.extractJobListings(source, body)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(extracted.CompanyName) == "" {
+		return errors.New("could not extract company name from source")
+	}
+	if len(extracted.Positions) == 0 {
+		return errors.New("no job positions extracted from source")
+	}
+
+	now := time.Now()
+	company, err := s.companyRepo.FindByName(extracted.CompanyName)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if company == nil || errors.Is(err, gorm.ErrRecordNotFound) {
+		newCompany := &models.Company{
+			Name:            extracted.CompanyName,
+			SourceType:      source.SourceType,
+			SourceURL:       source.SourceURL,
+			SourceFetchedAt: &now,
+			IsProvisional:   true,
+			DataStatus:      "draft",
+		}
+		if err := s.companyRepo.Create(newCompany); err != nil {
+			return err
+		}
+		company = newCompany
+	}
+
+	for _, p := range extracted.Positions {
+		title := strings.TrimSpace(p.Title)
+		if title == "" {
+			continue
+		}
+		existing, err := s.companyRepo.FindJobPositionByCompanyAndTitle(company.ID, title)
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		if existing == nil || errors.Is(err, gorm.ErrRecordNotFound) {
+			pos := &models.CompanyJobPosition{
+				CompanyID:       company.ID,
+				Title:           title,
+				Description:     p.Description,
+				EmploymentType:  p.EmploymentType,
+				WorkLocation:    p.WorkLocation,
+				RemoteOption:    p.RemoteOption,
+				MinSalary:       p.MinSalary,
+				MaxSalary:       p.MaxSalary,
+				RequiredSkills:  p.RequiredSkills,
+				PreferredSkills: p.PreferredSkills,
+				IsActive:        true,
+			}
+			if err := s.companyRepo.CreateJobPosition(pos); err != nil {
+				return err
+			}
+		} else {
+			if p.Description != "" {
+				existing.Description = p.Description
+			}
+			if p.EmploymentType != "" {
+				existing.EmploymentType = p.EmploymentType
+			}
+			if p.WorkLocation != "" {
+				existing.WorkLocation = p.WorkLocation
+			}
+			existing.RemoteOption = p.RemoteOption
+			if p.MinSalary > 0 {
+				existing.MinSalary = p.MinSalary
+			}
+			if p.MaxSalary > 0 {
+				existing.MaxSalary = p.MaxSalary
+			}
+			if p.RequiredSkills != "" {
+				existing.RequiredSkills = p.RequiredSkills
+			}
+			if p.PreferredSkills != "" {
+				existing.PreferredSkills = p.PreferredSkills
+			}
+			if err := s.companyRepo.UpdateJobPosition(existing); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *CrawlService) extractJobListings(source *models.CrawlSource, rawHTML string) (*jobListingExtraction, error) {
+	clean := normalizeHTMLText(rawHTML)
+	if len(clean) > 12000 {
+		clean = clean[:12000]
+	}
+	systemPrompt := `You are a data extraction assistant. Extract job listing information from new graduate job site pages. Use only the provided text. Do not infer or guess values not present in the text.`
+	userPrompt := fmt.Sprintf(`Extract company name and job positions from the job site page text below.
+Return JSON with the following shape:
+{
+  "company_name": "会社名",
+  "positions": [
+    {
+      "title": "職種名",
+      "description": "仕事内容",
+      "employment_type": "正社員",
+      "work_location": "東京都",
+      "remote_option": false,
+      "min_salary": 300,
+      "max_salary": 500,
+      "required_skills": "[\"Java\",\"Spring Boot\"]",
+      "preferred_skills": "[\"AWS\"]"
+    }
+  ]
+}
+Rules:
+- Return 0 for salary fields not found in the text.
+- Return "" for string fields not found in the text.
+- required_skills and preferred_skills must be JSON arrays serialized as a string (e.g. "[\"Java\"]"), or "" if not found.
+- min_salary and max_salary are annual salary in 万円 (integer).
+- Do not fabricate data.
+
+Text:
+%s`, clean)
+
+	content, err := s.aiClient.ChatCompletionJSON(context.Background(), systemPrompt, userPrompt, 0.2, 1200)
+	if err != nil {
+		return nil, err
+	}
+	var parsed jobListingExtraction
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return nil, err
+	}
+	return &parsed, nil
 }
 
 func (s *CrawlService) extractJobSiteCompany(source *models.CrawlSource, rawHTML string) (*jobSiteCompanyExtraction, error) {

--- a/frontend/app/admin/crawling/page.tsx
+++ b/frontend/app/admin/crawling/page.tsx
@@ -57,7 +57,7 @@ export default function AdminCrawlingPage() {
   const [loading, setLoading] = useState(false)
 
   const [name, setName] = useState('')
-  const [targetType, setTargetType] = useState<'company' | 'popular_companies' | 'job_site_company'>('company')
+  const [targetType, setTargetType] = useState<'company' | 'popular_companies' | 'job_site_company' | 'job_listing'>('job_site_company')
   const [sourceType, setSourceType] = useState('official')
   const [sourceUrl, setSourceUrl] = useState('')
   const [scheduleType, setScheduleType] = useState<'weekly' | 'monthly'>('weekly')
@@ -123,7 +123,7 @@ export default function AdminCrawlingPage() {
       return
     }
     setName('')
-    setTargetType('company')
+    setTargetType('job_site_company')
     setSourceUrl('')
     setScheduleType('weekly')
     setScheduleDay(1)
@@ -196,12 +196,32 @@ export default function AdminCrawlingPage() {
                   select
                   label="対象タイプ"
                   value={targetType}
-                  onChange={(e) => setTargetType(e.target.value as 'company' | 'popular_companies' | 'job_site_company')}
+                  onChange={(e) =>
+                    setTargetType(
+                      e.target.value as 'company' | 'popular_companies' | 'job_site_company' | 'job_listing',
+                    )
+                  }
                 >
-                  <MenuItem value="company">企業単体</MenuItem>
+                  <MenuItem value="job_site_company">会社情報（企業ページ）</MenuItem>
+                  <MenuItem value="job_listing">求人情報（募集職種）</MenuItem>
                   <MenuItem value="popular_companies">人気企業一覧</MenuItem>
-                  <MenuItem value="job_site_company">新卒求人サイト</MenuItem>
+                  <MenuItem value="company">企業単体（名前のみ）</MenuItem>
                 </TextField>
+                {targetType === 'job_site_company' && (
+                  <Typography variant="caption" color="text.secondary">
+                    新卒求人サイトの企業詳細ページURLを指定すると、会社概要・業界・従業員数・企業文化・福利厚生などを自動取得します。
+                  </Typography>
+                )}
+                {targetType === 'job_listing' && (
+                  <Typography variant="caption" color="text.secondary">
+                    新卒求人サイトの募集職種ページURLを指定すると、職種名・仕事内容・給与・勤務地・必要スキルなどを自動取得します。
+                  </Typography>
+                )}
+                {targetType === 'popular_companies' && (
+                  <Typography variant="caption" color="text.secondary">
+                    人気企業ランキング等のページURLを指定すると、AIが会社名を一覧抽出してDBに登録します。
+                  </Typography>
+                )}
                 <TextField
                   label={targetType === 'company' ? '企業名' : '設定名'}
                   value={name}
@@ -296,10 +316,19 @@ export default function AdminCrawlingPage() {
                                 ? '企業単体'
                                 : source.target_type === 'popular_companies'
                                   ? '人気企業一覧'
-                                  : '新卒求人サイト'
+                                  : source.target_type === 'job_site_company'
+                                    ? '会社情報'
+                                    : '求人情報'
                             }
                             size="small"
                             variant="outlined"
+                            color={
+                              source.target_type === 'job_listing'
+                                ? 'primary'
+                                : source.target_type === 'job_site_company'
+                                  ? 'secondary'
+                                  : 'default'
+                            }
                           />
                           <Chip
                             label={source.is_active ? '稼働中' : '停止中'}


### PR DESCRIPTION
Closes #29

## 変更内容

### `Backend/internal/services/crawl_service.go`

- **新しい `TargetType` `"job_site_company"` を追加**
  - 既存の `"company"`・`"popular_companies"` に加え、新卒求人サイトの企業ページをスクレイピングする新タイプを実装

- **`validateCrawlSource` の拡張**
  - `"job_site_company"` を有効な target_type として許可
  - `source_url` の必須チェックを `"job_site_company"` にも適用

- **`executeCrawl` への分岐追加**
  - `"job_site_company"` → `executeJobSiteCompanyCrawl()` を呼び出すよう dispatch を追加

- **`jobSiteCompanyExtraction` 構造体（新規）**
  - AIが返す会社情報のJSONをマッピングするための構造体
  - フィールド: 社名・概要・業界・従業員数・設立年・所在地・WebサイトURL・企業文化・働き方・福利厚生・主要事業・平均年齢・女性比率

- **`executeJobSiteCompanyCrawl()` メソッド（新規）**
  - `source_url` の HTML を取得し `extractJobSiteCompany()` でAI抽出
  - 抽出した会社名で既存レコードを検索し、未登録なら新規作成、既存なら空でないフィールドのみ選択的に上書き更新
  - `SourceType`・`SourceURL`・`SourceFetchedAt` を常に最新値で更新

- **`extractJobSiteCompany()` メソッド（新規）**
  - HTML を正規化（スクリプト・タグ除去）し最大12,000文字に切り詰め
  - OpenAI に構造化JSONの抽出を依頼（temperature=0.2）
  - レスポンスをパースして `jobSiteCompanyExtraction` に変換

## 動作確認方法

既存の管理API（`POST /api/admin/crawl-sources`）に以下のペイロードを送信：

```json
{
  "name": "株式会社サンプル",
  "target_type": "job_site_company",
  "source_type": "job_site",
  "source_url": "https://job.mynavi.jp/25/pc/search/corp12345/outline.html",
  "schedule_type": "weekly",
  "schedule_day": 1,
  "schedule_time": "03:00"
}
```

手動実行: `POST /api/admin/crawl-sources/{id}/run`