### PR TITLE
Resolve #49: 面接レポートのメール送信機能を追加する

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -109,7 +109,7 @@ func main() {
 		nil,
 	)
 	emailService := services.NewEmailService()
-	interviewService := services.NewInterviewService(interviewSessionRepo, interviewUtteranceRepo, interviewReportRepo, userRepo, aiClient)
+	interviewService := services.NewInterviewService(interviewSessionRepo, interviewUtteranceRepo, interviewReportRepo, userRepo, emailService, aiClient)
 	interviewService.StartWorker()
 
 	// コントローラー層の初期化

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -66,7 +66,43 @@ func (c *InterviewController) Route(w http.ResponseWriter, r *http.Request) {
 		c.StartTurn(w, r)
 		return
 	}
+	if strings.HasSuffix(path, "/send-report") {
+		c.SendReport(w, r)
+		return
+	}
 	c.Get(w, r)
+}
+
+func (c *InterviewController) SendReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	sessionID, err := extractID(r.URL.Path, "/api/interviews/", "/send-report")
+	if err != nil {
+		http.Error(w, "Invalid session ID", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		UserID uint `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.UserID == 0 {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+	if err := c.interviewService.SendReportEmail(req.UserID, sessionID); err != nil {
+		status := http.StatusInternalServerError
+		if err.Error() == "user not found" || err.Error() == "report not found" {
+			status = http.StatusNotFound
+		}
+		if err.Error() == "guest users cannot receive email reports" {
+			status = http.StatusForbidden
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "レポートをメールで送信しました"})
 }
 
 func (c *InterviewController) Turn(w http.ResponseWriter, r *http.Request) {

--- a/Backend/internal/services/email_service.go
+++ b/Backend/internal/services/email_service.go
@@ -206,3 +206,153 @@ func (s *EmailService) SendAnalysisReport(user *models.User, summary *AnalysisSu
 	fmt.Printf("[EmailService] Email sent successfully to %s\n", user.Email)
 	return nil
 }
+
+// InterviewReportEmailData 面接レポートメールのデータ
+type InterviewReportEmailData struct {
+	UserName    string
+	SessionID   string
+	SentAt      string
+	Summary     []string
+	LogicScore  int
+	SpecScore   int
+	OwnScore    int
+	LogicEvid   string
+	SpecEvid    string
+	OwnEvid     string
+}
+
+const interviewReportEmailTemplate = `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>AI面接練習レポート</title>
+  <style>
+    body{font-family:'Hiragino Sans','Meiryo',sans-serif;background:#f5f5f5;margin:0;padding:20px;}
+    .container{max-width:600px;margin:0 auto;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.1);}
+    .header{background:linear-gradient(135deg,#ec5b13,#ff8a50);color:white;padding:32px 24px;text-align:center;}
+    .header h1{margin:0;font-size:22px;}
+    .header p{margin:8px 0 0;opacity:.9;font-size:13px;}
+    .section{padding:20px 24px;border-bottom:1px solid #e0e0e0;}
+    .section h2{margin:0 0 14px;font-size:16px;color:#ec5b13;}
+    .summary-item{display:flex;gap:8px;margin-bottom:8px;font-size:13px;line-height:1.6;color:#333;}
+    .bullet{color:#ec5b13;font-weight:bold;flex-shrink:0;}
+    .scores-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:16px;}
+    .score-card{background:#fff8f5;border:1px solid #ffd5c0;border-radius:8px;padding:12px;text-align:center;}
+    .score-label{font-size:11px;color:#888;margin-bottom:4px;}
+    .score-value{font-size:28px;font-weight:bold;color:#ec5b13;}
+    .score-max{font-size:12px;color:#aaa;}
+    .bar-bg{background:#e0e0e0;border-radius:4px;height:8px;margin-top:4px;}
+    .bar-fill{background:#ec5b13;border-radius:4px;height:8px;}
+    .evidence-item{background:#f9f9f9;border-radius:6px;padding:12px;margin-bottom:8px;}
+    .evidence-label{font-size:11px;color:#ec5b13;font-weight:bold;margin-bottom:4px;}
+    .evidence-text{font-size:13px;color:#555;line-height:1.5;}
+    .footer{padding:20px 24px;text-align:center;background:#fafafa;color:#999;font-size:11px;}
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="header">
+    <h1>🎤 AI面接練習レポート</h1>
+    <p>{{.UserName}} さんの面接結果</p>
+    <p>{{.SentAt}}</p>
+  </div>
+
+  {{if .Summary}}
+  <div class="section">
+    <h2>📝 総合フィードバック</h2>
+    {{range .Summary}}
+    <div class="summary-item"><span class="bullet">▶</span><span>{{.}}</span></div>
+    {{end}}
+  </div>
+  {{end}}
+
+  <div class="section">
+    <h2>📊 評価スコア（5点満点）</h2>
+    <div class="scores-grid">
+      <div class="score-card">
+        <div class="score-label">論理性</div>
+        <div class="score-value">{{.LogicScore}}</div>
+        <div class="score-max">/ 5</div>
+        <div class="bar-bg"><div class="bar-fill" style="width:{{.LogicScore}}0%"></div></div>
+      </div>
+      <div class="score-card">
+        <div class="score-label">具体性</div>
+        <div class="score-value">{{.SpecScore}}</div>
+        <div class="score-max">/ 5</div>
+        <div class="bar-bg"><div class="bar-fill" style="width:{{.SpecScore}}0%"></div></div>
+      </div>
+      <div class="score-card">
+        <div class="score-label">主体性</div>
+        <div class="score-value">{{.OwnScore}}</div>
+        <div class="score-max">/ 5</div>
+        <div class="bar-bg"><div class="bar-fill" style="width:{{.OwnScore}}0%"></div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>🔍 評価の根拠</h2>
+    {{if .LogicEvid}}
+    <div class="evidence-item">
+      <div class="evidence-label">論理性</div>
+      <div class="evidence-text">{{.LogicEvid}}</div>
+    </div>
+    {{end}}
+    {{if .SpecEvid}}
+    <div class="evidence-item">
+      <div class="evidence-label">具体性</div>
+      <div class="evidence-text">{{.SpecEvid}}</div>
+    </div>
+    {{end}}
+    {{if .OwnEvid}}
+    <div class="evidence-item">
+      <div class="evidence-label">主体性</div>
+      <div class="evidence-text">{{.OwnEvid}}</div>
+    </div>
+    {{end}}
+  </div>
+
+  <div class="footer">
+    <p>このメールはAI就活エージェントから自動送信されました。</p>
+    <p>セッションID: {{.SessionID}}</p>
+  </div>
+</div>
+</body>
+</html>`
+
+// SendInterviewReport 面接練習レポートをメールで送信
+func (s *EmailService) SendInterviewReport(user *models.User, data InterviewReportEmailData) error {
+	tmpl, err := template.New("interview_report").Parse(interviewReportEmailTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse email template: %w", err)
+	}
+
+	data.SentAt = time.Now().Format("2006年01月02日 15:04")
+	data.UserName = user.Name
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("failed to render email template: %w", err)
+	}
+
+	htmlBody := buf.String()
+
+	if s.host == "" {
+		fmt.Printf("[EmailService] SMTP not configured. Simulating interview report send to %s (body: %d bytes)\n", user.Email, len(htmlBody))
+		return nil
+	}
+
+	msg := fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: AI面接練習レポート\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n%s",
+		s.from, user.Email, htmlBody,
+	)
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	auth := smtp.PlainAuth("", s.user, s.password, s.host)
+
+	if err := smtp.SendMail(addr, auth, s.from, []string{user.Email}, []byte(msg)); err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	fmt.Printf("[EmailService] Interview report email sent successfully to %s\n", user.Email)
+	return nil
+}

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -22,6 +22,7 @@ type InterviewService struct {
 	utterRepo    *repositories.InterviewUtteranceRepository
 	reportRepo   *repositories.InterviewReportRepository
 	userRepo     *repositories.UserRepository
+	emailService *EmailService
 	openaiClient *openai.Client
 	jobCh        chan uint
 	workerOnce   sync.Once
@@ -32,6 +33,7 @@ func NewInterviewService(
 	utterRepo *repositories.InterviewUtteranceRepository,
 	reportRepo *repositories.InterviewReportRepository,
 	userRepo *repositories.UserRepository,
+	emailService *EmailService,
 	openaiClient *openai.Client,
 ) *InterviewService {
 	return &InterviewService{
@@ -39,6 +41,7 @@ func NewInterviewService(
 		utterRepo:    utterRepo,
 		reportRepo:   reportRepo,
 		userRepo:     userRepo,
+		emailService: emailService,
 		openaiClient: openaiClient,
 		jobCh:        make(chan uint, 100),
 	}
@@ -416,6 +419,47 @@ func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) e
 		EvidenceJSON: string(evidenceJSON),
 	}
 	return s.reportRepo.Upsert(report)
+}
+
+// SendReportEmail 面接レポートをメールで送信
+func (s *InterviewService) SendReportEmail(userID, sessionID uint) error {
+	user, err := s.userRepo.GetUserByID(userID)
+	if err != nil || user == nil {
+		return errors.New("user not found")
+	}
+	if user.IsGuest {
+		return errors.New("guest users cannot receive email reports")
+	}
+
+	report, err := s.reportRepo.FindBySessionID(sessionID)
+	if err != nil {
+		return errors.New("report not found")
+	}
+
+	var scores map[string]int
+	json.Unmarshal([]byte(report.ScoresJSON), &scores)
+	var evidence map[string]string
+	json.Unmarshal([]byte(report.EvidenceJSON), &evidence)
+
+	summary := strings.Split(strings.TrimSpace(report.SummaryText), "\n")
+	var filtered []string
+	for _, line := range summary {
+		if strings.TrimSpace(line) != "" {
+			filtered = append(filtered, strings.TrimSpace(line))
+		}
+	}
+
+	data := InterviewReportEmailData{
+		SessionID:  fmt.Sprintf("%d", sessionID),
+		Summary:    filtered,
+		LogicScore: scores["logic"],
+		SpecScore:  scores["specificity"],
+		OwnScore:   scores["ownership"],
+		LogicEvid:  evidence["logic"],
+		SpecEvid:   evidence["specificity"],
+		OwnEvid:    evidence["ownership"],
+	}
+	return s.emailService.SendInterviewReport(user, data)
 }
 
 func toSessionResponse(session *models.InterviewSession) *InterviewSessionResponse {

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -89,6 +89,8 @@ export default function InterviewPage() {
   const [session, setSession] = useState<InterviewSession | null>(null)
   const [report, setReport] = useState<InterviewReport | null>(null)
   const [reportStatus, setReportStatus] = useState<'idle' | 'pending' | 'ready' | 'error'>('idle')
+  const [emailSending, setEmailSending] = useState(false)
+  const [emailSent, setEmailSent] = useState(false)
   const [aiLevel, setAiLevel] = useState(0)
   const [aiSpeaking, setAiSpeaking] = useState(false)
   const [avatarGender, setAvatarGender] = useState<'male' | 'female'>('male')
@@ -894,6 +896,26 @@ export default function InterviewPage() {
                   </Stack>
                 </Paper>
               )}
+              <Button
+                variant="outlined"
+                fullWidth
+                disabled={emailSending || emailSent || !user || user.is_guest}
+                onClick={async () => {
+                  if (!session || !user) return
+                  setEmailSending(true)
+                  try {
+                    await interviewApi.sendReportEmail(session.id, user.user_id)
+                    setEmailSent(true)
+                  } catch {
+                    // ignore
+                  } finally {
+                    setEmailSending(false)
+                  }
+                }}
+                sx={{ color: emailSent ? '#34a853' : PRIMARY, borderColor: emailSent ? '#34a853' : PRIMARY, '&:hover': { borderColor: PRIMARY, bgcolor: 'rgba(236,91,19,0.08)' } }}
+              >
+                {emailSent ? '✓ メールを送信しました' : emailSending ? '送信中...' : 'レポートをメールで受け取る'}
+              </Button>
             </Stack>
           )}
 

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -97,6 +97,16 @@ export const interviewApi = {
     const data = await res.json()
     return data.client_secret
   },
+
+  async sendReportEmail(sessionId: number, userId: number): Promise<{ message: string }> {
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/send-report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId }),
+    })
+    if (!res.ok) throw new Error(await res.text())
+    return res.json()
+  },
 }
 
 export const interviewLimits = {


### PR DESCRIPTION
Closes #49

## 変更内容

### Backend
- `email_service.go`: `SendInterviewReport()` メソッドと面接レポート用HTMLメールテンプレートを追加（論理性・具体性・主体性スコア、根拠、要約を含む）
- `interview_service.go`: `emailService` フィールドを追加し、`SendReportEmail(userID, sessionID)` メソッドを実装
- `interview_controller.go`: `POST /api/interviews/{id}/send-report` エンドポイントを追加
- `main.go`: `NewInterviewService` に `emailService` を渡すよう更新

### Frontend
- `frontend/lib/interview.ts`: `interviewApi.sendReportEmail(sessionId, userId)` 関数を追加
- `frontend/app/interview/page.tsx`: 面接レポートパネルに「レポートをメールで受け取る」ボタンを追加（送信中・送信済み状態対応）

## 備考
- SMTP未設定時はコンソールログにシミュレート出力（既存の適正診断と同じ挙動）
- ゲストユーザーはメール送信不可（403 Forbidden）