### PR TITLE
Fix #38: utterance保存エラーのログ追加とレポート生成失敗を修正

### DIFF
--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -362,7 +362,14 @@ func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) e
 		return err
 	}
 	if len(utterances) == 0 {
-		return errors.New("no utterances")
+		// utterances が0件の場合は空レポートを保存して正常終了
+		empty := &models.InterviewReport{
+			SessionID:    sessionID,
+			SummaryText:  "発話データがありませんでした。",
+			ScoresJSON:   `{"logic":0,"specificity":0,"ownership":0}`,
+			EvidenceJSON: `{}`,
+		}
+		return s.reportRepo.Upsert(empty)
 	}
 	var transcriptBuilder strings.Builder
 	for _, u := range utterances {

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -292,7 +292,7 @@ export default function InterviewPage() {
     if (aiText) {
       historyRef.current.push({ role: 'assistant', content: aiText })
       setUtterances(p => [...p, { role: 'ai', text: aiText }])
-      try { await interviewApi.saveUtterance(sessionId, userId, 'ai', aiText) } catch { /* ignore */ }
+      try { await interviewApi.saveUtterance(sessionId, userId, 'ai', aiText) } catch (e) { console.error('[utterance save error]', e) }
     }
     await playAudioBlob(audio)
   }
@@ -406,12 +406,12 @@ export default function InterviewPage() {
       if (userText) {
         historyRef.current.push({ role: 'user', content: userText })
         setUtterances(p => [...p, { role: 'user', text: userText }])
-        try { await interviewApi.saveUtterance(session.id, user.user_id, 'user', userText) } catch { /* ignore */ }
+        try { await interviewApi.saveUtterance(session.id, user.user_id, 'user', userText) } catch (e) { console.error('[utterance save error]', e) }
       }
       if (aiText) {
         historyRef.current.push({ role: 'assistant', content: aiText })
         setUtterances(p => [...p, { role: 'ai', text: aiText }])
-        try { await interviewApi.saveUtterance(session.id, user.user_id, 'ai', aiText) } catch { /* ignore */ }
+        try { await interviewApi.saveUtterance(session.id, user.user_id, 'ai', aiText) } catch (e) { console.error('[utterance save error]', e) }
       }
       await playAudioBlob(audio)
     } catch (e: any) {


### PR DESCRIPTION
Closes #38

## 変更内容

### Backend
- `interview_service.go`: utterances が0件の場合でもエラーではなく空レポートを保存するよう変更（「発話データがありませんでした。」メッセージ、スコアは全0）

### Frontend
- `interview/page.tsx`: `saveUtterance` の catch ブロックを `catch { /* ignore */ }` から `catch (e) { console.error('[utterance save error]', e) }` に変更し、エラーを可視化