### PR TITLE
Fix #39: 管理APIにサーバーサイドの管理者権限チェックを追加する

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -132,7 +132,7 @@ func main() {
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)

--- a/Backend/internal/middleware/admin_auth.go
+++ b/Backend/internal/middleware/admin_auth.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"Backend/internal/repositories"
+	"net/http"
+)
+
+// AdminAuth X-Admin-Email ヘッダーでユーザーを検証し is_admin が true であることを確認する
+func AdminAuth(userRepo *repositories.UserRepository, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		email := r.Header.Get("X-Admin-Email")
+		if email == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		user, err := userRepo.GetUserByEmail(email)
+		if err != nil || user == nil || !user.IsAdmin {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// AdminAuthFunc AdminAuth の http.HandlerFunc バージョン
+func AdminAuthFunc(userRepo *repositories.UserRepository, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := r.Header.Get("X-Admin-Email")
+		if email == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		user, err := userRepo.GetUserByEmail(email)
+		if err != nil || user == nil || !user.IsAdmin {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		next(w, r)
+	}
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"Backend/internal/controllers"
+	"Backend/internal/middleware"
+	"Backend/internal/repositories"
 	"net/http"
 )
 
@@ -11,18 +13,23 @@ func SetupAdminRoutes(
 	adminJobController *controllers.AdminJobController,
 	adminUserController *controllers.AdminUserController,
 	adminAuditController *controllers.AdminAuditController,
+	userRepo *repositories.UserRepository,
 ) {
-	http.HandleFunc("/api/admin/companies", adminCompanyController.ListOrCreate)
-	http.HandleFunc("/api/admin/companies/", adminCompanyController.Detail)
-	http.HandleFunc("/api/admin/crawl-sources", adminCrawlController.Sources)
-	http.HandleFunc("/api/admin/crawl-sources/", adminCrawlController.SourceDetail)
-	http.HandleFunc("/api/admin/crawl-runs", adminCrawlController.Runs)
-	http.HandleFunc("/api/admin/job-categories", adminJobController.JobCategories)
-	http.HandleFunc("/api/admin/job-positions", adminJobController.JobPositions)
-	http.HandleFunc("/api/admin/job-positions/", adminJobController.JobPositionAction)
-	http.HandleFunc("/api/admin/graduate-employments", adminJobController.GraduateEmployments)
-	http.HandleFunc("/api/admin/graduate-employments/", adminJobController.GraduateEmploymentDetail)
-	http.HandleFunc("/api/admin/users", adminUserController.List)
-	http.HandleFunc("/api/admin/users/", adminUserController.Update)
-	http.HandleFunc("/api/admin/audit-logs", adminAuditController.List)
+	auth := func(f http.HandlerFunc) http.HandlerFunc {
+		return middleware.AdminAuthFunc(userRepo, f)
+	}
+
+	http.HandleFunc("/api/admin/companies", auth(adminCompanyController.ListOrCreate))
+	http.HandleFunc("/api/admin/companies/", auth(adminCompanyController.Detail))
+	http.HandleFunc("/api/admin/crawl-sources", auth(adminCrawlController.Sources))
+	http.HandleFunc("/api/admin/crawl-sources/", auth(adminCrawlController.SourceDetail))
+	http.HandleFunc("/api/admin/crawl-runs", auth(adminCrawlController.Runs))
+	http.HandleFunc("/api/admin/job-categories", auth(adminJobController.JobCategories))
+	http.HandleFunc("/api/admin/job-positions", auth(adminJobController.JobPositions))
+	http.HandleFunc("/api/admin/job-positions/", auth(adminJobController.JobPositionAction))
+	http.HandleFunc("/api/admin/graduate-employments", auth(adminJobController.GraduateEmployments))
+	http.HandleFunc("/api/admin/graduate-employments/", auth(adminJobController.GraduateEmploymentDetail))
+	http.HandleFunc("/api/admin/users", auth(adminUserController.List))
+	http.HandleFunc("/api/admin/users/", auth(adminUserController.Update))
+	http.HandleFunc("/api/admin/audit-logs", auth(adminAuditController.List))
 }

--- a/frontend/app/admin/audit-logs/page.tsx
+++ b/frontend/app/admin/audit-logs/page.tsx
@@ -37,7 +37,10 @@ export default function AdminAuditLogsPage() {
 
   const loadLogs = async () => {
     setError('')
-    const response = await fetch('/api/admin/audit-logs')
+    const admin = authService.getStoredUser()
+    const response = await fetch('/api/admin/audit-logs', {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
     const data = await response.json()
     if (!response.ok) {
       setError(data?.error || '監査ログの取得に失敗しました')

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -50,7 +50,10 @@ export default function AdminCompaniesPage() {
 
   const fetchCompanies = async () => {
     setError('')
-    const res = await fetch('/api/admin/companies')
+    const admin = authService.getStoredUser()
+    const res = await fetch('/api/admin/companies', {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
     const data = await res.json()
     if (!res.ok) {
       setError(data?.error || '企業一覧の取得に失敗しました')

--- a/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
+++ b/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
@@ -44,10 +44,12 @@ export default function AdminGraduateEmploymentEditPage() {
 
   useEffect(() => {
     if (!id) return
+    const admin = authService.getStoredUser()
+    const headers = { 'X-Admin-Email': admin?.email || '' }
     Promise.all([
-      fetch('/api/admin/companies').then((r) => r.json()),
-      fetch('/api/admin/job-positions?limit=100').then((r) => r.json()),
-      fetch(`/api/admin/graduate-employments/${id}`).then((r) => r.json()),
+      fetch('/api/admin/companies', { headers }).then((r) => r.json()),
+      fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()),
+      fetch(`/api/admin/graduate-employments/${id}`, { headers }).then((r) => r.json()),
     ]).then(([companiesData, positionsData, entry]) => {
       setCompanies(companiesData?.companies || [])
       setJobPositions(positionsData?.positions || [])

--- a/frontend/app/admin/graduate-employments/new/page.tsx
+++ b/frontend/app/admin/graduate-employments/new/page.tsx
@@ -40,8 +40,10 @@ export default function AdminGraduateEmploymentNewPage() {
   const [note, setNote] = useState('')
 
   useEffect(() => {
-    fetch('/api/admin/companies').then((r) => r.json()).then((d) => setCompanies(d?.companies || []))
-    fetch('/api/admin/job-positions?limit=100').then((r) => r.json()).then((d) => setJobPositions(d?.positions || []))
+    const admin = authService.getStoredUser()
+    const headers = { 'X-Admin-Email': admin?.email || '' }
+    fetch('/api/admin/companies', { headers }).then((r) => r.json()).then((d) => setCompanies(d?.companies || []))
+    fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()).then((d) => setJobPositions(d?.positions || []))
   }, [])
 
   const handleCreate = async () => {

--- a/frontend/app/admin/graduate-employments/page.tsx
+++ b/frontend/app/admin/graduate-employments/page.tsx
@@ -38,7 +38,10 @@ export default function AdminGraduateEmploymentsPage() {
   const [graduateEntries, setGraduateEntries] = useState<GraduateEmployment[]>([])
 
   useEffect(() => {
-    fetch('/api/admin/graduate-employments?limit=100')
+    const admin = authService.getStoredUser()
+    fetch('/api/admin/graduate-employments?limit=100', {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
       .then((r) => r.json())
       .then((data) => setGraduateEntries(data?.entries || []))
       .catch(() => {})

--- a/frontend/app/admin/job-positions/page.tsx
+++ b/frontend/app/admin/job-positions/page.tsx
@@ -47,7 +47,10 @@ export default function AdminJobPositionsPage() {
   const [filterStatus, setFilterStatus] = useState<'all' | 'draft' | 'published' | 'rejected'>('all')
 
   const fetchJobPositions = async () => {
-    const res = await fetch('/api/admin/job-positions?limit=100')
+    const admin = authService.getStoredUser()
+    const res = await fetch('/api/admin/job-positions?limit=100', {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
     const data = await res.json()
     if (res.ok) setJobPositions(data?.positions || [])
   }

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -62,7 +62,10 @@ export default function AdminUsersPage() {
       })
       if (query.trim()) params.set('q', query.trim())
 
-      const response = await fetch(`/api/admin/users?${params}`)
+      const admin = authService.getStoredUser()
+      const response = await fetch(`/api/admin/users?${params}`, {
+        headers: { 'X-Admin-Email': admin?.email || '' },
+      })
       const data = await response.json()
       if (cancelled) return
       if (!response.ok) {


### PR DESCRIPTION
Closes #39

## 変更内容

### Backend
- `Backend/internal/middleware/admin_auth.go` を新規作成: `X-Admin-Email` ヘッダーを検証し、DB で `is_admin=true` を確認するミドルウェア
- `admin_routes.go`: 全 `/api/admin/*` ルートに `AdminAuthFunc` ミドルウェアを適用
- `main.go`: `SetupAdminRoutes` に `userRepo` を追加

### Frontend
- 管理画面の GET リクエストに `X-Admin-Email` ヘッダーを追加（以下のページ）:
  - `audit-logs/page.tsx`
  - `graduate-employments/page.tsx`
  - `graduate-employments/new/page.tsx`
  - `graduate-employments/[id]/edit/page.tsx`
  - `job-positions/page.tsx`
  - `companies/page.tsx`
  - `users/page.tsx`