### PR TITLE
Resolve #72: 求人管理画面にクローリング取得情報を表示

### DIFF
--- a/frontend/app/admin/job-positions/page.tsx
+++ b/frontend/app/admin/job-positions/page.tsx
@@ -9,10 +9,16 @@ import {
   Card,
   CardContent,
   Chip,
+  Collapse,
   Divider,
+  IconButton,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { authService } from '@/lib/auth'
 
 type JobPosition = {
@@ -23,8 +29,20 @@ type JobPosition = {
   employment_type?: string
   work_location?: string
   remote_option?: boolean
+  min_salary?: number
+  max_salary?: number
+  required_skills?: string
+  preferred_skills?: string
   data_status?: string
-  company?: { id: number; name: string }
+  created_at?: string
+  company?: {
+    id: number
+    name: string
+    source_url?: string
+    source_type?: string
+    source_fetched_at?: string
+    is_provisional?: boolean
+  }
   job_category?: { id: number; name: string }
 }
 
@@ -32,6 +50,186 @@ const statusBadge = (status?: string) => {
   if (status === 'published') return <Chip label="公開" color="success" size="small" />
   if (status === 'rejected') return <Chip label="却下" color="error" size="small" />
   return <Chip label="審査中" color="warning" size="small" />
+}
+
+const formatDate = (dateStr?: string) => {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleDateString('ja-JP', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+const parsedSkills = (json?: string): string[] => {
+  if (!json) return []
+  try {
+    const parsed = JSON.parse(json)
+    if (Array.isArray(parsed)) return parsed.map(String)
+  } catch {}
+  return json.split(/[,、]/).map((s) => s.trim()).filter(Boolean)
+}
+
+function JobPositionCard({
+  position,
+  onPublish,
+  onReject,
+}: {
+  position: JobPosition
+  onPublish: (id: number) => void
+  onReject: (id: number) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const reqSkills = parsedSkills(position.required_skills)
+  const prefSkills = parsedSkills(position.preferred_skills)
+  const hasCrawlInfo = !!(position.company?.source_url || position.company?.source_fetched_at || position.description || position.min_salary || reqSkills.length || prefSkills.length)
+
+  return (
+    <Box sx={{ border: '1px solid #e0e0e0', borderRadius: 1, p: 2 }}>
+      <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1}>
+        <Box flex={1} minWidth={0}>
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ mb: 0.5 }}>
+            <Typography variant="subtitle1" fontWeight="bold">
+              {position.title}
+            </Typography>
+            {statusBadge(position.data_status)}
+            {position.company?.is_provisional && (
+              <Chip label="仮登録" size="small" variant="outlined" color="warning" />
+            )}
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {position.company?.name || `企業ID ${position.company_id}`}
+            {position.job_category?.name ? ` / ${position.job_category.name}` : ''}
+            {position.employment_type ? ` / ${position.employment_type}` : ''}
+            {position.work_location ? ` / ${position.work_location}` : ''}
+            {position.remote_option ? ' / リモート可' : ''}
+            {position.min_salary || position.max_salary ? (
+              ` / ${position.min_salary ? position.min_salary + '万' : ''}〜${position.max_salary ? position.max_salary + '万円' : ''}`
+            ) : ''}
+          </Typography>
+          {position.created_at && (
+            <Typography variant="caption" color="text.secondary">
+              取得日: {formatDate(position.created_at)}
+            </Typography>
+          )}
+        </Box>
+        <Stack direction="row" alignItems="center" spacing={1} flexShrink={0}>
+          {(position.data_status || 'draft') !== 'published' && (
+            <>
+              <Button
+                variant="contained"
+                color="success"
+                size="small"
+                onClick={() => onPublish(position.id)}
+              >
+                承認
+              </Button>
+              {(position.data_status || 'draft') !== 'rejected' && (
+                <Button
+                  variant="outlined"
+                  color="error"
+                  size="small"
+                  onClick={() => onReject(position.id)}
+                >
+                  却下
+                </Button>
+              )}
+            </>
+          )}
+          {hasCrawlInfo && (
+            <Tooltip title={expanded ? '詳細を閉じる' : 'クロール情報を表示'}>
+              <IconButton size="small" onClick={() => setExpanded(!expanded)}>
+                {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+      </Stack>
+
+      <Collapse in={expanded}>
+        <Divider sx={{ my: 1.5 }} />
+        <Stack spacing={1.5}>
+          {/* クロール元情報 */}
+          {(position.company?.source_url || position.company?.source_fetched_at || position.company?.source_type) && (
+            <Box>
+              <Typography variant="caption" fontWeight="bold" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                クロール元情報
+              </Typography>
+              <Stack spacing={0.5}>
+                {position.company?.source_url && (
+                  <Stack direction="row" alignItems="center" spacing={0.5}>
+                    <Typography variant="body2" color="text.secondary">URL:</Typography>
+                    <Link
+                      href={position.company.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ display: 'flex', alignItems: 'center', gap: 2, fontSize: 13 }}
+                    >
+                      {position.company.source_url.length > 60
+                        ? position.company.source_url.slice(0, 60) + '…'
+                        : position.company.source_url}
+                      <OpenInNewIcon sx={{ fontSize: 13, ml: 0.25 }} />
+                    </Link>
+                  </Stack>
+                )}
+                {position.company?.source_type && (
+                  <Typography variant="body2" color="text.secondary">
+                    ソースタイプ: {position.company.source_type}
+                  </Typography>
+                )}
+                {position.company?.source_fetched_at && (
+                  <Typography variant="body2" color="text.secondary">
+                    取得日時: {formatDate(position.company.source_fetched_at)}
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+          )}
+
+          {/* 職務内容 */}
+          {position.description && (
+            <Box>
+              <Typography variant="caption" fontWeight="bold" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                職務内容
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+                {position.description.length > 300
+                  ? position.description.slice(0, 300) + '…'
+                  : position.description}
+              </Typography>
+            </Box>
+          )}
+
+          {/* 必須スキル */}
+          {reqSkills.length > 0 && (
+            <Box>
+              <Typography variant="caption" fontWeight="bold" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                必須スキル
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.5}>
+                {reqSkills.map((s, i) => (
+                  <Chip key={i} label={s} size="small" color="primary" variant="outlined" />
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          {/* 歓迎スキル */}
+          {prefSkills.length > 0 && (
+            <Box>
+              <Typography variant="caption" fontWeight="bold" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                歓迎スキル
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.5}>
+                {prefSkills.map((s, i) => (
+                  <Chip key={i} label={s} size="small" variant="outlined" />
+                ))}
+              </Stack>
+            </Box>
+          )}
+        </Stack>
+      </Collapse>
+    </Box>
+  )
 }
 
 export default function AdminJobPositionsPage() {
@@ -105,10 +303,13 @@ export default function AdminJobPositionsPage() {
           <Button variant="outlined" size="small" component={Link} href="/admin/graduate-employments">
             就職情報管理
           </Button>
+          <Button variant="outlined" size="small" component={Link} href="/admin/crawling">
+            クローリング管理
+          </Button>
         </Stack>
       </Stack>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        クローリングで取得した求人情報を審査・公開します。
+        クローリングで取得した求人情報を審査・公開します。各求人の▼ボタンでクロール元URL・スキル・職務内容を確認できます。
       </Typography>
 
       {error && (
@@ -120,7 +321,12 @@ export default function AdminJobPositionsPage() {
       <Card>
         <CardContent>
           <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-            <Typography variant="h6">求人一覧</Typography>
+            <Typography variant="h6">
+              求人一覧
+              <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                ({filtered.length}件)
+              </Typography>
+            </Typography>
             <Stack direction="row" spacing={1}>
               {(['all', 'draft', 'published', 'rejected'] as const).map((s) => (
                 <Chip
@@ -142,47 +348,12 @@ export default function AdminJobPositionsPage() {
               </Typography>
             ) : (
               filtered.map((position) => (
-                <Box key={position.id} sx={{ border: '1px solid #eee', borderRadius: 1, p: 2 }}>
-                  <Stack direction="row" alignItems="center" justifyContent="space-between">
-                    <Box>
-                      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
-                        <Typography variant="subtitle1" fontWeight="bold">
-                          {position.title}
-                        </Typography>
-                        {statusBadge(position.data_status)}
-                      </Stack>
-                      <Typography variant="body2" color="text.secondary">
-                        {position.company?.name || `企業ID ${position.company_id}`}
-                        {position.job_category?.name ? ` / ${position.job_category.name}` : ''}
-                        {position.employment_type ? ` / ${position.employment_type}` : ''}
-                        {position.work_location ? ` / ${position.work_location}` : ''}
-                        {position.remote_option ? ' / リモート可' : ''}
-                      </Typography>
-                    </Box>
-                    {(position.data_status || 'draft') !== 'published' && (
-                      <Stack direction="row" spacing={1}>
-                        <Button
-                          variant="contained"
-                          color="success"
-                          size="small"
-                          onClick={() => handlePublish(position.id)}
-                        >
-                          承認
-                        </Button>
-                        {(position.data_status || 'draft') !== 'rejected' && (
-                          <Button
-                            variant="outlined"
-                            color="error"
-                            size="small"
-                            onClick={() => handleReject(position.id)}
-                          >
-                            却下
-                          </Button>
-                        )}
-                      </Stack>
-                    )}
-                  </Stack>
-                </Box>
+                <JobPositionCard
+                  key={position.id}
+                  position={position}
+                  onPublish={handlePublish}
+                  onReject={handleReject}
+                />
               ))
             )}
           </Stack>


### PR DESCRIPTION
Closes #72

## 変更内容

### フロントエンド (`frontend/app/admin/job-positions/page.tsx`)

- **型定義の拡張**: `JobPosition` 型に以下のフィールドを追加
  - `description`, `min_salary`, `max_salary`, `required_skills`, `preferred_skills`, `created_at`
  - `company.source_url`, `company.source_type`, `company.source_fetched_at`, `company.is_provisional`

- **展開可能なカードコンポーネント化**: 各求人を `JobPositionCard` コンポーネントに分離し、▼ボタンでクロール取得情報を開閉できる UI を追加

- **クロール元情報の表示**: 展開時に以下を表示
  - クロール元 URL（外部リンク付き）
  - ソースタイプ・取得日時
  - 職務内容（300文字まで）
  - 必須スキル・歓迎スキル（Chip コンポーネントで一覧表示）

- **サマリー行の拡充**: 給与範囲（最低〜最高万円）・取得日をカード上部に表示
- **仮登録バッジ**: `is_provisional` フラグがある企業に「仮登録」バッジを追加
- **件数表示・ナビゲーション改善**: 一覧の件数表示と「クローリング管理」へのリンクを追加