### PR TITLE
Resolve #67, #74, #75: 分析結果の適性職種コメント・面接練習企業/職種機能強化・スクレイピング関連会社相関図反映

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -81,6 +81,7 @@ func main() {
 	auditLogRepo := repositories.NewAuditLogRepository(db)
 	matchRepo := repositories.NewUserCompanyMatchRepository(db)
 	resumeRepo := repositories.NewResumeRepository(db)
+	companyRelationRepo := repositories.NewCompanyRelationRepository(db)
 	userEmbeddingRepo := repositories.NewUserEmbeddingRepository(db)
 	jobEmbeddingRepo := repositories.NewJobCategoryEmbeddingRepository(db)
 	interviewSessionRepo := repositories.NewInterviewSessionRepository(db)
@@ -128,7 +129,7 @@ func main() {
 		CareerTasu: scraper.NewCareerTasuScraper(),
 		Threshold:  0.75,
 	}
-	adminCompanyGraphController := controllers.NewAdminCompanyGraphController(companyGraphPipeline, companyRepo, auditLogService)
+	adminCompanyGraphController := controllers.NewAdminCompanyGraphController(companyGraphPipeline, companyRepo, companyRelationRepo, auditLogService)
 	resumeController := controllers.NewResumeController(resumeService)
 
 	// S3 upload service for interview videos (optional — skipped if env vars are not set)

--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -8,9 +8,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +22,14 @@ import (
 
 // AdminCompanyGraphController exposes the multi-source scraping pipeline via HTTP.
 type AdminCompanyGraphController struct {
-	pipeline    *scraper.Pipeline
-	companyRepo *repositories.CompanyRepository
-	audit       *services.AuditLogService
+	pipeline     *scraper.Pipeline
+	companyRepo  *repositories.CompanyRepository
+	relationRepo *repositories.CompanyRelationRepository
+	audit        *services.AuditLogService
 }
 
-func NewAdminCompanyGraphController(pipeline *scraper.Pipeline, companyRepo *repositories.CompanyRepository, audit *services.AuditLogService) *AdminCompanyGraphController {
-	return &AdminCompanyGraphController{pipeline: pipeline, companyRepo: companyRepo, audit: audit}
+func NewAdminCompanyGraphController(pipeline *scraper.Pipeline, companyRepo *repositories.CompanyRepository, relationRepo *repositories.CompanyRelationRepository, audit *services.AuditLogService) *AdminCompanyGraphController {
+	return &AdminCompanyGraphController{pipeline: pipeline, companyRepo: companyRepo, relationRepo: relationRepo, audit: audit}
 }
 
 // TargetYear handles GET /api/admin/company-graph/target-year
@@ -114,14 +117,18 @@ func (c *AdminCompanyGraphController) Crawl(w http.ResponseWriter, r *http.Reque
 	// DB 保存
 	saved, skipped := c.upsertNodes(nodes)
 
+	// スクレイピングで取得した関連会社・取引先を company_relations に同期
+	relSynced := c.syncRelationsFromNodes(nodes)
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"ok":          true,
-		"logs":        logs,
-		"nodes":       len(nodes),
-		"saved":       saved,
-		"skipped":     skipped,
-		"target_year": targetYear,
+		"ok":            true,
+		"logs":          logs,
+		"nodes":         len(nodes),
+		"saved":         saved,
+		"skipped":       skipped,
+		"target_year":   targetYear,
+		"relations_synced": relSynced,
 	})
 
 	adminEmail := r.Header.Get("X-Admin-Email")
@@ -179,6 +186,90 @@ func (c *AdminCompanyGraphController) crawlViaService(
 		return nil, result.Logs, result.TargetYear, errors.New(result.Error)
 	}
 	return result.Nodes, result.Logs, result.TargetYear, nil
+}
+
+var reRelationSep = regexp.MustCompile(`[,、，\r\n]+`)
+var reRelationNoise = regexp.MustCompile(`(?:など|等|・$|その他.*$)`)
+
+// parseCompanyNames はスクレイピングで得た関係テキストを企業名リストに分解する。
+func parseCompanyNames(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	parts := reRelationSep.Split(text, -1)
+	var names []string
+	for _, p := range parts {
+		p = reRelationNoise.ReplaceAllString(strings.TrimSpace(p), "")
+		p = strings.TrimSpace(p)
+		if len([]rune(p)) >= 2 {
+			names = append(names, p)
+		}
+	}
+	return names
+}
+
+// syncRelationsFromNodes はスクレイピングノードの関連会社・取引先テキストを解析し、
+// company_relations テーブルへ Upsert する。
+// 戻り値: 登録成功した関係レコード件数
+func (c *AdminCompanyGraphController) syncRelationsFromNodes(nodes map[string]*scraper.CompanyNode) int {
+	if c.relationRepo == nil || c.companyRepo == nil {
+		return 0
+	}
+	now := time.Now()
+	synced := 0
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		// 法人番号で元企業を特定（UNKNOWN_プレフィックスは名寄せ未済のためスキップ）
+		if strings.HasPrefix(node.CorporateNumber, "UNKNOWN_") {
+			continue
+		}
+		fromCompany, err := c.companyRepo.FindByCorporateNumber(node.CorporateNumber)
+		if err != nil || fromCompany == nil {
+			continue
+		}
+
+		type relEntry struct {
+			text         string
+			relationType string
+		}
+		entries := []relEntry{
+			{node.RelatedCompaniesText, "capital_affiliate"},
+			{node.BusinessPartnersText, "business_partner"},
+		}
+
+		for _, entry := range entries {
+			names := parseCompanyNames(entry.text)
+			for _, name := range names {
+				// 既存企業を名前で検索、なければプロビジョナル企業として登録
+				toCompany, err := c.companyRepo.FindByName(name)
+				if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				if toCompany == nil {
+					toCompany = &models.Company{
+						Name:            name,
+						SourceType:      "scraping",
+						SourceFetchedAt: &now,
+						IsProvisional:   true,
+						DataStatus:      "draft",
+					}
+					if err := c.companyRepo.Create(toCompany); err != nil {
+						continue
+					}
+				}
+				desc := fmt.Sprintf("scraping:%s", node.OfficialName)
+				if err := c.relationRepo.UpsertBusinessRelation(fromCompany.ID, toCompany.ID, entry.relationType, desc); err != nil {
+					continue
+				}
+				synced++
+			}
+		}
+	}
+	return synced
 }
 
 // upsertNodes は CompanyNode を companies テーブルへ upsert する。

--- a/Backend/internal/scraper/gbizinfo.go
+++ b/Backend/internal/scraper/gbizinfo.go
@@ -136,29 +136,33 @@ func (c *GBizClient) Match(ctx context.Context, raw *RawCompany, threshold float
 
 	needsReview := bestScore < threshold
 	return &CompanyNode{
-		CorporateNumber:  best.CorporateNumber,
-		OfficialName:     best.Name,
-		SourceURLs:       []string{raw.SourceURL},
-		BusinessCategory: best.BusinessSummary.MajorClassificationName,
-		Address:          best.Location,
-		Website:          best.CompanyURL,
-		Capital:          raw.Capital,
-		Employees:        raw.Employees,
-		MatchScore:       bestScore,
-		NeedsReview:      needsReview,
+		CorporateNumber:      best.CorporateNumber,
+		OfficialName:         best.Name,
+		SourceURLs:           []string{raw.SourceURL},
+		BusinessCategory:     best.BusinessSummary.MajorClassificationName,
+		Address:              best.Location,
+		Website:              best.CompanyURL,
+		Capital:              raw.Capital,
+		Employees:            raw.Employees,
+		MatchScore:           bestScore,
+		NeedsReview:          needsReview,
+		RelatedCompaniesText: raw.RelatedCompaniesText,
+		BusinessPartnersText: raw.BusinessPartnersText,
 	}, nil
 }
 
 func fallbackNode(raw *RawCompany) *CompanyNode {
 	return &CompanyNode{
-		CorporateNumber: "UNKNOWN_" + NormalizeName(raw.RawName),
-		OfficialName:    raw.RawName,
-		SourceURLs:      []string{raw.SourceURL},
-		Address:         raw.Address,
-		Website:         raw.Website,
-		Capital:         raw.Capital,
-		Employees:       raw.Employees,
-		MatchScore:      0,
-		NeedsReview:     true,
+		CorporateNumber:      "UNKNOWN_" + NormalizeName(raw.RawName),
+		OfficialName:         raw.RawName,
+		SourceURLs:           []string{raw.SourceURL},
+		Address:              raw.Address,
+		Website:              raw.Website,
+		Capital:              raw.Capital,
+		Employees:            raw.Employees,
+		MatchScore:           0,
+		NeedsReview:          true,
+		RelatedCompaniesText: raw.RelatedCompaniesText,
+		BusinessPartnersText: raw.BusinessPartnersText,
 	}
 }

--- a/Backend/internal/scraper/scraper.go
+++ b/Backend/internal/scraper/scraper.go
@@ -35,16 +35,18 @@ type RawCompany struct {
 
 // CompanyNode is a normalized company record keyed by corporate number.
 type CompanyNode struct {
-	CorporateNumber  string
-	OfficialName     string
-	SourceURLs       []string
-	BusinessCategory string
-	Address          string
-	Website          string
-	Capital          string
-	Employees        string
-	MatchScore       float64
-	NeedsReview      bool
+	CorporateNumber      string
+	OfficialName         string
+	SourceURLs           []string
+	BusinessCategory     string
+	Address              string
+	Website              string
+	Capital              string
+	Employees            string
+	MatchScore           float64
+	NeedsReview          bool
+	RelatedCompaniesText string // 関連会社テキスト（スクレイピング由来）
+	BusinessPartnersText string // 主要取引先テキスト（スクレイピング由来）
 }
 
 // RunRequest parameterises a pipeline run.


### PR DESCRIPTION
Closes #67
Closes #74
Closes #75

## 変更内容

### #74 分析結果ページにユーザー適性職種コメントを追加
- `analysis_scoring_service.go`: `buildJobSuitabilityComment()` 関数を追加し、ユーザーの強み（リーダーシップ・チームワーク・技術志向など）から適性職種を判定するロジックを実装
- `AnalysisSummary` に `JobSuitabilityComment` / `SuggestedRoles` フィールドを追加
- `frontend/app/results/page.tsx`: 企業ランキングの上に「🎯 あなたに向いている職種」カードセクションを追加、適性職種コメントとロール一覧を表示

### #75 面接練習の志望企業を企業管理・WEB検索から取得できるようにする
- `company_relation_controller.go`: Wikipedia ja APIを使ったWEB検索ハンドラ `WebSearchCompanies` を追加（APIキー不要）
- `Backend/internal/routes/company_routes.go`: `/api/companies/web-search` エンドポイントを追加
- `frontend/app/api/companies/web-search/route.ts`: Next.js APIプロキシルートを新規作成
- `frontend/app/interview/page.tsx`: 企業選択UIに「🏢 企業管理から選択」/「🔍 WEB検索」タブ切り替えを追加

### SIer職種カテゴリの追加
- `frontend/app/interview/page.tsx`: `Position` 型に `category` フィールドを追加し、SE・インフラエンジニア・ITコンサルタント・PMO・ネットワークエンジニア・テスト/QAの6職種を追加
- 「💼 一般・IT職種」/「🏗️ SIer職種」タブ切り替えUIを実装

### #67 スクレイピングデータの関連企業・取引先を企業相関図に反映
- `scraper.go`: `CompanyNode` に `RelatedCompaniesText` / `BusinessPartnersText` フィールドを追加
- `gbizinfo.go`: `Match()` / `fallbackNode()` でスクレイピング由来のテキストを `CompanyNode` に引き継ぐよう修正
- `admin_company_graph_controller.go`: `syncRelationsFromNodes()` メソッドを追加し、スクレイピングで取得した関連会社・取引先テキストを解析して `company_relations` テーブルへUpsert
- `main.go`: `companyRelationRepo` を初期化し `NewAdminCompanyGraphController` に渡すよう更新