### PR TITLE
Resolve #71: 管理者が面接動画を閲覧できる機能の追加

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -141,13 +141,14 @@ func main() {
 	videoRepo := repositories.NewInterviewVideoRepository(db)
 	interviewController := controllers.NewInterviewController(interviewService, videoRepo, s3UploadService)
 	realtimeController := controllers.NewRealtimeController(interviewService)
+	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, userRepo)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)

--- a/Backend/internal/controllers/admin_interview_controller.go
+++ b/Backend/internal/controllers/admin_interview_controller.go
@@ -1,0 +1,197 @@
+package controllers
+
+import (
+	"Backend/internal/repositories"
+	"Backend/internal/services"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// AdminInterviewController provides admin endpoints for viewing interview sessions and videos.
+type AdminInterviewController struct {
+	interviewService *services.InterviewService
+	videoRepo        *repositories.InterviewVideoRepository
+	s3Service        *services.S3UploadService
+}
+
+func NewAdminInterviewController(
+	interviewService *services.InterviewService,
+	videoRepo *repositories.InterviewVideoRepository,
+	s3Service *services.S3UploadService,
+) *AdminInterviewController {
+	return &AdminInterviewController{
+		interviewService: interviewService,
+		videoRepo:        videoRepo,
+		s3Service:        s3Service,
+	}
+}
+
+// ListSessions handles GET /api/admin/interviews
+// Returns all interview sessions with pagination.
+func (c *AdminInterviewController) ListSessions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Use admin user ID from header to verify admin privilege via service
+	adminEmail := r.Header.Get("X-Admin-Email")
+	if adminEmail == "" {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	page := parseIntQuery(r, "page", 1)
+	limit := parseIntQuery(r, "limit", 20)
+	if limit > 100 {
+		limit = 100
+	}
+	offset := (page - 1) * limit
+
+	// adminUserID is resolved inside interviewService.ListSessions via userRepo
+	adminUserIDStr := r.URL.Query().Get("admin_user_id")
+	adminUserID, err := strconv.ParseUint(adminUserIDStr, 10, 32)
+	if err != nil || adminUserID == 0 {
+		http.Error(w, "admin_user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	sessions, total, err := c.interviewService.ListSessions(uint(adminUserID), true, limit, offset)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if err.Error() == "forbidden" {
+			status = http.StatusForbidden
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"sessions": sessions,
+		"total":    total,
+		"page":     page,
+		"limit":    limit,
+	})
+}
+
+// ListVideos handles GET /api/admin/interviews/{id}/videos
+func (c *AdminInterviewController) ListVideos(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessionID, err := extractAdminInterviewID(r.URL.Path, "/videos")
+	if err != nil {
+		http.Error(w, "Invalid session ID", http.StatusBadRequest)
+		return
+	}
+
+	videos, err := c.videoRepo.FindBySessionID(r.Context(), sessionID)
+	if err != nil {
+		http.Error(w, "Failed to fetch videos", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"videos": videos,
+	})
+}
+
+// VideoURL handles GET /api/admin/interviews/{id}/videos/{video_id}/url
+// Returns a presigned S3 URL valid for 15 minutes.
+func (c *AdminInterviewController) VideoURL(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	videoID, err := extractVideoID(r.URL.Path)
+	if err != nil {
+		http.Error(w, "Invalid video ID", http.StatusBadRequest)
+		return
+	}
+
+	video, err := c.videoRepo.FindByID(r.Context(), videoID)
+	if err != nil || video == nil {
+		http.Error(w, "Video not found", http.StatusNotFound)
+		return
+	}
+
+	if video.Status != "done" || video.DriveFileID == "" {
+		http.Error(w, "Video is not available yet", http.StatusUnprocessableEntity)
+		return
+	}
+
+	if c.s3Service == nil {
+		// S3 not configured: return the stored URL directly
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"url":        video.DriveFileURL,
+			"expires_at": "",
+		})
+		return
+	}
+
+	expires := 15 * time.Minute
+	presignedURL, err := c.s3Service.PresignGetURL(r.Context(), video.DriveFileID, expires)
+	if err != nil {
+		http.Error(w, "Failed to generate video URL: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"url":        presignedURL,
+		"expires_at": time.Now().Add(expires).UTC().Format(time.RFC3339),
+	})
+}
+
+// Route dispatches /api/admin/interviews/ sub-paths.
+func (c *AdminInterviewController) Route(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+
+	// /api/admin/interviews/{id}/videos/{video_id}/url
+	if strings.HasSuffix(path, "/url") && strings.Contains(path, "/videos/") {
+		c.VideoURL(w, r)
+		return
+	}
+	// /api/admin/interviews/{id}/videos
+	if strings.HasSuffix(path, "/videos") {
+		c.ListVideos(w, r)
+		return
+	}
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+func extractAdminInterviewID(path, suffix string) (uint, error) {
+	// /api/admin/interviews/{id}/videos → extract {id}
+	trimmed := strings.TrimPrefix(path, "/api/admin/interviews/")
+	if idx := strings.Index(trimmed, "/"); idx != -1 {
+		trimmed = trimmed[:idx]
+	}
+	trimmed = strings.TrimSuffix(trimmed, suffix)
+	id, err := strconv.ParseUint(trimmed, 10, 32)
+	return uint(id), err
+}
+
+func extractVideoID(path string) (uint, error) {
+	// /api/admin/interviews/{id}/videos/{video_id}/url
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// parts: ["api","admin","interviews","{id}","videos","{video_id}","url"]
+	for i, p := range parts {
+		if p == "videos" && i+1 < len(parts) {
+			vidStr := parts[i+1]
+			// remove trailing /url if present
+			vidStr = strings.TrimSuffix(vidStr, "/url")
+			id, err := strconv.ParseUint(vidStr, 10, 32)
+			return uint(id), err
+		}
+	}
+	return 0, strconv.ErrSyntax
+}

--- a/Backend/internal/repositories/interview_video_repository.go
+++ b/Backend/internal/repositories/interview_video_repository.go
@@ -36,3 +36,12 @@ func (r *InterviewVideoRepository) FindBySessionID(ctx context.Context, sessionI
 	err := r.db.WithContext(ctx).Where("session_id = ?", sessionID).Find(&videos).Error
 	return videos, err
 }
+
+func (r *InterviewVideoRepository) FindByID(ctx context.Context, id uint) (*models.InterviewVideo, error) {
+	var video models.InterviewVideo
+	err := r.db.WithContext(ctx).First(&video, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &video, nil
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -14,6 +14,7 @@ func SetupAdminRoutes(
 	adminUserController *controllers.AdminUserController,
 	adminAuditController *controllers.AdminAuditController,
 	adminCompanyGraphController *controllers.AdminCompanyGraphController,
+	adminInterviewController *controllers.AdminInterviewController,
 	userRepo *repositories.UserRepository,
 ) {
 	auth := func(f http.HandlerFunc) http.HandlerFunc {
@@ -38,4 +39,8 @@ func SetupAdminRoutes(
 	// Company graph (scraping pipeline)
 	http.HandleFunc("/api/admin/company-graph/target-year", adminCompanyGraphController.TargetYear)
 	http.HandleFunc("/api/admin/company-graph/crawl", auth(adminCompanyGraphController.Crawl))
+
+	// Interview management
+	http.HandleFunc("/api/admin/interviews", auth(adminInterviewController.ListSessions))
+	http.HandleFunc("/api/admin/interviews/", auth(adminInterviewController.Route))
 }

--- a/Backend/internal/services/s3_upload_service.go
+++ b/Backend/internal/services/s3_upload_service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -16,6 +17,7 @@ import (
 type S3UploadService struct {
 	bucket   string
 	region   string
+	client   *s3.Client
 	uploader *manager.Uploader
 }
 
@@ -42,6 +44,7 @@ func NewS3UploadService() (*S3UploadService, error) {
 	return &S3UploadService{
 		bucket:   bucket,
 		region:   region,
+		client:   client,
 		uploader: uploader,
 	}, nil
 }
@@ -60,4 +63,19 @@ func (s *S3UploadService) UploadFile(ctx context.Context, key, mimeType string, 
 
 	url := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", s.bucket, s.region, key)
 	return key, url, nil
+}
+
+// PresignGetURL returns a presigned GET URL valid for the given duration.
+// key is the S3 object key (DriveFileID stored in InterviewVideo).
+func (s *S3UploadService) PresignGetURL(ctx context.Context, key string, expires time.Duration) (string, error) {
+	presignClient := s3.NewPresignClient(s.client)
+	req, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.bucket),
+		Key:                        aws.String(key),
+		ResponseContentDisposition: aws.String("inline"),
+	}, s3.WithPresignExpires(expires))
+	if err != nil {
+		return "", fmt.Errorf("presign: %w", err)
+	}
+	return req.URL, nil
 }

--- a/frontend/app/admin/interviews/[id]/page.tsx
+++ b/frontend/app/admin/interviews/[id]/page.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { authService } from '@/lib/auth'
+
+type InterviewVideo = {
+  id: number
+  session_id: number
+  user_id: number
+  drive_file_id: string
+  drive_file_url: string
+  file_name: string
+  file_size_bytes: number
+  mime_type: string
+  status: string
+  error_message?: string
+  uploaded_at?: string
+  created_at: string
+}
+
+const VIDEO_STATUS: Record<string, { label: string; color: 'default' | 'primary' | 'warning' | 'success' | 'error' }> = {
+  pending: { label: '待機中', color: 'default' },
+  uploading: { label: 'アップロード中', color: 'primary' },
+  done: { label: '完了', color: 'success' },
+  error: { label: 'エラー', color: 'error' },
+}
+
+export default function AdminInterviewDetailPage() {
+  const params = useParams()
+  const sessionId = params.id as string
+
+  const [videos, setVideos] = useState<InterviewVideo[]>([])
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [playingURL, setPlayingURL] = useState<string | null>(null)
+  const [urlLoading, setUrlLoading] = useState<number | null>(null)
+  const [urlError, setUrlError] = useState('')
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  useEffect(() => {
+    const fetchVideos = async () => {
+      const admin = authService.getStoredUser()
+      if (!admin) return
+      setLoading(true)
+      setError('')
+      const response = await fetch(`/api/admin/interviews/${sessionId}/videos`, {
+        headers: { 'X-Admin-Email': admin.email || '' },
+      })
+      const data = await response.json()
+      setLoading(false)
+      if (!response.ok) {
+        setError(data?.error || '動画一覧の取得に失敗しました')
+        return
+      }
+      setVideos(data?.videos || [])
+    }
+    fetchVideos()
+  }, [sessionId])
+
+  const handlePlayVideo = async (video: InterviewVideo) => {
+    if (video.status !== 'done') return
+    setUrlLoading(video.id)
+    setUrlError('')
+    setPlayingURL(null)
+    const admin = authService.getStoredUser()
+    const response = await fetch(`/api/admin/interviews/${sessionId}/videos/${video.id}/url`, {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
+    const data = await response.json()
+    setUrlLoading(null)
+    if (!response.ok) {
+      setUrlError(data?.error || 'URLの取得に失敗しました')
+      return
+    }
+    setPlayingURL(data.url)
+  }
+
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
+        <Button variant="text" component={Link} href="/admin/interviews" size="small">
+          ← 一覧へ戻る
+        </Button>
+      </Stack>
+      <Typography variant="h4" fontWeight="bold" gutterBottom>
+        面接セッション #{sessionId} — 動画一覧
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      {urlError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {urlError}
+        </Alert>
+      )}
+
+      {playingURL && (
+        <Card sx={{ mb: 3, border: '1px solid', borderColor: 'primary.main' }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              動画プレイヤー
+            </Typography>
+            <Box
+              component="video"
+              src={playingURL}
+              controls
+              sx={{ width: '100%', maxHeight: 480, borderRadius: 1, bgcolor: 'black' }}
+            />
+            <Button
+              size="small"
+              variant="text"
+              sx={{ mt: 1 }}
+              onClick={() => setPlayingURL(null)}
+            >
+              閉じる
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            録画動画
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : videos.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              このセッションに動画はありません。
+            </Typography>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>ファイル名</TableCell>
+                    <TableCell>サイズ</TableCell>
+                    <TableCell>ステータス</TableCell>
+                    <TableCell>アップロード日時</TableCell>
+                    <TableCell align="right">操作</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {videos.map((video) => {
+                    const st = VIDEO_STATUS[video.status] ?? { label: video.status, color: 'default' as const }
+                    return (
+                      <TableRow key={video.id}>
+                        <TableCell>{video.id}</TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                            {video.file_name}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {video.mime_type}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>{formatBytes(video.file_size_bytes)}</TableCell>
+                        <TableCell>
+                          <Chip label={st.label} color={st.color} size="small" />
+                          {video.error_message && (
+                            <Typography variant="caption" color="error" display="block">
+                              {video.error_message}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {video.uploaded_at
+                            ? new Date(video.uploaded_at).toLocaleString('ja-JP')
+                            : '—'}
+                        </TableCell>
+                        <TableCell align="right">
+                          <Stack direction="row" spacing={1} justifyContent="flex-end">
+                            <Button
+                              size="small"
+                              variant="contained"
+                              disabled={video.status !== 'done' || urlLoading === video.id}
+                              onClick={() => handlePlayVideo(video)}
+                            >
+                              {urlLoading === video.id ? (
+                                <CircularProgress size={16} />
+                              ) : (
+                                '再生'
+                              )}
+                            </Button>
+                            {video.drive_file_url && video.status === 'done' && (
+                              <Button
+                                size="small"
+                                variant="outlined"
+                                component="a"
+                                href={video.drive_file_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                DL
+                              </Button>
+                            )}
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}

--- a/frontend/app/admin/interviews/page.tsx
+++ b/frontend/app/admin/interviews/page.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { authService } from '@/lib/auth'
+
+type InterviewSession = {
+  id: number
+  user_id: number
+  status: string
+  company_name?: string
+  position?: string
+  language?: string
+  started_at?: string
+  finished_at?: string
+  created_at: string
+}
+
+const STATUS_LABEL: Record<string, { label: string; color: 'default' | 'primary' | 'success' | 'error' }> = {
+  created: { label: '作成済み', color: 'default' },
+  started: { label: '進行中', color: 'primary' },
+  finished: { label: '完了', color: 'success' },
+  error: { label: 'エラー', color: 'error' },
+}
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50]
+
+export default function AdminInterviewsPage() {
+  const [sessions, setSessions] = useState<InterviewSession[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(0)
+  const [rowsPerPage, setRowsPerPage] = useState(25)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  useEffect(() => {
+    const fetchSessions = async () => {
+      const admin = authService.getStoredUser()
+      if (!admin) return
+      setError('')
+      const params = new URLSearchParams({
+        page: String(page + 1),
+        limit: String(rowsPerPage),
+        admin_user_id: String(admin.id),
+      })
+      const response = await fetch(`/api/admin/interviews?${params}`, {
+        headers: { 'X-Admin-Email': admin.email || '' },
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        setError(data?.error || '面接セッション一覧の取得に失敗しました')
+        return
+      }
+      setSessions(data?.sessions || [])
+      setTotal(data?.total ?? 0)
+    }
+    fetchSessions()
+  }, [page, rowsPerPage])
+
+  const handleChangePage = (_: unknown, newPage: number) => setPage(newPage)
+  const handleChangeRowsPerPage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10))
+    setPage(0)
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 1200, mx: 'auto' }}>
+      <Typography variant="h4" fontWeight="bold" gutterBottom>
+        面接管理
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        全ユーザーの面接セッション一覧です。動画を確認するには詳細ページを開いてください。
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            セッション一覧
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          {sessions.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              面接セッションがありません。
+            </Typography>
+          ) : (
+            <>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>ID</TableCell>
+                      <TableCell>ユーザーID</TableCell>
+                      <TableCell>志望企業</TableCell>
+                      <TableCell>ポジション</TableCell>
+                      <TableCell>ステータス</TableCell>
+                      <TableCell>開始日時</TableCell>
+                      <TableCell>作成日時</TableCell>
+                      <TableCell align="right">操作</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {sessions.map((session) => {
+                      const st = STATUS_LABEL[session.status] ?? { label: session.status, color: 'default' as const }
+                      return (
+                        <TableRow key={session.id}>
+                          <TableCell>{session.id}</TableCell>
+                          <TableCell>{session.user_id}</TableCell>
+                          <TableCell>{session.company_name || '—'}</TableCell>
+                          <TableCell>{session.position || '—'}</TableCell>
+                          <TableCell>
+                            <Chip label={st.label} color={st.color} size="small" />
+                          </TableCell>
+                          <TableCell>
+                            {session.started_at
+                              ? new Date(session.started_at).toLocaleString('ja-JP')
+                              : '—'}
+                          </TableCell>
+                          <TableCell>
+                            {new Date(session.created_at).toLocaleString('ja-JP')}
+                          </TableCell>
+                          <TableCell align="right">
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              component={Link}
+                              href={`/admin/interviews/${session.id}`}
+                            >
+                              詳細・動画
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <TablePagination
+                component="div"
+                count={total}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+                rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+                labelRowsPerPage="表示件数:"
+                labelDisplayedRows={({ from, to, count }) => `${from}–${to} / ${count}件`}
+              />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -163,6 +163,22 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                面接管理
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                全ユーザーの面接セッションと録画動画を確認できます。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/interviews">
+                面接管理へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
       </Grid>
 
       <Stack spacing={2}>

--- a/frontend/app/api/admin/interviews/[id]/videos/[video_id]/url/route.ts
+++ b/frontend/app/api/admin/interviews/[id]/videos/[video_id]/url/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string; video_id: string } }
+) {
+  const url = `${BACKEND_URL}/api/admin/interviews/${params.id}/videos/${params.video_id}/url`
+  const response = await fetch(url, {
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+  })
+  const data = await response.json().catch(() => ({}))
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/interviews/[id]/videos/route.ts
+++ b/frontend/app/api/admin/interviews/[id]/videos/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const url = `${BACKEND_URL}/api/admin/interviews/${params.id}/videos`
+  const response = await fetch(url, {
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+  })
+  const data = await response.json().catch(() => ({}))
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/interviews/route.ts
+++ b/frontend/app/api/admin/interviews/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const params = new URLSearchParams()
+  for (const key of ['page', 'limit', 'admin_user_id']) {
+    const v = searchParams.get(key)
+    if (v !== null) params.set(key, v)
+  }
+  const url = `${BACKEND_URL}/api/admin/interviews?${params}`
+  const response = await fetch(url, {
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+  })
+  const data = await response.json().catch(() => ({}))
+  return NextResponse.json(data, { status: response.status })
+}


### PR DESCRIPTION
Closes #71

## 変更内容

### バックエンド

- **`S3UploadService.PresignGetURL()`** 追加 — aws-sdk-go-v2 の PresignClient を使い、15分有効の署名付きGET URLを発行
- **`InterviewVideoRepository.FindByID()`** 追加 — video_id による単一レコード取得
- **`AdminInterviewController`** 新規作成（`Backend/internal/controllers/admin_interview_controller.go`）
  - `GET /api/admin/interviews` — 全セッション一覧取得（ページネーション対応、管理者認証必須）
  - `GET /api/admin/interviews/{id}/videos` — 指定セッションの動画一覧取得
  - `GET /api/admin/interviews/{id}/videos/{video_id}/url` — presigned URL発行（S3未設定時はDriveFileURLを返すフォールバック付き）
- **`admin_routes.go`** — 上記3エンドポイントを管理者認証ミドルウェア付きで登録
- **`main.go`** — `AdminInterviewController` の初期化と注入

### フロントエンド

- **`/admin/interviews`** (`frontend/app/admin/interviews/page.tsx`) — 全セッション一覧ページ（ユーザーID・企業名・ポジション・ステータスChip・開始日時・詳細リンク）
- **`/admin/interviews/[id]`** (`frontend/app/admin/interviews/[id]/page.tsx`) — セッション詳細ページ
  - 動画一覧テーブル（ファイル名・サイズ・ステータス・アップロード日時）
  - 「再生」ボタンでpresigned URLを取得し、ページ内の`<video>`タグでインライン再生
  - 「DL」ボタンで直接ダウンロードリンクを提供
- **Next.js API proxy ルート** 3本追加
  - `app/api/admin/interviews/route.ts`
  - `app/api/admin/interviews/[id]/videos/route.ts`
  - `app/api/admin/interviews/[id]/videos/[video_id]/url/route.ts`
- **管理者ダッシュボード** (`/admin`) に「面接管理」カードを追加