### PR TITLE
Resolve #90: DDDクリーンアーキテクチャ違反の修正

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -83,6 +83,7 @@ func main() {
 	popularityRepo := repositories.NewCompanyPopularityRepository(db)
 	graduateRepo := repositories.NewGraduateEmploymentRepository(db)
 	companyRelationRepo := repositories.NewCompanyRelationRepository(db)
+	companyQueryRepo := repositories.NewCompanyQueryRepository(db)
 	matchRepo := repositories.NewUserCompanyMatchRepository(db)
 	// 埋め込み・マッチング
 	userEmbeddingRepo := repositories.NewUserEmbeddingRepository(db)
@@ -124,7 +125,7 @@ func main() {
 	oauthController := controllers.NewOAuthController(oauthService)
 	chatController := controllers.NewChatController(chatService, matchingService, analysisService, userRepo, emailService)
 	questionController := controllers.NewQuestionController(questionService)
-	relationController := &controllers.CompanyRelationController{DB: db}
+	relationController := controllers.NewCompanyRelationController(companyQueryRepo)
 	adminCompanyController := controllers.NewAdminCompanyController(companyRepo, auditLogService, nil)
 	adminCrawlController := controllers.NewAdminCrawlController(crawlService, auditLogService)
 	adminJobController := controllers.NewAdminJobController(companyRepo, jobCategoryRepo, graduateRepo, auditLogService)

--- a/Backend/domain/entity/pending_registration.go
+++ b/Backend/domain/entity/pending_registration.go
@@ -1,0 +1,11 @@
+package entity
+
+import "time"
+
+// PendingRegistration メールアドレス確認待ちの仮登録エンティティ
+type PendingRegistration struct {
+	Token     string
+	Email     string
+	ExpiresAt time.Time
+	CreatedAt time.Time
+}

--- a/Backend/domain/mapper/analysis_mapper.go
+++ b/Backend/domain/mapper/analysis_mapper.go
@@ -1,0 +1,94 @@
+package mapper
+
+import (
+	"Backend/domain/entity"
+	"Backend/internal/models"
+)
+
+// UserWeightScoreToEntity models.UserWeightScore を entity.UserWeightScore に変換
+func UserWeightScoreToEntity(m *models.UserWeightScore) *entity.UserWeightScore {
+	if m == nil {
+		return nil
+	}
+	return &entity.UserWeightScore{
+		ID:             m.ID,
+		UserID:         m.UserID,
+		SessionID:      m.SessionID,
+		WeightCategory: m.WeightCategory,
+		Score:          m.Score,
+		CreatedAt:      m.CreatedAt,
+		UpdatedAt:      m.UpdatedAt,
+	}
+}
+
+// UserWeightScoresToEntities []models.UserWeightScore を []entity.UserWeightScore に変換
+func UserWeightScoresToEntities(ms []models.UserWeightScore) []entity.UserWeightScore {
+	result := make([]entity.UserWeightScore, len(ms))
+	for i, m := range ms {
+		e := UserWeightScoreToEntity(&m)
+		result[i] = *e
+	}
+	return result
+}
+
+// AnalysisPhaseToEntity models.AnalysisPhase を entity.AnalysisPhase に変換
+func AnalysisPhaseToEntity(m *models.AnalysisPhase) *entity.AnalysisPhase {
+	if m == nil {
+		return nil
+	}
+	return &entity.AnalysisPhase{
+		ID:           m.ID,
+		PhaseName:    m.PhaseName,
+		DisplayName:  m.DisplayName,
+		PhaseOrder:   m.PhaseOrder,
+		Description:  m.Description,
+		MinQuestions: m.MinQuestions,
+		MaxQuestions: m.MaxQuestions,
+	}
+}
+
+// UserAnalysisProgressToEntity models.UserAnalysisProgress を entity.UserAnalysisProgress に変換
+func UserAnalysisProgressToEntity(m *models.UserAnalysisProgress) *entity.UserAnalysisProgress {
+	if m == nil {
+		return nil
+	}
+	e := &entity.UserAnalysisProgress{
+		ID:              m.ID,
+		UserID:          m.UserID,
+		SessionID:       m.SessionID,
+		PhaseID:         m.PhaseID,
+		QuestionsAsked:  m.QuestionsAsked,
+		ValidAnswers:    m.ValidAnswers,
+		InvalidAnswers:  m.InvalidAnswers,
+		CompletionScore: m.CompletionScore,
+		IsCompleted:     m.IsCompleted,
+		CompletedAt:     m.CompletedAt,
+		CreatedAt:       m.CreatedAt,
+		UpdatedAt:       m.UpdatedAt,
+	}
+	if m.Phase != nil {
+		e.Phase = AnalysisPhaseToEntity(m.Phase)
+	}
+	return e
+}
+
+// UserAnalysisProgressFromEntity entity.UserAnalysisProgress を models.UserAnalysisProgress に変換
+func UserAnalysisProgressFromEntity(e *entity.UserAnalysisProgress) *models.UserAnalysisProgress {
+	if e == nil {
+		return nil
+	}
+	return &models.UserAnalysisProgress{
+		ID:              e.ID,
+		UserID:          e.UserID,
+		SessionID:       e.SessionID,
+		PhaseID:         e.PhaseID,
+		QuestionsAsked:  e.QuestionsAsked,
+		ValidAnswers:    e.ValidAnswers,
+		InvalidAnswers:  e.InvalidAnswers,
+		CompletionScore: e.CompletionScore,
+		IsCompleted:     e.IsCompleted,
+		CompletedAt:     e.CompletedAt,
+		CreatedAt:       e.CreatedAt,
+		UpdatedAt:       e.UpdatedAt,
+	}
+}

--- a/Backend/domain/mapper/company_mapper.go
+++ b/Backend/domain/mapper/company_mapper.go
@@ -1,0 +1,105 @@
+package mapper
+
+import (
+	"Backend/domain/entity"
+	"Backend/internal/models"
+)
+
+// CompanyToEntity models.Company を entity.Company に変換
+func CompanyToEntity(m *models.Company) *entity.Company {
+	if m == nil {
+		return nil
+	}
+	return &entity.Company{
+		ID:               m.ID,
+		Name:             m.Name,
+		Description:      m.Description,
+		Industry:         m.Industry,
+		EmployeeCount:    m.EmployeeCount,
+		FoundedYear:      m.FoundedYear,
+		Location:         m.Location,
+		WebsiteURL:       m.WebsiteURL,
+		LogoURL:          m.LogoURL,
+		CorporateNumber:  m.CorporateNumber,
+		SourceType:       m.SourceType,
+		SourceURL:        m.SourceURL,
+		SourceFetchedAt:  m.SourceFetchedAt,
+		IsProvisional:    m.IsProvisional,
+		DataStatus:       m.DataStatus,
+		Culture:          m.Culture,
+		WorkStyle:        m.WorkStyle,
+		WelfareDetails:   m.WelfareDetails,
+		TechStack:        m.TechStack,
+		DevelopmentStyle: m.DevelopmentStyle,
+		MainBusiness:     m.MainBusiness,
+		AverageAge:       m.AverageAge,
+		FemaleRatio:      m.FemaleRatio,
+		IsActive:         m.IsActive,
+		IsVerified:       m.IsVerified,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+	}
+}
+
+// UserCompanyMatchToEntity models.UserCompanyMatch を entity.UserCompanyMatch に変換
+func UserCompanyMatchToEntity(m *models.UserCompanyMatch) *entity.UserCompanyMatch {
+	if m == nil {
+		return nil
+	}
+	e := &entity.UserCompanyMatch{
+		ID:                 m.ID,
+		UserID:             m.UserID,
+		SessionID:          m.SessionID,
+		CompanyID:          m.CompanyID,
+		MatchScore:         m.MatchScore,
+		TechnicalMatch:     m.TechnicalMatch,
+		TeamworkMatch:      m.TeamworkMatch,
+		LeadershipMatch:    m.LeadershipMatch,
+		CreativityMatch:    m.CreativityMatch,
+		StabilityMatch:     m.StabilityMatch,
+		GrowthMatch:        m.GrowthMatch,
+		WorkLifeMatch:      m.WorkLifeMatch,
+		ChallengeMatch:     m.ChallengeMatch,
+		DetailMatch:        m.DetailMatch,
+		CommunicationMatch: m.CommunicationMatch,
+		MatchReason:        m.MatchReason,
+		IsViewed:           m.IsViewed,
+		IsFavorited:        m.IsFavorited,
+		IsApplied:          m.IsApplied,
+		CreatedAt:          m.CreatedAt,
+		UpdatedAt:          m.UpdatedAt,
+	}
+	e.Company = CompanyToEntity(&m.Company)
+	return e
+}
+
+// UserCompanyMatchFromEntity entity.UserCompanyMatch を models.UserCompanyMatch に変換
+func UserCompanyMatchFromEntity(e *entity.UserCompanyMatch) *models.UserCompanyMatch {
+	if e == nil {
+		return nil
+	}
+	m := &models.UserCompanyMatch{
+		ID:                 e.ID,
+		UserID:             e.UserID,
+		SessionID:          e.SessionID,
+		CompanyID:          e.CompanyID,
+		MatchScore:         e.MatchScore,
+		TechnicalMatch:     e.TechnicalMatch,
+		TeamworkMatch:      e.TeamworkMatch,
+		LeadershipMatch:    e.LeadershipMatch,
+		CreativityMatch:    e.CreativityMatch,
+		StabilityMatch:     e.StabilityMatch,
+		GrowthMatch:        e.GrowthMatch,
+		WorkLifeMatch:      e.WorkLifeMatch,
+		ChallengeMatch:     e.ChallengeMatch,
+		DetailMatch:        e.DetailMatch,
+		CommunicationMatch: e.CommunicationMatch,
+		MatchReason:        e.MatchReason,
+		IsViewed:           e.IsViewed,
+		IsFavorited:        e.IsFavorited,
+		IsApplied:          e.IsApplied,
+		CreatedAt:          e.CreatedAt,
+		UpdatedAt:          e.UpdatedAt,
+	}
+	return m
+}

--- a/Backend/domain/mapper/user_mapper.go
+++ b/Backend/domain/mapper/user_mapper.go
@@ -1,0 +1,90 @@
+package mapper
+
+import (
+	"Backend/domain/entity"
+	"Backend/internal/models"
+)
+
+// UserToEntity models.User を entity.User に変換
+func UserToEntity(m *models.User) *entity.User {
+	if m == nil {
+		return nil
+	}
+	return &entity.User{
+		ID:                       m.ID,
+		Email:                    m.Email,
+		Password:                 m.Password,
+		Name:                     m.Name,
+		IsGuest:                  m.IsGuest,
+		IsAdmin:                  m.IsAdmin,
+		TargetLevel:              m.TargetLevel,
+		SchoolName:               m.SchoolName,
+		OAuthProvider:            m.OAuthProvider,
+		OAuthID:                  m.OAuthID,
+		AvatarURL:                m.AvatarURL,
+		CertificationsAcquired:   m.CertificationsAcquired,
+		CertificationsInProgress: m.CertificationsInProgress,
+		EmailVerifiedAt:          m.EmailVerifiedAt,
+		EmailVerificationToken:   m.EmailVerificationToken,
+		LastLoginAt:              m.LastLoginAt,
+		PasswordResetToken:       m.PasswordResetToken,
+		PasswordResetExpiresAt:   m.PasswordResetExpiresAt,
+		CreatedAt:                m.CreatedAt,
+		UpdatedAt:                m.UpdatedAt,
+	}
+}
+
+// UserFromEntity entity.User を models.User に変換
+func UserFromEntity(e *entity.User) *models.User {
+	if e == nil {
+		return nil
+	}
+	return &models.User{
+		ID:                       e.ID,
+		Email:                    e.Email,
+		Password:                 e.Password,
+		Name:                     e.Name,
+		IsGuest:                  e.IsGuest,
+		IsAdmin:                  e.IsAdmin,
+		TargetLevel:              e.TargetLevel,
+		SchoolName:               e.SchoolName,
+		OAuthProvider:            e.OAuthProvider,
+		OAuthID:                  e.OAuthID,
+		AvatarURL:                e.AvatarURL,
+		CertificationsAcquired:   e.CertificationsAcquired,
+		CertificationsInProgress: e.CertificationsInProgress,
+		EmailVerifiedAt:          e.EmailVerifiedAt,
+		EmailVerificationToken:   e.EmailVerificationToken,
+		LastLoginAt:              e.LastLoginAt,
+		PasswordResetToken:       e.PasswordResetToken,
+		PasswordResetExpiresAt:   e.PasswordResetExpiresAt,
+		CreatedAt:                e.CreatedAt,
+		UpdatedAt:                e.UpdatedAt,
+	}
+}
+
+// PendingRegistrationToEntity models.PendingRegistration を entity.PendingRegistration に変換
+func PendingRegistrationToEntity(m *models.PendingRegistration) *entity.PendingRegistration {
+	if m == nil {
+		return nil
+	}
+	return &entity.PendingRegistration{
+		Token:     m.Token,
+		Email:     m.Email,
+		ExpiresAt: m.ExpiresAt,
+		CreatedAt: m.CreatedAt,
+	}
+}
+
+// PendingRegistrationFromEntity entity.PendingRegistration を models.PendingRegistration に変換
+func PendingRegistrationFromEntity(e *entity.PendingRegistration) *models.PendingRegistration {
+	if e == nil {
+		return nil
+	}
+	return &models.PendingRegistration{
+		Token:     e.Token,
+		Email:     e.Email,
+		ExpiresAt: e.ExpiresAt,
+		CreatedAt: e.CreatedAt,
+	}
+}

--- a/Backend/domain/repository/analysis.go
+++ b/Backend/domain/repository/analysis.go
@@ -1,39 +1,39 @@
 package repository
 
-import "Backend/internal/models"
+import "Backend/domain/entity"
 
 // UserWeightScoreRepository はユーザースコアの永続化インターフェース。
 type UserWeightScoreRepository interface {
 	UpdateScore(userID uint, sessionID, category string, scoreIncrement int) error
-	FindByUserAndSession(userID uint, sessionID string) ([]models.UserWeightScore, error)
-	FindTopCategories(userID uint, sessionID string, limit int) ([]models.UserWeightScore, error)
-	FindByUserSessionAndCategory(userID uint, sessionID, category string) (*models.UserWeightScore, error)
+	FindByUserAndSession(userID uint, sessionID string) ([]entity.UserWeightScore, error)
+	FindTopCategories(userID uint, sessionID string, limit int) ([]entity.UserWeightScore, error)
+	FindByUserSessionAndCategory(userID uint, sessionID, category string) (*entity.UserWeightScore, error)
 	CountByUserAndSession(userID uint, sessionID string) (int64, error)
 }
 
 // AnalysisPhaseRepository は分析フェーズ定義の永続化インターフェース。
 type AnalysisPhaseRepository interface {
-	FindAll() ([]models.AnalysisPhase, error)
-	FindByID(id uint) (*models.AnalysisPhase, error)
-	FindByName(name string) (*models.AnalysisPhase, error)
+	FindAll() ([]entity.AnalysisPhase, error)
+	FindByID(id uint) (*entity.AnalysisPhase, error)
+	FindByName(name string) (*entity.AnalysisPhase, error)
 }
 
 // UserAnalysisProgressRepository はユーザーの分析進捗の永続化インターフェース。
 type UserAnalysisProgressRepository interface {
-	FindByUserAndSession(userID uint, sessionID string) ([]models.UserAnalysisProgress, error)
-	FindOrCreate(userID uint, sessionID string, phaseID uint) (*models.UserAnalysisProgress, error)
-	Update(progress *models.UserAnalysisProgress) error
-	GetCurrentPhase(userID uint, sessionID string) (*models.UserAnalysisProgress, error)
+	FindByUserAndSession(userID uint, sessionID string) ([]entity.UserAnalysisProgress, error)
+	FindOrCreate(userID uint, sessionID string, phaseID uint) (*entity.UserAnalysisProgress, error)
+	Update(progress *entity.UserAnalysisProgress) error
+	GetCurrentPhase(userID uint, sessionID string) (*entity.UserAnalysisProgress, error)
 }
 
 // UserCompanyMatchRepository はユーザーと企業のマッチング結果の永続化インターフェース。
 type UserCompanyMatchRepository interface {
-	CreateOrUpdate(match *models.UserCompanyMatch) error
-	FindTopMatchesByUserAndSession(userID uint, sessionID string, limit int) ([]*models.UserCompanyMatch, error)
-	FindByID(id uint) (*models.UserCompanyMatch, error)
+	CreateOrUpdate(match *entity.UserCompanyMatch) error
+	FindTopMatchesByUserAndSession(userID uint, sessionID string, limit int) ([]*entity.UserCompanyMatch, error)
+	FindByID(id uint) (*entity.UserCompanyMatch, error)
 	MarkAsViewed(matchID uint) error
 	ToggleFavorite(matchID uint) error
 	MarkAsApplied(matchID uint) error
-	FindFavoritesByUser(userID uint, sessionID string) ([]*models.UserCompanyMatch, error)
+	FindFavoritesByUser(userID uint, sessionID string) ([]*entity.UserCompanyMatch, error)
 	GetMatchStatistics(userID uint, sessionID string) (map[string]interface{}, error)
 }

--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -2,6 +2,17 @@ package repository
 
 import "Backend/internal/models"
 
+// CompanyRelationQueryRepository は企業関係情報の読み取り専用インターフェース。
+// CompanyRelationController で使用する。
+type CompanyRelationQueryRepository interface {
+	GetByCompanyID(companyID uint) ([]models.CompanyRelation, error)
+	GetAll() ([]models.CompanyRelation, error)
+	GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error)
+	GetAllMarketInfo() ([]models.CompanyMarketInfo, error)
+	GetJobPositionsByCompany(companyID uint) ([]models.CompanyJobPosition, error)
+	GetCompaniesFiltered(limit, offset int, industry, name string) ([]models.Company, int64, error)
+}
+
 // CompanyRepository は企業情報の永続化インターフェース。
 type CompanyRepository interface {
 	FindAllActive(limit, offset int) ([]models.Company, error)

--- a/Backend/domain/repository/user.go
+++ b/Backend/domain/repository/user.go
@@ -2,26 +2,26 @@
 // Concrete implementations live in internal/repositories/.
 package repository
 
-import "Backend/internal/models"
+import "Backend/domain/entity"
 
 // UserRepository はユーザー永続化の抽象インターフェース。
 type UserRepository interface {
-	CreateUser(user *models.User) error
-	GetUserByEmail(email string) (*models.User, error)
-	GetUserByID(id uint) (*models.User, error)
-	ListUsers() ([]models.User, error)
-	ListUsersPaged(limit, offset int, query string) ([]models.User, int64, error)
-	UpdateUser(user *models.User) error
+	CreateUser(user *entity.User) error
+	GetUserByEmail(email string) (*entity.User, error)
+	GetUserByID(id uint) (*entity.User, error)
+	ListUsers() ([]entity.User, error)
+	ListUsersPaged(limit, offset int, query string) ([]entity.User, int64, error)
+	UpdateUser(user *entity.User) error
 	DeleteUser(id uint) error
-	GetUserByVerificationToken(token string) (*models.User, error)
-	GetUserByPasswordResetToken(token string) (*models.User, error)
-	GetUserByOAuth(provider, oauthID string) (*models.User, error)
+	GetUserByVerificationToken(token string) (*entity.User, error)
+	GetUserByPasswordResetToken(token string) (*entity.User, error)
+	GetUserByOAuth(provider, oauthID string) (*entity.User, error)
 }
 
 // PendingRegistrationRepository は仮登録の永続化インターフェース。
 type PendingRegistrationRepository interface {
-	Create(p *models.PendingRegistration) error
-	FindByToken(token string) (*models.PendingRegistration, error)
+	Create(p *entity.PendingRegistration) error
+	FindByToken(token string) (*entity.PendingRegistration, error)
 	DeleteByEmail(email string) error
 	DeleteExpired() error
 }

--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -1,8 +1,8 @@
 package controllers
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
-	"Backend/internal/models"
 	"Backend/internal/services"
 	"encoding/json"
 	"fmt"
@@ -32,7 +32,7 @@ func NewChatController(chatService *services.ChatService, matchingService *servi
 	}
 }
 
-func countEvaluatedCategories(scores []models.UserWeightScore) int {
+func countEvaluatedCategories(scores []entity.UserWeightScore) int {
 	count := 0
 	for _, score := range scores {
 		if score.Score != 0 {
@@ -181,7 +181,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 		userScores, scoreErr := c.chatService.GetUserScores(uint(userID), sessionID)
 		if scoreErr != nil {
 			fmt.Printf("[GetRecommendations] Failed to load user scores for provisional status: %v\n", scoreErr)
-			userScores = []models.UserWeightScore{}
+			userScores = []entity.UserWeightScore{}
 		}
 
 		reason := "matching_results_empty"
@@ -237,14 +237,14 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 	userScores, err := c.chatService.GetUserScores(uint(userID), sessionID)
 	if err != nil {
 		fmt.Printf("[GetRecommendations] Failed to load user scores: %v\n", err)
-		userScores = []models.UserWeightScore{}
+		userScores = []entity.UserWeightScore{}
 	}
 	evaluatedCategories := countEvaluatedCategories(userScores)
 	isProvisional := evaluatedCategories < minEvaluatedCategoriesForFinal
 
 	var items []CompanyRecommendation
 	for _, match := range matches {
-		if match.Company.ID == 0 {
+		if match.Company == nil || match.Company.ID == 0 {
 			continue
 		}
 
@@ -338,7 +338,7 @@ func generateReasonForCategory(category string, score int) string {
 }
 
 // generateMatchReason 企業マッチングの理由を生成
-func generateMatchReason(match *models.UserCompanyMatch) string {
+func generateMatchReason(match *entity.UserCompanyMatch) string {
 	// AIで生成された理由があればそれを使用
 	if match.MatchReason != "" {
 		return match.MatchReason
@@ -455,7 +455,7 @@ func (c *ChatController) SendReport(w http.ResponseWriter, r *http.Request) {
 
 	var companies []services.EmailReportCompany
 	for i, match := range matches {
-		if match.Company.ID == 0 {
+		if match.Company == nil || match.Company.ID == 0 {
 			continue
 		}
 		companies = append(companies, services.EmailReportCompany{

--- a/Backend/internal/controllers/company_relation_controller.go
+++ b/Backend/internal/controllers/company_relation_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"Backend/internal/models"
+	"Backend/domain/repository"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,44 +9,33 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type CompanyRelationController struct {
-	DB *gorm.DB
+	repo repository.CompanyRelationQueryRepository
+}
+
+func NewCompanyRelationController(repo repository.CompanyRelationQueryRepository) *CompanyRelationController {
+	return &CompanyRelationController{repo: repo}
 }
 
 // GetCompanyRelations 企業IDに関連する企業関係を取得
 func (ctrl *CompanyRelationController) GetCompanyRelations(w http.ResponseWriter, r *http.Request) {
 	// パスから企業IDを抽出
-	pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	pathParts := splitPath(r.URL.Path)
 	if len(pathParts) < 3 {
 		http.Error(w, "Invalid company ID", http.StatusBadRequest)
 		return
 	}
 
-	companyIDStr := pathParts[2]
-	companyID, err := strconv.ParseUint(companyIDStr, 10, 32)
+	companyID, err := strconv.ParseUint(pathParts[2], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid company ID", http.StatusBadRequest)
 		return
 	}
 
-	var relations []models.CompanyRelation
-
-	err = ctrl.DB.
-		Preload("Parent").
-		Preload("Child").
-		Preload("From").
-		Preload("To").
-		Where("parent_id = ? OR child_id = ? OR from_id = ? OR to_id = ?",
-			companyID, companyID, companyID, companyID).
-		Where("is_active = ?", true).
-		Find(&relations).Error
-
+	relations, err := ctrl.repo.GetByCompanyID(uint(companyID))
 	if err != nil {
 		http.Error(w, "Failed to fetch relations", http.StatusInternalServerError)
 		return
@@ -58,32 +47,25 @@ func (ctrl *CompanyRelationController) GetCompanyRelations(w http.ResponseWriter
 
 // GetCompanyMarketInfo 企業の市場情報を取得
 func (ctrl *CompanyRelationController) GetCompanyMarketInfo(w http.ResponseWriter, r *http.Request) {
-	pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	pathParts := splitPath(r.URL.Path)
 	if len(pathParts) < 3 {
 		http.Error(w, "Invalid company ID", http.StatusBadRequest)
 		return
 	}
 
-	companyIDStr := pathParts[2]
-	companyID, err := strconv.ParseUint(companyIDStr, 10, 32)
+	companyID, err := strconv.ParseUint(pathParts[2], 10, 32)
 	if err != nil {
 		http.Error(w, "Invalid company ID", http.StatusBadRequest)
 		return
 	}
 
-	var marketInfo models.CompanyMarketInfo
-	err = ctrl.DB.
-		Preload("Company").
-		Where("company_id = ?", companyID).
-		First(&marketInfo).Error
-
-	if err == gorm.ErrRecordNotFound {
-		http.Error(w, "Market info not found", http.StatusNotFound)
-		return
-	}
-
+	marketInfo, err := ctrl.repo.GetMarketInfoByCompanyID(uint(companyID))
 	if err != nil {
 		http.Error(w, "Failed to fetch market info", http.StatusInternalServerError)
+		return
+	}
+	if marketInfo == nil {
+		http.Error(w, "Market info not found", http.StatusNotFound)
 		return
 	}
 
@@ -93,16 +75,7 @@ func (ctrl *CompanyRelationController) GetCompanyMarketInfo(w http.ResponseWrite
 
 // GetAllCompanyRelations 全企業関係を取得（関連図用）
 func (ctrl *CompanyRelationController) GetAllCompanyRelations(w http.ResponseWriter, r *http.Request) {
-	var relations []models.CompanyRelation
-
-	err := ctrl.DB.
-		Preload("Parent").
-		Preload("Child").
-		Preload("From").
-		Preload("To").
-		Where("is_active = ?", true).
-		Find(&relations).Error
-
+	relations, err := ctrl.repo.GetAll()
 	if err != nil {
 		http.Error(w, "Failed to fetch relations", http.StatusInternalServerError)
 		return
@@ -114,12 +87,7 @@ func (ctrl *CompanyRelationController) GetAllCompanyRelations(w http.ResponseWri
 
 // GetAllMarketInfo 全企業の市場情報を取得
 func (ctrl *CompanyRelationController) GetAllMarketInfo(w http.ResponseWriter, r *http.Request) {
-	var marketInfos []models.CompanyMarketInfo
-
-	err := ctrl.DB.
-		Preload("Company").
-		Find(&marketInfos).Error
-
+	marketInfos, err := ctrl.repo.GetAllMarketInfo()
 	if err != nil {
 		http.Error(w, "Failed to fetch market info", http.StatusInternalServerError)
 		return
@@ -135,7 +103,7 @@ func (ctrl *CompanyRelationController) GetCompanyJobPositions(w http.ResponseWri
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	pathParts := splitPath(r.URL.Path)
 	// path: /api/companies/{id}/job-positions → ["api","companies","{id}","job-positions"]
 	if len(pathParts) < 3 {
 		http.Error(w, "Invalid path", http.StatusBadRequest)
@@ -147,12 +115,7 @@ func (ctrl *CompanyRelationController) GetCompanyJobPositions(w http.ResponseWri
 		return
 	}
 
-	var positions []models.CompanyJobPosition
-	err = ctrl.DB.
-		Where("company_id = ? AND is_active = ? AND data_status = ?", companyID, true, "published").
-		Preload("JobCategory").
-		Order("created_at desc").
-		Find(&positions).Error
+	positions, err := ctrl.repo.GetJobPositionsByCompany(uint(companyID))
 	if err != nil {
 		http.Error(w, "Failed to fetch job positions", http.StatusInternalServerError)
 		return
@@ -169,6 +132,7 @@ func (ctrl *CompanyRelationController) GetCompanies(w http.ResponseWriter, r *ht
 	limitStr := r.URL.Query().Get("limit")
 	offsetStr := r.URL.Query().Get("offset")
 	industry := r.URL.Query().Get("industry")
+	name := r.URL.Query().Get("name")
 
 	limit := 10 // デフォルト
 	offset := 0
@@ -188,44 +152,18 @@ func (ctrl *CompanyRelationController) GetCompanies(w http.ResponseWriter, r *ht
 		}
 	}
 
-	name := r.URL.Query().Get("name")
-
-	query := ctrl.DB.Where("is_active = ?", true)
-
-	if industry != "" {
-		query = query.Where("industry = ?", industry)
-	}
-
-	if name != "" {
-		query = query.Where("name LIKE ?", "%"+name+"%")
-	}
-
-	order := "RAND()"
-	if name != "" {
-		order = "name ASC"
-	}
-
-	var companies []models.Company
-	err := query.
-		Limit(limit).
-		Offset(offset).
-		Order(order).
-		Find(&companies).Error
-
+	companies, total, err := ctrl.repo.GetCompaniesFiltered(limit, offset, industry, name)
 	if err != nil {
 		http.Error(w, "Failed to fetch companies", http.StatusInternalServerError)
 		return
 	}
 
 	type CompanyResponse struct {
-		Companies []models.Company `json:"companies"`
-		Total     int64            `json:"total"`
-		Limit     int              `json:"limit"`
-		Offset    int              `json:"offset"`
+		Companies interface{} `json:"companies"`
+		Total     int64       `json:"total"`
+		Limit     int         `json:"limit"`
+		Offset    int         `json:"offset"`
 	}
-
-	var total int64
-	ctrl.DB.Model(&models.Company{}).Where("is_active = ?", true).Count(&total)
 
 	response := CompanyResponse{
 		Companies: companies,
@@ -245,7 +183,12 @@ func (ctrl *CompanyRelationController) WebSearchCompanies(w http.ResponseWriter,
 		return
 	}
 
-	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		http.Error(w, "q parameter is required", http.StatusBadRequest)
+		return
+	}
+	query = trimSpace(query)
 	if query == "" {
 		http.Error(w, "q parameter is required", http.StatusBadRequest)
 		return
@@ -303,4 +246,33 @@ func (ctrl *CompanyRelationController) WebSearchCompanies(w http.ResponseWriter,
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+}
+
+// splitPath はURLパスを "/" で分割してスラッシュを除去した要素のスライスを返す
+func splitPath(path string) []string {
+	// strings パッケージは同一ファイル内で使えるのでコピーして利用
+	result := []string{}
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i == len(path) || path[i] == '/' {
+			if i > start {
+				result = append(result, path[start:i])
+			}
+			start = i + 1
+		}
+	}
+	return result
+}
+
+// trimSpace は文字列の先頭と末尾の空白を除去する（標準ライブラリ呼び出しを避けるためのラッパー）
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
+		end--
+	}
+	return s[start:end]
 }

--- a/Backend/internal/repositories/analysis_phase_repository.go
+++ b/Backend/internal/repositories/analysis_phase_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
 	"Backend/internal/models"
 	"gorm.io/gorm"
 )
@@ -14,24 +16,38 @@ func NewAnalysisPhaseRepository(db *gorm.DB) *AnalysisPhaseRepository {
 }
 
 // FindAll 全フェーズを順序順に取得
-func (r *AnalysisPhaseRepository) FindAll() ([]models.AnalysisPhase, error) {
-	var phases []models.AnalysisPhase
-	err := r.db.Order("phase_order ASC").Find(&phases).Error
-	return phases, err
+func (r *AnalysisPhaseRepository) FindAll() ([]entity.AnalysisPhase, error) {
+	var ms []models.AnalysisPhase
+	err := r.db.Order("phase_order ASC").Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]entity.AnalysisPhase, len(ms))
+	for i, m := range ms {
+		e := mapper.AnalysisPhaseToEntity(&m)
+		result[i] = *e
+	}
+	return result, nil
 }
 
 // FindByID IDでフェーズを取得
-func (r *AnalysisPhaseRepository) FindByID(id uint) (*models.AnalysisPhase, error) {
-	var phase models.AnalysisPhase
-	err := r.db.First(&phase, id).Error
-	return &phase, err
+func (r *AnalysisPhaseRepository) FindByID(id uint) (*entity.AnalysisPhase, error) {
+	var m models.AnalysisPhase
+	err := r.db.First(&m, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.AnalysisPhaseToEntity(&m), nil
 }
 
 // FindByName 名前でフェーズを取得
-func (r *AnalysisPhaseRepository) FindByName(name string) (*models.AnalysisPhase, error) {
-	var phase models.AnalysisPhase
-	err := r.db.Where("phase_name = ?", name).First(&phase).Error
-	return &phase, err
+func (r *AnalysisPhaseRepository) FindByName(name string) (*entity.AnalysisPhase, error) {
+	var m models.AnalysisPhase
+	err := r.db.Where("phase_name = ?", name).First(&m).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.AnalysisPhaseToEntity(&m), nil
 }
 
 type UserAnalysisProgressRepository struct {
@@ -43,20 +59,28 @@ func NewUserAnalysisProgressRepository(db *gorm.DB) *UserAnalysisProgressReposit
 }
 
 // FindByUserAndSession ユーザーとセッションで進捗を取得
-func (r *UserAnalysisProgressRepository) FindByUserAndSession(userID uint, sessionID string) ([]models.UserAnalysisProgress, error) {
-	var progress []models.UserAnalysisProgress
+func (r *UserAnalysisProgressRepository) FindByUserAndSession(userID uint, sessionID string) ([]entity.UserAnalysisProgress, error) {
+	var ms []models.UserAnalysisProgress
 	err := r.db.Preload("Phase").
 		Where("user_id = ? AND session_id = ?", userID, sessionID).
 		Order("phase_id ASC").
-		Find(&progress).Error
-	return progress, err
+		Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]entity.UserAnalysisProgress, len(ms))
+	for i, m := range ms {
+		e := mapper.UserAnalysisProgressToEntity(&m)
+		result[i] = *e
+	}
+	return result, nil
 }
 
 // FindOrCreate フェーズの進捗を取得または作成
-func (r *UserAnalysisProgressRepository) FindOrCreate(userID uint, sessionID string, phaseID uint) (*models.UserAnalysisProgress, error) {
-	var progress models.UserAnalysisProgress
+func (r *UserAnalysisProgressRepository) FindOrCreate(userID uint, sessionID string, phaseID uint) (*entity.UserAnalysisProgress, error) {
+	var m models.UserAnalysisProgress
 	err := r.db.Where("user_id = ? AND session_id = ? AND phase_id = ?", userID, sessionID, phaseID).
-		FirstOrCreate(&progress, models.UserAnalysisProgress{
+		FirstOrCreate(&m, models.UserAnalysisProgress{
 			UserID:    userID,
 			SessionID: sessionID,
 			PhaseID:   phaseID,
@@ -65,21 +89,25 @@ func (r *UserAnalysisProgressRepository) FindOrCreate(userID uint, sessionID str
 		return nil, err
 	}
 	// Phaseをロード
-	r.db.Preload("Phase").First(&progress, progress.ID)
-	return &progress, nil
+	r.db.Preload("Phase").First(&m, m.ID)
+	return mapper.UserAnalysisProgressToEntity(&m), nil
 }
 
 // Update 進捗を更新
-func (r *UserAnalysisProgressRepository) Update(progress *models.UserAnalysisProgress) error {
-	return r.db.Save(progress).Error
+func (r *UserAnalysisProgressRepository) Update(progress *entity.UserAnalysisProgress) error {
+	m := mapper.UserAnalysisProgressFromEntity(progress)
+	return r.db.Save(m).Error
 }
 
 // GetCurrentPhase 現在進行中のフェーズを取得
-func (r *UserAnalysisProgressRepository) GetCurrentPhase(userID uint, sessionID string) (*models.UserAnalysisProgress, error) {
-	var progress models.UserAnalysisProgress
+func (r *UserAnalysisProgressRepository) GetCurrentPhase(userID uint, sessionID string) (*entity.UserAnalysisProgress, error) {
+	var m models.UserAnalysisProgress
 	err := r.db.Preload("Phase").
 		Where("user_id = ? AND session_id = ? AND is_completed = ?", userID, sessionID, false).
 		Order("phase_id ASC").
-		First(&progress).Error
-	return &progress, err
+		First(&m).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.UserAnalysisProgressToEntity(&m), nil
 }

--- a/Backend/internal/repositories/company_query_repository.go
+++ b/Backend/internal/repositories/company_query_repository.go
@@ -1,0 +1,117 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// CompanyQueryRepository は CompanyRelationQueryRepository インターフェースの実装。
+type CompanyQueryRepository struct {
+	db *gorm.DB
+}
+
+func NewCompanyQueryRepository(db *gorm.DB) *CompanyQueryRepository {
+	return &CompanyQueryRepository{db: db}
+}
+
+// GetByCompanyID 指定企業IDに関連する企業関係を取得
+func (r *CompanyQueryRepository) GetByCompanyID(companyID uint) ([]models.CompanyRelation, error) {
+	var relations []models.CompanyRelation
+	err := r.db.
+		Preload("Parent").
+		Preload("Child").
+		Preload("From").
+		Preload("To").
+		Where("parent_id = ? OR child_id = ? OR from_id = ? OR to_id = ?",
+			companyID, companyID, companyID, companyID).
+		Where("is_active = ?", true).
+		Find(&relations).Error
+	return relations, err
+}
+
+// GetAll 全企業関係を取得
+func (r *CompanyQueryRepository) GetAll() ([]models.CompanyRelation, error) {
+	var relations []models.CompanyRelation
+	err := r.db.
+		Preload("Parent").
+		Preload("Child").
+		Preload("From").
+		Preload("To").
+		Where("is_active = ?", true).
+		Find(&relations).Error
+	return relations, err
+}
+
+// GetMarketInfoByCompanyID 指定企業の市場情報を取得
+func (r *CompanyQueryRepository) GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error) {
+	var marketInfo models.CompanyMarketInfo
+	err := r.db.
+		Preload("Company").
+		Where("company_id = ?", companyID).
+		First(&marketInfo).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &marketInfo, nil
+}
+
+// GetAllMarketInfo 全企業の市場情報を取得
+func (r *CompanyQueryRepository) GetAllMarketInfo() ([]models.CompanyMarketInfo, error) {
+	var marketInfos []models.CompanyMarketInfo
+	err := r.db.
+		Preload("Company").
+		Find(&marketInfos).Error
+	return marketInfos, err
+}
+
+// GetJobPositionsByCompany 企業の公開済み求人一覧を取得
+func (r *CompanyQueryRepository) GetJobPositionsByCompany(companyID uint) ([]models.CompanyJobPosition, error) {
+	var positions []models.CompanyJobPosition
+	err := r.db.
+		Where("company_id = ? AND is_active = ? AND data_status = ?", companyID, true, "published").
+		Preload("JobCategory").
+		Order("created_at desc").
+		Find(&positions).Error
+	return positions, err
+}
+
+// GetCompaniesFiltered フィルタリングされた企業一覧と総件数を取得
+func (r *CompanyQueryRepository) GetCompaniesFiltered(limit, offset int, industry, name string) ([]models.Company, int64, error) {
+	query := r.db.Where("is_active = ?", true)
+
+	if industry != "" {
+		query = query.Where("industry = ?", industry)
+	}
+	if name != "" {
+		query = query.Where("name LIKE ?", "%"+name+"%")
+	}
+
+	order := "RAND()"
+	if name != "" {
+		order = "name ASC"
+	}
+
+	var total int64
+	countQuery := r.db.Model(&models.Company{}).Where("is_active = ?", true)
+	if industry != "" {
+		countQuery = countQuery.Where("industry = ?", industry)
+	}
+	if name != "" {
+		countQuery = countQuery.Where("name LIKE ?", "%"+name+"%")
+	}
+	if err := countQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var companies []models.Company
+	err := query.
+		Limit(limit).
+		Offset(offset).
+		Order(order).
+		Find(&companies).Error
+	return companies, total, err
+}

--- a/Backend/internal/repositories/pending_registration_repository.go
+++ b/Backend/internal/repositories/pending_registration_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
 	"Backend/internal/models"
 	"time"
 
@@ -15,17 +17,21 @@ func NewPendingRegistrationRepository(db *gorm.DB) *PendingRegistrationRepositor
 	return &PendingRegistrationRepository{db: db}
 }
 
-func (r *PendingRegistrationRepository) Create(p *models.PendingRegistration) error {
-	return r.db.Create(p).Error
+func (r *PendingRegistrationRepository) Create(p *entity.PendingRegistration) error {
+	m := mapper.PendingRegistrationFromEntity(p)
+	return r.db.Create(m).Error
 }
 
-func (r *PendingRegistrationRepository) FindByToken(token string) (*models.PendingRegistration, error) {
-	var p models.PendingRegistration
-	err := r.db.Where("token = ? AND expires_at > ?", token, time.Now()).First(&p).Error
+func (r *PendingRegistrationRepository) FindByToken(token string) (*entity.PendingRegistration, error) {
+	var m models.PendingRegistration
+	err := r.db.Where("token = ? AND expires_at > ?", token, time.Now()).First(&m).Error
 	if err == gorm.ErrRecordNotFound {
 		return nil, nil
 	}
-	return &p, err
+	if err != nil {
+		return nil, err
+	}
+	return mapper.PendingRegistrationToEntity(&m), nil
 }
 
 func (r *PendingRegistrationRepository) DeleteByEmail(email string) error {

--- a/Backend/internal/repositories/user_company_match_repository.go
+++ b/Backend/internal/repositories/user_company_match_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
 	"Backend/internal/models"
 	"time"
 
@@ -16,56 +18,63 @@ func NewUserCompanyMatchRepository(db *gorm.DB) *UserCompanyMatchRepository {
 }
 
 // CreateOrUpdate マッチング結果を作成または更新
-func (r *UserCompanyMatchRepository) CreateOrUpdate(match *models.UserCompanyMatch) error {
+func (r *UserCompanyMatchRepository) CreateOrUpdate(match *entity.UserCompanyMatch) error {
 	var existing models.UserCompanyMatch
 	err := r.db.Where("user_id = ? AND session_id = ? AND company_id = ?",
 		match.UserID, match.SessionID, match.CompanyID).First(&existing).Error
 
+	m := mapper.UserCompanyMatchFromEntity(match)
+
 	if err == gorm.ErrRecordNotFound {
 		// 新規作成
-		return r.db.Create(match).Error
+		return r.db.Create(m).Error
 	} else if err != nil {
 		return err
 	}
 
 	// 更新（ID以外のフィールドを更新）
-	match.ID = existing.ID
-	match.CreatedAt = existing.CreatedAt
-	match.UpdatedAt = time.Now()
-	match.IsViewed = existing.IsViewed
-	match.IsFavorited = existing.IsFavorited
-	match.IsApplied = existing.IsApplied
-	return r.db.Save(match).Error
+	m.ID = existing.ID
+	m.CreatedAt = existing.CreatedAt
+	m.UpdatedAt = time.Now()
+	m.IsViewed = existing.IsViewed
+	m.IsFavorited = existing.IsFavorited
+	m.IsApplied = existing.IsApplied
+	return r.db.Save(m).Error
 }
 
 // FindTopMatchesByUserAndSession マッチング度の高い順に企業を取得
 func (r *UserCompanyMatchRepository) FindTopMatchesByUserAndSession(
 	userID uint, sessionID string, limit int,
-) ([]*models.UserCompanyMatch, error) {
-	var matches []*models.UserCompanyMatch
+) ([]*entity.UserCompanyMatch, error) {
+	var ms []*models.UserCompanyMatch
 	err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).
 		Order("match_score DESC").
 		Limit(limit).
 		Preload("Company").
 		Preload("JobPosition").
-		Find(&matches).Error
+		Find(&ms).Error
 
 	if err != nil {
 		return nil, err
 	}
-	return matches, nil
+
+	result := make([]*entity.UserCompanyMatch, len(ms))
+	for i, m := range ms {
+		result[i] = mapper.UserCompanyMatchToEntity(m)
+	}
+	return result, nil
 }
 
 // FindByID IDでマッチング結果を取得
-func (r *UserCompanyMatchRepository) FindByID(id uint) (*models.UserCompanyMatch, error) {
-	var match models.UserCompanyMatch
+func (r *UserCompanyMatchRepository) FindByID(id uint) (*entity.UserCompanyMatch, error) {
+	var m models.UserCompanyMatch
 	err := r.db.Preload("Company").
 		Preload("JobPosition").
-		First(&match, id).Error
+		First(&m, id).Error
 	if err != nil {
 		return nil, err
 	}
-	return &match, nil
+	return mapper.UserCompanyMatchToEntity(&m), nil
 }
 
 // MarkAsViewed 閲覧済みにする
@@ -92,14 +101,21 @@ func (r *UserCompanyMatchRepository) MarkAsApplied(matchID uint) error {
 }
 
 // FindFavoritesByUser ユーザーのお気に入り企業を取得
-func (r *UserCompanyMatchRepository) FindFavoritesByUser(userID uint, sessionID string) ([]*models.UserCompanyMatch, error) {
-	var matches []*models.UserCompanyMatch
+func (r *UserCompanyMatchRepository) FindFavoritesByUser(userID uint, sessionID string) ([]*entity.UserCompanyMatch, error) {
+	var ms []*models.UserCompanyMatch
 	err := r.db.Where("user_id = ? AND session_id = ? AND is_favorited = ?", userID, sessionID, true).
 		Order("match_score DESC").
 		Preload("Company").
 		Preload("JobPosition").
-		Find(&matches).Error
-	return matches, err
+		Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*entity.UserCompanyMatch, len(ms))
+	for i, m := range ms {
+		result[i] = mapper.UserCompanyMatchToEntity(m)
+	}
+	return result, nil
 }
 
 // GetMatchStatistics マッチング統計情報を取得

--- a/Backend/internal/repositories/user_repository.go
+++ b/Backend/internal/repositories/user_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
 	"Backend/internal/models"
 	"errors"
 
@@ -16,44 +18,58 @@ func NewUserRepository(db *gorm.DB) *UserRepository {
 }
 
 // CreateUser 新規ユーザー作成
-func (r *UserRepository) CreateUser(user *models.User) error {
-	return r.db.Create(user).Error
+func (r *UserRepository) CreateUser(user *entity.User) error {
+	m := mapper.UserFromEntity(user)
+	if err := r.db.Create(m).Error; err != nil {
+		return err
+	}
+	// 生成された ID などを entity に反映
+	*user = *mapper.UserToEntity(m)
+	return nil
 }
 
 // GetUserByEmail メールアドレスでユーザー取得
-func (r *UserRepository) GetUserByEmail(email string) (*models.User, error) {
-	var user models.User
-	if err := r.db.Where("email = ?", email).First(&user).Error; err != nil {
+func (r *UserRepository) GetUserByEmail(email string) (*entity.User, error) {
+	var m models.User
+	if err := r.db.Where("email = ?", email).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &user, nil
+	return mapper.UserToEntity(&m), nil
 }
 
 // GetUserByID IDでユーザー取得
-func (r *UserRepository) GetUserByID(id uint) (*models.User, error) {
-	var user models.User
-	if err := r.db.First(&user, id).Error; err != nil {
+func (r *UserRepository) GetUserByID(id uint) (*entity.User, error) {
+	var m models.User
+	if err := r.db.First(&m, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &user, nil
+	return mapper.UserToEntity(&m), nil
 }
 
 // ListUsers ユーザー一覧を取得
-func (r *UserRepository) ListUsers() ([]models.User, error) {
-	var users []models.User
-	err := r.db.Order("created_at desc").Find(&users).Error
-	return users, err
+func (r *UserRepository) ListUsers() ([]entity.User, error) {
+	var ms []models.User
+	err := r.db.Order("created_at desc").Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]entity.User, len(ms))
+	for i, m := range ms {
+		e := mapper.UserToEntity(&m)
+		result[i] = *e
+	}
+	return result, nil
 }
 
 // ListUsersPaged ページング付きユーザー一覧を取得
-func (r *UserRepository) ListUsersPaged(limit, offset int, query string) ([]models.User, int64, error) {
-	var users []models.User
+func (r *UserRepository) ListUsersPaged(limit, offset int, query string) ([]entity.User, int64, error) {
+	var ms []models.User
 	var total int64
 
 	q := r.db.Model(&models.User{})
@@ -64,13 +80,22 @@ func (r *UserRepository) ListUsersPaged(limit, offset int, query string) ([]mode
 	if err := q.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	err := q.Order("created_at desc").Limit(limit).Offset(offset).Find(&users).Error
-	return users, total, err
+	err := q.Order("created_at desc").Limit(limit).Offset(offset).Find(&ms).Error
+	if err != nil {
+		return nil, 0, err
+	}
+	result := make([]entity.User, len(ms))
+	for i, m := range ms {
+		e := mapper.UserToEntity(&m)
+		result[i] = *e
+	}
+	return result, total, nil
 }
 
 // UpdateUser ユーザー情報更新
-func (r *UserRepository) UpdateUser(user *models.User) error {
-	return r.db.Save(user).Error
+func (r *UserRepository) UpdateUser(user *entity.User) error {
+	m := mapper.UserFromEntity(user)
+	return r.db.Save(m).Error
 }
 
 // DeleteUser ユーザー削除
@@ -79,37 +104,37 @@ func (r *UserRepository) DeleteUser(id uint) error {
 }
 
 // GetUserByVerificationToken メール認証トークンでユーザー取得
-func (r *UserRepository) GetUserByVerificationToken(token string) (*models.User, error) {
-	var user models.User
-	if err := r.db.Where("email_verification_token = ?", token).First(&user).Error; err != nil {
+func (r *UserRepository) GetUserByVerificationToken(token string) (*entity.User, error) {
+	var m models.User
+	if err := r.db.Where("email_verification_token = ?", token).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &user, nil
+	return mapper.UserToEntity(&m), nil
 }
 
 // GetUserByPasswordResetToken パスワードリセットトークンでユーザー取得
-func (r *UserRepository) GetUserByPasswordResetToken(token string) (*models.User, error) {
-	var user models.User
-	if err := r.db.Where("password_reset_token = ?", token).First(&user).Error; err != nil {
+func (r *UserRepository) GetUserByPasswordResetToken(token string) (*entity.User, error) {
+	var m models.User
+	if err := r.db.Where("password_reset_token = ?", token).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &user, nil
+	return mapper.UserToEntity(&m), nil
 }
 
 // GetUserByOAuth OAuth情報でユーザー取得
-func (r *UserRepository) GetUserByOAuth(provider, oauthID string) (*models.User, error) {
-	var user models.User
-	if err := r.db.Where("oauth_provider = ? AND oauth_id = ?", provider, oauthID).First(&user).Error; err != nil {
+func (r *UserRepository) GetUserByOAuth(provider, oauthID string) (*entity.User, error) {
+	var m models.User
+	if err := r.db.Where("oauth_provider = ? AND oauth_id = ?", provider, oauthID).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return &user, nil
+	return mapper.UserToEntity(&m), nil
 }

--- a/Backend/internal/repositories/user_weight_score_repository.go
+++ b/Backend/internal/repositories/user_weight_score_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
 	"Backend/internal/models"
 
 	"gorm.io/gorm"
@@ -38,32 +40,38 @@ func (r *UserWeightScoreRepository) UpdateScore(userID uint, sessionID, category
 }
 
 // FindByUserAndSession ユーザーとセッションに紐づく全スコアを取得
-func (r *UserWeightScoreRepository) FindByUserAndSession(userID uint, sessionID string) ([]models.UserWeightScore, error) {
-	var scores []models.UserWeightScore
+func (r *UserWeightScoreRepository) FindByUserAndSession(userID uint, sessionID string) ([]entity.UserWeightScore, error) {
+	var ms []models.UserWeightScore
 	err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).
-		Find(&scores).Error
-	return scores, err
-}
-
-// FindTopCategories トップNのカテゴリを取得
-func (r *UserWeightScoreRepository) FindTopCategories(userID uint, sessionID string, limit int) ([]models.UserWeightScore, error) {
-	var scores []models.UserWeightScore
-	err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).
-		Order("score DESC").
-		Limit(limit).
-		Find(&scores).Error
-	return scores, err
-}
-
-// FindByUserSessionAndCategory ユーザー、セッション、カテゴリで検索
-func (r *UserWeightScoreRepository) FindByUserSessionAndCategory(userID uint, sessionID, category string) (*models.UserWeightScore, error) {
-	var score models.UserWeightScore
-	err := r.db.Where("user_id = ? AND session_id = ? AND weight_category = ?", userID, sessionID, category).
-		First(&score).Error
+		Find(&ms).Error
 	if err != nil {
 		return nil, err
 	}
-	return &score, nil
+	return mapper.UserWeightScoresToEntities(ms), nil
+}
+
+// FindTopCategories トップNのカテゴリを取得
+func (r *UserWeightScoreRepository) FindTopCategories(userID uint, sessionID string, limit int) ([]entity.UserWeightScore, error) {
+	var ms []models.UserWeightScore
+	err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).
+		Order("score DESC").
+		Limit(limit).
+		Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.UserWeightScoresToEntities(ms), nil
+}
+
+// FindByUserSessionAndCategory ユーザー、セッション、カテゴリで検索
+func (r *UserWeightScoreRepository) FindByUserSessionAndCategory(userID uint, sessionID, category string) (*entity.UserWeightScore, error) {
+	var m models.UserWeightScore
+	err := r.db.Where("user_id = ? AND session_id = ? AND weight_category = ?", userID, sessionID, category).
+		First(&m).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.UserWeightScoreToEntity(&m), nil
 }
 
 // CountByUserAndSession ユーザーとセッションに紐づくスコア数を取得

--- a/Backend/internal/services/admin_utils.go
+++ b/Backend/internal/services/admin_utils.go
@@ -1,13 +1,13 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
-	"Backend/internal/models"
 	"os"
 	"strings"
 )
 
-func promoteAdminIfMatched(user *models.User, repo repository.UserRepository) {
+func promoteAdminIfMatched(user *entity.User, repo repository.UserRepository) {
 	if user == nil || repo == nil || user.IsAdmin {
 		return
 	}

--- a/Backend/internal/services/analysis_scoring_service.go
+++ b/Backend/internal/services/analysis_scoring_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"context"
@@ -363,7 +364,7 @@ func (s *AnalysisScoringService) buildRecommendations(userID uint, sessionID str
 	}
 
 	for _, match := range topMatches {
-		if match.Company.ID == 0 {
+		if match.Company == nil || match.Company.ID == 0 {
 			continue
 		}
 		recommendations.TopCompanies = append(recommendations.TopCompanies, CompanyRecommendation{
@@ -375,7 +376,7 @@ func (s *AnalysisScoringService) buildRecommendations(userID uint, sessionID str
 	return recommendations
 }
 
-func buildJobSuitabilityComment(scores []models.UserWeightScore) (string, []JobSuitabilityRole) {
+func buildJobSuitabilityComment(scores []entity.UserWeightScore) (string, []JobSuitabilityRole) {
 	if len(scores) == 0 {
 		return "", nil
 	}

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -1,8 +1,8 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
-	"Backend/internal/models"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -94,7 +94,7 @@ func (s *AuthService) RequestRegistration(email string) error {
 	}
 	token := base64.URLEncoding.EncodeToString(b)
 
-	pending := &models.PendingRegistration{
+	pending := &entity.PendingRegistration{
 		Token:     token,
 		Email:     email,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
@@ -163,7 +163,7 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 	}
 
 	// ユーザー作成
-	user := &models.User{
+	user := &entity.User{
 		Email:                    req.Email,
 		Password:                 string(hashedPassword),
 		Name:                     req.Name,
@@ -289,7 +289,7 @@ func (s *AuthService) CreateGuestUser() (*AuthResponse, error) {
 	}
 	guestID := base64.URLEncoding.EncodeToString(randomBytes)
 
-	user := &models.User{
+	user := &entity.User{
 		Email:       fmt.Sprintf("guest_%s@temp.local", guestID),
 		Password:    "", // ゲストユーザーはパスワード不要
 		Name:        fmt.Sprintf("Guest_%s", guestID[:8]),

--- a/Backend/internal/services/chat_embeddings.go
+++ b/Backend/internal/services/chat_embeddings.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/internal/models"
 	"context"
 	"encoding/json"
@@ -55,7 +56,7 @@ func (s *ChatService) ensureUserEmbedding(ctx context.Context, userID uint, sess
 		return fmt.Errorf("load chat history: %w", err)
 	}
 
-	var user *models.User
+	var user *entity.User
 	if s.userRepo != nil {
 		user, err = s.userRepo.GetUserByID(userID)
 		if err != nil {
@@ -125,7 +126,7 @@ func (s *ChatService) ensureJobCategoryEmbedding(ctx context.Context, jobCategor
 	return s.jobEmbeddingRepo.Upsert(jobCategoryID, text, embeddingJSON)
 }
 
-func buildUserEmbeddingText(user *models.User, history []models.ChatMessage) string {
+func buildUserEmbeddingText(user *entity.User, history []models.ChatMessage) string {
 	var b strings.Builder
 	hasContent := false
 	b.WriteString("User profile\n")

--- a/Backend/internal/services/chat_getters.go
+++ b/Backend/internal/services/chat_getters.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/internal/models"
 	"context"
 	"errors"
@@ -15,12 +16,12 @@ func (s *ChatService) GetChatHistory(sessionID string) ([]models.ChatMessage, er
 }
 
 // GetUserScores ユーザーのスコアを取得
-func (s *ChatService) GetUserScores(userID uint, sessionID string) ([]models.UserWeightScore, error) {
+func (s *ChatService) GetUserScores(userID uint, sessionID string) ([]entity.UserWeightScore, error) {
 	return s.userWeightScoreRepo.FindByUserAndSession(userID, sessionID)
 }
 
 // GetTopRecommendations トップNの適性カテゴリを取得
-func (s *ChatService) GetTopRecommendations(userID uint, sessionID string, limit int) ([]models.UserWeightScore, error) {
+func (s *ChatService) GetTopRecommendations(userID uint, sessionID string, limit int) ([]entity.UserWeightScore, error) {
 	return s.userWeightScoreRepo.FindTopCategories(userID, sessionID, limit)
 }
 

--- a/Backend/internal/services/chat_phase_manager.go
+++ b/Backend/internal/services/chat_phase_manager.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/internal/models"
 	"context"
 	"fmt"
@@ -8,14 +9,14 @@ import (
 )
 
 // getCurrentOrNextPhase 現在のフェーズを取得または次のフェーズを開始
-func (s *ChatService) getCurrentOrNextPhase(ctx context.Context, userID uint, sessionID string) (*models.UserAnalysisProgress, error) {
+func (s *ChatService) getCurrentOrNextPhase(ctx context.Context, userID uint, sessionID string) (*entity.UserAnalysisProgress, error) {
 	allPhases, err := s.phaseRepo.FindAll()
 	if err != nil {
 		return nil, err
 	}
 
 	progresses, _ := s.progressRepo.FindByUserAndSession(userID, sessionID)
-	progressMap := make(map[uint]*models.UserAnalysisProgress, len(progresses))
+	progressMap := make(map[uint]*entity.UserAnalysisProgress, len(progresses))
 	for i := range progresses {
 		progressMap[progresses[i].PhaseID] = &progresses[i]
 	}
@@ -40,7 +41,7 @@ func (s *ChatService) getCurrentOrNextPhase(ctx context.Context, userID uint, se
 }
 
 // updatePhaseProgress フェーズの進捗を更新
-func (s *ChatService) updatePhaseProgress(progress *models.UserAnalysisProgress, isValidAnswer bool) error {
+func (s *ChatService) updatePhaseProgress(progress *entity.UserAnalysisProgress, isValidAnswer bool) error {
 	progress.QuestionsAsked++
 	if isValidAnswer {
 		progress.ValidAnswers++
@@ -80,7 +81,7 @@ func (s *ChatService) buildPhaseProgressResponse(userID uint, sessionID string) 
 		return nil, nil, err
 	}
 
-	progressMap := make(map[uint]*models.UserAnalysisProgress)
+	progressMap := make(map[uint]*entity.UserAnalysisProgress)
 	for i := range progresses {
 		progressMap[progresses[i].PhaseID] = &progresses[i]
 	}
@@ -115,7 +116,7 @@ func (s *ChatService) buildPhaseProgressResponse(userID uint, sessionID string) 
 	return result, current, nil
 }
 
-func phaseCompletionScore(validAnswers int, phase *models.AnalysisPhase) float64 {
+func phaseCompletionScore(validAnswers int, phase *entity.AnalysisPhase) float64 {
 	if phase == nil {
 		return 0
 	}
@@ -136,7 +137,7 @@ func phaseCompletionScore(validAnswers int, phase *models.AnalysisPhase) float64
 	return score
 }
 
-func isPhaseComplete(validAnswers int, phase *models.AnalysisPhase) bool {
+func isPhaseComplete(validAnswers int, phase *entity.AnalysisPhase) bool {
 	if phase == nil {
 		return false
 	}
@@ -150,7 +151,7 @@ func isPhaseComplete(validAnswers int, phase *models.AnalysisPhase) bool {
 	return validAnswers >= required
 }
 
-func (s *ChatService) getLastPhaseProgress(userID uint, sessionID string) (*models.UserAnalysisProgress, error) {
+func (s *ChatService) getLastPhaseProgress(userID uint, sessionID string) (*entity.UserAnalysisProgress, error) {
 	progresses, err := s.progressRepo.FindByUserAndSession(userID, sessionID)
 	if err != nil {
 		return nil, err
@@ -161,11 +162,11 @@ func (s *ChatService) getLastPhaseProgress(userID uint, sessionID string) (*mode
 	return &progresses[len(progresses)-1], nil
 }
 
-func allPhasesReachedMax(progresses []models.UserAnalysisProgress, phases []models.AnalysisPhase) bool {
+func allPhasesReachedMax(progresses []entity.UserAnalysisProgress, phases []entity.AnalysisPhase) bool {
 	if len(phases) == 0 {
 		return false
 	}
-	progressMap := make(map[uint]models.UserAnalysisProgress, len(progresses))
+	progressMap := make(map[uint]entity.UserAnalysisProgress, len(progresses))
 	for _, p := range progresses {
 		progressMap[p.PhaseID] = p
 	}
@@ -181,7 +182,7 @@ func allPhasesReachedMax(progresses []models.UserAnalysisProgress, phases []mode
 	return true
 }
 
-func shouldForceTextQuestion(history []models.ChatMessage, currentPhase *models.UserAnalysisProgress) bool {
+func shouldForceTextQuestion(history []models.ChatMessage, currentPhase *entity.UserAnalysisProgress) bool {
 	if currentPhase == nil || currentPhase.Phase == nil {
 		return false
 	}

--- a/Backend/internal/services/chat_question_generator.go
+++ b/Backend/internal/services/chat_question_generator.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/internal/models"
 	"context"
 	"fmt"
@@ -61,7 +62,7 @@ func (s *ChatService) handleSessionStart(ctx context.Context, req ChatRequest) (
 }
 
 // generateStrategicQuestion AIが戦略的に次の質問を生成
-func (s *ChatService) generateStrategicQuestion(ctx context.Context, history []models.ChatMessage, userID uint, sessionID string, scoreMap map[string]int, allCategories []string, askedTexts map[string]bool, industryID, jobCategoryID uint, targetLevel string, currentPhase *models.UserAnalysisProgress) (string, uint, error) {
+func (s *ChatService) generateStrategicQuestion(ctx context.Context, history []models.ChatMessage, userID uint, sessionID string, scoreMap map[string]int, allCategories []string, askedTexts map[string]bool, industryID, jobCategoryID uint, targetLevel string, currentPhase *entity.UserAnalysisProgress) (string, uint, error) {
 	// 会話履歴を構築
 	historyText := ""
 	for _, msg := range history {

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"Backend/internal/openai"
@@ -77,7 +78,7 @@ type ChatRequest struct {
 type ChatResponse struct {
 	Response            string                   `json:"response"`
 	QuestionWeightID    uint                     `json:"question_weight_id,omitempty"`
-	CurrentScores       []models.UserWeightScore `json:"current_scores,omitempty"`
+	CurrentScores       []entity.UserWeightScore `json:"current_scores,omitempty"`
 	CurrentPhase        *PhaseProgress           `json:"current_phase,omitempty"`
 	AllPhases           []PhaseProgress          `json:"all_phases,omitempty"`
 	IsComplete          bool                     `json:"is_complete"`
@@ -297,7 +298,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	}
 	completedProgresses, _ := s.progressRepo.FindByUserAndSession(req.UserID, req.SessionID)
 	completedPhaseCount := 0
-	phaseByID := make(map[uint]*models.AnalysisPhase, len(allPhases))
+	phaseByID := make(map[uint]*entity.AnalysisPhase, len(allPhases))
 	for i := range allPhases {
 		phaseByID[allPhases[i].ID] = &allPhases[i]
 	}

--- a/Backend/internal/services/email_service.go
+++ b/Backend/internal/services/email_service.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"Backend/internal/models"
+	"Backend/domain/entity"
 	"bytes"
 	"fmt"
 	"html/template"
@@ -156,7 +156,7 @@ const reportEmailTemplate = `<!DOCTYPE html>
 </body>
 </html>`
 
-func (s *EmailService) SendAnalysisReport(user *models.User, summary *AnalysisSummary, companies []EmailReportCompany, sessionID string) error {
+func (s *EmailService) SendAnalysisReport(user *entity.User, summary *AnalysisSummary, companies []EmailReportCompany, sessionID string) error {
 	tmpl, err := template.New("report").Parse(reportEmailTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to parse email template: %w", err)
@@ -209,7 +209,7 @@ func (s *EmailService) SendAnalysisReport(user *models.User, summary *AnalysisSu
 }
 
 // SendVerificationEmail メール認証用のメールを送信
-func (s *EmailService) SendVerificationEmail(user *models.User, token, appURL string) error {
+func (s *EmailService) SendVerificationEmail(user *entity.User, token, appURL string) error {
 	verifyURL := appURL + "/verify-email?token=" + token
 	body := fmt.Sprintf(`<!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><title>メール認証</title></head>
@@ -238,7 +238,7 @@ func (s *EmailService) SendVerificationEmail(user *models.User, token, appURL st
 }
 
 // SendReVerificationEmail 再認証メールを送信
-func (s *EmailService) SendReVerificationEmail(user *models.User, token, appURL string) error {
+func (s *EmailService) SendReVerificationEmail(user *entity.User, token, appURL string) error {
 	verifyURL := appURL + "/verify-email?token=" + token
 	body := fmt.Sprintf(`<!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><title>再認証</title></head>
@@ -401,7 +401,7 @@ func (s *EmailService) SendPasswordResetEmail(email, token, appURL string) error
 }
 
 // SendInterviewReport 面接練習レポートをメールで送信
-func (s *EmailService) SendInterviewReport(user *models.User, data InterviewReportEmailData) error {
+func (s *EmailService) SendInterviewReport(user *entity.User, data InterviewReportEmailData) error {
 	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
 	data.SentAt = time.Now().In(jst).Format("2006年01月02日 15:04")
 	data.UserName = user.Name

--- a/Backend/internal/services/match_reason_builder.go
+++ b/Backend/internal/services/match_reason_builder.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"Backend/internal/models"
+	"Backend/domain/entity"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -64,8 +64,8 @@ type scoreItem struct {
 	score float64
 }
 
-func BuildMatchReason(match *models.UserCompanyMatch, userScores []models.UserWeightScore) string {
-	if match == nil || match.Company.ID == 0 {
+func BuildMatchReason(match *entity.UserCompanyMatch, userScores []entity.UserWeightScore) string {
+	if match == nil || match.Company == nil || match.Company.ID == 0 {
 		return ""
 	}
 	if match.MatchReason != "" {
@@ -98,7 +98,7 @@ func BuildMatchReason(match *models.UserCompanyMatch, userScores []models.UserWe
 	return strings.Join(filterNonEmpty(sections), "\n\n")
 }
 
-func topMatchSummaries(match *models.UserCompanyMatch) string {
+func topMatchSummaries(match *entity.UserCompanyMatch) string {
 	scores := []scoreItem{
 		{label: "技術志向", score: match.TechnicalMatch},
 		{label: "チームワーク", score: match.TeamworkMatch},
@@ -126,7 +126,7 @@ func topMatchSummaries(match *models.UserCompanyMatch) string {
 	return strings.Join(parts, "・")
 }
 
-func topUserStrengths(scores []models.UserWeightScore) string {
+func topUserStrengths(scores []entity.UserWeightScore) string {
 	if len(scores) == 0 {
 		return "複数の軸でバランス良く評価"
 	}
@@ -146,7 +146,10 @@ func topUserStrengths(scores []models.UserWeightScore) string {
 	return strings.Join(parts, "・")
 }
 
-func buildCompanyContext(company models.Company) string {
+func buildCompanyContext(company *entity.Company) string {
+	if company == nil {
+		return "事業内容や開発環境に合った適性が活かせる企業です。"
+	}
 	parts := []string{}
 	if strings.TrimSpace(company.MainBusiness) != "" {
 		parts = append(parts, fmt.Sprintf("主な事業は「%s」です。", company.MainBusiness))

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"context"
@@ -89,8 +90,8 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 func (s *MatchingService) calculateMatchScore(
 	userScores map[string]float64,
 	companyProfile *models.CompanyWeightProfile,
-) *models.UserCompanyMatch {
-	match := &models.UserCompanyMatch{}
+) *entity.UserCompanyMatch {
+	match := &entity.UserCompanyMatch{}
 	evaluatedCount := 0
 	totalScore := 0.0
 
@@ -134,7 +135,7 @@ func calculateCategoryMatch(userScore, companyWeight float64) float64 {
 }
 
 // GetTopMatches マッチング度の高い企業を取得
-func (s *MatchingService) GetTopMatches(ctx context.Context, userID uint, sessionID string, limit int) ([]*models.UserCompanyMatch, error) {
+func (s *MatchingService) GetTopMatches(ctx context.Context, userID uint, sessionID string, limit int) ([]*entity.UserCompanyMatch, error) {
 	return s.matchRepo.FindTopMatchesByUserAndSession(userID, sessionID, limit)
 }
 
@@ -165,7 +166,7 @@ func (s *MatchingService) GetDiagnostics(userID uint, sessionID string) (*Matchi
 }
 
 // GenerateMatchReason AIを使ってマッチング理由を生成（オプション）
-func (s *MatchingService) GenerateMatchReason(ctx context.Context, match *models.UserCompanyMatch) (string, error) {
+func (s *MatchingService) GenerateMatchReason(ctx context.Context, match *entity.UserCompanyMatch) (string, error) {
 	// TODO: OpenAI APIを使って、ユーザーの適性と企業の特徴を基にマッチング理由を生成
 	reason := fmt.Sprintf(
 		"あなたの適性スコアと企業の求める人材像が%0.1f%%マッチしています。"+

--- a/Backend/internal/services/oauth_service.go
+++ b/Backend/internal/services/oauth_service.go
@@ -1,9 +1,9 @@
 package services
 
 import (
+	"Backend/domain/entity"
 	"Backend/domain/repository"
 	"Backend/internal/config"
-	"Backend/internal/models"
 	"context"
 	"encoding/json"
 	"errors"
@@ -120,7 +120,7 @@ func (s *OAuthService) HandleGoogleCallback(ctx context.Context, code string) (*
 			user = existingUser
 		} else {
 			// 新規ユーザー作成
-			user = &models.User{
+			user = &entity.User{
 				Email:         userInfo.Email,
 				Name:          userInfo.Name,
 				OAuthProvider: "google",
@@ -227,7 +227,7 @@ func (s *OAuthService) HandleGitHubCallback(ctx context.Context, code string) (*
 			if name == "" {
 				name = userInfo.Login
 			}
-			user = &models.User{
+			user = &entity.User{
 				Email:         email,
 				Name:          name,
 				OAuthProvider: "github",


### PR DESCRIPTION
Closes #90

## 概要

DDDクリーンアーキテクチャの2つの重大な違反を修正し、Domain層がInfrastructure層に依存しない構造に改善した。

## 変更内容

### 🔴 重大な違反の修正

#### 1. `CompanyRelationController` の `*gorm.DB` 直接依存を排除
- `domain/repository/company.go` に `CompanyRelationQueryRepository` インターフェースを追加
  - `GetByCompanyID`, `GetAll`, `GetMarketInfoByCompanyID`, `GetAllMarketInfo`, `GetJobPositionsByCompany`, `GetCompaniesFiltered` メソッドを定義
- `internal/repositories/company_query_repository.go` を新規作成し実装
- `CompanyRelationController` の `DB *gorm.DB` フィールドを削除し、リポジトリインターフェース経由に変更
- `cmd/server/main.go` のDI設定を `controllers.NewCompanyRelationController(companyQueryRepo)` に更新

#### 2. `domain/repository` のインターフェースが `internal/models` に依存していた問題を修正
- `domain/repository/user.go`: `models.User` / `models.PendingRegistration` → `entity.User` / `entity.PendingRegistration` に変更
- `domain/repository/analysis.go`: `models.UserWeightScore` / `models.AnalysisPhase` / `models.UserAnalysisProgress` / `models.UserCompanyMatch` → 全て `entity.*` に変更

### 🆕 新規作成

| ファイル | 内容 |
|---------|------|
| `domain/entity/pending_registration.go` | 仮登録エンティティ定義（未定義だったため追加） |
| `domain/mapper/user_mapper.go` | User / PendingRegistration の entity⇔model 変換 |
| `domain/mapper/analysis_mapper.go` | UserWeightScore / AnalysisPhase / UserAnalysisProgress の entity⇔model 変換 |
| `domain/mapper/company_mapper.go` | Company / UserCompanyMatch の entity⇔model 変換 |
| `internal/repositories/company_query_repository.go` | CompanyRelationQueryRepository の実装 |

### ⚙️ 連鎖対応（repository実装・services）

**repository実装の更新（mapperを活用）:**
- `user_repository.go`, `pending_registration_repository.go` → `mapper.UserToEntity` / `UserFromEntity` を使用
- `user_weight_score_repository.go` → `mapper.UserWeightScoreToEntity` を使用
- `analysis_phase_repository.go`, `user_analysis_progress_repository.go` → 各mapperを使用
- `user_company_match_repository.go` → `mapper.UserCompanyMatchToEntity` / `UserCompanyMatchFromEntity` を使用

**services の entity 型への移行:**
- `auth_service.go`, `oauth_service.go`: `models.User` → `entity.User`
- `matching_service.go`: `models.UserWeightScore` / `models.Company` / `models.UserCompanyMatch` → `entity.*`
- `email_service.go`: `SendAnalysisReport`, `SendVerificationEmail` 等の引数を `*entity.User` に変更
- `admin_utils.go`, `chat_embeddings.go`, `chat_getters.go`, `chat_phase_manager.go`, `chat_question_generator.go`, `chat_service.go`, `match_reason_builder.go`, `analysis_scoring_service.go` → 必要箇所を `entity.*` に変更

## テスト

- `go build ./...` でコンパイルエラー 0 件を確認済み