### PR TITLE
Resolve #99: GitHub API連携基盤の実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -96,11 +96,14 @@ func main() {
 	// その他
 	resumeRepo := repositories.NewResumeRepository(db)
 	auditLogRepo := repositories.NewAuditLogRepository(db)
+	// GitHub連携
+	githubRepo := repositories.NewGitHubRepository(db)
 
 	// サービス層の初期化
 	emailService := services.NewEmailService()
 	authService := services.NewAuthService(userRepo, pendingRegistrationRepo, emailService)
-	oauthService := services.NewOAuthService(userRepo, oauthConfig)
+	githubService := services.NewGitHubService(githubRepo)
+	oauthService := services.NewOAuthService(userRepo, oauthConfig, githubService)
 	chatService := services.NewChatService(aiClient, questionWeightRepo, chatMessageRepo, userWeightScoreRepo, aiGeneratedQuestionRepo, predefinedQuestionRepo, jobCategoryRepo, userRepo, userEmbeddingRepo, jobEmbeddingRepo, phaseRepo, progressRepo, sessionValidationRepo, conversationContextRepo)
 	questionService := services.NewQuestionGeneratorService(aiClient, questionWeightRepo)
 	matchingService := services.NewMatchingService(userWeightScoreRepo, companyRepo, matchRepo)
@@ -150,6 +153,7 @@ func main() {
 	realtimeController := controllers.NewRealtimeController(interviewService)
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
+	githubController := controllers.NewGitHubController(githubService)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
@@ -158,6 +162,7 @@ func main() {
 	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
+	routes.SetupGitHubRoutes(githubController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
 
 	go crawlService.StartScheduler()

--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -1,0 +1,130 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// GitHubController GitHub連携APIのコントローラー
+type GitHubController struct {
+	githubService *services.GitHubService
+}
+
+func NewGitHubController(githubService *services.GitHubService) *GitHubController {
+	return &GitHubController{githubService: githubService}
+}
+
+// GetProfile GitHubプロフィール・リポジトリ・言語統計を取得する
+// GET /api/github/profile?user_id=<id>
+func (c *GitHubController) GetProfile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, err := parseUserID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	profile, err := c.githubService.GetProfile(userID)
+	if err != nil {
+		http.Error(w, "failed to get github profile", http.StatusInternalServerError)
+		return
+	}
+	if profile == nil {
+		http.Error(w, "github profile not found", http.StatusNotFound)
+		return
+	}
+
+	repos, err := c.githubService.GetRepositories(userID)
+	if err != nil {
+		http.Error(w, "failed to get repositories", http.StatusInternalServerError)
+		return
+	}
+
+	langStats, err := c.githubService.GetLanguageStats(userID)
+	if err != nil {
+		http.Error(w, "failed to get language stats", http.StatusInternalServerError)
+		return
+	}
+
+	resp := map[string]any{
+		"profile":        profile,
+		"repositories":   repos,
+		"language_stats": langStats,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// Sync GitHubデータの非同期同期をトリガーする
+// POST /api/github/sync?user_id=<id>
+func (c *GitHubController) Sync(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, err := parseUserID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	profile, err := c.githubService.GetProfile(userID)
+	if err != nil || profile == nil {
+		http.Error(w, "github profile not found: please connect your GitHub account", http.StatusNotFound)
+		return
+	}
+
+	c.githubService.TriggerAsyncSync(userID)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "sync started",
+	})
+}
+
+// SyncAndWait GitHubデータを同期してから結果を返す（同期的）
+// POST /api/github/sync/wait?user_id=<id>
+func (c *GitHubController) SyncAndWait(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, err := parseUserID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := c.githubService.SyncUserData(context.Background(), userID); err != nil {
+		http.Error(w, "sync failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "sync completed",
+	})
+}
+
+func parseUserID(r *http.Request) (uint, error) {
+	userIDStr := r.URL.Query().Get("user_id")
+	if userIDStr == "" {
+		return 0, fmt.Errorf("user_id is required")
+	}
+	id, err := strconv.ParseUint(userIDStr, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid user_id")
+	}
+	return uint(id), nil
+}

--- a/Backend/internal/models/github_profile.go
+++ b/Backend/internal/models/github_profile.go
@@ -1,0 +1,45 @@
+package models
+
+import "time"
+
+// GitHubProfile GitHubアカウント連携情報
+type GitHubProfile struct {
+	ID                 uint       `gorm:"primaryKey"`
+	UserID             uint       `gorm:"uniqueIndex;not null"`
+	GitHubLogin        string     `gorm:"size:255;not null"`
+	AccessToken        string     `gorm:"size:500;not null"`
+	TotalContributions int        // 年間コントリビューション数
+	PublicRepos        int        // 公開リポジトリ数
+	Followers          int
+	Following          int
+	SyncedAt           *time.Time // 最終同期日時（レート制限キャッシュ用）
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// GitHubRepo GitHubリポジトリ情報
+type GitHubRepo struct {
+	ID              uint      `gorm:"primaryKey"`
+	UserID          uint      `gorm:"index;not null"`
+	Name            string    `gorm:"size:255;not null"`
+	FullName        string    `gorm:"size:500;not null"`
+	Description     string    `gorm:"type:text"`
+	Language        string    `gorm:"size:100"` // メイン言語
+	Stars           int
+	Forks           int
+	IsForked        bool
+	GitHubUpdatedAt time.Time // GitHubのupdated_at
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// GitHubLanguageStat 言語使用比率
+type GitHubLanguageStat struct {
+	ID         uint    `gorm:"primaryKey"`
+	UserID     uint    `gorm:"index;not null"`
+	Language   string  `gorm:"size:100;not null"`
+	Bytes      int64   // バイト数
+	Percentage float64 // 使用比率（%）
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -49,5 +49,9 @@ func AutoMigrate(db *gorm.DB) error {
 		&InterviewReport{},
 		&InterviewVideo{},
 		&PendingRegistration{},
+		// GitHub連携
+		&GitHubProfile{},
+		&GitHubRepo{},
+		&GitHubLanguageStat{},
 	)
 }

--- a/Backend/internal/repositories/github_repository.go
+++ b/Backend/internal/repositories/github_repository.go
@@ -1,0 +1,90 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GitHubRepository GitHub連携データのDB操作
+type GitHubRepository struct {
+	db *gorm.DB
+}
+
+func NewGitHubRepository(db *gorm.DB) *GitHubRepository {
+	return &GitHubRepository{db: db}
+}
+
+// UpsertProfile GitHubプロフィールを保存/更新
+func (r *GitHubRepository) UpsertProfile(profile *models.GitHubProfile) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"git_hub_login", "access_token", "total_contributions", "public_repos", "followers", "following", "synced_at", "updated_at"}),
+	}).Create(profile).Error
+}
+
+// GetProfile ユーザーIDでGitHubプロフィールを取得
+func (r *GitHubRepository) GetProfile(userID uint) (*models.GitHubProfile, error) {
+	var profile models.GitHubProfile
+	if err := r.db.Where("user_id = ?", userID).First(&profile).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &profile, nil
+}
+
+// ReplaceRepositories ユーザーのリポジトリ一覧を全件置換
+func (r *GitHubRepository) ReplaceRepositories(userID uint, repos []models.GitHubRepo) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubRepo{}).Error; err != nil {
+			return err
+		}
+		if len(repos) == 0 {
+			return nil
+		}
+		return tx.Create(&repos).Error
+	})
+}
+
+// GetRepositories ユーザーのリポジトリ一覧を取得（star数降順）
+func (r *GitHubRepository) GetRepositories(userID uint) ([]models.GitHubRepo, error) {
+	var repos []models.GitHubRepo
+	if err := r.db.Where("user_id = ?", userID).Order("stars desc").Find(&repos).Error; err != nil {
+		return nil, err
+	}
+	return repos, nil
+}
+
+// ReplaceLanguageStats ユーザーの言語使用比率を全件置換
+func (r *GitHubRepository) ReplaceLanguageStats(userID uint, stats []models.GitHubLanguageStat) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubLanguageStat{}).Error; err != nil {
+			return err
+		}
+		if len(stats) == 0 {
+			return nil
+		}
+		return tx.Create(&stats).Error
+	})
+}
+
+// GetLanguageStats ユーザーの言語使用比率を取得（使用量降順）
+func (r *GitHubRepository) GetLanguageStats(userID uint) ([]models.GitHubLanguageStat, error) {
+	var stats []models.GitHubLanguageStat
+	if err := r.db.Where("user_id = ?", userID).Order("bytes desc").Find(&stats).Error; err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
+// UpdateSyncedAt 最終同期日時を更新
+func (r *GitHubRepository) UpdateSyncedAt(userID uint, t time.Time) error {
+	return r.db.Model(&models.GitHubProfile{}).
+		Where("user_id = ?", userID).
+		Update("synced_at", t).Error
+}

--- a/Backend/internal/routes/github_routes.go
+++ b/Backend/internal/routes/github_routes.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"Backend/internal/controllers"
+	"net/http"
+)
+
+// SetupGitHubRoutes GitHub連携関連のルーティング設定
+func SetupGitHubRoutes(githubController *controllers.GitHubController) {
+	http.HandleFunc("/api/github/profile", githubController.GetProfile)
+	http.HandleFunc("/api/github/sync", githubController.Sync)
+	http.HandleFunc("/api/github/sync/wait", githubController.SyncAndWait)
+}

--- a/Backend/internal/services/github_service.go
+++ b/Backend/internal/services/github_service.go
@@ -1,0 +1,358 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/repositories"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	githubAPIBase    = "https://api.github.com"
+	githubGraphQLURL = "https://api.github.com/graphql"
+	// レート制限: 最終同期から1時間以内は再同期しない
+	syncCacheDuration = time.Hour
+	// レート制限リトライ: 最大2回
+	maxRetries = 2
+)
+
+// GitHubService GitHub API連携サービス
+type GitHubService struct {
+	githubRepo *repositories.GitHubRepository
+}
+
+func NewGitHubService(githubRepo *repositories.GitHubRepository) *GitHubService {
+	return &GitHubService{githubRepo: githubRepo}
+}
+
+// StoreAccessToken GitHubアクセストークンとプロフィール基本情報を保存する
+func (s *GitHubService) StoreAccessToken(userID uint, login, accessToken string) error {
+	profile := &models.GitHubProfile{
+		UserID:      userID,
+		GitHubLogin: login,
+		AccessToken: accessToken,
+	}
+	return s.githubRepo.UpsertProfile(profile)
+}
+
+// TriggerAsyncSync 非同期でGitHubデータ同期を開始する（ノンブロッキング）
+func (s *GitHubService) TriggerAsyncSync(userID uint) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := s.SyncUserData(ctx, userID); err != nil {
+			log.Printf("[GitHubService] async sync failed for user %d: %v", userID, err)
+		}
+	}()
+}
+
+// SyncUserData GitHubからリポジトリ・言語比率・コントリビューション数を取得してDBに保存する
+func (s *GitHubService) SyncUserData(ctx context.Context, userID uint) error {
+	profile, err := s.githubRepo.GetProfile(userID)
+	if err != nil {
+		return fmt.Errorf("get profile: %w", err)
+	}
+	if profile == nil {
+		return fmt.Errorf("github profile not found for user %d", userID)
+	}
+
+	// キャッシュチェック: 1時間以内に同期済みならスキップ
+	if profile.SyncedAt != nil && time.Since(*profile.SyncedAt) < syncCacheDuration {
+		log.Printf("[GitHubService] user %d: skipping sync (last synced %s ago)", userID, time.Since(*profile.SyncedAt).Round(time.Minute))
+		return nil
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	token := profile.AccessToken
+	login := profile.GitHubLogin
+
+	// 1. リポジトリ一覧取得
+	repos, err := s.fetchRepositories(ctx, client, token, login)
+	if err != nil {
+		return fmt.Errorf("fetch repositories: %w", err)
+	}
+
+	// 2. 言語使用比率集計
+	langStats := aggregateLanguages(userID, repos)
+
+	// userIDをセット
+	for i := range repos {
+		repos[i].UserID = userID
+	}
+
+	// 3. コントリビューション数取得（GraphQL）
+	contributions, err := s.fetchTotalContributions(ctx, client, token, login)
+	if err != nil {
+		log.Printf("[GitHubService] fetch contributions warning: %v", err)
+		// コントリビューション取得失敗はwarn扱いで続行
+	}
+
+	// 4. プロフィール統計更新
+	now := time.Now()
+	profile.TotalContributions = contributions
+	profile.PublicRepos = len(repos)
+	profile.SyncedAt = &now
+	if err := s.githubRepo.UpsertProfile(profile); err != nil {
+		return fmt.Errorf("update profile: %w", err)
+	}
+
+	// 5. リポジトリ保存
+	if err := s.githubRepo.ReplaceRepositories(userID, repos); err != nil {
+		return fmt.Errorf("save repositories: %w", err)
+	}
+
+	// 6. 言語比率保存
+	if err := s.githubRepo.ReplaceLanguageStats(userID, langStats); err != nil {
+		return fmt.Errorf("save language stats: %w", err)
+	}
+
+	log.Printf("[GitHubService] user %d: sync completed (%d repos, %d contributions)", userID, len(repos), contributions)
+	return nil
+}
+
+// GetProfile DBからGitHubプロフィールを取得する
+func (s *GitHubService) GetProfile(userID uint) (*models.GitHubProfile, error) {
+	return s.githubRepo.GetProfile(userID)
+}
+
+// GetRepositories DBからリポジトリ一覧を取得する
+func (s *GitHubService) GetRepositories(userID uint) ([]models.GitHubRepo, error) {
+	return s.githubRepo.GetRepositories(userID)
+}
+
+// GetLanguageStats DBから言語使用比率を取得する
+func (s *GitHubService) GetLanguageStats(userID uint) ([]models.GitHubLanguageStat, error) {
+	return s.githubRepo.GetLanguageStats(userID)
+}
+
+// --- 内部ヘルパー ---
+
+// githubAPIRepository GitHub API レスポンスのリポジトリ構造体
+type githubAPIRepository struct {
+	Name        string `json:"name"`
+	FullName    string `json:"full_name"`
+	Description string `json:"description"`
+	Language    string `json:"language"`
+	StargazersCount int `json:"stargazers_count"`
+	ForksCount  int    `json:"forks_count"`
+	Fork        bool   `json:"fork"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// fetchRepositories GitHub APIからリポジトリ一覧を全ページ取得する
+func (s *GitHubService) fetchRepositories(ctx context.Context, client *http.Client, token, login string) ([]models.GitHubRepo, error) {
+	var allRepos []models.GitHubRepo
+	page := 1
+
+	for {
+		url := fmt.Sprintf("%s/users/%s/repos?type=owner&sort=updated&per_page=100&page=%d", githubAPIBase, login, page)
+		body, err := s.doRequestWithRetry(ctx, client, token, url)
+		if err != nil {
+			return nil, err
+		}
+
+		var apiRepos []githubAPIRepository
+		if err := json.Unmarshal(body, &apiRepos); err != nil {
+			return nil, fmt.Errorf("unmarshal repos page %d: %w", page, err)
+		}
+
+		if len(apiRepos) == 0 {
+			break
+		}
+
+		for _, r := range apiRepos {
+			updatedAt, _ := time.Parse(time.RFC3339, r.UpdatedAt)
+			allRepos = append(allRepos, models.GitHubRepo{
+				Name:            r.Name,
+				FullName:        r.FullName,
+				Description:     r.Description,
+				Language:        r.Language,
+				Stars:           r.StargazersCount,
+				Forks:           r.ForksCount,
+				IsForked:        r.Fork,
+				GitHubUpdatedAt: updatedAt,
+			})
+		}
+
+		if len(apiRepos) < 100 {
+			break
+		}
+		page++
+	}
+
+	return allRepos, nil
+}
+
+// githubLanguagesResponse GitHub言語APIレスポンス（言語名→バイト数のmap）
+type githubLanguagesResponse map[string]int64
+
+// aggregateLanguages リポジトリ一覧から言語使用統計を集計する
+func aggregateLanguages(userID uint, repos []models.GitHubRepo) []models.GitHubLanguageStat {
+	langBytes := make(map[string]int64)
+	var total int64
+
+	for _, r := range repos {
+		if r.Language != "" {
+			// リポジトリのメイン言語のみ集計（バイト数は不明なので件数ベース）
+			langBytes[r.Language]++
+			total++
+		}
+	}
+
+	if total == 0 {
+		return nil
+	}
+
+	stats := make([]models.GitHubLanguageStat, 0, len(langBytes))
+	for lang, count := range langBytes {
+		stats = append(stats, models.GitHubLanguageStat{
+			UserID:     userID,
+			Language:   lang,
+			Bytes:      count,
+			Percentage: float64(count) / float64(total) * 100,
+		})
+	}
+	return stats
+}
+
+// contributionsGraphQLResponse GraphQLレスポンス構造体
+type contributionsGraphQLResponse struct {
+	Data struct {
+		User struct {
+			ContributionsCollection struct {
+				ContributionCalendar struct {
+					TotalContributions int `json:"totalContributions"`
+				} `json:"contributionCalendar"`
+			} `json:"contributionsCollection"`
+		} `json:"user"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// fetchTotalContributions GraphQL APIで年間コントリビューション数を取得する
+func (s *GitHubService) fetchTotalContributions(ctx context.Context, client *http.Client, token, login string) (int, error) {
+	query := fmt.Sprintf(`{"query":"query{user(login:\"%s\"){contributionsCollection{contributionCalendar{totalContributions}}}}"}`, login)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubGraphQLURL, bytes.NewBufferString(query))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkRateLimit(resp); err != nil {
+		return 0, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var result contributionsGraphQLResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, fmt.Errorf("unmarshal graphql response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return 0, fmt.Errorf("graphql error: %s", result.Errors[0].Message)
+	}
+
+	return result.Data.User.ContributionsCollection.ContributionCalendar.TotalContributions, nil
+}
+
+// doRequestWithRetry レート制限対応GETリクエスト（最大maxRetriesリトライ）
+func (s *GitHubService) doRequestWithRetry(ctx context.Context, client *http.Client, token, url string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		body, err := s.doGet(ctx, client, token, url)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+
+		// レート制限エラーの場合はリトライしない
+		if isRateLimitError(err) {
+			return nil, err
+		}
+
+		if attempt < maxRetries {
+			wait := time.Duration(attempt+1) * 2 * time.Second
+			log.Printf("[GitHubService] request failed (attempt %d/%d), retrying in %s: %v", attempt+1, maxRetries, wait, err)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+	}
+	return nil, lastErr
+}
+
+// doGet GitHub APIへGETリクエストを送る
+func (s *GitHubService) doGet(ctx context.Context, client *http.Client, token, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkRateLimit(resp); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("github api error: status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// rateLimitError レート制限エラー型
+type rateLimitError struct {
+	resetAt time.Time
+}
+
+func (e *rateLimitError) Error() string {
+	return fmt.Sprintf("github rate limit exceeded, resets at %s", e.resetAt.Format(time.RFC3339))
+}
+
+func isRateLimitError(err error) bool {
+	_, ok := err.(*rateLimitError)
+	return ok
+}
+
+// checkRateLimit レスポンスヘッダーからレート制限を確認する
+func checkRateLimit(resp *http.Response) error {
+	if resp.StatusCode != 403 && resp.StatusCode != 429 {
+		return nil
+	}
+	remaining := resp.Header.Get("X-RateLimit-Remaining")
+	if remaining == "0" || resp.StatusCode == 429 {
+		resetUnix, _ := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64)
+		resetAt := time.Unix(resetUnix, 0)
+		return &rateLimitError{resetAt: resetAt}
+	}
+	return nil
+}

--- a/Backend/internal/services/oauth_service.go
+++ b/Backend/internal/services/oauth_service.go
@@ -15,14 +15,16 @@ import (
 )
 
 type OAuthService struct {
-	userRepo    repository.UserRepository
-	oauthConfig *config.OAuthConfig
+	userRepo      repository.UserRepository
+	oauthConfig   *config.OAuthConfig
+	githubService *GitHubService
 }
 
-func NewOAuthService(userRepo repository.UserRepository, oauthConfig *config.OAuthConfig) *OAuthService {
+func NewOAuthService(userRepo repository.UserRepository, oauthConfig *config.OAuthConfig, githubService *GitHubService) *OAuthService {
 	return &OAuthService{
-		userRepo:    userRepo,
-		oauthConfig: oauthConfig,
+		userRepo:      userRepo,
+		oauthConfig:   oauthConfig,
+		githubService: githubService,
 	}
 }
 
@@ -241,6 +243,17 @@ func (s *OAuthService) HandleGitHubCallback(ctx context.Context, code string) (*
 			if err := s.userRepo.CreateUser(user); err != nil {
 				return nil, fmt.Errorf("failed to create user: %w", err)
 			}
+		}
+	}
+
+	// アクセストークン保存 & 非同期データ同期
+	if s.githubService != nil {
+		accessToken := token.AccessToken
+		if err := s.githubService.StoreAccessToken(user.ID, userInfo.Login, accessToken); err != nil {
+			// トークン保存失敗はログのみ（ログイン自体は成功扱い）
+			fmt.Printf("[OAuthService] failed to store github access token for user %d: %v\n", user.ID, err)
+		} else {
+			s.githubService.TriggerAsyncSync(user.ID)
 		}
 	}
 


### PR DESCRIPTION
Closes #99

## 変更内容

### 新規モデル (`Backend/internal/models/github_profile.go`)
- `GitHubProfile`: ユーザーのGitHubアカウント連携情報（アクセストークン・コントリビューション数・フォロワー数等）を管理
- `GitHubRepo`: GitHubリポジトリ情報（名前・言語・star数・fork数・fork有無等）を管理
- `GitHubLanguageStat`: 言語使用比率（バイト数・パーセンテージ）を管理

### DBマイグレーション (`Backend/internal/models/migrate.go`)
- `GitHubProfile`・`GitHubRepo`・`GitHubLanguageStat` を `AutoMigrate` に追加

### リポジトリ層 (`Backend/internal/repositories/github_repository.go`)
- `UpsertProfile`: GitHubプロフィールの新規作成/更新（ON CONFLICT対応）
- `GetProfile`: ユーザーIDによるプロフィール取得
- `ReplaceRepositories`: リポジトリ一覧の全件置換（トランザクション）
- `GetRepositories`: star数降順のリポジトリ一覧取得
- `ReplaceLanguageStats`: 言語比率の全件置換（トランザクション）
- `GetLanguageStats`: バイト数降順の言語比率取得

### サービス層 (`Backend/internal/services/github_service.go`)
- `StoreAccessToken`: OAuthログイン時のアクセストークン保存
- `TriggerAsyncSync`: 非同期（goroutine）でのデータ同期トリガー
- `SyncUserData`: GitHub APIからリポジトリ・言語比率・コントリビューション数を取得してDB保存
  - キャッシュ制御: 最終同期から1時間以内はスキップ
  - 全リポジトリページネーション対応（100件/ページ）
  - GitHub GraphQL APIでの年間コントリビューション数取得
  - レート制限対応: `X-RateLimit-Remaining` ヘッダー確認、超過時はエラー返却
  - 指数バックオフによるリトライ（最大2回）

### OAuthサービス修正 (`Backend/internal/services/oauth_service.go`)
- `GitHubService` を依存注入するよう `OAuthService` を拡張
- GitHub OAuthコールバック完了後、アクセストークンを `GitHubProfile` に保存
- 保存成功後、非同期でGitHubデータ同期を起動

### コントローラー (`Backend/internal/controllers/github_controller.go`)
- `GET /api/github/profile?user_id=<id>`: プロフィール・リポジトリ一覧・言語比率を一括返却
- `POST /api/github/sync?user_id=<id>`: 非同期sync起動（即時レスポンス）
- `POST /api/github/sync/wait?user_id=<id>`: 同期的にsyncを実行して結果を返却

### ルーティング (`Backend/internal/routes/github_routes.go`)
- GitHub連携APIのルーティング設定を追加

### DI配線 (`Backend/cmd/server/main.go`)
- `GitHubRepository`・`GitHubService`・`GitHubController` を起動時に初期化・配線