### PR TITLE
Resolve #102: IT企業マスタへの技術スタック詳細項目の追加

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -131,7 +131,7 @@ func main() {
 	chatController := controllers.NewChatController(chatService, matchingService, analysisService, userRepo, emailService)
 	questionController := controllers.NewQuestionController(questionService)
 	relationController := controllers.NewCompanyRelationController(companyQueryRepo, aiClient)
-	adminCompanyController := controllers.NewAdminCompanyController(companyRepo, auditLogService, nil)
+	adminCompanyController := controllers.NewAdminCompanyController(companyRepo, auditLogService, nil, aiClient)
 	adminCrawlController := controllers.NewAdminCrawlController(crawlService, auditLogService)
 	adminJobController := controllers.NewAdminJobController(companyRepo, jobCategoryRepo, graduateRepo, auditLogService)
 	adminUserController := controllers.NewAdminUserController(userRepo, auditLogService)

--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -10,7 +10,8 @@ type CompanyRelationQueryRepository interface {
 	GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error)
 	GetAllMarketInfo() ([]models.CompanyMarketInfo, error)
 	GetJobPositionsByCompany(companyID uint) ([]models.CompanyJobPosition, error)
-	GetCompaniesFiltered(limit, offset int, industry, name string) ([]models.Company, int64, error)
+	GetCompaniesFiltered(limit, offset int, industry, name, tech string) ([]models.Company, int64, error)
+	GetCompanyByID(id uint) (*models.Company, error)
 }
 
 // CompanyRepository は企業情報の永続化インターフェース。

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -3,9 +3,12 @@ package controllers
 import (
 	"Backend/domain/repository"
 	"Backend/internal/models"
+	"Backend/internal/openai"
 	"Backend/internal/services"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,13 +16,18 @@ import (
 )
 
 type AdminCompanyController struct {
-	repo  repository.CompanyRepository
-	audit *services.AuditLogService
-	gbiz  *services.GBizInfoService
+	repo        repository.CompanyRepository
+	audit       *services.AuditLogService
+	gbiz        *services.GBizInfoService
+	openaiClient *openai.Client
 }
 
-func NewAdminCompanyController(repo repository.CompanyRepository, audit *services.AuditLogService, gbiz *services.GBizInfoService) *AdminCompanyController {
-	return &AdminCompanyController{repo: repo, audit: audit, gbiz: gbiz}
+func NewAdminCompanyController(repo repository.CompanyRepository, audit *services.AuditLogService, gbiz *services.GBizInfoService, openaiClient ...*openai.Client) *AdminCompanyController {
+	ctrl := &AdminCompanyController{repo: repo, audit: audit, gbiz: gbiz}
+	if len(openaiClient) > 0 {
+		ctrl.openaiClient = openaiClient[0]
+	}
+	return ctrl
 }
 
 func (c *AdminCompanyController) ListOrCreate(w http.ResponseWriter, r *http.Request) {
@@ -46,6 +54,10 @@ func (c *AdminCompanyController) Detail(w http.ResponseWriter, r *http.Request) 
 	}
 	if strings.HasSuffix(idStr, "/gbiz-sync") {
 		c.syncGBiz(w, r, strings.TrimSuffix(idStr, "/gbiz-sync"))
+		return
+	}
+	if strings.HasSuffix(idStr, "/tech-stack-search") {
+		c.fetchTechStack(w, r, strings.TrimSuffix(idStr, "/tech-stack-search"))
 		return
 	}
 	if strings.HasSuffix(idStr, "/publish") {
@@ -270,6 +282,107 @@ func (c *AdminCompanyController) syncGBiz(w http.ResponseWriter, r *http.Request
 	json.NewEncoder(w).Encode(result)
 }
 
+// fetchTechStack はOpenAI WebSearchで企業の技術スタックを取得してDBを更新する
+func (c *AdminCompanyController) fetchTechStack(w http.ResponseWriter, r *http.Request, idStr string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idStr = strings.Trim(idStr, "/")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		http.Error(w, "invalid company id", http.StatusBadRequest)
+		return
+	}
+	if c.openaiClient == nil {
+		http.Error(w, "openai client not configured", http.StatusServiceUnavailable)
+		return
+	}
+	company, err := c.repo.FindByID(uint(id))
+	if err != nil {
+		http.Error(w, "company not found", http.StatusNotFound)
+		return
+	}
+
+	prompt := fmt.Sprintf(
+		`「%s」という日本のIT企業の技術スタックを調査してください。以下のJSON形式のみで回答してください（余分な説明は不要）。
+{
+  "tech_stack": ["言語・フレームワーク名（例: Go, React, TypeScript）"],
+  "infra_stack": ["インフラ名（例: AWS, GCP, Azure, オンプレ）"],
+  "cicd_tools": ["CI/CDツール名（例: GitHub Actions, Jenkins, CircleCI）"],
+  "development_style": "開発手法（例: スクラム, ウォーターフォール, カンバン）"
+}`,
+		company.Name,
+	)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	text, err := c.openaiClient.WebSearchQuery(ctx, prompt)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("web search failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// JSON部分を抽出
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end == -1 || end <= start {
+		http.Error(w, "failed to parse web search response", http.StatusInternalServerError)
+		return
+	}
+
+	type techStackResult struct {
+		TechStack        []string `json:"tech_stack"`
+		InfraStack       []string `json:"infra_stack"`
+		CicdTools        []string `json:"cicd_tools"`
+		DevelopmentStyle string   `json:"development_style"`
+	}
+	var result techStackResult
+	if err := json.Unmarshal([]byte(text[start:end+1]), &result); err != nil {
+		http.Error(w, "failed to parse tech stack json", http.StatusInternalServerError)
+		return
+	}
+
+	// JSON配列をシリアライズしてDBに保存
+	if len(result.TechStack) > 0 {
+		if b, err := json.Marshal(result.TechStack); err == nil {
+			company.TechStack = string(b)
+		}
+	}
+	if len(result.InfraStack) > 0 {
+		if b, err := json.Marshal(result.InfraStack); err == nil {
+			company.InfraStack = string(b)
+		}
+	}
+	if len(result.CicdTools) > 0 {
+		if b, err := json.Marshal(result.CicdTools); err == nil {
+			company.CicdTools = string(b)
+		}
+	}
+	if result.DevelopmentStyle != "" {
+		company.DevelopmentStyle = result.DevelopmentStyle
+	}
+
+	if err := c.repo.Update(company); err != nil {
+		http.Error(w, "failed to update company", http.StatusInternalServerError)
+		return
+	}
+
+	actor := r.Header.Get("X-Admin-Email")
+	c.audit.Record(actor, "company.tech_stack_search", "company", company.ID, map[string]interface{}{
+		"name": company.Name,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"tech_stack":        result.TechStack,
+		"infra_stack":       result.InfraStack,
+		"cicd_tools":        result.CicdTools,
+		"development_style": result.DevelopmentStyle,
+	})
+}
+
 func applyCompanyDefaults(company *models.Company) {
 	if strings.TrimSpace(company.SourceType) == "" {
 		company.SourceType = "manual"
@@ -331,6 +444,12 @@ func mergeCompany(existing *models.Company, payload *models.Company) error {
 	}
 	if strings.TrimSpace(payload.TechStack) != "" {
 		existing.TechStack = payload.TechStack
+	}
+	if strings.TrimSpace(payload.InfraStack) != "" {
+		existing.InfraStack = payload.InfraStack
+	}
+	if strings.TrimSpace(payload.CicdTools) != "" {
+		existing.CicdTools = payload.CicdTools
 	}
 	if strings.TrimSpace(payload.DevelopmentStyle) != "" {
 		existing.DevelopmentStyle = payload.DevelopmentStyle

--- a/Backend/internal/controllers/company_relation_controller.go
+++ b/Backend/internal/controllers/company_relation_controller.go
@@ -98,6 +98,33 @@ func (ctrl *CompanyRelationController) GetAllMarketInfo(w http.ResponseWriter, r
 	json.NewEncoder(w).Encode(marketInfos)
 }
 
+// GetCompanyByID 企業IDで企業詳細を取得
+func (ctrl *CompanyRelationController) GetCompanyByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	pathParts := splitPath(r.URL.Path)
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+	companyID, err := strconv.ParseUint(pathParts[2], 10, 32)
+	if err != nil {
+		http.Error(w, "Invalid company ID", http.StatusBadRequest)
+		return
+	}
+
+	company, err := ctrl.repo.GetCompanyByID(uint(companyID))
+	if err != nil {
+		http.Error(w, "Company not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(company)
+}
+
 // GetCompanyJobPositions 企業の公開済み求人一覧を取得
 func (ctrl *CompanyRelationController) GetCompanyJobPositions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -134,6 +161,7 @@ func (ctrl *CompanyRelationController) GetCompanies(w http.ResponseWriter, r *ht
 	offsetStr := r.URL.Query().Get("offset")
 	industry := r.URL.Query().Get("industry")
 	name := r.URL.Query().Get("name")
+	tech := r.URL.Query().Get("tech")
 
 	limit := 10 // デフォルト
 	offset := 0
@@ -153,7 +181,7 @@ func (ctrl *CompanyRelationController) GetCompanies(w http.ResponseWriter, r *ht
 		}
 	}
 
-	companies, total, err := ctrl.repo.GetCompaniesFiltered(limit, offset, industry, name)
+	companies, total, err := ctrl.repo.GetCompaniesFiltered(limit, offset, industry, name, tech)
 	if err != nil {
 		http.Error(w, "Failed to fetch companies", http.StatusInternalServerError)
 		return

--- a/Backend/internal/models/company.go
+++ b/Backend/internal/models/company.go
@@ -30,8 +30,10 @@ type Company struct {
 	WelfareDetails string `gorm:"type:text" json:"welfare_details"`    // 福利厚生の詳細
 
 	// 技術情報
-	TechStack        string `gorm:"type:text" json:"tech_stack"`                // 使用技術スタック（JSON形式）
-	DevelopmentStyle string `gorm:"type:varchar(100)" json:"development_style"` // アジャイル、ウォーターフォールなど
+	TechStack        string `gorm:"type:text" json:"tech_stack"`                // 使用技術スタック（JSON形式: 言語・フレームワーク）
+	InfraStack       string `gorm:"type:text" json:"infra_stack"`               // インフラ構成（JSON形式: AWS/GCP/Azure等）
+	CicdTools        string `gorm:"type:text" json:"cicd_tools"`                // CI/CDツール（JSON形式: GitHub Actions/Jenkins等）
+	DevelopmentStyle string `gorm:"type:varchar(100)" json:"development_style"` // 開発手法（スクラム/ウォーターフォール等）
 
 	// ビジネス情報
 	MainBusiness string  `gorm:"type:text" json:"main_business"` // 主要事業内容

--- a/Backend/internal/repositories/company_query_repository.go
+++ b/Backend/internal/repositories/company_query_repository.go
@@ -79,15 +79,36 @@ func (r *CompanyQueryRepository) GetJobPositionsByCompany(companyID uint) ([]mod
 	return positions, err
 }
 
-// GetCompaniesFiltered フィルタリングされた企業一覧と総件数を取得
-func (r *CompanyQueryRepository) GetCompaniesFiltered(limit, offset int, industry, name string) ([]models.Company, int64, error) {
-	query := r.db.Where("is_active = ?", true)
-
-	if industry != "" {
-		query = query.Where("industry = ?", industry)
+// GetCompanyByID 指定IDの企業を取得
+func (r *CompanyQueryRepository) GetCompanyByID(id uint) (*models.Company, error) {
+	var company models.Company
+	err := r.db.Where("id = ? AND is_active = ?", id, true).First(&company).Error
+	if err != nil {
+		return nil, err
 	}
-	if name != "" {
-		query = query.Where("name LIKE ?", "%"+name+"%")
+	return &company, nil
+}
+
+// GetCompaniesFiltered フィルタリングされた企業一覧と総件数を取得
+func (r *CompanyQueryRepository) GetCompaniesFiltered(limit, offset int, industry, name, tech string) ([]models.Company, int64, error) {
+	applyFilters := func(q interface{ Where(query interface{}, args ...interface{}) *gorm.DB }) *gorm.DB {
+		db := q.Where("is_active = ?", true)
+		if industry != "" {
+			db = db.Where("industry = ?", industry)
+		}
+		if name != "" {
+			db = db.Where("name LIKE ?", "%"+name+"%")
+		}
+		if tech != "" {
+			like := "%" + tech + "%"
+			db = db.Where("tech_stack LIKE ? OR infra_stack LIKE ? OR cicd_tools LIKE ?", like, like, like)
+		}
+		return db
+	}
+
+	var total int64
+	if err := applyFilters(r.db.Model(&models.Company{})).Count(&total).Error; err != nil {
+		return nil, 0, err
 	}
 
 	order := "RAND()"
@@ -95,20 +116,8 @@ func (r *CompanyQueryRepository) GetCompaniesFiltered(limit, offset int, industr
 		order = "name ASC"
 	}
 
-	var total int64
-	countQuery := r.db.Model(&models.Company{}).Where("is_active = ?", true)
-	if industry != "" {
-		countQuery = countQuery.Where("industry = ?", industry)
-	}
-	if name != "" {
-		countQuery = countQuery.Where("name LIKE ?", "%"+name+"%")
-	}
-	if err := countQuery.Count(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
 	var companies []models.Company
-	err := query.
+	err := applyFilters(r.db).
 		Limit(limit).
 		Offset(offset).
 		Order(order).

--- a/Backend/internal/routes/company_routes.go
+++ b/Backend/internal/routes/company_routes.go
@@ -16,6 +16,9 @@ func SetupCompanyRoutes(relationController *controllers.CompanyRelationControlle
 		path := strings.TrimPrefix(r.URL.Path, "/api/companies/")
 		if strings.HasSuffix(path, "/job-positions") {
 			relationController.GetCompanyJobPositions(w, r)
+		} else if !strings.Contains(path, "/") {
+			// /api/companies/{id}
+			relationController.GetCompanyByID(w, r)
 		} else {
 			http.NotFound(w, r)
 		}

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { authService } from '@/lib/auth'
+
+const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
+
+function ChipEditor({
+  label,
+  values,
+  onChange,
+}: {
+  label: string
+  values: string[]
+  onChange: (v: string[]) => void
+}) {
+  const [input, setInput] = useState('')
+  const add = () => {
+    const v = input.trim()
+    if (v && !values.includes(v)) onChange([...values, v])
+    setInput('')
+  }
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+        {label}
+      </Typography>
+      <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: 1 }}>
+        {values.map((v) => (
+          <Chip key={v} label={v} onDelete={() => onChange(values.filter((x) => x !== v))} size="small" />
+        ))}
+      </Stack>
+      <Stack direction="row" spacing={1}>
+        <TextField
+          size="small"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && add()}
+          placeholder="入力してEnter"
+          sx={{ flex: 1 }}
+        />
+        <Button variant="outlined" size="small" onClick={add}>
+          追加
+        </Button>
+      </Stack>
+    </Box>
+  )
+}
+
+function parseJsonArray(s: string): string[] {
+  try {
+    const parsed = JSON.parse(s)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return s ? s.split(',').map((x) => x.trim()).filter(Boolean) : []
+  }
+}
+
+export default function AdminCompanyEditPage() {
+  const params = useParams()
+  const router = useRouter()
+  const id = params.id as string
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) window.location.href = '/'
+  }, [])
+
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [aiLoading, setAiLoading] = useState(false)
+  const [name, setName] = useState('')
+  const [techStack, setTechStack] = useState<string[]>([])
+  const [infraStack, setInfraStack] = useState<string[]>([])
+  const [cicdTools, setCicdTools] = useState<string[]>([])
+  const [devStyle, setDevStyle] = useState('')
+
+  useEffect(() => {
+    const admin = authService.getStoredUser()
+    fetch(`/api/admin/companies/${id}`, {
+      headers: { 'X-Admin-Email': admin?.email || '' },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setName(data.name || '')
+        setTechStack(parseJsonArray(data.tech_stack || ''))
+        setInfraStack(parseJsonArray(data.infra_stack || ''))
+        setCicdTools(parseJsonArray(data.cicd_tools || ''))
+        setDevStyle(data.development_style || '')
+      })
+      .catch(() => setError('企業情報の取得に失敗しました'))
+  }, [id])
+
+  const handleAiFill = async () => {
+    setAiLoading(true)
+    setError('')
+    const admin = authService.getStoredUser()
+    try {
+      const res = await fetch(`/api/admin/companies/${id}/tech-stack-search`, {
+        method: 'POST',
+        headers: { 'X-Admin-Email': admin?.email || '' },
+      })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        setError(d?.error || 'AI自動入力に失敗しました')
+        return
+      }
+      const data = await res.json()
+      if (data.tech_stack?.length) setTechStack(data.tech_stack)
+      if (data.infra_stack?.length) setInfraStack(data.infra_stack)
+      if (data.cicd_tools?.length) setCicdTools(data.cicd_tools)
+      if (data.development_style) setDevStyle(data.development_style)
+      setSuccess('AI自動入力が完了しました（保存ボタンで確定してください）')
+    } finally {
+      setAiLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setError('')
+    setSuccess('')
+    const admin = authService.getStoredUser()
+    const res = await fetch(`/api/admin/companies/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Email': admin?.email || '',
+      },
+      body: JSON.stringify({
+        tech_stack: JSON.stringify(techStack),
+        infra_stack: JSON.stringify(infraStack),
+        cicd_tools: JSON.stringify(cicdTools),
+        development_style: devStyle,
+      }),
+    })
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}))
+      setError(d?.error || '保存に失敗しました')
+      return
+    }
+    setSuccess('保存しました')
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
+      <Button variant="text" onClick={() => router.back()} sx={{ mb: 2 }}>
+        ← 戻る
+      </Button>
+      <Typography variant="h5" fontWeight="bold" sx={{ mb: 3 }}>
+        技術スタック編集: {name}
+      </Typography>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+      <Card>
+        <CardContent>
+          <Stack spacing={3}>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleAiFill}
+              disabled={aiLoading}
+              sx={{ alignSelf: 'flex-start' }}
+            >
+              {aiLoading ? 'AI検索中...' : '🤖 AI自動入力（OpenAI WebSearch）'}
+            </Button>
+
+            <Divider />
+
+            <ChipEditor
+              label="言語・フレームワーク（例: Go, React, TypeScript）"
+              values={techStack}
+              onChange={setTechStack}
+            />
+            <ChipEditor
+              label="インフラ（例: AWS, GCP, Azure, オンプレ）"
+              values={infraStack}
+              onChange={setInfraStack}
+            />
+            <ChipEditor
+              label="CI/CDツール（例: GitHub Actions, Jenkins, CircleCI）"
+              values={cicdTools}
+              onChange={setCicdTools}
+            />
+            <TextField
+              select
+              label="開発手法"
+              value={devStyle}
+              onChange={(e) => setDevStyle(e.target.value)}
+              size="small"
+            >
+              <MenuItem value="">未設定</MenuItem>
+              {DEV_STYLES.map((s) => (
+                <MenuItem key={s} value={s}>{s}</MenuItem>
+              ))}
+            </TextField>
+
+            <Button variant="contained" onClick={handleSave} sx={{ alignSelf: 'flex-end' }}>
+              保存
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -178,26 +178,36 @@ export default function AdminCompaniesPage() {
                       {company.industry || '業種未設定'} / {company.location || '所在地未設定'}
                     </Typography>
                   </Box>
-                  {company.data_status !== 'published' && (
-                    <Stack direction="row" spacing={1}>
-                      <Button
-                        variant="contained"
-                        color="success"
-                        size="small"
-                        onClick={() => handlePublish(company.id)}
-                      >
-                        承認
-                      </Button>
-                      <Button
-                        variant="outlined"
-                        color="error"
-                        size="small"
-                        onClick={() => handleReject(company.id)}
-                      >
-                        却下
-                      </Button>
-                    </Stack>
-                  )}
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      component={Link}
+                      href={`/admin/companies/${company.id}/edit`}
+                    >
+                      編集
+                    </Button>
+                    {company.data_status !== 'published' && (
+                      <>
+                        <Button
+                          variant="contained"
+                          color="success"
+                          size="small"
+                          onClick={() => handlePublish(company.id)}
+                        >
+                          承認
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          color="error"
+                          size="small"
+                          onClick={() => handleReject(company.id)}
+                        >
+                          却下
+                        </Button>
+                      </>
+                    )}
+                  </Stack>
                 </Stack>
               </Box>
             ))}

--- a/frontend/app/api/admin/companies/[id]/tech-stack-search/route.ts
+++ b/frontend/app/api/admin/companies/[id]/tech-stack-search/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/tech-stack-search`, {
+    method: 'POST',
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+  })
+  const raw = await response.text()
+  let data: Record<string, unknown> = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/companies/route.ts
+++ b/frontend/app/api/companies/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
     const offset = searchParams.get('offset') || '0'
     const industry = searchParams.get('industry') || ''
     const name = searchParams.get('name') || ''
+    const tech = searchParams.get('tech') || ''
 
     let url = `${API_BASE_URL}/api/companies?limit=${limit}&offset=${offset}`
     if (industry) {
@@ -16,6 +17,9 @@ export async function GET(request: NextRequest) {
     }
     if (name) {
       url += `&name=${encodeURIComponent(name)}`
+    }
+    if (tech) {
+      url += `&tech=${encodeURIComponent(tech)}`
     }
     
     console.log('[API] Fetching companies from:', url)

--- a/frontend/app/company/[id]/page.tsx
+++ b/frontend/app/company/[id]/page.tsx
@@ -18,16 +18,23 @@ type Company = {
   name: string
   industry: string
   location: string
+  employee_count?: number
   employees: string
   description: string
   matchScore: number
   tags: string[]
+  tech_stack?: string
   techStack: string[]
+  infra_stack?: string
+  cicd_tools?: string
+  development_style?: string
   projectTypes: string[]
   salary: string
   benefits: string[]
   culture: string[]
+  founded_year?: number
   founded: string
+  website_url?: string
   website: string
   size: string
   parentCompany?: string
@@ -35,6 +42,16 @@ type Company = {
   partnerships?: string[]
   capitalStructure?: {
     shareholders: { name: string; percentage: number }[]
+  }
+}
+
+function parseJsonArray(s?: string): string[] {
+  if (!s) return []
+  try {
+    const parsed = JSON.parse(s)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return s.split(',').map((x) => x.trim()).filter(Boolean)
   }
 }
 
@@ -67,6 +84,18 @@ export default function CompanyDetailPage() {
 
         if (response.ok) {
           const data = await response.json()
+          // DB形式のフィールドをUI向けに補完
+          data.techStack = parseJsonArray(data.tech_stack)
+          data.matchScore = data.matchScore ?? 0
+          data.tags = data.tags ?? []
+          data.projectTypes = data.projectTypes ?? []
+          data.salary = data.salary ?? ''
+          data.benefits = data.benefits ?? []
+          data.culture = data.culture ? (Array.isArray(data.culture) ? data.culture : [data.culture]) : []
+          data.founded = data.founded_year ? `${data.founded_year}年` : ''
+          data.website = data.website_url ?? ''
+          data.employees = data.employee_count ? `${data.employee_count}名` : ''
+          data.size = data.employee_count ? `${data.employee_count}名規模` : ''
           setCompany(data)
         } else {
           console.error('Failed to fetch company details:', response.statusText)
@@ -216,12 +245,46 @@ export default function CompanyDetailPage() {
                 技術スタック
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2">
-                {company.techStack.map((tech, index) => (
-                  <Badge key={index} variant="outline">{tech}</Badge>
-                ))}
-              </div>
+            <CardContent className="space-y-3">
+              {company.techStack.length > 0 && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">言語・フレームワーク</p>
+                  <div className="flex flex-wrap gap-2">
+                    {company.techStack.map((tech, index) => (
+                      <Badge key={index} variant="outline">{tech}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {parseJsonArray(company.infra_stack).length > 0 && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">インフラ</p>
+                  <div className="flex flex-wrap gap-2">
+                    {parseJsonArray(company.infra_stack).map((item, index) => (
+                      <Badge key={index} variant="secondary">{item}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {parseJsonArray(company.cicd_tools).length > 0 && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">CI/CD</p>
+                  <div className="flex flex-wrap gap-2">
+                    {parseJsonArray(company.cicd_tools).map((item, index) => (
+                      <Badge key={index} variant="secondary">{item}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {company.development_style && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">開発手法</p>
+                  <Badge>{company.development_style}</Badge>
+                </div>
+              )}
+              {company.techStack.length === 0 && !company.infra_stack && !company.cicd_tools && (
+                <p className="text-sm text-muted-foreground">技術情報未登録</p>
+              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
Closes #102

## 変更内容

### Backend
- `Company` モデルに `InfraStack`（インフラ構成）・`CicdTools`（CI/CDツール）フィールドを追加（JSON配列テキスト型）
- `GET /api/companies/{id}` エンドポイントを新規追加（企業詳細取得）
- `GET /api/companies` に `tech` クエリパラメータを追加（TechStack/InfraStack/CicdToolsのLIKE検索）
- `POST /api/admin/companies/{id}/tech-stack-search` を追加：OpenAI WebSearchで企業名から技術スタックを自動収集しDBに保存
- `mergeCompany()` に `InfraStack`・`CicdTools` フィールドのマージ処理を追加

### Frontend
- `/admin/companies/[id]/edit` ページを新規作成
  - 言語・フレームワーク / インフラ / CI/CDツール / 開発手法のChipエディタ
  - 「AI自動入力（OpenAI WebSearch）」ボタンで技術スタックを自動取得
- 管理画面企業一覧に「編集」ボタンを追加
- 企業詳細ページ（`/company/[id]`）に InfraStack・CicdTools・DevelopmentStyle を表示
- `/api/companies` に `tech` フィルタパラメータを転送

## OpenAI WebSearch 連携
企業名を元に `web_search_preview` ツールで技術スタック（言語・インフラ・CI/CD・開発手法）を自動取得し、DBに保存。管理画面の「AI自動入力」ボタンから1クリックで実行可能。