### PR TITLE
Resolve #120: VAD無音タイムアウト延長による発話途中送信バグの修正

### DIFF
--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -244,7 +244,8 @@ export default function InterviewPage() {
   useEffect(() => {
     if (!handsFreeMode || status !== 'connected' || !streamRef.current) return
     const VAD_THRESHOLD = 0.015   // 発話検知の音量閾値 (RMS)
-    const SILENCE_MS = 1500       // この無音時間が続いたら自動送信
+    const SILENCE_MS = 2500       // この無音時間が続いたら自動送信（長めに設定して途切れ防止）
+    const MIN_RECORDING_MS = 1000 // 録音開始後この時間は自動停止しない（息継ぎなどで誤停止しない）
     const audioCtx = new AudioContext()
     const source = audioCtx.createMediaStreamSource(streamRef.current)
     const analyser = audioCtx.createAnalyser()
@@ -252,6 +253,7 @@ export default function InterviewPage() {
     source.connect(analyser)
     const buf = new Float32Array(analyser.fftSize)
     let silenceStart: number | null = null
+    let recordingStartTime: number | null = null
     let rafId: number
     const tick = () => {
       rafId = requestAnimationFrame(tick)
@@ -261,15 +263,22 @@ export default function InterviewPage() {
       if (speaking) {
         silenceStart = null
         if (!isRecordingRef.current && !turnPendingRef.current && !aiSpeakingRef.current) {
+          recordingStartTime = Date.now()
           startRecording()
         }
       } else if (isRecordingRef.current) {
+        // 録音開始直後の短い無音（息継ぎ等）では止めない
+        const elapsed = recordingStartTime ? Date.now() - recordingStartTime : Infinity
+        if (elapsed < MIN_RECORDING_MS) return
         if (silenceStart === null) {
           silenceStart = Date.now()
         } else if (Date.now() - silenceStart > SILENCE_MS) {
           silenceStart = null
+          recordingStartTime = null
           stopRecording()
         }
+      } else {
+        silenceStart = null
       }
     }
     rafId = requestAnimationFrame(tick)
@@ -497,7 +506,7 @@ export default function InterviewPage() {
   const setAiSpeaking = (v: boolean) => { aiSpeakingRef.current = v; _setAiSpeaking(v) }
 
   const startRecording = () => {
-    if (!streamRef.current || isRecording || turnPending) return
+    if (!streamRef.current || isRecordingRef.current || turnPendingRef.current) return
     const audioTracks = streamRef.current.getAudioTracks()
     if (audioTracks.length === 0) return
     const micStream = new MediaStream(audioTracks)


### PR DESCRIPTION
Closes #120

## 変更内容

### `frontend/app/interview/page.tsx`

- **無音判定タイムアウトを延長**: `SILENCE_MS` を 1500ms → **2500ms** に変更
  - 自然な話し方でのわずかな間（文と文の間のポーズ等）で誤って送信されないようにする

- **録音最低保持時間を追加**: `MIN_RECORDING_MS = 1000ms` を新設
  - 録音開始から1秒以内は自動停止を行わないガード処理を追加
  - 話し始め直後の息継ぎや短い無音で録音が即座に止まる問題を防止

- **非録音中の `silenceStart` リセットを追加**
  - 録音していない状態で無音が続いても `silenceStart` をクリアし、状態の一貫性を維持

- **`startRecording` のステール閉包バグを修正**
  - `isRecording`（state値・VADクロージャ内では古い値を参照）→ `isRecordingRef.current`（ref・常に最新値）に変更
  - `turnPending` も同様に `turnPendingRef.current` を参照するよう統一
  - VADエフェクトがマウント時に一度だけ生成するクロージャ内から安全に参照可能になった