### PR TITLE
Resolve #121: AI面接レポートを教員用・生徒用の2種類に対応

### DIFF
--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -455,7 +455,11 @@ func (c *InterviewController) Get(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid user_id", http.StatusBadRequest)
 		return
 	}
-	resp, err := c.interviewService.GetSessionDetail(uint(userID), sessionID)
+	role := r.URL.Query().Get("role")
+	if role == "" {
+		role = "student"
+	}
+	resp, err := c.interviewService.GetSessionDetailWithRole(uint(userID), sessionID, role)
 	if err != nil {
 		status := http.StatusBadRequest
 		if err.Error() == "forbidden" {

--- a/Backend/internal/models/interview_report.go
+++ b/Backend/internal/models/interview_report.go
@@ -4,10 +4,11 @@ import "time"
 
 // InterviewReport 面接後の要約・評価
 type InterviewReport struct {
-	SessionID    uint   `gorm:"primaryKey"`
-	SummaryText  string `gorm:"type:text"`
-	ScoresJSON   string `gorm:"type:json"`
-	EvidenceJSON string `gorm:"type:json"`
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	SessionID          uint   `gorm:"primaryKey"`
+	SummaryText        string `gorm:"type:text"`
+	ScoresJSON         string `gorm:"type:json"`
+	EvidenceJSON       string `gorm:"type:json"`
+	TeacherReportJSON  string `gorm:"type:json"` // 教員用詳細レポート（指導コメント・エビデンス等）
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }

--- a/Backend/internal/models/user.go
+++ b/Backend/internal/models/user.go
@@ -9,6 +9,7 @@ type User struct {
 	Password                 string `gorm:"size:255"` // ハッシュ化されたパスワード (OAuth時は空)
 	Name                     string `gorm:"size:100"`
 	IsGuest                  bool   `gorm:"default:false"`                               // ゲストユーザーフラグ
+	Role                     string `gorm:"size:20;default:'student'" json:"role"`       // ユーザーロール: student / teacher
 	TargetLevel              string `gorm:"size:20;default:'新卒'"`                        // 新卒 or 中途
 	SchoolName               string `gorm:"size:255;column:school_name"`                 // 学校名
 	IsAdmin                  bool   `gorm:"default:false" json:"is_admin"`               // 管理者フラグ

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -216,6 +216,10 @@ func (s *InterviewService) ListSessions(userID uint, all bool, limit int, offset
 }
 
 func (s *InterviewService) GetSessionDetail(userID uint, sessionID uint) (*InterviewDetailResponse, error) {
+	return s.GetSessionDetailWithRole(userID, sessionID, "student")
+}
+
+func (s *InterviewService) GetSessionDetailWithRole(userID uint, sessionID uint, role string) (*InterviewDetailResponse, error) {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
 		return nil, err
@@ -234,6 +238,12 @@ func (s *InterviewService) GetSessionDetail(userID uint, sessionID uint) (*Inter
 			return nil, err
 		}
 		report = nil
+	}
+	// 教員以外には教員用レポートを返さない
+	if report != nil && role != "teacher" {
+		sanitized := *report
+		sanitized.TeacherReportJSON = ""
+		report = &sanitized
 	}
 	return &InterviewDetailResponse{
 		Session:    *toSessionResponse(session),
@@ -498,10 +508,11 @@ func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) e
 	if len(utterances) == 0 {
 		// utterances が0件の場合は空レポートを保存して正常終了
 		empty := &models.InterviewReport{
-			SessionID:    sessionID,
-			SummaryText:  "発話データがありませんでした。",
-			ScoresJSON:   `{"logic":0,"specificity":0,"ownership":0}`,
-			EvidenceJSON: `{}`,
+			SessionID:         sessionID,
+			SummaryText:       "発話データがありませんでした。",
+			ScoresJSON:        `{"logic":0,"specificity":0,"ownership":0}`,
+			EvidenceJSON:      `{}`,
+			TeacherReportJSON: `{}`,
 		}
 		return s.reportRepo.Upsert(empty)
 	}
@@ -528,25 +539,40 @@ func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) e
 
 ## 出力フォーマット（このキーと型を厳守してください）
 {
-  "summary": ["評価コメント1", "評価コメント2", "評価コメント3"],
+  "summary": ["生徒向け評価コメント1（やさしい言葉で）", "コメント2", "コメント3"],
   "scores": {"logic": 3, "specificity": 2, "ownership": 4},
-  "evidence": {"logic": "論理性の根拠となった発言", "specificity": "具体性の根拠となった発言", "ownership": "主体性の根拠となった発言"}
+  "evidence": {"logic": "根拠となった発言の引用", "specificity": "根拠となった発言の引用", "ownership": "根拠となった発言の引用"},
+  "teacher": {
+    "overall_comment": "教員向け総評（指導観点・クラス内での位置づけ等）",
+    "detailed_evidence": {"logic": "詳細な根拠と指導ポイント", "specificity": "詳細な根拠と指導ポイント", "ownership": "詳細な根拠と指導ポイント"},
+    "coaching_points": ["具体的な改善指導ポイント1", "ポイント2", "ポイント3"],
+    "strengths_for_teacher": ["指導者が把握すべき強み1", "強み2"],
+    "next_steps": ["次回面接に向けた具体的な課題1", "課題2"]
+  }
 }
 
-※ summaryは最大5件で日本語の簡潔な文章。scoresは実際の会話内容に基づいて正直に採点してください（全て同じ値は避ける）。
+※ summaryは生徒が読むことを想定した励ましを含む文章。teacher以下は教員専用の詳細情報。scoresは実際の会話内容に基づいて正直に採点（全て同じ値は避ける）。
 
 Interview transcript:
 %s`, lang, transcript)
 
 	model := getEnv("INTERVIEW_REPORT_MODEL", "")
-	raw, err := s.openaiClient.ChatCompletionJSON(ctx, systemPrompt, userPrompt, 0.4, 1000, model)
+	raw, err := s.openaiClient.ChatCompletionJSON(ctx, systemPrompt, userPrompt, 0.4, 1500, model)
 	if err != nil {
 		return err
+	}
+	type teacherReport struct {
+		OverallComment      string            `json:"overall_comment"`
+		DetailedEvidence    map[string]string `json:"detailed_evidence"`
+		CoachingPoints      []string          `json:"coaching_points"`
+		StrengthsForTeacher []string          `json:"strengths_for_teacher"`
+		NextSteps           []string          `json:"next_steps"`
 	}
 	type reportPayload struct {
 		Summary  []string          `json:"summary"`
 		Scores   map[string]int    `json:"scores"`
 		Evidence map[string]string `json:"evidence"`
+		Teacher  *teacherReport    `json:"teacher"`
 	}
 	// markdown コードブロック除去（モデルによっては ```json ... ``` で包まれることがある）
 	cleaned := strings.TrimSpace(raw)
@@ -563,12 +589,17 @@ Interview transcript:
 	summaryText := strings.Join(payload.Summary, "\n")
 	scoresJSON, _ := json.Marshal(payload.Scores)
 	evidenceJSON, _ := json.Marshal(payload.Evidence)
+	teacherJSON := []byte("{}")
+	if payload.Teacher != nil {
+		teacherJSON, _ = json.Marshal(payload.Teacher)
+	}
 
 	report := &models.InterviewReport{
-		SessionID:    sessionID,
-		SummaryText:  summaryText,
-		ScoresJSON:   string(scoresJSON),
-		EvidenceJSON: string(evidenceJSON),
+		SessionID:         sessionID,
+		SummaryText:       summaryText,
+		ScoresJSON:        string(scoresJSON),
+		EvidenceJSON:      string(evidenceJSON),
+		TeacherReportJSON: string(teacherJSON),
 	}
 	return s.reportRepo.Upsert(report)
 }

--- a/frontend/app/interview/history/page.tsx
+++ b/frontend/app/interview/history/page.tsx
@@ -17,7 +17,7 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import PsychologyIcon from '@mui/icons-material/Psychology'
 import { authService, User } from '@/lib/auth'
-import { interviewApi, InterviewDetail, InterviewSession } from '@/lib/interview'
+import { interviewApi, InterviewDetail, InterviewSession, TeacherReport } from '@/lib/interview'
 
 const PRIMARY = '#ec5b13'
 
@@ -56,12 +56,14 @@ export default function InterviewHistoryPage() {
       .finally(() => setLoading(false))
   }, [user, page])
 
+  const isTeacher = user?.role === 'teacher'
+
   const handleSelectSession = async (session: InterviewSession) => {
     if (!user) return
     setDetailLoading(true)
     setSelectedDetail(null)
     try {
-      const detail = await interviewApi.getDetail(session.id, user.user_id)
+      const detail = await interviewApi.getDetail(session.id, user.user_id, user.role)
       setSelectedDetail(detail)
     } catch { /* ignore */ }
     finally { setDetailLoading(false) }
@@ -76,6 +78,9 @@ export default function InterviewHistoryPage() {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           <Box sx={{ color: PRIMARY }}><PsychologyIcon sx={{ fontSize: 32 }} /></Box>
           <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>面接履歴</Typography>
+          {user?.role === 'teacher' && (
+            <Chip label="教員モード" size="small" sx={{ bgcolor: '#3b82f6', color: '#fff', fontWeight: 700, ml: 1 }} />
+          )}
         </Box>
         <IconButton onClick={() => router.push('/interview')} sx={{ bgcolor: '#f1f5f9', color: '#475569' }}>
           <ArrowBackIcon />
@@ -191,6 +196,59 @@ export default function InterviewHistoryPage() {
                         </Stack>
                       </Paper>
                     ) : null
+                  })()}
+
+                  {/* 教員用レポートパネル */}
+                  {isTeacher && (() => {
+                    const tr: TeacherReport | null = parseJsonSafe(selectedDetail.report?.teacher_report_json)
+                    if (!tr) return null
+                    return (
+                      <Paper elevation={0} sx={{ p: 2.5, borderRadius: 2, border: '2px solid #3b82f6', bgcolor: '#eff6ff' }}>
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                          <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: '#3b82f6' }} />
+                          <Typography sx={{ fontWeight: 700, color: '#1d4ed8', fontSize: 14 }}>教員用詳細レポート</Typography>
+                        </Stack>
+                        {tr.overall_comment && (
+                          <Box sx={{ mb: 1.5 }}>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: '#1d4ed8', display: 'block', mb: 0.5 }}>総評</Typography>
+                            <Typography variant="body2" sx={{ color: '#1e3a8a', lineHeight: 1.7 }}>{tr.overall_comment}</Typography>
+                          </Box>
+                        )}
+                        {tr.coaching_points?.length > 0 && (
+                          <Box sx={{ mb: 1.5 }}>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: '#1d4ed8', display: 'block', mb: 0.5 }}>指導ポイント</Typography>
+                            <Stack spacing={0.5}>
+                              {tr.coaching_points.map((p, i) => (
+                                <Typography key={i} variant="body2" sx={{ color: '#1e3a8a', pl: 1 }}>・{p}</Typography>
+                              ))}
+                            </Stack>
+                          </Box>
+                        )}
+                        {tr.next_steps?.length > 0 && (
+                          <Box sx={{ mb: 1.5 }}>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: '#1d4ed8', display: 'block', mb: 0.5 }}>次回に向けた課題</Typography>
+                            <Stack spacing={0.5}>
+                              {tr.next_steps.map((s, i) => (
+                                <Typography key={i} variant="body2" sx={{ color: '#1e3a8a', pl: 1 }}>・{s}</Typography>
+                              ))}
+                            </Stack>
+                          </Box>
+                        )}
+                        {tr.detailed_evidence && Object.keys(tr.detailed_evidence).length > 0 && (
+                          <Box>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: '#1d4ed8', display: 'block', mb: 0.5 }}>評価根拠（詳細）</Typography>
+                            <Stack spacing={0.5}>
+                              {Object.entries(tr.detailed_evidence).map(([k, v]) => (
+                                <Box key={k}>
+                                  <Typography variant="caption" sx={{ fontWeight: 700, color: '#2563eb' }}>{k}: </Typography>
+                                  <Typography variant="caption" sx={{ color: '#1e3a8a' }}>{v}</Typography>
+                                </Box>
+                              ))}
+                            </Stack>
+                          </Box>
+                        )}
+                      </Paper>
+                    )
                   })()}
                 </>
               ) : (

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -24,6 +24,7 @@ export interface User {
   email: string
   name: string
   is_guest: boolean
+  role?: 'student' | 'teacher'
   target_level?: string
   school_name?: string
   is_admin?: boolean

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -42,11 +42,20 @@ export type InterviewUtterance = {
   created_at: string
 }
 
+export type TeacherReport = {
+  overall_comment: string
+  detailed_evidence: Record<string, string>
+  coaching_points: string[]
+  strengths_for_teacher: string[]
+  next_steps: string[]
+}
+
 export type InterviewReport = {
   session_id: number
   summary_text: string
   scores_json: string
   evidence_json: string
+  teacher_report_json?: string  // 教員のみ返却
   created_at: string
   updated_at: string
 }
@@ -97,8 +106,9 @@ export const interviewApi = {
     if (!res.ok) throw new Error(await res.text())
   },
 
-  async getDetail(sessionId: number, userId: number): Promise<InterviewDetail> {
-    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}?user_id=${userId}`)
+  async getDetail(sessionId: number, userId: number, role?: string): Promise<InterviewDetail> {
+    const roleParam = role ? `&role=${role}` : ''
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}?user_id=${userId}${roleParam}`)
     if (!res.ok) throw new Error(await res.text())
     return res.json()
   },


### PR DESCRIPTION
Closes #121

## 変更内容

### バックエンド

#### `Backend/internal/models/user.go`
- `Role` フィールドを追加（`size:20; default:'student'`）
- 値は `"student"` または `"teacher"`

#### `Backend/internal/models/interview_report.go`
- `TeacherReportJSON` フィールドを追加（教員専用の詳細情報を格納）

#### `Backend/internal/services/interview_service.go`
- `generateReport` のLLMプロンプトを拡張し、生徒用サマリーと教員用詳細情報（総評・指導ポイント・次回課題・詳細エビデンス）を1回のAPI呼び出しで同時生成
- `GetSessionDetailWithRole(userID, sessionID, role)` メソッドを新設
  - `role != "teacher"` の場合は `TeacherReportJSON` を空文字にして返却し、教員専用情報を非公開化
- 既存の `GetSessionDetail` は `GetSessionDetailWithRole` へのラッパーとして維持（後方互換性保持）

#### `Backend/internal/controllers/interview_controller.go`
- `GET /api/interviews/{id}` に `role` クエリパラメータを追加
  - 例: `?user_id=1&role=teacher`
- `role` パラメータを `GetSessionDetailWithRole` に渡すよう変更

### フロントエンド

#### `frontend/lib/auth.ts`
- `User` 型に `role?: 'student' | 'teacher'` フィールドを追加

#### `frontend/lib/interview.ts`
- `InterviewReport` 型に `teacher_report_json?: string` フィールドを追加
- `TeacherReport` 型を新設（`overall_comment`, `detailed_evidence`, `coaching_points`, `strengths_for_teacher`, `next_steps`）
- `getDetail(sessionId, userId, role?)` に `role` オプション引数を追加し、APIリクエストに `&role=xxx` を付与

#### `frontend/app/interview/history/page.tsx`
- ユーザーロールが `teacher` の場合、ヘッダーに「教員モード」バッジを表示
- セッション詳細取得時に `user.role` を `getDetail` に渡すよう変更
- 教員ロール時のみ表示される「教員用詳細レポートパネル」を追加
  - 総評、指導ポイント一覧、次回に向けた課題、評価根拠（詳細）を青色パネルで表示

## 動作フロー

1. ユーザーの `role` が `"teacher"` の場合、APIは `teacher_report_json` を含むレスポンスを返す
2. `role` が `"student"`（または未設定）の場合、`teacher_report_json` は空で返り、フロントエンドの教員パネルも非表示
3. レポート生成（`generateReport`）は1回のLLM呼び出しで生徒用・教員用の両データを同時出力するため、追加コストは最小限