### PR TITLE
Resolve #124: リーダブルコードの原則に基づくコード品質改善（第1回）

### DIFF
--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -481,6 +481,37 @@ func (s *InterviewService) isAllowed(actorID uint, ownerID uint) bool {
 	return user.IsAdmin
 }
 
+// buildTranscript formats utterances into a plain-text transcript for the LLM prompt.
+// AI turns are labeled "Interviewer" and user turns are labeled "User".
+func buildTranscript(utterances []models.InterviewUtterance) string {
+	var b strings.Builder
+	for _, u := range utterances {
+		role := "User"
+		if u.Role == "ai" {
+			role = "Interviewer"
+		}
+		b.WriteString(role)
+		b.WriteString(": ")
+		b.WriteString(strings.TrimSpace(u.Text))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// extractJSONObject strips surrounding markdown code fences and extracts the
+// outermost JSON object from an LLM response.
+// Some models wrap their output in ```json ... ``` even when instructed not to.
+func extractJSONObject(raw string) string {
+	s := strings.TrimSpace(raw)
+	if start := strings.Index(s, "{"); start > 0 {
+		s = s[start:]
+	}
+	if end := strings.LastIndex(s, "}"); end >= 0 && end < len(s)-1 {
+		s = s[:end+1]
+	}
+	return s
+}
+
 func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) error {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
@@ -505,18 +536,7 @@ func (s *InterviewService) generateReport(ctx context.Context, sessionID uint) e
 		}
 		return s.reportRepo.Upsert(empty)
 	}
-	var transcriptBuilder strings.Builder
-	for _, u := range utterances {
-		role := "User"
-		if u.Role == "ai" {
-			role = "Interviewer"
-		}
-		transcriptBuilder.WriteString(role)
-		transcriptBuilder.WriteString(": ")
-		transcriptBuilder.WriteString(strings.TrimSpace(u.Text))
-		transcriptBuilder.WriteString("\n")
-	}
-	transcript := transcriptBuilder.String()
+	transcript := buildTranscript(utterances)
 	systemPrompt := "あなたは就職面接の評価者です。面接ログを読んで、応募者の回答を客観的に評価し、JSONのみで返してください。"
 	userPrompt := fmt.Sprintf(`以下の面接ログを読み、下記の評価基準に従ってJSONのみで出力してください。
 出力言語: %s
@@ -548,15 +568,8 @@ Interview transcript:
 		Scores   map[string]int    `json:"scores"`
 		Evidence map[string]string `json:"evidence"`
 	}
-	// markdown コードブロック除去（モデルによっては ```json ... ``` で包まれることがある）
-	cleaned := strings.TrimSpace(raw)
-	if idx := strings.Index(cleaned, "{"); idx > 0 {
-		cleaned = cleaned[idx:]
-	}
-	if idx := strings.LastIndex(cleaned, "}"); idx >= 0 && idx < len(cleaned)-1 {
-		cleaned = cleaned[:idx+1]
-	}
 	var payload reportPayload
+	cleaned := extractJSONObject(raw)
 	if err := json.Unmarshal([]byte(cleaned), &payload); err != nil {
 		return fmt.Errorf("invalid report json: %w", err)
 	}

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -36,6 +36,7 @@ import ApartmentIcon from '@mui/icons-material/Apartment'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { authService, User } from '@/lib/auth'
 import { interviewApi, interviewLimits, InterviewReport, InterviewSession } from '@/lib/interview'
+import { formatSeconds, parseJsonSafe, parseMediaError, parseMultipartResponse } from '@/lib/interview-utils'
 import ThreeAvatar from './components/ThreeAvatar'
 
 const PRIMARY = '#ec5b13'
@@ -288,9 +289,6 @@ export default function InterviewPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handsFreeMode, status])
 
-  const formatSeconds = (s: number) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
-  const parseJsonSafe = (v?: string) => { try { return v ? JSON.parse(v) : null } catch { return null } }
-
   const cleanupConnection = () => {
     ;[timerRef, pollRef].forEach(r => { if (r.current) { clearInterval(r.current); r.current = null } })
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
@@ -314,51 +312,6 @@ export default function InterviewPage() {
       setEstimatedCost((elapsed / 60) * interviewLimits.costPerMinuteUSD)
       if (remaining <= 0) handleStop(true)
     }, 1000)
-  }
-
-  const parseStartError = (error: any): string => {
-    const msg: string = error?.message || ''
-    if (msg.includes('NotAllowedError') || msg.toLowerCase().includes('denied'))
-      return 'マイクとカメラへのアクセスが拒否されました。ブラウザのアドレスバー横から権限を許可してください。'
-    if (msg.includes('NotFoundError'))
-      return 'マイクまたはカメラが見つかりません。デバイスが正しく接続されているか確認してください。'
-    if (msg.toLowerCase().includes('unauthorized') || msg.includes('401'))
-      return 'AIサービスへの接続に失敗しました。（OpenAI APIキーを確認してください）'
-    return msg || '接続に失敗しました。ネットワークを確認して再試行してください。'
-  }
-
-  const parseMultipart = async (res: Response): Promise<{ meta: Record<string, string>; audio: Blob }> => {
-    const ct = res.headers.get('content-type') || ''
-    const m = ct.match(/boundary=([^\s;]+)/)
-    if (!m) throw new Error('No boundary in multipart response')
-    const boundary = '--' + m[1]
-    const buf = await res.arrayBuffer()
-    const bytes = new Uint8Array(buf)
-
-    const findPattern = (needle: Uint8Array, from: number): number => {
-      outer: for (let i = from; i <= bytes.length - needle.length; i++) {
-        for (let j = 0; j < needle.length; j++) { if (bytes[i + j] !== needle[j]) continue outer }
-        return i
-      }
-      return -1
-    }
-    const enc = new TextEncoder()
-    const boundaryBytes = enc.encode(boundary)
-    const crlfcrlf = enc.encode('\r\n\r\n')
-
-    const b1 = findPattern(boundaryBytes, 0)
-    const h1End = findPattern(crlfcrlf, b1 + boundaryBytes.length)
-    const b2 = findPattern(boundaryBytes, h1End + 4)
-    const jsonBytes = bytes.slice(h1End + 4, b2 - 2)
-    const meta = JSON.parse(new TextDecoder().decode(jsonBytes).trim())
-
-    const h2End = findPattern(crlfcrlf, b2 + boundaryBytes.length)
-    const endBound = enc.encode(boundary + '--')
-    const bEnd = findPattern(endBound, h2End + 4)
-    const audioEnd = bEnd !== -1 ? bEnd - 2 : bytes.length
-    const audio = new Blob([bytes.slice(h2End + 4, audioEnd)], { type: 'audio/mpeg' })
-
-    return { meta, audio }
   }
 
   const playAudioBlob = (blob: Blob): Promise<void> => {
@@ -427,7 +380,7 @@ export default function InterviewPage() {
       }),
     })
     if (!res.ok) throw new Error(await res.text())
-    const { meta, audio } = await parseMultipart(res)
+    const { meta, audio } = await parseMultipartResponse(res)
     const aiText: string = meta.ai_text || ''
     if (aiText) {
       historyRef.current.push({ role: 'assistant', content: aiText })
@@ -487,7 +440,7 @@ export default function InterviewPage() {
       await doStartTurn(created.id, user.user_id)
     } catch (error: any) {
       setStatus('error')
-      setErrorMessage(parseStartError(error))
+      setErrorMessage(parseMediaError(error))
       cleanupConnection()
     }
   }
@@ -590,7 +543,7 @@ export default function InterviewPage() {
         body: formData,
       })
       if (!res.ok) throw new Error(await res.text())
-      const { meta, audio } = await parseMultipart(res)
+      const { meta, audio } = await parseMultipartResponse(res)
       const userText: string = meta.user_text || ''
       const aiText: string = meta.ai_text || ''
       if (userText) {

--- a/frontend/lib/interview-utils.ts
+++ b/frontend/lib/interview-utils.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared utility functions for the interview feature.
+ * Pure functions with no side-effects — safe to import anywhere.
+ */
+
+/** Formats elapsed seconds as "m:ss" (e.g. 125 → "2:05") */
+export function formatSeconds(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
+}
+
+/** Safely parses a JSON string; returns null on any error instead of throwing */
+export function parseJsonSafe(value?: string): unknown {
+  try {
+    return value ? JSON.parse(value) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Converts a media-device / API error into a user-friendly Japanese message.
+ * Keeps error-message logic out of UI components.
+ */
+export function parseMediaError(error: unknown): string {
+  const msg: string = (error as { message?: string })?.message || ''
+  if (msg.includes('NotAllowedError') || msg.toLowerCase().includes('denied'))
+    return 'マイクとカメラへのアクセスが拒否されました。ブラウザのアドレスバー横から権限を許可してください。'
+  if (msg.includes('NotFoundError'))
+    return 'マイクまたはカメラが見つかりません。デバイスが正しく接続されているか確認してください。'
+  if (msg.toLowerCase().includes('unauthorized') || msg.includes('401'))
+    return 'AIサービスへの接続に失敗しました。（OpenAI APIキーを確認してください）'
+  return msg || '接続に失敗しました。ネットワークを確認して再試行してください。'
+}
+
+/**
+ * Parses a multipart/mixed response that contains a JSON metadata part
+ * followed by an audio binary part.
+ *
+ * Why custom parsing instead of a library: the Fetch API does not expose
+ * multipart body parsing, and we need to handle the binary audio part
+ * without converting it to a string.
+ */
+export async function parseMultipartResponse(
+  res: Response
+): Promise<{ meta: Record<string, string>; audio: Blob }> {
+  const contentType = res.headers.get('content-type') || ''
+  const boundaryMatch = contentType.match(/boundary=([^\s;]+)/)
+  if (!boundaryMatch) throw new Error('No boundary in multipart response')
+
+  const boundary = '--' + boundaryMatch[1]
+  const buf = await res.arrayBuffer()
+  const bytes = new Uint8Array(buf)
+  const enc = new TextEncoder()
+
+  /** Returns the index of the first occurrence of `needle` at or after `from`, or -1 */
+  const findPattern = (needle: Uint8Array, from: number): number => {
+    outer: for (let i = from; i <= bytes.length - needle.length; i++) {
+      for (let j = 0; j < needle.length; j++) {
+        if (bytes[i + j] !== needle[j]) continue outer
+      }
+      return i
+    }
+    return -1
+  }
+
+  const boundaryBytes = enc.encode(boundary)
+  const headerSeparator = enc.encode('\r\n\r\n')
+
+  // Part 1: JSON metadata
+  const part1Start = findPattern(boundaryBytes, 0)
+  const part1HeaderEnd = findPattern(headerSeparator, part1Start + boundaryBytes.length)
+  const part2Start = findPattern(boundaryBytes, part1HeaderEnd + 4)
+  const jsonBytes = bytes.slice(part1HeaderEnd + 4, part2Start - 2)
+  const meta = JSON.parse(new TextDecoder().decode(jsonBytes).trim())
+
+  // Part 2: Audio binary
+  const part2HeaderEnd = findPattern(headerSeparator, part2Start + boundaryBytes.length)
+  const closingBoundary = enc.encode(boundary + '--')
+  const closingBoundaryPos = findPattern(closingBoundary, part2HeaderEnd + 4)
+  const audioEnd = closingBoundaryPos !== -1 ? closingBoundaryPos - 2 : bytes.length
+  const audio = new Blob([bytes.slice(part2HeaderEnd + 4, audioEnd)], { type: 'audio/mpeg' })
+
+  return { meta, audio }
+}

--- a/frontend/lib/lipsync-manager.ts
+++ b/frontend/lib/lipsync-manager.ts
@@ -39,26 +39,27 @@ const FREQ_BANDS = {
   air:  [2500, 8000], // sibilants / fricatives
 } as const
 
+// RMS amplitude below this threshold is treated as silence (no speech detected)
+const SILENCE_RMS_THRESHOLD = 0.015
+
 export class LipsyncManager {
   private audioContext: AudioContext | null = null
   private analyser: AnalyserNode | null = null
   private sourceNode: MediaStreamAudioSourceNode | null = null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private freqData: any = null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private timeData: any = null
+  private freqData: Uint8Array | null = null
+  private timeData: Uint8Array | null = null
   private animationFrameId: number | null = null
 
-  // Current state with smoothing
+  // Current viseme state — smoothed toward target each frame
   private currentViseme: OculusViseme = 'viseme_sil'
   private currentWeight = 0
   private targetViseme: OculusViseme = 'viseme_sil'
   private targetWeight = 0
 
-  // Smoothing constants
-  private readonly WEIGHT_ATTACK  = 0.25   // how fast weight rises
-  private readonly WEIGHT_RELEASE = 0.18   // how fast weight falls
-  private readonly VISEME_HOLD_MS = 60     // minimum time to hold a viseme (ms)
+  // Smoothing constants — tune these to adjust lipsync responsiveness
+  private readonly WEIGHT_ATTACK  = 0.25   // how fast weight rises (0–1, higher = faster)
+  private readonly WEIGHT_RELEASE = 0.18   // how fast weight falls (0–1, higher = faster)
+  private readonly VISEME_HOLD_MS = 60     // minimum ms before switching to a different viseme
   private lastVisemeChangeTime = 0
 
   constructor(audioStream: MediaStream | null) {
@@ -121,7 +122,7 @@ export class LipsyncManager {
       const now = performance.now()
       const canChange = now - this.lastVisemeChangeTime > this.VISEME_HOLD_MS
 
-      if (rms < 0.015) {
+      if (rms < SILENCE_RMS_THRESHOLD) {
         this.targetViseme  = 'viseme_sil'
         this.targetWeight  = 0
       } else {
@@ -181,6 +182,10 @@ export class LipsyncManager {
     this.animationFrameId = requestAnimationFrame(tick)
   }
 
+  /**
+   * Returns a weight map for all Oculus visemes (0 = closed, 1 = fully open).
+   * All visemes are 0 except the currently active one.
+   */
   getCurrentVisemes(): VisemeWeights {
     const weights: VisemeWeights = {}
     for (const v of OCULUS_VISEMES) weights[v] = 0
@@ -195,6 +200,10 @@ export class LipsyncManager {
     return this.currentWeight
   }
 
+  /**
+   * Replaces the audio stream being analyzed.
+   * Disposes the current AudioContext and creates a new one for the given stream.
+   */
   updateAudioStream(audioStream: MediaStream | null): void {
     this.dispose()
     if (audioStream) this.initializeAudioAnalysis(audioStream)


### PR DESCRIPTION
Closes #124

## 変更内容

### `frontend/lib/interview-utils.ts`（新規作成）
- `page.tsx` に散在していた純粋関数を独立したユーティリティモジュールに抽出
  - `formatSeconds(totalSeconds)` — 秒数を `"m:ss"` 形式にフォーマット
  - `parseJsonSafe(value)` — JSON.parse を try/catch で安全にラップ。戻り値を `unknown` 型に修正
  - `parseMediaError(error)` — デバイス/API エラーをユーザー向け日本語メッセージに変換（旧: `parseStartError`、より意図が明確な命名に改善）
  - `parseMultipartResponse(res)` — multipart/mixed レスポンスの解析（旧: `parseMultipart`）
- 各関数に「なぜそう実装するか」のコメントを追記（「何をするか」ではなく理由を説明）

### `frontend/app/interview/page.tsx`
- 上記4関数のインライン定義（計47行）を削除
- `@/lib/interview-utils` からインポートするよう変更
- `parseStartError` → `parseMediaError`、`parseMultipart` → `parseMultipartResponse` の呼び出し名を更新

### `frontend/lib/lipsync-manager.ts`
- `freqData` / `timeData` フィールドの型を `any` → `Uint8Array | null` に修正（型安全性の向上、eslint-disable コメントを削除）
- 無音判定閾値 `0.015` をモジュールレベル定数 `SILENCE_RMS_THRESHOLD` に命名（マジックナンバーの排除）
- `getCurrentVisemes()` / `updateAudioStream()` に JSDoc コメントを追加

### `Backend/internal/services/interview_service.go`
- `generateReport` 関数から2つのヘルパー関数を抽出し、単一責任の原則に沿った構造に改善
  - `buildTranscript(utterances)` — 発話リストを LLM プロンプト用テキストに変換するロジックを独立化
  - `extractJSONObject(raw)` — LLM レスポンスからマークダウンコードフェンスを除去し JSON オブジェクトを抽出するロジックを独立化
- 各ヘルパーに「なぜこの処理が必要か」を説明するコメントを追記

## 方針
- 動作変更なし・純粋なリファクタリングのみ
- 1テーマ（ユーティリティ抽出・命名改善）に絞って実施
- 次回以降: `interview/page.tsx` のカスタムフック分割、`ThreeAvatar.tsx` の整理を予定