### PR TITLE
Resolve #105: エンジニア向けESリライト機能の実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -156,6 +156,7 @@ func main() {
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
 	githubController := controllers.NewGitHubController(githubService, skillScoreService)
+	esRewriteController := controllers.NewESRewriteController(aiClient)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
@@ -165,6 +166,7 @@ func main() {
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)
+	routes.SetupESRoutes(esRewriteController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
 
 	go crawlService.StartScheduler()

--- a/Backend/internal/controllers/es_rewrite_controller.go
+++ b/Backend/internal/controllers/es_rewrite_controller.go
@@ -1,0 +1,119 @@
+package controllers
+
+import (
+	"Backend/internal/openai"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type ESRewriteController struct {
+	openaiClient *openai.Client
+}
+
+func NewESRewriteController(openaiClient *openai.Client) *ESRewriteController {
+	return &ESRewriteController{openaiClient: openaiClient}
+}
+
+type esRewriteRequest struct {
+	OriginalText string `json:"original_text"`
+	QuestionType string `json:"question_type"` // "志望動機" | "自己PR" | "学チカ" | "その他"
+	TechStack    string `json:"tech_stack"`    // 任意: 使用技術スタック
+}
+
+type starBreakdown struct {
+	Situation string `json:"situation"`
+	Task      string `json:"task"`
+	Action    string `json:"action"`
+	Result    string `json:"result"`
+}
+
+type esRewriteResponse struct {
+	RewrittenText string        `json:"rewritten_text"`
+	Star          starBreakdown `json:"star"`
+}
+
+func (c *ESRewriteController) Rewrite(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req esRewriteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	req.OriginalText = strings.TrimSpace(req.OriginalText)
+	if req.OriginalText == "" {
+		http.Error(w, "original_text is required", http.StatusBadRequest)
+		return
+	}
+	if req.QuestionType == "" {
+		req.QuestionType = "その他"
+	}
+
+	systemPrompt := `あなたはエンジニア就職活動の専門アドバイザーです。
+学生が書いたES文章を、採用担当者に刺さるエンジニア向けの表現にリライトしてください。
+JSONのみで返してください。`
+
+	techInfo := ""
+	if req.TechStack != "" {
+		techInfo = "\n使用技術スタック（参考）: " + req.TechStack
+	}
+
+	userPrompt := `以下のES文章を、STAR法（Situation/Task/Action/Result）に沿ったエンジニア採用向けの表現にリライトしてください。
+
+【質問種別】` + req.QuestionType + `
+【元のES文章】
+` + req.OriginalText + techInfo + `
+
+## リライトのルール
+- 「頑張りました」「工夫しました」等の抽象表現を、具体的な技術・数値・成果に置き換える
+- STAR法: Situation（状況）/ Task（課題）/ Action（技術的施策）/ Result（成果・数値）の構造で記述する
+- エンジニア採用に刺さる技術的な動詞・名詞を使用する（実装した、設計した、最適化した、削減した等）
+- 元の内容を大きく変えず、言語化を強化する方向でリライトする
+- 文字数は元の文章の120〜150%程度を目安にする
+
+## 出力フォーマット（このキーと型を厳守）
+{
+  "rewritten_text": "リライト後の完成文章",
+  "star": {
+    "situation": "状況（背景・前提）の部分の説明",
+    "task": "課題・目標の部分の説明",
+    "action": "技術的な施策・行動の部分の説明",
+    "result": "成果・結果の部分の説明"
+  }
+}`
+
+	raw, err := c.openaiClient.ChatCompletionJSON(context.Background(), systemPrompt, userPrompt, 0.7, 1500)
+	if err != nil {
+		http.Error(w, "AI generation failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Extract JSON object in case of markdown fences
+	cleaned := extractESJSON(raw)
+
+	var resp esRewriteResponse
+	if err := json.Unmarshal([]byte(cleaned), &resp); err != nil {
+		http.Error(w, "Failed to parse AI response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// extractESJSON strips markdown code fences and extracts the outermost JSON object.
+func extractESJSON(raw string) string {
+	s := strings.TrimSpace(raw)
+	if start := strings.Index(s, "{"); start > 0 {
+		s = s[start:]
+	}
+	if end := strings.LastIndex(s, "}"); end >= 0 && end < len(s)-1 {
+		s = s[:end+1]
+	}
+	return s
+}

--- a/Backend/internal/routes/es_routes.go
+++ b/Backend/internal/routes/es_routes.go
@@ -1,0 +1,10 @@
+package routes
+
+import (
+	"Backend/internal/controllers"
+	"net/http"
+)
+
+func SetupESRoutes(esRewriteController *controllers.ESRewriteController) {
+	http.HandleFunc("/api/es/rewrite", esRewriteController.Rewrite)
+}

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -1,0 +1,290 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import CheckIcon from '@mui/icons-material/Check'
+import EditNoteIcon from '@mui/icons-material/EditNote'
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+const PRIMARY = '#ec5b13'
+
+const QUESTION_TYPES = ['志望動機', '自己PR', '学チカ', 'ガクチカ', 'その他']
+
+type StarBreakdown = {
+  situation: string
+  task: string
+  action: string
+  result: string
+}
+
+type RewriteResult = {
+  rewritten_text: string
+  star: StarBreakdown
+}
+
+const STAR_LABELS: { key: keyof StarBreakdown; label: string; color: string; emoji: string }[] = [
+  { key: 'situation', label: 'Situation（状況）', color: '#3b82f6', emoji: '📍' },
+  { key: 'task',      label: 'Task（課題）',      color: '#8b5cf6', emoji: '🎯' },
+  { key: 'action',    label: 'Action（施策）',    color: PRIMARY,   emoji: '⚡' },
+  { key: 'result',    label: 'Result（成果）',    color: '#10b981', emoji: '📊' },
+]
+
+export default function ESRewritePage() {
+  const router = useRouter()
+
+  const [originalText, setOriginalText] = useState('')
+  const [questionType, setQuestionType] = useState('学チカ')
+  const [techStack, setTechStack] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<RewriteResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const handleRewrite = async () => {
+    if (!originalText.trim()) return
+    setLoading(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/es/rewrite`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          original_text: originalText,
+          question_type: questionType,
+          tech_stack: techStack,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      const data: RewriteResult = await res.json()
+      setResult(data)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'リライトに失敗しました。再試行してください。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!result) return
+    await navigator.clipboard.writeText(result.rewritten_text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: '#f8f6f6' }}>
+      {/* Header */}
+      <Box
+        component="header"
+        sx={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          px: { xs: 3, lg: 8 }, py: 2,
+          bgcolor: '#fff', borderBottom: '1px solid #e2e8f0',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Box sx={{ color: PRIMARY }}><EditNoteIcon sx={{ fontSize: 32 }} /></Box>
+          <Box>
+            <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>ESリライト</Typography>
+            <Typography sx={{ fontSize: 12, color: '#64748b' }}>AIがあなたのES文章をエンジニア向けにリライトします</Typography>
+          </Box>
+        </Box>
+        <IconButton onClick={() => router.push('/')} sx={{ bgcolor: '#f1f5f9', color: '#475569' }}>
+          <ArrowBackIcon />
+        </IconButton>
+      </Box>
+
+      {/* Main */}
+      <Box sx={{ maxWidth: 1200, mx: 'auto', p: { xs: 2, md: 4 } }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', lg: result ? '1fr 1fr' : '1fr' },
+            gap: 3,
+            alignItems: 'start',
+          }}
+        >
+          {/* ── Left: Input ── */}
+          <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+            <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2.5 }}>元のES文章を入力</Typography>
+
+            {/* 質問種別 */}
+            <Box sx={{ mb: 2.5 }}>
+              <Typography sx={{ fontSize: 13, fontWeight: 600, color: '#475569', mb: 1 }}>質問種別</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {QUESTION_TYPES.map(type => (
+                  <Chip
+                    key={type}
+                    label={type}
+                    onClick={() => setQuestionType(type)}
+                    sx={{
+                      cursor: 'pointer',
+                      fontWeight: 600,
+                      bgcolor: questionType === type ? PRIMARY : '#f1f5f9',
+                      color: questionType === type ? '#fff' : '#475569',
+                      '&:hover': { bgcolor: questionType === type ? `${PRIMARY}e0` : '#e2e8f0' },
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+
+            {/* ES本文 */}
+            <TextField
+              multiline
+              rows={10}
+              fullWidth
+              value={originalText}
+              onChange={e => setOriginalText(e.target.value)}
+              placeholder={`例）チームで開発した経験があります。最初は上手くいきませんでしたが、話し合いを重ねて最終的には完成させることができました。この経験から協調性の大切さを学びました。`}
+              sx={{
+                mb: 2.5,
+                '& .MuiOutlinedInput-root': {
+                  fontSize: 14, lineHeight: 1.8,
+                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                },
+              }}
+            />
+
+            {/* 技術スタック（任意） */}
+            <TextField
+              fullWidth
+              size="small"
+              value={techStack}
+              onChange={e => setTechStack(e.target.value)}
+              label="使用技術スタック（任意）"
+              placeholder="例: React, Node.js, PostgreSQL, Docker"
+              sx={{
+                mb: 3,
+                '& .MuiOutlinedInput-root': {
+                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                },
+                '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
+              }}
+            />
+
+            <Button
+              variant="contained"
+              fullWidth
+              size="large"
+              disabled={!originalText.trim() || loading}
+              onClick={handleRewrite}
+              startIcon={loading ? <CircularProgress size={18} sx={{ color: '#fff' }} /> : <AutoFixHighIcon />}
+              sx={{
+                bgcolor: PRIMARY, '&:hover': { bgcolor: `${PRIMARY}e0` },
+                borderRadius: 2, py: 1.5, fontWeight: 700, fontSize: 16,
+                textTransform: 'none',
+                '&:disabled': { bgcolor: '#e2e8f0', color: '#94a3b8' },
+              }}
+            >
+              {loading ? 'リライト中...' : 'AIでリライトする'}
+            </Button>
+
+            {error && (
+              <Alert severity="error" sx={{ mt: 2, borderRadius: 2 }}>{error}</Alert>
+            )}
+          </Paper>
+
+          {/* ── Right: Result ── */}
+          {result && (
+            <Stack spacing={2}>
+              {/* Rewritten text */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: `2px solid ${PRIMARY}`, bgcolor: `${PRIMARY}04` }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <AutoFixHighIcon sx={{ color: PRIMARY, fontSize: 20 }} />
+                    <Typography sx={{ fontWeight: 700, fontSize: 17, color: PRIMARY }}>リライト後</Typography>
+                  </Box>
+                  <Tooltip title={copied ? 'コピーしました' : 'クリップボードにコピー'}>
+                    <IconButton
+                      size="small"
+                      onClick={handleCopy}
+                      sx={{ bgcolor: copied ? '#10b981' : '#f1f5f9', '&:hover': { bgcolor: copied ? '#059669' : '#e2e8f0' } }}
+                    >
+                      {copied
+                        ? <CheckIcon sx={{ color: '#fff', fontSize: 18 }} />
+                        : <ContentCopyIcon sx={{ color: '#475569', fontSize: 18 }} />
+                      }
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+                <Typography
+                  sx={{ fontSize: 14, lineHeight: 1.9, color: '#1e293b', whiteSpace: 'pre-wrap' }}
+                >
+                  {result.rewritten_text}
+                </Typography>
+              </Paper>
+
+              {/* STAR breakdown */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 16, mb: 2 }}>STAR法 分解</Typography>
+                <Stack spacing={2}>
+                  {STAR_LABELS.map(({ key, label, color, emoji }, idx) => (
+                    <Box key={key}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.8 }}>
+                        <Box
+                          sx={{
+                            width: 28, height: 28, borderRadius: 1.5,
+                            bgcolor: `${color}15`,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            fontSize: 14,
+                          }}
+                        >
+                          {emoji}
+                        </Box>
+                        <Typography sx={{ fontWeight: 700, fontSize: 13, color }}>
+                          {label}
+                        </Typography>
+                      </Box>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: '#475569', lineHeight: 1.75,
+                          borderLeft: `3px solid ${color}40`, pl: 1.5,
+                        }}
+                      >
+                        {result.star[key] || '—'}
+                      </Typography>
+                      {idx < STAR_LABELS.length - 1 && (
+                        <Divider sx={{ mt: 1.5, borderColor: '#f1f5f9' }} />
+                      )}
+                    </Box>
+                  ))}
+                </Stack>
+              </Paper>
+
+              {/* Compare hint */}
+              <Paper elevation={0} sx={{ p: 2, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 13, mb: 1, color: '#64748b' }}>元の文章</Typography>
+                <Typography variant="body2" sx={{ color: '#94a3b8', lineHeight: 1.8, whiteSpace: 'pre-wrap' }}>
+                  {originalText}
+                </Typography>
+              </Paper>
+            </Stack>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
Closes #105

## 変更内容

### バックエンド

- **`ESRewriteController` の新規作成** (`Backend/internal/controllers/es_rewrite_controller.go`):
  - `POST /api/es/rewrite` エンドポイントを実装
  - リクエスト: `original_text`（元ES文章）・`question_type`（志望動機/自己PR/学チカ等）・`tech_stack`（技術スタック、任意）
  - OpenAI に STAR法プロンプト（Situation/Task/Action/Result）を送り、「頑張りました」等の抽象表現を具体的な技術・数値・成果表現にリライト
  - レスポンス: `rewritten_text`（完成文章）+ `star`（S/T/A/R 各要素の分解説明）
  - マークダウンコードフェンスを除去する `extractESJSON` ヘルパー関数を実装

- **`SetupESRoutes` の追加** (`Backend/internal/routes/es_routes.go`):
  - `/api/es/rewrite` ルートを登録する新規ルートファイルを作成

- **`main.go` の更新** (`Backend/cmd/server/main.go`):
  - `ESRewriteController` を初期化し `SetupESRoutes` を呼び出してルーティングを登録

### フロントエンド

- **`/es-rewrite` ページの新規作成** (`frontend/app/es-rewrite/page.tsx`):
  - **入力パネル**: 質問種別チップ選択（志望動機/自己PR/学チカ/ガクチカ/その他）・ES本文テキストエリア（10行）・技術スタック入力フィールド（任意）・リライトボタン
  - **結果パネル（生成後に表示）**:
    - リライト後の文章をオレンジボーダーカードで強調表示
    - クリップボードへのコピーボタン（コピー完了時にチェックアイコンに切り替わる）
    - STAR法分解パネル: S/T/A/R 各要素を色分けアイコン付きで表示
    - 元文章との比較パネルを下部に表示
  - 生成完了前後で 1カラム → 2カラム レイアウトに自動切り替え
  - ローディング中スピナー表示・エラーアラート対応