### PR TITLE
Resolve #101: ポートフォリオAI要約機能の実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -104,7 +104,7 @@ func main() {
 	emailService := services.NewEmailService()
 	authService := services.NewAuthService(userRepo, pendingRegistrationRepo, emailService)
 	skillScoreService := services.NewSkillScoreService(skillScoreRepo)
-	githubService := services.NewGitHubService(githubRepo, skillScoreService)
+	githubService := services.NewGitHubService(githubRepo, skillScoreService, aiClient)
 	oauthService := services.NewOAuthService(userRepo, oauthConfig, githubService)
 	chatService := services.NewChatService(aiClient, questionWeightRepo, chatMessageRepo, userWeightScoreRepo, aiGeneratedQuestionRepo, predefinedQuestionRepo, jobCategoryRepo, userRepo, userEmbeddingRepo, jobEmbeddingRepo, phaseRepo, progressRepo, sessionValidationRepo, conversationContextRepo)
 	questionService := services.NewQuestionGeneratorService(aiClient, questionWeightRepo)

--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -145,6 +145,64 @@ func (c *GitHubController) GetSkills(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(scores)
 }
 
+// ListRepoSummaries ユーザーのリポジトリAI要約一覧を取得する
+// GET /api/github/repo/summaries?user_id=<id>
+func (c *GitHubController) ListRepoSummaries(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, err := parseUserID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	summaries, err := c.githubService.ListRepoSummaries(userID)
+	if err != nil {
+		http.Error(w, "failed to get repo summaries", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(summaries)
+}
+
+// SummarizeRepo リポジトリのAI要約を生成・キャッシュする
+// POST /api/github/repo/summarize?user_id=<id>
+// Body: { "full_name": "owner/repo", "force_refresh": false }
+func (c *GitHubController) SummarizeRepo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, err := parseUserID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		FullName     string `json:"full_name"`
+		ForceRefresh bool   `json:"force_refresh"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.FullName == "" {
+		http.Error(w, "full_name is required", http.StatusBadRequest)
+		return
+	}
+
+	summary, err := c.githubService.SummarizeRepo(r.Context(), userID, body.FullName, body.ForceRefresh)
+	if err != nil {
+		http.Error(w, "summarize failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(summary)
+}
+
 func parseUserID(r *http.Request) (uint, error) {
 	userIDStr := r.URL.Query().Get("user_id")
 	if userIDStr == "" {

--- a/Backend/internal/routes/github_routes.go
+++ b/Backend/internal/routes/github_routes.go
@@ -11,4 +11,6 @@ func SetupGitHubRoutes(githubController *controllers.GitHubController) {
 	http.HandleFunc("/api/github/sync", githubController.Sync)
 	http.HandleFunc("/api/github/sync/wait", githubController.SyncAndWait)
 	http.HandleFunc("/api/github/skills", githubController.GetSkills)
+	http.HandleFunc("/api/github/repo/summaries", githubController.ListRepoSummaries)
+	http.HandleFunc("/api/github/repo/summarize", githubController.SummarizeRepo)
 }

--- a/Backend/internal/services/github_service.go
+++ b/Backend/internal/services/github_service.go
@@ -2,15 +2,18 @@ package services
 
 import (
 	"Backend/internal/models"
+	"Backend/internal/openai"
 	"Backend/internal/repositories"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -25,14 +28,16 @@ const (
 
 // GitHubService GitHub API連携サービス
 type GitHubService struct {
-	githubRepo      *repositories.GitHubRepository
+	githubRepo        *repositories.GitHubRepository
 	skillScoreService *SkillScoreService
+	openaiClient      *openai.Client
 }
 
-func NewGitHubService(githubRepo *repositories.GitHubRepository, skillScoreService *SkillScoreService) *GitHubService {
+func NewGitHubService(githubRepo *repositories.GitHubRepository, skillScoreService *SkillScoreService, openaiClient *openai.Client) *GitHubService {
 	return &GitHubService{
-		githubRepo:      githubRepo,
+		githubRepo:        githubRepo,
 		skillScoreService: skillScoreService,
+		openaiClient:      openaiClient,
 	}
 }
 
@@ -141,6 +146,149 @@ func (s *GitHubService) GetRepositories(userID uint) ([]models.GitHubRepo, error
 // GetLanguageStats DBから言語使用比率を取得する
 func (s *GitHubService) GetLanguageStats(userID uint) ([]models.GitHubLanguageStat, error) {
 	return s.githubRepo.GetLanguageStats(userID)
+}
+
+// ListRepoSummaries DBからAI要約一覧を取得する
+func (s *GitHubService) ListRepoSummaries(userID uint) ([]models.GitHubRepoSummary, error) {
+	return s.githubRepo.ListRepoSummaries(userID)
+}
+
+// SummarizeRepo リポジトリのREADMEをAIが解析し、技術的強みを要約する。
+// キャッシュがあれば再生成しない。forceRefresh=trueで強制再生成。
+func (s *GitHubService) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error) {
+	// キャッシュ確認
+	if !forceRefresh {
+		cached, err := s.githubRepo.GetRepoSummary(userID, fullName)
+		if err != nil {
+			return nil, err
+		}
+		if cached != nil {
+			return cached, nil
+		}
+	}
+
+	profile, err := s.githubRepo.GetProfile(userID)
+	if err != nil || profile == nil {
+		return nil, fmt.Errorf("github profile not found")
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// README取得
+	readme, err := s.fetchREADME(ctx, client, profile.AccessToken, fullName)
+	if err != nil {
+		log.Printf("[SummarizeRepo] README fetch warning for %s: %v", fullName, err)
+		readme = ""
+	}
+
+	// AI要約生成
+	summary, err := s.generateRepoSummary(ctx, fullName, readme)
+	if err != nil {
+		return nil, fmt.Errorf("AI summary generation failed: %w", err)
+	}
+
+	summary.UserID = userID
+	// DBに保存
+	if err := s.githubRepo.UpsertRepoSummary(summary); err != nil {
+		return nil, fmt.Errorf("save summary: %w", err)
+	}
+	return summary, nil
+}
+
+// fetchREADME GitHub API経由でリポジトリのREADMEを取得する
+func (s *GitHubService) fetchREADME(ctx context.Context, client *http.Client, token, fullName string) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/readme", githubAPIBase, fullName)
+	body, err := s.doGet(ctx, client, token, url)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", err
+	}
+	if resp.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(resp.Content, "\n", ""))
+		if err != nil {
+			return "", err
+		}
+		text := string(decoded)
+		// 長すぎる場合は先頭4000文字に絞る
+		if len(text) > 4000 {
+			text = text[:4000]
+		}
+		return text, nil
+	}
+	return resp.Content, nil
+}
+
+// generateRepoSummary OpenAIを使ってリポジトリの技術的強みを要約する
+func (s *GitHubService) generateRepoSummary(ctx context.Context, fullName, readme string) (*models.GitHubRepoSummary, error) {
+	if s.openaiClient == nil {
+		return nil, fmt.Errorf("openai client not configured")
+	}
+
+	readmeSection := "（READMEなし）"
+	if readme != "" {
+		readmeSection = readme
+	}
+
+	systemPrompt := `あなたはエンジニア採用のキャリアアドバイザーです。
+GitHubリポジトリのREADMEを読み、技術的な強みを簡潔にまとめてください。JSONのみで返してください。`
+
+	userPrompt := fmt.Sprintf(`以下のGitHubリポジトリ「%s」のREADMEを読み、エンジニア採用担当者に伝わる技術的強みを3点でまとめてください。
+
+## README
+%s
+
+## 出力フォーマット（このキーと型を厳守）
+{
+  "summary_text": "技術的な強みの3行要約（全体を1段落で簡潔に）",
+  "tech_reason": "技術選定の理由（なぜその技術・言語・フレームワークを選んだか）",
+  "challenge": "解決した課題（どんな問題に取り組み、どう解決したか）",
+  "achievement": "成果（数値・具体的な改善・学んだこと）"
+}
+
+※ 情報が不足している場合はREADMEから推測して記述してください。各フィールドは1〜2文で簡潔に。`, fullName, readmeSection)
+
+	raw, err := s.openaiClient.ChatCompletionJSON(ctx, systemPrompt, userPrompt, 0.5, 800)
+	if err != nil {
+		return nil, err
+	}
+
+	cleaned := extractRepoSummaryJSON(raw)
+	var payload struct {
+		SummaryText string `json:"summary_text"`
+		TechReason  string `json:"tech_reason"`
+		Challenge   string `json:"challenge"`
+		Achievement string `json:"achievement"`
+	}
+	if err := json.Unmarshal([]byte(cleaned), &payload); err != nil {
+		return nil, fmt.Errorf("parse summary json: %w", err)
+	}
+
+	// FullName からユーザーIDは呼び出し元で設定するため0を仮置き
+	return &models.GitHubRepoSummary{
+		FullName:    fullName,
+		SummaryText: payload.SummaryText,
+		TechReason:  payload.TechReason,
+		Challenge:   payload.Challenge,
+		Achievement: payload.Achievement,
+	}, nil
+}
+
+// extractRepoSummaryJSON マークダウンコードフェンスを除去してJSONを抽出する
+func extractRepoSummaryJSON(raw string) string {
+	s := strings.TrimSpace(raw)
+	if start := strings.Index(s, "{"); start > 0 {
+		s = s[start:]
+	}
+	if end := strings.LastIndex(s, "}"); end >= 0 && end < len(s)-1 {
+		s = s[:end+1]
+	}
+	return s
 }
 
 // --- 内部ヘルパー ---

--- a/frontend/components/github-skills.tsx
+++ b/frontend/components/github-skills.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Box, Typography, Chip, CircularProgress, Paper, Alert, Button } from '@mui/material'
+import { Box, Typography, Chip, CircularProgress, Paper, Alert, Button, Divider, Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
 
@@ -24,6 +26,15 @@ interface GitHubProfile {
   TotalContributions: number
   PublicRepos: number
   Followers: number
+}
+
+interface RepoSummary {
+  ID: number
+  FullName: string
+  SummaryText: string
+  TechReason: string
+  Challenge: string
+  Achievement: string
 }
 
 // カテゴリ別の表示色
@@ -171,11 +182,13 @@ export default function GitHubSkills({ userId }: { userId: number }) {
   const [scores, setScores] = useState<SkillScore[]>([])
   const [profile, setProfile] = useState<GitHubProfile | null>(null)
   const [langStats, setLangStats] = useState<LanguageStat[]>([])
+  const [summaries, setSummaries] = useState<RepoSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
   const [notLinked, setNotLinked] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
+  const [summarizingRepo, setSummarizingRepo] = useState<string | null>(null)
 
   useEffect(() => {
     fetchAll()
@@ -186,9 +199,10 @@ export default function GitHubSkills({ userId }: { userId: number }) {
     setError(null)
     setNotLinked(false)
     try {
-      const [skillsRes, profileRes] = await Promise.all([
+      const [skillsRes, profileRes, summariesRes] = await Promise.all([
         fetch(`${BACKEND_URL}/api/github/skills?user_id=${userId}`),
         fetch(`${BACKEND_URL}/api/github/profile?user_id=${userId}`),
+        fetch(`${BACKEND_URL}/api/github/repo/summaries?user_id=${userId}`),
       ])
 
       if (skillsRes.ok) {
@@ -207,10 +221,36 @@ export default function GitHubSkills({ userId }: { userId: number }) {
       } else if (profileRes.status === 404) {
         setNotLinked(true)
       }
+
+      if (summariesRes.ok) {
+        const data = await summariesRes.json()
+        setSummaries(Array.isArray(data) ? data : [])
+      }
     } catch {
       setError('データの取得に失敗しました')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleSummarizeRepo = async (fullName: string) => {
+    setSummarizingRepo(fullName)
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/github/repo/summarize?user_id=${userId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ full_name: fullName }),
+      })
+      if (!res.ok) throw new Error()
+      const newSummary: RepoSummary = await res.json()
+      setSummaries(prev => {
+        const filtered = prev.filter(s => s.FullName !== fullName)
+        return [newSummary, ...filtered]
+      })
+    } catch {
+      setError(`${fullName} の要約生成に失敗しました`)
+    } finally {
+      setSummarizingRepo(null)
     }
   }
 
@@ -389,6 +429,77 @@ export default function GitHubSkills({ userId }: { userId: number }) {
         <Typography variant="body2" sx={{ color: '#64748b', textAlign: 'center', py: 2 }}>
           スキルデータがありません。「同期」ボタンでGitHubデータを取得してください。
         </Typography>
+      )}
+
+      {/* リポジトリAI要約セクション */}
+      {summaries.length > 0 && (
+        <>
+          <Divider sx={{ borderColor: '#1e293b', my: 3 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+            <AutoAwesomeIcon sx={{ color: '#818cf8', fontSize: 18 }} />
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: '#f1f5f9' }}>
+              リポジトリAI要約
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {summaries.map(s => (
+              <Accordion
+                key={s.ID}
+                sx={{ bgcolor: '#1e293b', color: '#e2e8f0', borderRadius: 1, '&:before': { display: 'none' } }}
+                disableGutters
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: '#64748b' }} />}>
+                  <Typography variant="body2" sx={{ fontWeight: 600, color: '#94a3b8' }}>
+                    {s.FullName}
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails sx={{ pt: 0 }}>
+                  <Typography variant="body2" sx={{ color: '#cbd5e1', mb: 1.5 }}>{s.SummaryText}</Typography>
+                  {[
+                    { label: '技術選定の理由', value: s.TechReason, color: '#4FC3F7' },
+                    { label: '解決した課題', value: s.Challenge, color: '#81C784' },
+                    { label: '成果', value: s.Achievement, color: '#FFB74D' },
+                  ].map(item => (
+                    <Box key={item.label} sx={{ mb: 1 }}>
+                      <Typography variant="caption" sx={{ color: item.color, fontWeight: 700 }}>
+                        {item.label}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: '#94a3b8' }}>{item.value}</Typography>
+                    </Box>
+                  ))}
+                  <Button
+                    size="small"
+                    startIcon={summarizingRepo === s.FullName ? <CircularProgress size={12} /> : <AutoAwesomeIcon />}
+                    onClick={() => handleSummarizeRepo(s.FullName)}
+                    disabled={summarizingRepo !== null}
+                    sx={{ mt: 1, color: '#818cf8', fontSize: '0.7rem' }}
+                  >
+                    再生成
+                  </Button>
+                </AccordionDetails>
+              </Accordion>
+            ))}
+          </Box>
+        </>
+      )}
+
+      {/* リポジトリ要約生成ボタン（未生成時） */}
+      {profile && summaries.length === 0 && !loading && (
+        <>
+          <Divider sx={{ borderColor: '#1e293b', my: 3 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <AutoAwesomeIcon sx={{ color: '#818cf8', fontSize: 18 }} />
+            <Typography variant="subtitle2" sx={{ color: '#94a3b8' }}>
+              リポジトリAI要約
+            </Typography>
+          </Box>
+          <Typography variant="body2" sx={{ color: '#64748b', mb: 2 }}>
+            リポジトリのREADMEをAIが解析し、技術的強みを要約します。
+          </Typography>
+          <Typography variant="caption" sx={{ color: '#475569' }}>
+            個別リポジトリから要約を生成するには、プロフィールページのリポジトリ一覧から選択してください。
+          </Typography>
+        </>
       )}
     </Paper>
   )


### PR DESCRIPTION
Closes #101

## 変更内容

### バックエンド
- `GitHubService.NewGitHubService` に `openaiClient` を追加し、`main.go` の呼び出し箇所を修正
- `SummarizeRepo` の UserID 未設定バグを修正（`summary.UserID = userID` をUpsert前に設定）
- `GitHubController` に2つのハンドラを追加:
  - `GET /api/github/repo/summaries` — ユーザーのAI要約一覧取得
  - `POST /api/github/repo/summarize` — 指定リポジトリのAI要約生成（DBキャッシュ付き、`force_refresh` オプション対応）
- `github_routes.go` に上記2エンドポイントを登録

### フロントエンド (`github-skills.tsx`)
- 初期ロード時に `/api/github/repo/summaries` から要約一覧を取得
- 要約があればアコーディオン形式で表示（summary_text / tech_reason / challenge / achievement）
- 各要約カードに「再生成」ボタンを配置（`force_refresh=false` で呼び出し）
- 要約がない場合は説明テキストを表示