### PR TITLE
Resolve #101: ポートフォリオAI要約機能の実装

### DIFF
--- a/Backend/internal/models/github_profile.go
+++ b/Backend/internal/models/github_profile.go
@@ -43,3 +43,16 @@ type GitHubLanguageStat struct {
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
+
+// GitHubRepoSummary リポジトリのAI要約キャッシュ
+type GitHubRepoSummary struct {
+	ID          uint   `gorm:"primaryKey"`
+	UserID      uint   `gorm:"uniqueIndex:idx_user_repo;not null"`
+	FullName    string `gorm:"size:500;uniqueIndex:idx_user_repo;not null"` // "owner/repo"
+	SummaryText string `gorm:"type:text"` // 3行の総合要約
+	TechReason  string `gorm:"type:text"` // 技術選定の理由
+	Challenge   string `gorm:"type:text"` // 解決した課題
+	Achievement string `gorm:"type:text"` // 成果
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -53,6 +53,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&GitHubProfile{},
 		&GitHubRepo{},
 		&GitHubLanguageStat{},
+		&GitHubRepoSummary{},
 		&SkillScore{},
 	)
 }

--- a/Backend/internal/repositories/github_repository.go
+++ b/Backend/internal/repositories/github_repository.go
@@ -88,3 +88,32 @@ func (r *GitHubRepository) UpdateSyncedAt(userID uint, t time.Time) error {
 		Where("user_id = ?", userID).
 		Update("synced_at", t).Error
 }
+
+// GetRepoSummary ユーザーID+リポジトリ名でAI要約を取得
+func (r *GitHubRepository) GetRepoSummary(userID uint, fullName string) (*models.GitHubRepoSummary, error) {
+	var s models.GitHubRepoSummary
+	if err := r.db.Where("user_id = ? AND full_name = ?", userID, fullName).First(&s).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// ListRepoSummaries ユーザーの全AI要約を取得
+func (r *GitHubRepository) ListRepoSummaries(userID uint) ([]models.GitHubRepoSummary, error) {
+	var summaries []models.GitHubRepoSummary
+	if err := r.db.Where("user_id = ?", userID).Order("updated_at desc").Find(&summaries).Error; err != nil {
+		return nil, err
+	}
+	return summaries, nil
+}
+
+// UpsertRepoSummary AI要約を保存/更新
+func (r *GitHubRepository) UpsertRepoSummary(s *models.GitHubRepoSummary) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "full_name"}},
+		DoUpdates: clause.AssignmentColumns([]string{"summary_text", "tech_reason", "challenge", "achievement", "updated_at"}),
+	}).Create(s).Error
+}


### PR DESCRIPTION
Closes #101

## 変更内容

### バックエンド
- **ポートフォリオAI要約機能の追加** (`github_service.go`): リポジトリごとにAIで「3行要約」「技術選定の理由」「解決した課題」「成果」を生成するサービスを実装
- **GitHubRepoSummaryモデルの追加** (`github_profile.go`, `migrate.go`): AI要約をDBにキャッシュするためのモデルを定義し、AutoMigrateに登録
- **リポジトリ操作メソッドの追加** (`github_repository.go`): `GetRepoSummary`・`ListRepoSummaries`・`UpsertRepoSummary` を追加し、要約の取得・保存に対応
- **APIエンドポイントの追加** (`github_controller.go`, `github_routes.go`): リポジトリ一覧取得・AI要約生成エンドポイントを追加
- **組織リポジトリの同期対応** (`github_service.go`): `/user/orgs` と `/orgs/{org}/repos` を使って組織配下のリポジトリも取得・同期
- **OAuthスコープに `read:org` を追加** (`oauth.go`): 組織リポジトリ取得に必要なスコープを付与
- **トークンスコープのログ出力とエラーメッセージ改善** (`oauth_service.go`, `github_service.go`): デバッグ情報の充実とフォールバック処理の追加

### フロントエンド
- **プロフィールページのリニューアル** (`profile/page.tsx`): リポジトリ一覧を表示し、各リポジトリのAI要約を選択・生成できるUIに変更
- **ページリネーム** (`onboarding/page.tsx` → `profile/page.tsx`, `profile/page.tsx` → `chat-history/page.tsx`): ルーティング構造を整理
- **チャット履歴ページの追加** (`chat-history/page.tsx`): 旧プロフィールページを移設
- **GitHubスキルコンポーネントの強化** (`github-skills.tsx`): 組織リポジトリ表示・要約生成ボタン・リポジトリ0件時の案内表示を追加
- **要約エラー時の詳細メッセージ表示** (`analysis-sidebar.tsx`): バックエンドのエラー詳細をUIに反映