### PR TITLE
Resolve #135: RAGサービスの依存バージョン固定問題の解消

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # RAG サービスの Python 依存を週次で自動更新
+  - package-ecosystem: pip
+    directory: /rag
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    # メジャーバージョンアップは手動で判断するため対象外
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions のバージョンを週次で自動更新
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/rag/constraints.txt
+++ b/rag/constraints.txt
@@ -1,12 +1,51 @@
-embedchain==0.1.114
-langchain==0.2.17
-langchain-community==0.2.19
-langchain-core==0.2.43
-langchain-openai==0.1.25
-langchain-text-splitters==0.2.4
-chromadb==0.4.24
+# ============================================================
+# RAG サービス 依存バージョン制約ファイル
+#
+# このファイルは `pip install -r requirements.txt -c constraints.txt` で使用される。
+# 直接依存・推移的依存のバージョン上限/下限を制御し、
+# 破壊的変更やセキュリティ問題を防ぐための制約を記述する。
+#
+# 更新履歴:
+#   - 2024: 初期固定 (LangChain 0.2.x, chromadb 0.4.x)
+#   - 2026-03: langchain 0.3.x へ更新、chromadb 0.5.x へ更新 (#135)
+# ============================================================
+
+# --- LangChain エコシステム ---
+# crewai の推移的依存。crewai 0.60+ は langchain 0.3.x をサポート済み。
+# 0.4.x 以降は API 破壊的変更の可能性があるため上限を設定。
+langchain>=0.3.0,<0.4
+langchain-community>=0.3.0,<0.4
+langchain-core>=0.3.0,<0.4
+# langchain-openai 0.2.x が langchain 0.3.x に対応するバージョン系列
+langchain-openai>=0.2.0,<0.3
+langchain-text-splitters>=0.3.0,<0.4
+
+# --- ベクトルストア ---
+# main.py で PersistentClient / get_or_create_collection / upsert / query を直接利用。
+# これらの API は 0.5.x でも互換性あり。
+# chromadb 0.4.x には修正済みの潜在的脆弱性が含まれる可能性があるため 0.5.x 以降に移行。
+# 1.0 以降は破壊的変更のリスクがあるため上限を設定。
+chromadb>=0.5.0,<1.0
+
+# --- 数値計算 ---
+# numpy 2.0 以降で chromadb および一部パッケージとの互換性問題が報告されているため上限を維持。
 numpy<2.0
-litellm==1.44.22
-openai==1.66.0
-tiktoken==0.7.0
-httpx==0.27.2
+
+# --- LLM プロキシ ---
+# litellm は crewai の推移的依存。メジャーバージョン固定で API 互換性を保証。
+litellm>=1.44.22,<2.0
+
+# --- OpenAI SDK ---
+# Dockerfile 内の検証スクリプトが client.responses API の存在を確認しており、
+# この API は openai>=1.66.0 で利用可能。メジャーバージョン変更時は要検証。
+openai>=1.66.0,<2.0
+
+# --- トークナイザー ---
+# tiktoken: OpenAI エンコーダーとのバイト互換を保つため 0.7.x に固定。
+# 0.8.x 以降はエンコーディング変更の可能性あり、アップグレード時は動作確認が必要。
+tiktoken>=0.7.0,<0.8
+
+# --- HTTP クライアント ---
+# httpx 0.28.x 以降で openai SDK との互換性問題が生じた実績があるため 0.27.x に固定。
+# openai SDK 側で httpx>=0.28 対応が確認されたら上限を緩和可能。
+httpx>=0.27.0,<0.28

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -1,4 +1,6 @@
-chromadb==0.4.24
+# RAG サービス 直接依存パッケージ
+# バージョン制約の詳細は constraints.txt を参照。
+chromadb>=0.5.0,<1.0
 crewai==0.64.0
 duckduckgo-search==6.2.5
 fastapi==0.112.0


### PR DESCRIPTION
Closes #135

## 変更内容

### `rag/constraints.txt`
- `embedchain==0.1.114` を削除（deprecated・archived パッケージ。crewai 0.64.0 は依存していないため不要）
- LangChain を `0.2.x` 固定から `>=0.3.0,<0.4` 範囲指定に更新（crewai 0.64.0 は langchain 0.3.x をサポート済み）
- `chromadb==0.4.24` を `>=0.5.0,<1.0` に更新（`PersistentClient` / `upsert` / `query` API は 0.5.x と互換）
- 全パッケージにバージョン固定理由のコメントを追加し、アップグレード判断基準を明文化

### `rag/requirements.txt`
- `chromadb==0.4.24` を `>=0.5.0,<1.0` に更新し `constraints.txt` と整合
- ファイル先頭に `constraints.txt` 参照を促すコメントを追加

### `.github/dependabot.yml`（新規）
- pip（`/rag` ディレクトリ）と GitHub Actions の依存を週次（月曜 09:00 JST）で自動更新
- メジャーバージョンアップは手動で判断するため `version-update:semver-major` を除外設定