### PR TITLE
Resolve #137: スクレイピングの法的・安定性リスク対応

### DIFF
--- a/Backend/internal/scraper/mynavi.go
+++ b/Backend/internal/scraper/mynavi.go
@@ -17,6 +17,14 @@ import (
 // RemoteURL, if set, is a Chrome DevTools WebSocket URL (e.g. "ws://chromedp:9222") and
 // causes the scraper to connect to an external Chrome instance.
 // When RemoteURL is empty, a local Chromium binary is launched via chromedp.NewExecAllocator.
+//
+// !! 利用規約リスク !!
+// マイナビの利用規約はスクレイピング・自動収集を禁止している可能性があります。
+// 本スクレイパーの運用前に必ず最新の利用規約（https://job.mynavi.jp/）を確認し、
+// 法務部門の承認を取得してください。
+// 違反した場合、サービス停止・法的措置のリスクがあります。
+// 代替手段として公式API・RSS・プレスリリース情報源への切り替えを検討してください。
+// 現在のセレクタバージョン: MynaviSelectorVersion（scraper.go 参照）
 type MynaviScraper struct {
 	RemoteURL string
 	UserAgent string

--- a/Backend/internal/scraper/pipeline.go
+++ b/Backend/internal/scraper/pipeline.go
@@ -26,6 +26,7 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	// ── Phase 1: collect ────────────────────────────────────────────────
 	var rawCompanies []*RawCompany
+	var warnings []ScrapeWarning
 
 	for _, site := range req.Sites {
 		switch site {
@@ -37,9 +38,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.Mynavi.Search(req.Query, year, req.MaxPages)
 			if err != nil {
 				log.Logf("[mynavi] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "mynavi",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", MynaviSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[mynavi] %d 件の企業URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "mynavi",
+					Message: fmt.Sprintf(
+						"企業URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						MynaviSelectorVersion,
+					),
+				})
+			}
+			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -52,10 +68,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[mynavi] %d 件取得完了", countSite(rawCompanies, "mynavi"))
+			collected := len(rawCompanies) - before
+			log.Logf("[mynavi] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				// More than half have empty names → likely DOM change
+				warnings = append(warnings, ScrapeWarning{
+					Site: "mynavi",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, MynaviSelectorVersion,
+					),
+				})
+			}
 
 		case "rikunabi":
 			if p.Rikunabi == nil {
@@ -65,10 +95,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.Rikunabi.Search(req.Query, req.MaxPages)
 			if err != nil {
 				log.Logf("[rikunabi] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "rikunabi",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", RikunabiSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[rikunabi] %d 件の求人URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "rikunabi",
+					Message: fmt.Sprintf(
+						"求人URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						RikunabiSelectorVersion,
+					),
+				})
+			}
 			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -81,10 +125,23 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[rikunabi] %d 件取得完了", len(rawCompanies)-before)
+			collected := len(rawCompanies) - before
+			log.Logf("[rikunabi] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "rikunabi",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, RikunabiSelectorVersion,
+					),
+				})
+			}
 
 		case "career_tasu":
 			if p.CareerTasu == nil {
@@ -94,10 +151,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.CareerTasu.Search(req.Query, req.MaxPages)
 			if err != nil {
 				log.Logf("[career_tasu] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "career_tasu",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", CareerTasuSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[career_tasu] %d 件の企業URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "career_tasu",
+					Message: fmt.Sprintf(
+						"企業URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						CareerTasuSelectorVersion,
+					),
+				})
+			}
 			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -110,10 +181,23 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[career_tasu] %d 件取得完了", len(rawCompanies)-before)
+			collected := len(rawCompanies) - before
+			log.Logf("[career_tasu] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "career_tasu",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, CareerTasuSelectorVersion,
+					),
+				})
+			}
 
 		default:
 			log.Logf("不明なサイト: %s (スキップ)", site)
@@ -122,11 +206,17 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	log.Logf("合計 %d 件の企業を収集", len(rawCompanies))
 
+	// Log warnings to the run log as well
+	for _, w := range warnings {
+		log.Logf("[WARNING][%s] %s", w.Site, w.Message)
+	}
+
 	if len(rawCompanies) == 0 {
 		return &RunResult{
 			TargetYear: year,
 			Nodes:      map[string]*CompanyNode{},
 			Logs:       log.Lines(),
+			Warnings:   warnings,
 		}, fmt.Errorf("no companies collected")
 	}
 
@@ -171,6 +261,7 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 		TargetYear: year,
 		Nodes:      nodes,
 		Logs:       log.Lines(),
+		Warnings:   warnings,
 	}, nil
 }
 

--- a/Backend/internal/scraper/rikunabi.go
+++ b/Backend/internal/scraper/rikunabi.go
@@ -18,6 +18,14 @@ var jobDescRe = regexp.MustCompile(`/n/job_descriptions/([a-z0-9]+)/`)
 //
 // ParseDetail → /n/job_descriptions/{id}/
 //   → h2: "{会社名}｜{業種}"
+//
+// !! 利用規約リスク !!
+// リクナビの利用規約はスクレイピング・自動収集を禁止している可能性があります。
+// 本スクレイパーの運用前に必ず最新の利用規約（https://job.rikunabi.com/）を確認し、
+// 法務部門の承認を取得してください。
+// 違反した場合、サービス停止・法的措置のリスクがあります。
+// 代替手段として公式API・RSS・プレスリリース情報源への切り替えを検討してください。
+// 現在のセレクタバージョン: RikunabiSelectorVersion（scraper.go 参照）
 type RikunabiScraper struct {
 	BaseURL   string
 	SearchURL string

--- a/Backend/internal/scraper/scraper.go
+++ b/Backend/internal/scraper/scraper.go
@@ -57,11 +57,31 @@ type RunRequest struct {
 	Year     int // 0 = auto-calculate
 }
 
+// ScrapeWarning represents a warning emitted during a pipeline run.
+// It is used to surface DOM-change alerts and site-level failures
+// without aborting the entire pipeline (graceful degradation).
+type ScrapeWarning struct {
+	Site    string
+	Message string
+}
+
+// Selector version constants track the CSS/JS selector schema for each scraper.
+// Increment the version whenever selectors are intentionally updated,
+// so that monitoring can distinguish intentional changes from unexpected breakage.
+const (
+	MynaviSelectorVersion     = 1 // last updated: 2024
+	RikunabiSelectorVersion   = 1 // last updated: 2024
+	CareerTasuSelectorVersion = 1 // last updated: 2024
+)
+
 // RunResult is returned by Pipeline.Run.
 type RunResult struct {
 	TargetYear int
 	Nodes      map[string]*CompanyNode // keyed by corporate_number
 	Logs       []string
+	// Warnings contains non-fatal issues such as possible DOM changes or
+	// site-level scraping failures. Callers should surface these to operators.
+	Warnings []ScrapeWarning
 }
 
 // ── Year resolution ──────────────────────────────────────────────────────────

--- a/tools/company-graph/internal/scraper/mynavi.go
+++ b/tools/company-graph/internal/scraper/mynavi.go
@@ -17,6 +17,14 @@ import (
 // RemoteURL, if set, is a Chrome DevTools WebSocket URL (e.g. "ws://chromedp:9222") and
 // causes the scraper to connect to an external Chrome instance.
 // When RemoteURL is empty, a local Chromium binary is launched via chromedp.NewExecAllocator.
+//
+// !! 利用規約リスク !!
+// マイナビの利用規約はスクレイピング・自動収集を禁止している可能性があります。
+// 本スクレイパーの運用前に必ず最新の利用規約（https://job.mynavi.jp/）を確認し、
+// 法務部門の承認を取得してください。
+// 違反した場合、サービス停止・法的措置のリスクがあります。
+// 代替手段として公式API・RSS・プレスリリース情報源への切り替えを検討してください。
+// 現在のセレクタバージョン: MynaviSelectorVersion（scraper.go 参照）
 type MynaviScraper struct {
 	RemoteURL string
 	UserAgent string

--- a/tools/company-graph/internal/scraper/pipeline.go
+++ b/tools/company-graph/internal/scraper/pipeline.go
@@ -26,6 +26,7 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	// ── Phase 1: collect ────────────────────────────────────────────────
 	var rawCompanies []*RawCompany
+	var warnings []ScrapeWarning
 
 	for _, site := range req.Sites {
 		switch site {
@@ -37,9 +38,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.Mynavi.Search(req.Query, year, req.MaxPages)
 			if err != nil {
 				log.Logf("[mynavi] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "mynavi",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", MynaviSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[mynavi] %d 件の企業URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "mynavi",
+					Message: fmt.Sprintf(
+						"企業URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						MynaviSelectorVersion,
+					),
+				})
+			}
+			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -52,10 +68,23 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[mynavi] %d 件取得完了", countSite(rawCompanies, "mynavi"))
+			collected := len(rawCompanies) - before
+			log.Logf("[mynavi] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "mynavi",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, MynaviSelectorVersion,
+					),
+				})
+			}
 
 		case "rikunabi":
 			if p.Rikunabi == nil {
@@ -65,10 +94,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.Rikunabi.Search(req.Query, req.MaxPages)
 			if err != nil {
 				log.Logf("[rikunabi] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "rikunabi",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", RikunabiSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[rikunabi] %d 件の求人URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "rikunabi",
+					Message: fmt.Sprintf(
+						"求人URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						RikunabiSelectorVersion,
+					),
+				})
+			}
 			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -81,10 +124,23 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[rikunabi] %d 件取得完了", len(rawCompanies)-before)
+			collected := len(rawCompanies) - before
+			log.Logf("[rikunabi] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "rikunabi",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, RikunabiSelectorVersion,
+					),
+				})
+			}
 
 		case "career_tasu":
 			if p.CareerTasu == nil {
@@ -94,10 +150,24 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 			urls, err := p.CareerTasu.Search(req.Query, req.MaxPages)
 			if err != nil {
 				log.Logf("[career_tasu] 検索エラー: %v", err)
+				warnings = append(warnings, ScrapeWarning{
+					Site:    "career_tasu",
+					Message: fmt.Sprintf("検索失敗（セレクタ v%d）: %v", CareerTasuSelectorVersion, err),
+				})
 				continue
 			}
 			log.Logf("[career_tasu] %d 件の企業URLを取得", len(urls))
+			if len(urls) == 0 {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "career_tasu",
+					Message: fmt.Sprintf(
+						"企業URL取得件数が0件（セレクタ v%d）。DOM変更・ログイン要求・アクセス制限の可能性があります",
+						CareerTasuSelectorVersion,
+					),
+				})
+			}
 			before := len(rawCompanies)
+			emptyName := 0
 			for _, u := range urls {
 				select {
 				case <-ctx.Done():
@@ -110,10 +180,23 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 					continue
 				}
 				if company != nil {
+					if company.RawName == "" {
+						emptyName++
+					}
 					rawCompanies = append(rawCompanies, company)
 				}
 			}
-			log.Logf("[career_tasu] %d 件取得完了", len(rawCompanies)-before)
+			collected := len(rawCompanies) - before
+			log.Logf("[career_tasu] %d 件取得完了", collected)
+			if collected > 0 && emptyName*2 > collected {
+				warnings = append(warnings, ScrapeWarning{
+					Site: "career_tasu",
+					Message: fmt.Sprintf(
+						"企業名空欄率が高い (%d/%d)（セレクタ v%d）。DOM変更の可能性があります",
+						emptyName, collected, CareerTasuSelectorVersion,
+					),
+				})
+			}
 
 		default:
 			log.Logf("不明なサイト: %s (スキップ)", site)
@@ -122,11 +205,17 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 
 	log.Logf("合計 %d 件の企業を収集", len(rawCompanies))
 
+	// Log warnings to the run log as well
+	for _, w := range warnings {
+		log.Logf("[WARNING][%s] %s", w.Site, w.Message)
+	}
+
 	if len(rawCompanies) == 0 {
 		return &RunResult{
 			TargetYear: year,
 			Nodes:      map[string]*CompanyNode{},
 			Logs:       log.Lines(),
+			Warnings:   warnings,
 		}, fmt.Errorf("no companies collected")
 	}
 
@@ -171,6 +260,7 @@ func (p *Pipeline) Run(ctx context.Context, req RunRequest) (*RunResult, error) 
 		TargetYear: year,
 		Nodes:      nodes,
 		Logs:       log.Lines(),
+		Warnings:   warnings,
 	}, nil
 }
 

--- a/tools/company-graph/internal/scraper/rikunabi.go
+++ b/tools/company-graph/internal/scraper/rikunabi.go
@@ -18,6 +18,14 @@ var jobDescRe = regexp.MustCompile(`/n/job_descriptions/([a-z0-9]+)/`)
 //
 // ParseDetail → /n/job_descriptions/{id}/
 //   → h2: "{会社名}｜{業種}"
+//
+// !! 利用規約リスク !!
+// リクナビの利用規約はスクレイピング・自動収集を禁止している可能性があります。
+// 本スクレイパーの運用前に必ず最新の利用規約（https://job.rikunabi.com/）を確認し、
+// 法務部門の承認を取得してください。
+// 違反した場合、サービス停止・法的措置のリスクがあります。
+// 代替手段として公式API・RSS・プレスリリース情報源への切り替えを検討してください。
+// 現在のセレクタバージョン: RikunabiSelectorVersion（scraper.go 参照）
 type RikunabiScraper struct {
 	BaseURL   string
 	SearchURL string

--- a/tools/company-graph/internal/scraper/scraper.go
+++ b/tools/company-graph/internal/scraper/scraper.go
@@ -55,11 +55,31 @@ type RunRequest struct {
 	Year     int // 0 = auto-calculate
 }
 
+// ScrapeWarning represents a warning emitted during a pipeline run.
+// It is used to surface DOM-change alerts and site-level failures
+// without aborting the entire pipeline (graceful degradation).
+type ScrapeWarning struct {
+	Site    string
+	Message string
+}
+
+// Selector version constants track the CSS/JS selector schema for each scraper.
+// Increment the version whenever selectors are intentionally updated,
+// so that monitoring can distinguish intentional changes from unexpected breakage.
+const (
+	MynaviSelectorVersion     = 1 // last updated: 2024
+	RikunabiSelectorVersion   = 1 // last updated: 2024
+	CareerTasuSelectorVersion = 1 // last updated: 2024
+)
+
 // RunResult is returned by Pipeline.Run.
 type RunResult struct {
 	TargetYear int
 	Nodes      map[string]*CompanyNode // keyed by corporate_number
 	Logs       []string
+	// Warnings contains non-fatal issues such as possible DOM changes or
+	// site-level scraping failures. Callers should surface these to operators.
+	Warnings []ScrapeWarning
 }
 
 // ── Year resolution ──────────────────────────────────────────────────────────

--- a/tools/company-graph/main.go
+++ b/tools/company-graph/main.go
@@ -92,9 +92,10 @@ func main() {
 		if err != nil && (result == nil || len(result.Nodes) == 0) {
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			json.NewEncoder(w).Encode(map[string]any{
-				"ok":    false,
-				"error": err.Error(),
-				"logs":  logs,
+				"ok":       false,
+				"error":    err.Error(),
+				"logs":     logs,
+				"warnings": result.Warnings,
 			})
 			return
 		}
@@ -109,6 +110,7 @@ func main() {
 			"logs":        logs,
 			"nodes":       result.Nodes,
 			"target_year": targetYear,
+			"warnings":    result.Warnings,
 		})
 	})
 


### PR DESCRIPTION
Closes #137

## 変更内容

### `scraper.go`（Backend / tools/company-graph 共通）
- `ScrapeWarning{Site, Message}` 型を追加し、パイプライン実行中の非致命的な問題を構造化して表現
- セレクタバージョン定数（`MynaviSelectorVersion` / `RikunabiSelectorVersion` / `CareerTasuSelectorVersion = 1`）を追加。セレクタ変更時にインクリメントすることで意図的変更と予期せぬ故障を区別可能に
- `RunResult` に `Warnings []ScrapeWarning` フィールドを追加し、呼び出し元がアラートを受け取れるように

### `pipeline.go`（Backend / tools/company-graph 共通）
- **DOM 変更検知**: 各サイトで以下2条件を検出し `ScrapeWarning` を生成（パイプラインは中断せず残サイトの処理を継続）
  - URL 取得件数 = 0 件 → DOM 変更・ログイン要求・アクセス制限の可能性
  - 企業名空欄率 > 50% → セレクタの DOM 変更の可能性
- 警告内容を実行ログにも出力し、既存の監視基盤からも確認可能に
- `RunResult` 返却時に warnings を必ず含める（エラー・正常終了いずれも）

### `mynavi.go`（Backend / tools/company-graph 共通）
- 利用規約リスク警告コメントを追加（ToS 確認・法務承認の必要性、代替手段への言及、セレクタバージョン参照先を明記）

### `rikunabi.go`（Backend / tools/company-graph 共通）
- 利用規約リスク警告コメントを追加（同上）

### `tools/company-graph/main.go`
- `/crawl` API レスポンスに `"warnings"` フィールドを追加。フロントエンドや外部モニタリングから DOM 変更アラートを確認できるように