### PR TITLE
Resolve #139: マイクロサービスの運用基盤整備 - /healthz 統一実装・ECS ヘルスチェック設定

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -12,9 +12,21 @@
         {
           "containerPort": 8080,
           "hostPort": 8080,
-          "protocol": "tcp"
+          "protocol": "tcp",
+          "name": "soc-backend-8080",
+          "appProtocol": "http"
         }
       ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:8080/healthz || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
       "environment": [
         {
           "name": "DB_HOST",
@@ -60,9 +72,21 @@
         {
           "containerPort": 3000,
           "hostPort": 3000,
-          "protocol": "tcp"
+          "protocol": "tcp",
+          "name": "soc-frontend-3000",
+          "appProtocol": "http"
         }
       ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:3000/api/healthz || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
       "environment": [
         {
           "name": "NEXT_PUBLIC_API_BASE_URL",
@@ -77,6 +101,102 @@
         "logDriver": "awslogs",
         "options": {
           "awslogs-group": "/ecs/soc-frontend",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "mountPoints": [],
+      "volumesFrom": [],
+      "systemControls": []
+    },
+    {
+      "name": "soc-rag",
+      "image": "970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-rag:latest",
+      "essential": false,
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 9000,
+          "hostPort": 9000,
+          "protocol": "tcp",
+          "name": "soc-rag-9000",
+          "appProtocol": "http"
+        }
+      ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:9000/healthz || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 10,
+        "retries": 3,
+        "startPeriod": 90
+      },
+      "environment": [
+        {
+          "name": "APP_ENV",
+          "value": "production"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "OPENAI_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:970835573274:secret:prod/openai/api-key-ctv4bB"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/soc-rag",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "mountPoints": [],
+      "volumesFrom": [],
+      "systemControls": []
+    },
+    {
+      "name": "soc-company-graph",
+      "image": "970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-company-graph:latest",
+      "essential": false,
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 9100,
+          "hostPort": 9100,
+          "protocol": "tcp",
+          "name": "soc-company-graph-9100",
+          "appProtocol": "http"
+        }
+      ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:9100/healthz || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
+      "environment": [
+        {
+          "name": "APP_ENV",
+          "value": "production"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "GBIZINFO_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:970835573274:secret:prod/gbizinfo/api-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/soc-company-graph",
           "awslogs-region": "ap-northeast-1",
           "awslogs-stream-prefix": "ecs"
         }

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -172,10 +172,15 @@ func main() {
 	go crawlService.StartScheduler()
 
 	// ヘルスチェックエンドポイント
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	// /healthz は ECS ターゲットグループ・ALB・Kubernetes の標準パス
+	// /health は後方互換のため維持
+	healthHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	})
+		w.Write([]byte(`{"status":"ok"}`))
+	}
+	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc("/healthz", healthHandler)
 
 	// サーバー起動
 	port := cfg.ServerPort

--- a/frontend/app/api/healthz/route.ts
+++ b/frontend/app/api/healthz/route.ts
@@ -1,0 +1,7 @@
+// /api/healthz は ECS ターゲットグループ・ALB・Kubernetes の標準ヘルスチェックパス
+// Next.js App Router の API Route として実装
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' })
+}

--- a/rag/main.py
+++ b/rag/main.py
@@ -406,6 +406,13 @@ def health() -> dict:
     return {"status": "ok"}
 
 
+# /healthz は ECS ターゲットグループ・ALB・Kubernetes の標準パス
+# /health は後方互換のため維持
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok"}
+
+
 @app.post("/resume/review", response_model=ReviewResponse)
 def review_resume(request: ReviewRequest) -> ReviewResponse:
     role_label = request.job_title or "指定なし"

--- a/tools/company-graph/main.go
+++ b/tools/company-graph/main.go
@@ -29,10 +29,14 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	// /healthz は ECS ターゲットグループ・ALB・Kubernetes の標準パス
+	// /health は後方互換のため維持
+	healthHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-	})
+	}
+	mux.HandleFunc("/health", healthHandler)
+	mux.HandleFunc("/healthz", healthHandler)
 
 	mux.HandleFunc("/target-year", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {


### PR DESCRIPTION
Closes #139

## 変更内容

### `/healthz` エンドポイントの全サービス統一実装
ECS ALB ターゲットグループ・Kubernetes の標準ヘルスチェックパスである `/healthz` を全4サービスに追加。既存の `/health` は後方互換のため維持。

- **`Backend/cmd/server/main.go`**: `healthHandler` を共通化し、`/health` と `/healthz` の両方に登録。レスポンスを JSON 形式（`{"status":"ok"}`）に統一
- **`tools/company-graph/main.go`**: 同様に `/healthz` を追加
- **`rag/main.py`**: FastAPI で `/healthz` エンドポイントを追加
- **`frontend/app/api/healthz/route.ts`**: Next.js App Router の API Route として `/api/healthz` を新規実装

### ECS タスク定義の強化（`.aws/task-definition-template.json`）
- **全コンテナに `healthCheck` を追加**: 30秒間隔・5秒タイムアウト・3回リトライ・起動猶予60秒（RAGは90秒）で `/healthz` をポーリング。ECS がコンテナの異常を自動検知して置き換えできるようになる
- **`soc-rag` コンテナ定義を新規追加**: port 9000、CloudWatch Logs（`/ecs/soc-rag`）設定済み
- **`soc-company-graph` コンテナ定義を新規追加**: port 9100、CloudWatch Logs（`/ecs/soc-company-graph`）設定済み。これにより全4サービスのログが CloudWatch に集約される
- **`portMappings` に `name`・`appProtocol: "http"` を追加**: ECS Service Connect によるサービス間通信の自動設定に対応（有効化時はコンソールまたは CLI で Service Connect の設定を追加するだけで動作）