### PR TITLE
Resolve #140: PDF注釈の日本語フォント依存問題の修正

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -42,6 +42,9 @@ FROM golang:1.24-bullseye
 WORKDIR /app
 
 ENV GOTOOLCHAIN=auto
+# フォントパスを明示的に設定（ランタイムステージで有効）
+# fonts-noto-cjk をインストール後のデフォルトパス
+ENV ANNOTATION_FONT_PATH=/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
 
 # Install runtime dependencies (OCR + PDF conversion)
 RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"Backend/internal/services"
 	"log"
 	"net/http"
+	"os"
 )
 
 func corsMiddleware(next http.Handler) http.Handler {
@@ -28,7 +29,30 @@ func corsMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// checkAnnotationFont はサーバー起動時に PDF アノテーション用フォントの存在を確認し、
+// 設定に問題がある場合は警告ログを出力する。
+// フォントが存在しない場合もサーバー起動は継続するが、PDF 注釈が劣化する旨を明示する。
+func checkAnnotationFont() {
+	fontPath := os.Getenv("ANNOTATION_FONT_PATH")
+	if fontPath == "" {
+		log.Println("WARNING: ANNOTATION_FONT_PATH が設定されていません。" +
+			"フォールバックフォントを使用します（日本語注釈が正常に表示されない可能性があります）。" +
+			"環境変数 ANNOTATION_FONT_PATH にフォントパスを設定してください。")
+		return
+	}
+	if _, err := os.Stat(fontPath); os.IsNotExist(err) {
+		log.Printf("WARNING: ANNOTATION_FONT_PATH のフォントが見つかりません: %q\n"+
+			"PDF注釈の日本語レビューページが生成されない場合があります。\n"+
+			"Dockerfileで fonts-noto-cjk がインストールされているか確認してください。", fontPath)
+		return
+	}
+	log.Printf("INFO: PDF アノテーションフォント確認済み: %q", fontPath)
+}
+
 func main() {
+	// PDF アノテーションフォントの存在チェック（起動時警告）
+	checkAnnotationFont()
+
 	// 設定を読み込む（環境変数の読み込みはconfig.LoadConfig内で実施）
 	cfg, err := config.LoadConfig()
 	if err != nil {

--- a/Backend/scripts/annotate_pdf.py
+++ b/Backend/scripts/annotate_pdf.py
@@ -3,6 +3,7 @@ import argparse
 import io
 import json
 import os
+import sys
 
 import fitz  # PyMuPDF
 from PIL import Image, ImageDraw, ImageFont
@@ -49,9 +50,25 @@ def get_color(severity):
 
 
 def resolve_japanese_font():
+    """日本語フォントのパスを解決する。
+
+    優先順位:
+    1. ANNOTATION_FONT_PATH 環境変数
+    2. 既知のフォントパス候補をフォールバック検索
+
+    Returns:
+        str | None: フォントファイルのパス。見つからない場合は None。
+    """
     env_path = os.getenv("ANNOTATION_FONT_PATH", "").strip()
-    if env_path and os.path.exists(env_path):
-        return env_path
+    if env_path:
+        if os.path.exists(env_path):
+            return env_path
+        # 環境変数が設定されているがファイルが存在しない場合は明示的に警告
+        print(
+            f"WARNING: ANNOTATION_FONT_PATH が設定されていますが、ファイルが存在しません: {env_path!r}\n"
+            "フォールバック候補を検索します。",
+            file=sys.stderr,
+        )
 
     candidates = [
         "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
@@ -70,7 +87,9 @@ def resolve_japanese_font():
 
     for path in candidates:
         if os.path.exists(path):
+            print(f"INFO: フォールバックフォントを使用: {path!r}", file=sys.stderr)
             return path
+
     return None
 
 
@@ -266,8 +285,23 @@ def main():
 
     doc = fitz.open(args.input)
     font_path = resolve_japanese_font()
+
     if not font_path:
-        raise SystemExit("Japanese font not found. Set ANNOTATION_FONT_PATH.")
+        # フォントが見つからない場合: 日本語レビューページはスキップし、
+        # 矩形アノテーションのみ付与してPDFを出力する（graceful degradation）
+        print(
+            "WARNING: 日本語フォントが見つかりません。\n"
+            "  - レビューサマリーページは生成されません（文字化け防止のため）。\n"
+            "  - アノテーション（矩形・バッジ）のみ付与して出力します。\n"
+            "  - 修正方法: ANNOTATION_FONT_PATH 環境変数にフォントパスを設定するか、\n"
+            "    fonts-noto-cjk パッケージをインストールしてください。",
+            file=sys.stderr,
+        )
+        if items:
+            annotate_pages(doc, items)
+        doc.save(args.output, garbage=4, deflate=True)
+        doc.close()
+        return
 
     if items:
         annotate_pages(doc, items)


### PR DESCRIPTION
Closes #140

## 変更内容

### `Backend/Dockerfile`
- `ANNOTATION_FONT_PATH` 環境変数をランタイムステージ（`FROM golang:1.24-bullseye` 以降）に追加
- ビルドステージ（`FROM golang:1.24-bullseye AS builder`）にのみ定義されており、実行時コンテナには引き継がれていなかった問題を修正
- `fonts-noto-cjk` はすでにランタイムステージでインストールされているため、正しいパスを env で明示することで確実に認識されるようになる

### `Backend/scripts/annotate_pdf.py`
- **`resolve_japanese_font()` に詳細な警告ログを追加**
  - `ANNOTATION_FONT_PATH` が設定されているがファイルが存在しない場合、具体的なパスとともに stderr へ警告を出力
  - フォールバック候補から見つかった場合も、実際に使用しているパスを INFO として stderr へ出力
- **フォント未検出時を graceful degradation に変更**
  - 変更前: `SystemExit("Japanese font not found...")` でスクリプト全体が終了し、Go 側でエラー扱いとなりアノテーション PDF が生成されなかった
  - 変更後: 矩形アノテーション（ページへの位置マーキング・バッジ）のみ付与した PDF を出力し、日本語テキストを含むレビューサマリーページの追加をスキップする。修正手順を stderr に出力するため原因特定が容易になる

### `Backend/cmd/server/main.go`
- **`checkAnnotationFont()` 関数を追加し、サーバー起動時にフォントの存在を確認**
  - `ANNOTATION_FONT_PATH` が未設定の場合: `WARNING` ログを出力し設定方法を案内
  - パスが設定されているがファイルが存在しない場合: `WARNING` ログにファイルパスを含めて出力（`Dockerfile` の `fonts-noto-cjk` インストール確認を促す）
  - 正常の場合: `INFO` ログでパスを確認出力
  - 起動は常に継続（フォント問題でサーバーが落ちることを防ぐ）