### PR TITLE
Resolve #141: 面接パフォーマンスのトレンド分析機能

### DIFF
--- a/Backend/domain/repository/interview.go
+++ b/Backend/domain/repository/interview.go
@@ -13,6 +13,9 @@ type InterviewSessionRepository interface {
 	Update(session *models.InterviewSession) error
 	ListByUser(userID uint, limit int, offset int) ([]models.InterviewSession, error)
 	ListAll(limit int, offset int) ([]models.InterviewSession, error)
+	// ListFinishedByUser は完了済み（status="finished"）セッションを新しい順に最大 limit 件返す。
+	// トレンド分析用。
+	ListFinishedByUser(userID uint, limit int) ([]models.InterviewSession, error)
 	CountByUser(userID uint) (int64, error)
 	CountAll() (int64, error)
 	CountByUserAndDay(userID uint, day time.Time) (int64, error)

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -94,6 +94,40 @@ func (c *InterviewController) Route(w http.ResponseWriter, r *http.Request) {
 	c.Get(w, r)
 }
 
+// GetTrend は GET /api/interviews/trend?user_id=X&limit=N を処理し、
+// 完了済みセッションのスコア時系列を返す。
+func (c *InterviewController) GetTrend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	userIDStr := r.URL.Query().Get("user_id")
+	if userIDStr == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+	userID, err := strconv.ParseUint(userIDStr, 10, 32)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	points, err := c.interviewService.GetTrend(uint(userID), limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"points": points,
+	})
+}
+
 func (c *InterviewController) GetReport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/Backend/internal/repositories/interview_session_repository.go
+++ b/Backend/internal/repositories/interview_session_repository.go
@@ -67,6 +67,18 @@ func (r *InterviewSessionRepository) CountAll() (int64, error) {
 	return count, err
 }
 
+func (r *InterviewSessionRepository) ListFinishedByUser(userID uint, limit int) ([]models.InterviewSession, error) {
+	var sessions []models.InterviewSession
+	query := r.db.Where("user_id = ? AND status = ?", userID, "finished").Order("created_at DESC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&sessions).Error; err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
 func (r *InterviewSessionRepository) CountByUserAndDay(userID uint, day time.Time) (int64, error) {
 	start := time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, day.Location())
 	end := start.Add(24 * time.Hour)

--- a/Backend/internal/routes/interview_routes.go
+++ b/Backend/internal/routes/interview_routes.go
@@ -7,6 +7,8 @@ import (
 
 // SetupInterviewRoutes 面接関連のルーティング設定
 func SetupInterviewRoutes(interviewController *controllers.InterviewController, realtimeController *controllers.RealtimeController) {
+	// /api/interviews/trend はワイルドカード /api/interviews/ より先に登録する必要がある
+	http.HandleFunc("/api/interviews/trend", interviewController.GetTrend)
 	http.HandleFunc("/api/interviews", interviewController.ListOrCreate)
 	http.HandleFunc("/api/interviews/", interviewController.Route)
 	http.HandleFunc("/api/realtime/token", realtimeController.Token)

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -270,6 +270,73 @@ func (s *InterviewService) GetReport(userID uint, sessionID uint) (*models.Inter
 	return report, nil
 }
 
+// InterviewTrendPoint は面接トレンド分析の1データポイント。
+type InterviewTrendPoint struct {
+	SessionID     uint      `json:"session_id"`
+	CreatedAt     time.Time `json:"created_at"`
+	Logic         *float64  `json:"logic"`
+	Specificity   *float64  `json:"specificity"`
+	Ownership     *float64  `json:"ownership"`
+	Communication *float64  `json:"communication"`
+	Enthusiasm    *float64  `json:"enthusiasm"`
+}
+
+// GetTrend は指定ユーザーの完了済み面接セッションのスコア時系列を返す。
+// sessions は古い順（昇順）で返却されるため、フロントエンドでそのままグラフに使える。
+func (s *InterviewService) GetTrend(userID uint, limit int) ([]InterviewTrendPoint, error) {
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+	// 新しい順で取得し、後で逆順にする（古い順でグラフ描画するため）
+	sessions, err := s.sessionRepo.ListFinishedByUser(userID, limit)
+	if err != nil {
+		return nil, err
+	}
+	// 古い順に並べ替え
+	for i, j := 0, len(sessions)-1; i < j; i, j = i+1, j-1 {
+		sessions[i], sessions[j] = sessions[j], sessions[i]
+	}
+
+	points := make([]InterviewTrendPoint, 0, len(sessions))
+	for _, session := range sessions {
+		report, err := s.reportRepo.FindBySessionID(session.ID)
+		if err != nil {
+			// レポート未生成のセッションはスキップ
+			continue
+		}
+		var scores map[string]float64
+		if err := json.Unmarshal([]byte(report.ScoresJSON), &scores); err != nil {
+			continue
+		}
+		pt := InterviewTrendPoint{
+			SessionID: session.ID,
+			CreatedAt: session.CreatedAt,
+		}
+		if v, ok := scores["logic"]; ok {
+			vv := v
+			pt.Logic = &vv
+		}
+		if v, ok := scores["specificity"]; ok {
+			vv := v
+			pt.Specificity = &vv
+		}
+		if v, ok := scores["ownership"]; ok {
+			vv := v
+			pt.Ownership = &vv
+		}
+		if v, ok := scores["communication"]; ok {
+			vv := v
+			pt.Communication = &vv
+		}
+		if v, ok := scores["enthusiasm"]; ok {
+			vv := v
+			pt.Enthusiasm = &vv
+		}
+		points = append(points, pt)
+	}
+	return points, nil
+}
+
 func (s *InterviewService) CreateRealtimeToken(ctx context.Context, userID uint, sessionID uint) (string, error) {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {

--- a/frontend/app/interview/history/page.tsx
+++ b/frontend/app/interview/history/page.tsx
@@ -10,12 +10,24 @@ import {
   IconButton,
   Paper,
   Stack,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import PsychologyIcon from '@mui/icons-material/Psychology'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
 import { authService, User } from '@/lib/auth'
-import { interviewApi, InterviewDetail, InterviewSession, TeacherReport } from '@/lib/interview'
+import { interviewApi, InterviewDetail, InterviewSession, InterviewTrendPoint, TeacherReport } from '@/lib/interview'
 import InterviewSummary from '../components/InterviewSummary'
 import { parseJsonSafe } from '@/lib/interview-utils'
 
@@ -36,6 +48,9 @@ export default function InterviewHistoryPage() {
   const [loading, setLoading] = useState(true)
   const [selectedDetail, setSelectedDetail] = useState<InterviewDetail | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
+  const [trendPoints, setTrendPoints] = useState<InterviewTrendPoint[]>([])
+  const [trendLimit, setTrendLimit] = useState<number>(10)
+  const [trendLoading, setTrendLoading] = useState(false)
 
   const limit = 10
 
@@ -53,6 +68,15 @@ export default function InterviewHistoryPage() {
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [user, page])
+
+  useEffect(() => {
+    if (!user) return
+    setTrendLoading(true)
+    interviewApi.getTrend(user.user_id, trendLimit)
+      .then(points => setTrendPoints(points))
+      .catch(() => setTrendPoints([]))
+      .finally(() => setTrendLoading(false))
+  }, [user, trendLimit])
 
   const isTeacher = user?.role === 'teacher'
 
@@ -83,6 +107,53 @@ export default function InterviewHistoryPage() {
         <IconButton onClick={() => router.push('/interview')} sx={{ bgcolor: '#f1f5f9', color: '#475569' }}>
           <ArrowBackIcon />
         </IconButton>
+      </Box>
+
+      {/* Trend chart */}
+      <Box sx={{ maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 4 }, pt: { xs: 2, md: 4 }, pb: 0 }}>
+        <Paper elevation={0} sx={{ p: { xs: 2, md: 3 }, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }} flexWrap="wrap" gap={1}>
+            <Typography sx={{ fontWeight: 700, fontSize: 16 }}>パフォーマンストレンド</Typography>
+            <ToggleButtonGroup
+              value={trendLimit}
+              exclusive
+              onChange={(_, v) => { if (v !== null) setTrendLimit(v) }}
+              size="small"
+            >
+              <ToggleButton value={5} sx={{ fontSize: 12, px: 1.5 }}>直近5回</ToggleButton>
+              <ToggleButton value={10} sx={{ fontSize: 12, px: 1.5 }}>直近10回</ToggleButton>
+              <ToggleButton value={0} sx={{ fontSize: 12, px: 1.5 }}>全期間</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+          {trendLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={28} sx={{ color: PRIMARY }} />
+            </Box>
+          ) : trendPoints.length === 0 ? (
+            <Typography color="text.secondary" fontSize={14} sx={{ py: 3, textAlign: 'center' }}>
+              完了した面接がないためトレンドを表示できません。
+            </Typography>
+          ) : (
+            <ResponsiveContainer width="100%" height={240}>
+              <LineChart data={trendPoints.map((p, i) => ({
+                ...p,
+                label: `#${p.session_id}`,
+                index: i + 1,
+              }))}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+                <XAxis dataKey="label" tick={{ fontSize: 12, fill: '#64748b' }} />
+                <YAxis domain={[0, 10]} tick={{ fontSize: 12, fill: '#64748b' }} width={28} />
+                <Tooltip formatter={(v: number) => v?.toFixed(1)} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Line type="monotone" dataKey="logic" name="論理性" stroke="#ec5b13" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+                <Line type="monotone" dataKey="specificity" name="具体性" stroke="#3b82f6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+                <Line type="monotone" dataKey="ownership" name="主体性" stroke="#10b981" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+                <Line type="monotone" dataKey="communication" name="コミュニケーション" stroke="#8b5cf6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+                <Line type="monotone" dataKey="enthusiasm" name="熱意" stroke="#f59e0b" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </Paper>
       </Box>
 
       <Box sx={{ display: 'flex', maxWidth: 1100, mx: 'auto', p: { xs: 2, md: 4 }, gap: 3, flexDirection: { xs: 'column', md: 'row' }, alignItems: 'flex-start' }}>

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -68,6 +68,16 @@ export type InterviewDetail = {
   report?: InterviewReport
 }
 
+export type InterviewTrendPoint = {
+  session_id: number
+  created_at: string
+  logic: number | null
+  specificity: number | null
+  ownership: number | null
+  communication: number | null
+  enthusiasm: number | null
+}
+
 export const interviewApi = {
   async createSession(userId: number, language = 'ja'): Promise<InterviewSession> {
     const res = await fetch(`${BACKEND_URL}/api/interviews`, {
@@ -137,6 +147,14 @@ export const interviewApi = {
     if (!res.ok) throw new Error(await res.text())
     const data = await res.json()
     return data.client_secret
+  },
+
+  async getTrend(userId: number, limit = 0): Promise<InterviewTrendPoint[]> {
+    const params = limit > 0 ? `?user_id=${userId}&limit=${limit}` : `?user_id=${userId}`
+    const res = await fetch(`${BACKEND_URL}/api/interviews/trend${params}`)
+    if (!res.ok) throw new Error(await res.text())
+    const data = await res.json()
+    return data.points as InterviewTrendPoint[]
   },
 
   async sendReportEmail(sessionId: number, userId: number): Promise<{ message: string }> {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react": "^19.2.0",
     "react-day-picker": "9.8.0",
     "react-dom": "^19.2.0",
+    "recharts": "^2.15.3",
     "reactflow": "^11.11.4",
     "tailwind-merge": "^2.4.0",
     "three": "^0.165.0",


### PR DESCRIPTION
Closes #141

## 変更内容

### バックエンド
- **`Backend/domain/repository/interview.go`**: `InterviewSessionRepository` インターフェースに `ListFinishedByUser(userID uint, limit int)` メソッドを追加
- **`Backend/internal/repositories/interview_session_repository.go`**: `ListFinishedByUser` の実装を追加（`status = 'finished'` のセッションを降順で取得）
- **`Backend/internal/services/interview_service.go`**: `InterviewTrendPoint` 構造体（session_id, created_at, logic/specificity/ownership/communication/enthusiasm スコア）と `GetTrend(userID, limit)` メソッドを追加。完了済みセッションのレポートからスコアを集計し、古い順に並び替えたトレンドデータを返す
- **`Backend/internal/controllers/interview_controller.go`**: `GET /api/interviews/trend?user_id=X&limit=N` に対応する `GetTrend` ハンドラを追加。`{"points": [...]}` 形式でレスポンス
- **`Backend/internal/routes/interview_routes.go`**: `/api/interviews/trend` をワイルドカードルート `/api/interviews/` より先に登録してルーティング競合を回避

### フロントエンド
- **`frontend/package.json`**: `recharts ^2.15.3` を依存関係に追加
- **`frontend/lib/interview.ts`**: `InterviewTrendPoint` 型定義と `interviewApi.getTrend(userId, limit)` API呼び出し関数を追加
- **`frontend/app/interview/history/page.tsx`**: 面接履歴ページの上部にトレンドチャートセクションを追加
  - 直近5回 / 直近10回 / 全期間 のピリオドフィルタ（ToggleButtonGroup）
  - recharts の ResponsiveContainer + LineChart で論理性・具体性・主体性・コミュニケーション・熱意の5指標を時系列で可視化
  - ローディング状態とデータなし状態のハンドリング