### PR TITLE
Resolve #143: ES（エントリーシート）添削機能の実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -181,6 +181,7 @@ func main() {
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
 	githubController := controllers.NewGitHubController(githubService, skillScoreService)
 	esRewriteController := controllers.NewESRewriteController(aiClient)
+	esReviewController := controllers.NewESReviewController()
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
@@ -190,7 +191,7 @@ func main() {
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)
-	routes.SetupESRoutes(esRewriteController)
+	routes.SetupESRoutes(esRewriteController, esReviewController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
 
 	go crawlService.StartScheduler()

--- a/Backend/internal/controllers/es_review_controller.go
+++ b/Backend/internal/controllers/es_review_controller.go
@@ -1,0 +1,85 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type ESReviewController struct{}
+
+func NewESReviewController() *ESReviewController {
+	return &ESReviewController{}
+}
+
+type esReviewRequest struct {
+	ESText       string `json:"es_text"`
+	QuestionType string `json:"question_type"`
+	CompanyName  string `json:"company_name"`
+}
+
+func (c *ESReviewController) Review(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req esReviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	req.ESText = strings.TrimSpace(req.ESText)
+	if req.ESText == "" {
+		http.Error(w, "es_text is required", http.StatusBadRequest)
+		return
+	}
+	if req.QuestionType == "" {
+		req.QuestionType = "その他"
+	}
+
+	ragURL := strings.TrimSpace(os.Getenv("RAG_REVIEW_URL"))
+	if ragURL == "" {
+		http.Error(w, "RAG_REVIEW_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		http.Error(w, "Failed to encode request", http.StatusInternalServerError)
+		return
+	}
+
+	url := strings.TrimRight(ragURL, "/") + "/es/review"
+	log.Printf("es_review: rag request question_type=%q company=%q", req.QuestionType, req.CompanyName)
+
+	ragReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "Failed to create RAG request", http.StatusInternalServerError)
+		return
+	}
+	ragReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(ragReq)
+	if err != nil {
+		http.Error(w, "RAG service unavailable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "Failed to read RAG response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	w.Write(respBody)
+}

--- a/Backend/internal/routes/es_routes.go
+++ b/Backend/internal/routes/es_routes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
-func SetupESRoutes(esRewriteController *controllers.ESRewriteController) {
+func SetupESRoutes(esRewriteController *controllers.ESRewriteController, esReviewController *controllers.ESReviewController) {
 	http.HandleFunc("/api/es/rewrite", esRewriteController.Rewrite)
+	http.HandleFunc("/api/es/review", esReviewController.Review)
 }

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   Divider,
   IconButton,
+  LinearProgress,
   Paper,
   Stack,
   TextField,
@@ -21,6 +22,7 @@ import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import EditNoteIcon from '@mui/icons-material/EditNote'
+import RateReviewIcon from '@mui/icons-material/RateReview'
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
 const PRIMARY = '#ec5b13'
@@ -39,6 +41,15 @@ type RewriteResult = {
   star: StarBreakdown
 }
 
+type ReviewResult = {
+  specificity_score: number
+  star_score: number
+  company_fit_score: number | null
+  length_balance_score: number
+  feedback: string
+  improved_text: string
+}
+
 const STAR_LABELS: { key: keyof StarBreakdown; label: string; color: string; emoji: string }[] = [
   { key: 'situation', label: 'Situation（状況）', color: '#3b82f6', emoji: '📍' },
   { key: 'task',      label: 'Task（課題）',      color: '#8b5cf6', emoji: '🎯' },
@@ -46,14 +57,24 @@ const STAR_LABELS: { key: keyof StarBreakdown; label: string; color: string; emo
   { key: 'result',    label: 'Result（成果）',    color: '#10b981', emoji: '📊' },
 ]
 
+const SCORE_ITEMS: { key: keyof Omit<ReviewResult, 'feedback' | 'improved_text'>; label: string; color: string }[] = [
+  { key: 'specificity_score',    label: '具体性',       color: '#3b82f6' },
+  { key: 'star_score',           label: 'STAR法準拠',   color: '#8b5cf6' },
+  { key: 'company_fit_score',    label: '企業適合性',   color: PRIMARY },
+  { key: 'length_balance_score', label: '文字数バランス', color: '#10b981' },
+]
+
 export default function ESRewritePage() {
   const router = useRouter()
 
+  const [mode, setMode] = useState<'rewrite' | 'review'>('rewrite')
   const [originalText, setOriginalText] = useState('')
   const [questionType, setQuestionType] = useState('学チカ')
   const [techStack, setTechStack] = useState('')
+  const [companyName, setCompanyName] = useState('')
   const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState<RewriteResult | null>(null)
+  const [rewriteResult, setRewriteResult] = useState<RewriteResult | null>(null)
+  const [reviewResult, setReviewResult] = useState<ReviewResult | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
@@ -61,7 +82,7 @@ export default function ESRewritePage() {
     if (!originalText.trim()) return
     setLoading(true)
     setError(null)
-    setResult(null)
+    setRewriteResult(null)
 
     try {
       const res = await fetch(`${BACKEND_URL}/api/es/rewrite`, {
@@ -74,8 +95,7 @@ export default function ESRewritePage() {
         }),
       })
       if (!res.ok) throw new Error(await res.text())
-      const data: RewriteResult = await res.json()
-      setResult(data)
+      setRewriteResult(await res.json())
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'リライトに失敗しました。再試行してください。')
     } finally {
@@ -83,12 +103,38 @@ export default function ESRewritePage() {
     }
   }
 
-  const handleCopy = async () => {
-    if (!result) return
-    await navigator.clipboard.writeText(result.rewritten_text)
+  const handleReview = async () => {
+    if (!originalText.trim()) return
+    setLoading(true)
+    setError(null)
+    setReviewResult(null)
+
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/es/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          es_text: originalText,
+          question_type: questionType,
+          company_name: companyName,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setReviewResult(await res.json())
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : '添削に失敗しました。再試行してください。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCopy = async (text: string) => {
+    await navigator.clipboard.writeText(text)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
+
+  const result = mode === 'rewrite' ? rewriteResult : reviewResult
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: '#f8f6f6' }}>
@@ -104,8 +150,8 @@ export default function ESRewritePage() {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           <Box sx={{ color: PRIMARY }}><EditNoteIcon sx={{ fontSize: 32 }} /></Box>
           <Box>
-            <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>ESリライト</Typography>
-            <Typography sx={{ fontSize: 12, color: '#64748b' }}>AIがあなたのES文章をエンジニア向けにリライトします</Typography>
+            <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>ES添削・リライト</Typography>
+            <Typography sx={{ fontSize: 12, color: '#64748b' }}>AIがあなたのES文章を添削・リライトします</Typography>
           </Box>
         </Box>
         <IconButton onClick={() => router.push('/')} sx={{ bgcolor: '#f1f5f9', color: '#475569' }}>
@@ -113,8 +159,38 @@ export default function ESRewritePage() {
         </IconButton>
       </Box>
 
+      {/* Mode toggle */}
+      <Box sx={{ maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 }, pt: 3 }}>
+        <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+          <Button
+            startIcon={<RateReviewIcon />}
+            onClick={() => { setMode('review'); setRewriteResult(null); setError(null) }}
+            sx={{
+              px: 2.5, py: 1, borderRadius: 2, textTransform: 'none', fontWeight: 700, fontSize: 14,
+              bgcolor: mode === 'review' ? PRIMARY : '#f1f5f9',
+              color: mode === 'review' ? '#fff' : '#475569',
+              '&:hover': { bgcolor: mode === 'review' ? `${PRIMARY}e0` : '#e2e8f0' },
+            }}
+          >
+            ES添削（RAGフィードバック）
+          </Button>
+          <Button
+            startIcon={<AutoFixHighIcon />}
+            onClick={() => { setMode('rewrite'); setReviewResult(null); setError(null) }}
+            sx={{
+              px: 2.5, py: 1, borderRadius: 2, textTransform: 'none', fontWeight: 700, fontSize: 14,
+              bgcolor: mode === 'rewrite' ? PRIMARY : '#f1f5f9',
+              color: mode === 'rewrite' ? '#fff' : '#475569',
+              '&:hover': { bgcolor: mode === 'rewrite' ? `${PRIMARY}e0` : '#e2e8f0' },
+            }}
+          >
+            ESリライト（STAR法）
+          </Button>
+        </Box>
+      </Box>
+
       {/* Main */}
-      <Box sx={{ maxWidth: 1200, mx: 'auto', p: { xs: 2, md: 4 } }}>
+      <Box sx={{ maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 }, pb: 4 }}>
         <Box
           sx={{
             display: 'grid',
@@ -125,7 +201,9 @@ export default function ESRewritePage() {
         >
           {/* ── Left: Input ── */}
           <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
-            <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2.5 }}>元のES文章を入力</Typography>
+            <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2.5 }}>
+              {mode === 'review' ? 'ES添削' : 'ESリライト'} — 元の文章を入力
+            </Typography>
 
             {/* 質問種別 */}
             <Box sx={{ mb: 2.5 }}>
@@ -137,8 +215,7 @@ export default function ESRewritePage() {
                     label={type}
                     onClick={() => setQuestionType(type)}
                     sx={{
-                      cursor: 'pointer',
-                      fontWeight: 600,
+                      cursor: 'pointer', fontWeight: 600,
                       bgcolor: questionType === type ? PRIMARY : '#f1f5f9',
                       color: questionType === type ? '#fff' : '#475569',
                       '&:hover': { bgcolor: questionType === type ? `${PRIMARY}e0` : '#e2e8f0' },
@@ -155,7 +232,7 @@ export default function ESRewritePage() {
               fullWidth
               value={originalText}
               onChange={e => setOriginalText(e.target.value)}
-              placeholder={`例）チームで開発した経験があります。最初は上手くいきませんでしたが、話し合いを重ねて最終的には完成させることができました。この経験から協調性の大切さを学びました。`}
+              placeholder="例）チームで開発した経験があります。最初は上手くいきませんでしたが、話し合いを重ねて最終的には完成させることができました。この経験から協調性の大切さを学びました。"
               sx={{
                 mb: 2.5,
                 '& .MuiOutlinedInput-root': {
@@ -166,31 +243,50 @@ export default function ESRewritePage() {
               }}
             />
 
-            {/* 技術スタック（任意） */}
-            <TextField
-              fullWidth
-              size="small"
-              value={techStack}
-              onChange={e => setTechStack(e.target.value)}
-              label="使用技術スタック（任意）"
-              placeholder="例: React, Node.js, PostgreSQL, Docker"
-              sx={{
-                mb: 3,
-                '& .MuiOutlinedInput-root': {
-                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
-                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
-                },
-                '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
-              }}
-            />
+            {/* 添削モード: 志望企業 / リライトモード: 技術スタック */}
+            {mode === 'review' ? (
+              <TextField
+                fullWidth
+                size="small"
+                value={companyName}
+                onChange={e => setCompanyName(e.target.value)}
+                label="志望企業名（任意・入力で企業適合性を評価）"
+                placeholder="例: 株式会社サイバーエージェント"
+                sx={{
+                  mb: 3,
+                  '& .MuiOutlinedInput-root': {
+                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                  },
+                  '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
+                }}
+              />
+            ) : (
+              <TextField
+                fullWidth
+                size="small"
+                value={techStack}
+                onChange={e => setTechStack(e.target.value)}
+                label="使用技術スタック（任意）"
+                placeholder="例: React, Node.js, PostgreSQL, Docker"
+                sx={{
+                  mb: 3,
+                  '& .MuiOutlinedInput-root': {
+                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: PRIMARY },
+                  },
+                  '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
+                }}
+              />
+            )}
 
             <Button
               variant="contained"
               fullWidth
               size="large"
               disabled={!originalText.trim() || loading}
-              onClick={handleRewrite}
-              startIcon={loading ? <CircularProgress size={18} sx={{ color: '#fff' }} /> : <AutoFixHighIcon />}
+              onClick={mode === 'review' ? handleReview : handleRewrite}
+              startIcon={loading ? <CircularProgress size={18} sx={{ color: '#fff' }} /> : (mode === 'review' ? <RateReviewIcon /> : <AutoFixHighIcon />)}
               sx={{
                 bgcolor: PRIMARY, '&:hover': { bgcolor: `${PRIMARY}e0` },
                 borderRadius: 2, py: 1.5, fontWeight: 700, fontSize: 16,
@@ -198,7 +294,10 @@ export default function ESRewritePage() {
                 '&:disabled': { bgcolor: '#e2e8f0', color: '#94a3b8' },
               }}
             >
-              {loading ? 'リライト中...' : 'AIでリライトする'}
+              {loading
+                ? (mode === 'review' ? '添削中...' : 'リライト中...')
+                : (mode === 'review' ? 'AIで添削する' : 'AIでリライトする')
+              }
             </Button>
 
             {error && (
@@ -207,7 +306,81 @@ export default function ESRewritePage() {
           </Paper>
 
           {/* ── Right: Result ── */}
-          {result && (
+          {mode === 'review' && reviewResult && (
+            <Stack spacing={2}>
+              {/* Score gauges */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: `2px solid ${PRIMARY}`, bgcolor: `${PRIMARY}04` }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 17, color: PRIMARY, mb: 2.5 }}>添削スコア</Typography>
+                <Stack spacing={2}>
+                  {SCORE_ITEMS.map(({ key, label, color }) => {
+                    const score = reviewResult[key]
+                    if (score === null) return (
+                      <Box key={key}>
+                        <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.5 }}>
+                          <Typography sx={{ fontSize: 13, fontWeight: 600, color: '#94a3b8' }}>{label}</Typography>
+                          <Typography sx={{ fontSize: 12, color: '#94a3b8' }}>企業名未入力</Typography>
+                        </Stack>
+                        <LinearProgress variant="determinate" value={0} sx={{ height: 6, borderRadius: 3, bgcolor: '#e2e8f0', '& .MuiLinearProgress-bar': { bgcolor: '#e2e8f0' } }} />
+                      </Box>
+                    )
+                    const pct = ((score as number) / 10) * 100
+                    return (
+                      <Box key={key}>
+                        <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.5 }}>
+                          <Typography sx={{ fontSize: 13, fontWeight: 600, color: '#475569' }}>{label}</Typography>
+                          <Typography sx={{ fontSize: 13, fontWeight: 700, color }}>{score} / 10</Typography>
+                        </Stack>
+                        <LinearProgress
+                          variant="determinate"
+                          value={pct}
+                          sx={{ height: 8, borderRadius: 4, bgcolor: '#e2e8f0', '& .MuiLinearProgress-bar': { bgcolor: color, borderRadius: 4 } }}
+                        />
+                      </Box>
+                    )
+                  })}
+                </Stack>
+              </Paper>
+
+              {/* Feedback */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 16, mb: 1.5 }}>フィードバック</Typography>
+                <Typography variant="body2" sx={{ color: '#475569', lineHeight: 1.8 }}>
+                  {reviewResult.feedback}
+                </Typography>
+              </Paper>
+
+              {/* Before / After comparison */}
+              {reviewResult.improved_text && (
+                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0', bgcolor: '#fff' }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                    <Typography sx={{ fontWeight: 700, fontSize: 16 }}>改善後テキスト</Typography>
+                    <Tooltip title={copied ? 'コピーしました' : 'クリップボードにコピー'}>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleCopy(reviewResult.improved_text)}
+                        sx={{ bgcolor: copied ? '#10b981' : '#f1f5f9', '&:hover': { bgcolor: copied ? '#059669' : '#e2e8f0' } }}
+                      >
+                        {copied
+                          ? <CheckIcon sx={{ color: '#fff', fontSize: 18 }} />
+                          : <ContentCopyIcon sx={{ color: '#475569', fontSize: 18 }} />
+                        }
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                  <Typography sx={{ fontSize: 14, lineHeight: 1.9, color: '#1e293b', whiteSpace: 'pre-wrap', mb: 2 }}>
+                    {reviewResult.improved_text}
+                  </Typography>
+                  <Divider sx={{ mb: 2 }} />
+                  <Typography sx={{ fontWeight: 700, fontSize: 13, mb: 1, color: '#64748b' }}>元の文章</Typography>
+                  <Typography variant="body2" sx={{ color: '#94a3b8', lineHeight: 1.8, whiteSpace: 'pre-wrap' }}>
+                    {originalText}
+                  </Typography>
+                </Paper>
+              )}
+            </Stack>
+          )}
+
+          {mode === 'rewrite' && rewriteResult && (
             <Stack spacing={2}>
               {/* Rewritten text */}
               <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: `2px solid ${PRIMARY}`, bgcolor: `${PRIMARY}04` }}>
@@ -219,7 +392,7 @@ export default function ESRewritePage() {
                   <Tooltip title={copied ? 'コピーしました' : 'クリップボードにコピー'}>
                     <IconButton
                       size="small"
-                      onClick={handleCopy}
+                      onClick={() => handleCopy(rewriteResult.rewritten_text)}
                       sx={{ bgcolor: copied ? '#10b981' : '#f1f5f9', '&:hover': { bgcolor: copied ? '#059669' : '#e2e8f0' } }}
                     >
                       {copied
@@ -229,10 +402,8 @@ export default function ESRewritePage() {
                     </IconButton>
                   </Tooltip>
                 </Box>
-                <Typography
-                  sx={{ fontSize: 14, lineHeight: 1.9, color: '#1e293b', whiteSpace: 'pre-wrap' }}
-                >
-                  {result.rewritten_text}
+                <Typography sx={{ fontSize: 14, lineHeight: 1.9, color: '#1e293b', whiteSpace: 'pre-wrap' }}>
+                  {rewriteResult.rewritten_text}
                 </Typography>
               </Paper>
 
@@ -243,32 +414,15 @@ export default function ESRewritePage() {
                   {STAR_LABELS.map(({ key, label, color, emoji }, idx) => (
                     <Box key={key}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.8 }}>
-                        <Box
-                          sx={{
-                            width: 28, height: 28, borderRadius: 1.5,
-                            bgcolor: `${color}15`,
-                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            fontSize: 14,
-                          }}
-                        >
+                        <Box sx={{ width: 28, height: 28, borderRadius: 1.5, bgcolor: `${color}15`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14 }}>
                           {emoji}
                         </Box>
-                        <Typography sx={{ fontWeight: 700, fontSize: 13, color }}>
-                          {label}
-                        </Typography>
+                        <Typography sx={{ fontWeight: 700, fontSize: 13, color }}>{label}</Typography>
                       </Box>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          color: '#475569', lineHeight: 1.75,
-                          borderLeft: `3px solid ${color}40`, pl: 1.5,
-                        }}
-                      >
-                        {result.star[key] || '—'}
+                      <Typography variant="body2" sx={{ color: '#475569', lineHeight: 1.75, borderLeft: `3px solid ${color}40`, pl: 1.5 }}>
+                        {rewriteResult.star[key] || '—'}
                       </Typography>
-                      {idx < STAR_LABELS.length - 1 && (
-                        <Divider sx={{ mt: 1.5, borderColor: '#f1f5f9' }} />
-                      )}
+                      {idx < STAR_LABELS.length - 1 && <Divider sx={{ mt: 1.5, borderColor: '#f1f5f9' }} />}
                     </Box>
                   ))}
                 </Stack>

--- a/rag/main.py
+++ b/rag/main.py
@@ -470,3 +470,115 @@ def review_resume(request: ReviewRequest) -> ReviewResponse:
     )
 
     return ReviewResponse(report=report)
+
+
+# ── ES添削エンドポイント ──────────────────────────────────────────────────────
+
+
+class ESReviewRequest(BaseModel):
+    es_text: str = Field(min_length=1)
+    question_type: str = Field(default="その他")
+    company_name: str = Field(default="")
+
+
+class ESReviewResponse(BaseModel):
+    specificity_score: int            # 1-10: 具体性
+    star_score: int                   # 1-10: STAR法準拠
+    company_fit_score: Optional[int]  # 1-10: 企業適合性（企業名なしは null）
+    length_balance_score: int         # 1-10: 文字数バランス
+    feedback: str                     # 全体フィードバック文
+    improved_text: str                # 改善後テキスト
+
+
+def _run_es_review(
+    es_text: str,
+    question_type: str,
+    company_name: str,
+    context_docs: List[str],
+) -> ESReviewResponse:
+    import json as _json
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY is required")
+    client = OpenAI(api_key=api_key)
+    model = os.getenv("OPENAI_CHAT_MODEL", "gpt-4o")
+    has_company = bool(company_name.strip())
+    context_text = "\n\n".join(context_docs) if context_docs else ""
+    company_section = (
+        f"\n\n【企業情報】\n{context_text[:2000]}" if context_text else ""
+    )
+    company_fit_key = (
+        '"company_fit_score": <1-10の整数: 企業の価値観・求める人物像との適合度>'
+        if has_company
+        else '"company_fit_score": null'
+    )
+    system_prompt = (
+        "あなたは就職活動の専門アドバイザーです。"
+        "学生のES文章を添削し、以下のJSONのみを返してください。説明文は不要です。"
+    )
+    user_prompt = (
+        f"【質問種別】{question_type}\n"
+        f"【ES文章】\n{es_text}"
+        + (f"\n\n【志望企業】{company_name}" if has_company else "")
+        + company_section
+        + f"""
+
+以下のJSONフォーマットで添削結果を返してください:
+{{
+  "specificity_score": <1-10の整数: 具体的な数値・エピソード・固有名詞が含まれているか>,
+  "star_score": <1-10の整数: Situation/Task/Action/Resultの構造が揃っているか>,
+  {company_fit_key},
+  "length_balance_score": <1-10の整数: 文字数・各要素のバランスが適切か>,
+  "feedback": "<具体性・STAR準拠・企業適合性・文字数について200字以内でアドバイス>",
+  "improved_text": "<元の文章を改善したバージョン（元の文字数の110〜130%を目安）>"
+}}"""
+    )
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.3,
+            max_tokens=1200,
+            response_format={"type": "json_object"},
+        )
+        data = _json.loads(resp.choices[0].message.content or "{}")
+        company_fit = data.get("company_fit_score")
+        if company_fit is not None:
+            company_fit = max(1, min(10, int(company_fit)))
+        return ESReviewResponse(
+            specificity_score=max(1, min(10, int(data.get("specificity_score", 5)))),
+            star_score=max(1, min(10, int(data.get("star_score", 5)))),
+            company_fit_score=company_fit,
+            length_balance_score=max(1, min(10, int(data.get("length_balance_score", 5)))),
+            feedback=str(data.get("feedback", "")),
+            improved_text=str(data.get("improved_text", "")),
+        )
+    except Exception as exc:
+        logger.warning("es review failed error=%s", exc)
+        raise HTTPException(status_code=500, detail=f"ES review failed: {exc}")
+
+
+@app.post("/es/review", response_model=ESReviewResponse)
+def es_review(request: ESReviewRequest) -> ESReviewResponse:
+    context_docs: List[str] = []
+    if request.company_name.strip():
+        cache_key = "{company}::es_review".format(company=request.company_name)
+        context_docs = get_cached_context(
+            cache_key, query=f"{request.company_name} 求める人物像 採用 価値観"
+        )
+        if not context_docs and ALLOW_DDG_FALLBACK:
+            query = f"{request.company_name} 求める人物像 大切にしている価値観 採用"
+            results, _ = run_search(query, limit=5)
+            if results:
+                context_docs = build_context(results)
+                set_cached_context(cache_key, context_docs)
+
+    return _run_es_review(
+        es_text=request.es_text,
+        question_type=request.question_type,
+        company_name=request.company_name,
+        context_docs=context_docs,
+    )


### PR DESCRIPTION
Closes #143

## 変更内容

### RAG service (`rag/main.py`)
- `ESReviewRequest` / `ESReviewResponse` Pydantic モデルを追加（入力: `es_text`, `question_type`, `company_name` / 出力: スコア4項目 + `feedback` + `improved_text`）
- `_run_es_review()` 関数を追加: OpenAI (`gpt-4o`) で具体性・STAR法準拠・企業適合性・文字数バランスの4項目を1-10でスコアリングし、改善後テキストと全体フィードバックを JSON 形式で生成
- `POST /es/review` エンドポイントを追加: 企業名が指定されている場合は ChromaDB キャッシュ → DuckDuckGo で企業情報を取得し、企業適合性評価のコンテキストとして活用

### Backend
- `es_review_controller.go` を新規作成: `RAG_REVIEW_URL` 環境変数経由で RAG service の `/es/review` にプロキシする `POST /api/es/review` ハンドラ（タイムアウト60秒）
- `es_routes.go`: `SetupESRoutes` に `ESReviewController` 引数を追加し `/api/es/review` ルートを登録
- `main.go`: `NewESReviewController()` の初期化と `SetupESRoutes` への渡しを追加

### フロントエンド (`frontend/app/es-rewrite/page.tsx`)
- `ReviewResult` 型を追加（スコア4項目 + `feedback` + `improved_text`）
- `mode` state（`'rewrite' | 'review'`）を追加し、ヘッダー直下にモード切り替えボタン（ES添削 / ESリライト）を配置
- 添削モード専用の入力フィールド「志望企業名（任意）」を追加（入力で企業適合性スコアが有効化）
- 添削結果パネルを追加:
  - スコアゲージ（`LinearProgress`）で4指標を視覚化（企業名未入力時は企業適合性をグレーアウト）
  - フィードバックテキストパネル
  - 改善後テキスト + 元の文章の比較表示 + クリップボードコピーボタン