### PR TITLE
Resolve #147: RAGレビュー結果のストリーミング表示対応

### DIFF
--- a/Backend/internal/controllers/resume_controller.go
+++ b/Backend/internal/controllers/resume_controller.go
@@ -120,6 +120,50 @@ func (c *ResumeController) Review(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+func (c *ResumeController) ReviewStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	docIDStr := r.URL.Query().Get("document_id")
+	if docIDStr == "" {
+		http.Error(w, "document_id is required", http.StatusBadRequest)
+		return
+	}
+	docID, err := strconv.ParseUint(docIDStr, 10, 32)
+	if err != nil {
+		http.Error(w, "Invalid document_id", http.StatusBadRequest)
+		return
+	}
+
+	var payload struct {
+		CompanyName   string `json:"company_name"`
+		CandidateType string `json:"candidate_type"`
+		JobTitle      string `json:"job_title"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+	}
+
+	log.Printf(
+		"resume_review_stream: start document_id=%d company=%q job_title=%q",
+		docID, payload.CompanyName, payload.JobTitle,
+	)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	if err := c.resumeService.ReviewDocumentStream(r.Context(), uint(docID), payload.CompanyName, payload.JobTitle, payload.CandidateType, w); err != nil {
+		log.Printf("resume_review_stream: error document_id=%d err=%v", docID, err)
+	}
+}
+
 func (c *ResumeController) Annotated(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/Backend/internal/routes/resume_routes.go
+++ b/Backend/internal/routes/resume_routes.go
@@ -8,5 +8,6 @@ import (
 func SetupResumeRoutes(resumeController *controllers.ResumeController) {
 	http.HandleFunc("/api/resume/upload", resumeController.Upload)
 	http.HandleFunc("/api/resume/review", resumeController.Review)
+	http.HandleFunc("/api/resume/review/stream", resumeController.ReviewStream)
 	http.HandleFunc("/api/resume/annotated", resumeController.Annotated)
 }

--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -4,6 +4,7 @@ import (
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"Backend/internal/openai"
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -676,6 +677,180 @@ func (s *ResumeService) fetchRAGReport(resumeText, companyName, jobTitle string)
 	return response.Report, nil
 }
 
+// fetchRAGReportStream は FastAPI ストリーミングエンドポイントを呼び出し、
+// SSE レスポンスボディ (io.ReadCloser) を返す。呼び出し元がクローズする責務を持つ。
+func (s *ResumeService) fetchRAGReportStream(ctx context.Context, resumeText, companyName, jobTitle string) (io.ReadCloser, error) {
+	baseURL := strings.TrimSpace(os.Getenv("RAG_REVIEW_URL"))
+	if baseURL == "" {
+		return nil, errors.New("RAG_REVIEW_URL is not set")
+	}
+
+	payload := ragReviewRequest{
+		ResumeText:  resumeText,
+		CompanyName: companyName,
+		JobTitle:    jobTitle,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/resume/review/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	// ストリーミングのためタイムアウトなし
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		resp.Body.Close()
+		return nil, fmt.Errorf("rag stream request failed: status %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+// ReviewDocumentStream はドキュメントを前処理した後、SSEでRAGレポートをストリーミングし、
+// 最後にスコア・指摘事項を complete イベントとして送信する。
+func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uint, companyName, jobTitle, candidateType string, w http.ResponseWriter) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("streaming not supported")
+	}
+
+	sendEvent := func(v map[string]interface{}) {
+		data, _ := json.Marshal(v)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	doc, err := s.repo.FindDocumentByID(documentID)
+	if err != nil {
+		sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})
+		return err
+	}
+	if s.s3 == nil || !s.s3.isEnabled() {
+		sendEvent(map[string]interface{}{"type": "error", "message": "s3 is required"})
+		return errors.New("s3 is required")
+	}
+	if strings.TrimSpace(companyName) == "" && strings.TrimSpace(jobTitle) == "" {
+		msg := "応募企業名または応募職種を入力してください"
+		sendEvent(map[string]interface{}{"type": "error", "message": msg})
+		return errors.New(msg)
+	}
+
+	workDir, err := s.ensureWorkingDir(doc.ID)
+	if err != nil {
+		sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})
+		return err
+	}
+	defer os.RemoveAll(workDir)
+
+	pdfPath, normalizedStored, err := s.normalizeToPDF(doc, workDir)
+	if err != nil {
+		sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})
+		return err
+	}
+	doc.NormalizedPath = normalizedStored
+	doc.Status = "normalized"
+	_ = s.repo.UpdateDocument(doc)
+
+	blocks, err := s.extractTextBlocks(doc, pdfPath)
+	if err != nil {
+		sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})
+		return err
+	}
+	hasText := false
+	for _, b := range blocks {
+		if strings.TrimSpace(b.Text) != "" {
+			hasText = true
+			break
+		}
+	}
+	if !hasText {
+		msg := "履歴書からテキストを抽出できませんでした。PDF の画質や形式を確認してください"
+		sendEvent(map[string]interface{}{"type": "error", "message": msg})
+		return errors.New(msg)
+	}
+	_ = s.repo.ReplaceTextBlocks(doc.ID, blocks)
+
+	text := buildResumeText(blocks, 30000)
+
+	// RAGレポートをストリーミングしつつ全文を収集する
+	var ragReport string
+	if strings.TrimSpace(companyName) != "" {
+		ragBody, ragErr := s.fetchRAGReportStream(ctx, text, companyName, jobTitle)
+		if ragErr == nil {
+			ragReport, _ = relaySSEChunks(ragBody, w, flusher)
+			ragBody.Close()
+		} else {
+			log.Printf("resume_review_stream: rag stream failed: %v", ragErr)
+		}
+	}
+
+	// スコア・指摘事項を生成
+	review, items, err := s.buildReviewScoreItems(blocks, companyName, jobTitle, candidateType, ragReport)
+	if err != nil {
+		log.Printf("resume_review_stream: build score failed: %v", err)
+		var ve *ValidationError
+		if errors.As(err, &ve) {
+			sendEvent(map[string]interface{}{"type": "error", "message": ve.Message})
+		} else {
+			sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})
+		}
+		return err
+	}
+
+	sendEvent(map[string]interface{}{
+		"type":   "complete",
+		"review": review,
+		"items":  items,
+	})
+	return nil
+}
+
+// relaySSEChunks はFastAPIからのSSEストリームを読み取り、chunk イベントをそのまま
+// クライアントに転送しつつ、全テキストを返す。
+func relaySSEChunks(body io.Reader, w io.Writer, flusher http.Flusher) (string, error) {
+	var accum strings.Builder
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 64*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := line[6:]
+
+		var event struct {
+			Type    string `json:"type"`
+			Text    string `json:"text"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "chunk":
+			accum.WriteString(event.Text)
+			fmt.Fprintf(w, "data: %s\n\n", payload)
+			flusher.Flush()
+		case "done":
+			return accum.String(), nil
+		case "error":
+			return accum.String(), fmt.Errorf("rag stream error: %s", event.Message)
+		}
+	}
+	return accum.String(), scanner.Err()
+}
+
 func (s *ResumeService) buildResumeReviewWithAI(blocks []models.ResumeTextBlock, companyName string, jobTitle string, candidateType string) (*models.ResumeReview, []models.ResumeReviewItem, error) {
 	text := buildResumeText(blocks, 30000)
 	if strings.TrimSpace(text) == "" {
@@ -693,6 +868,16 @@ func (s *ResumeService) buildResumeReviewWithAI(blocks []models.ResumeTextBlock,
 			log.Printf("resume_review: rag report failed: %v", err)
 		}
 	}
+	return s.buildReviewScoreItems(blocks, companyName, jobTitle, candidateType, companyInfo)
+}
+
+// buildReviewScoreItems はcompanyInfoを受け取りOpenAIでスコア・指摘事項を生成する。
+// fetchRAGReportStream など外部から取得したRAGレポートを直接渡す場合に使用する。
+func (s *ResumeService) buildReviewScoreItems(blocks []models.ResumeTextBlock, companyName, jobTitle, candidateType, companyInfo string) (*models.ResumeReview, []models.ResumeReviewItem, error) {
+	if s.aiClient == nil {
+		return nil, nil, fmt.Errorf("AIクライアントが初期化されていません")
+	}
+	text := buildResumeText(blocks, 30000)
 	if strings.TrimSpace(companyName) != "" && strings.TrimSpace(companyInfo) == "" {
 		companyPrompt := fmt.Sprintf(`企業名: %s
 採用観点（求める人物像・評価軸・事業領域）を簡潔に整理してください。

--- a/frontend/app/api/resume/review/stream/route.ts
+++ b/frontend/app/api/resume/review/stream/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const documentId = searchParams.get('document_id')
+  if (!documentId) {
+    return new Response('document_id is required', { status: 400 })
+  }
+
+  const body = await request.text()
+
+  const response = await fetch(
+    `${BACKEND_URL}/api/resume/review/stream?document_id=${documentId}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body || undefined,
+    }
+  )
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -56,6 +56,7 @@ export default function ResumePage() {
   const [uploadError, setUploadError] = useState('')
   const [reviewError, setReviewError] = useState('')
   const [review, setReview] = useState<ReviewResult | null>(null)
+  const [ragReport, setRagReport] = useState('')
 
   useEffect(() => {
     const user = authService.getStoredUser()
@@ -127,9 +128,12 @@ export default function ResumePage() {
       return
     }
     setReviewError('')
+    setReview(null)
+    setRagReport('')
     setReviewLoading(true)
+
     try {
-      const response = await fetch(`/api/resume/review?document_id=${documentId}`, {
+      const response = await fetch(`/api/resume/review/stream?document_id=${documentId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -138,22 +142,42 @@ export default function ResumePage() {
           candidate_type: candidateType,
         }),
       })
-      if (!response.ok) {
+
+      if (!response.ok || !response.body) {
         const errText = await response.text()
-        let message = errText
-        try {
-          const parsed = JSON.parse(errText)
-          message = parsed?.error || parsed?.message || errText
-        } catch {
-          message = errText || 'Review failed'
+        throw new Error(errText || 'Review failed')
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const data = JSON.parse(line.slice(6))
+            if (data.type === 'chunk') {
+              setRagReport((prev) => prev + data.text)
+            } else if (data.type === 'complete') {
+              setReview({ review: data.review, items: data.items })
+            } else if (data.type === 'error') {
+              throw new Error(data.message)
+            }
+          } catch (parseErr) {
+            if (parseErr instanceof Error && parseErr.message !== 'Unexpected token') {
+              throw parseErr
+            }
+          }
         }
-        throw new Error(message)
       }
-      const data = await response.json()
-      if (!data || !data.review) {
-        throw new Error('Review response is empty')
-      }
-      setReview(data)
     } catch (err) {
       setReviewError(err instanceof Error ? err.message : 'Review failed')
     } finally {
@@ -269,18 +293,42 @@ export default function ResumePage() {
             <Box>
               <LinearProgress />
               <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                レビューを生成中...（通常30〜60秒かかります）
+                {ragReport ? '企業別レビューレポートを生成中...' : 'PDFを解析中...（通常30〜60秒かかります）'}
               </Typography>
             </Box>
           )}
           {reviewError && (
             <Alert severity="error">{reviewError}</Alert>
           )}
-          {review && (
-            <Alert severity="success">レビューが完了しました。下の指摘事項ページをご確認ください。</Alert>
+          {review && !reviewLoading && (
+            <Alert severity="success">レビューが完了しました。下の指摘事項をご確認ください。</Alert>
           )}
         </Stack>
       </Paper>
+
+      {ragReport && (
+        <Paper sx={{ p: 3, mt: 4 }} elevation={2}>
+          <Typography variant="h5" fontWeight="bold" gutterBottom>
+            企業別レビューレポート
+            {reviewLoading && (
+              <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                生成中...
+              </Typography>
+            )}
+          </Typography>
+          <Box
+            sx={{
+              whiteSpace: 'pre-wrap',
+              fontFamily: 'inherit',
+              fontSize: '0.95rem',
+              lineHeight: 1.8,
+              color: 'text.primary',
+            }}
+          >
+            {ragReport}
+          </Box>
+        </Paper>
+      )}
 
       {review && (
         <Paper sx={{ p: 3, mt: 4 }} elevation={2}>

--- a/rag/main.py
+++ b/rag/main.py
@@ -1,10 +1,11 @@
+import json
 import logging
 import math
 import os
 import re
 import threading
 import time
-from typing import List, Optional, Tuple
+from typing import Generator, List, Optional, Tuple
 
 import chromadb
 import tiktoken
@@ -12,6 +13,7 @@ from crewai import Agent, Task, Crew, Process
 from duckduckgo_search import DDGS
 from duckduckgo_search.exceptions import RatelimitException
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 import openai as openai_module
 from openai import OpenAI
 from pydantic import BaseModel, Field
@@ -413,8 +415,8 @@ def healthz() -> dict:
     return {"status": "ok"}
 
 
-@app.post("/resume/review", response_model=ReviewResponse)
-def review_resume(request: ReviewRequest) -> ReviewResponse:
+def _gather_context(request: ReviewRequest) -> Tuple[List[str], str]:
+    """RAGコンテキストを収集し (docs, context_source) を返す。"""
     role_label = request.job_title or "指定なし"
     cache_key = "{company}::{role}".format(company=request.company_name, role=role_label)
     context_source = "none"
@@ -460,6 +462,90 @@ def review_resume(request: ReviewRequest) -> ReviewResponse:
                 if not retrieved:
                     retrieved = docs[:5]
                 context_source = "duckduckgo"
+
+    return retrieved, context_source
+
+
+@app.post("/resume/review/stream")
+def review_resume_stream(request: ReviewRequest) -> StreamingResponse:
+    """RAGレポートをSSEでストリーミング配信するエンドポイント。"""
+    role_label = request.job_title or "指定なし"
+
+    # コンテキスト収集（キャッシュ/DeepResearch/DDG）
+    retrieved, context_source = _gather_context(request)
+
+    source_labels = {
+        "deep_research": "OpenAI Deep Research（o3-deep-research）",
+        "duckduckgo": "DuckDuckGo ウェブ検索",
+        "cache": "chromadb キャッシュ（以前の検索結果）",
+        "none": "事前学習データのみ（外部検索なし）",
+    }
+    source_label = source_labels.get(context_source, context_source)
+
+    def generate() -> Generator[str, None, None]:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            yield "data: {}\n\n".format(json.dumps({"type": "error", "message": "OPENAI_API_KEY not set"}, ensure_ascii=False))
+            return
+
+        model = os.getenv("OPENAI_REVIEW_MODEL", "gpt-4o-mini")
+        context_block = "\n\n".join(retrieved) if retrieved else "（外部情報なし）"
+
+        prompt = (
+            "以下の企業の採用観点に照らして、候補者の履歴書のレビューレポートを日本語で作成してください。\n\n"
+            "【企業名】{company}\n"
+            "【職種】{role}\n"
+            "【企業情報（参考）】\n{context}\n\n"
+            "【履歴書テキスト】\n{resume}\n\n"
+            "以下のフォーマットに従って出力してください:\n\n"
+            "【企業別レビュー報告書】\n---\n"
+            "#### ■ 対象企業\n{company}\n\n"
+            "#### ■ この企業が求めている核心的要素\n- ...\n\n"
+            "#### ■ 履歴書の最適化アドバイス\n"
+            "- **強みの再定義**: ...\n"
+            "- **不足している情報の補足**: ...\n\n"
+            "#### ■ 職種別アドバイス（{role}）\n"
+            "この職種特有の評価ポイントを3点以上、具体的に記述してください。\n\n"
+            "#### ■ 修正後の自己PRイメージ\n...\n\n"
+            "#### ■ 情報の信頼度・参照元\n"
+            "- 情報ソース: {source}\n"
+            "- 注意: 外部情報に基づく内容は変化する可能性があります。最新情報は企業公式サイトで確認してください。\n"
+        ).format(
+            company=request.company_name,
+            role=role_label,
+            context=context_block,
+            resume=request.resume_text[:10000],
+            source=source_label,
+        )
+
+        try:
+            client = OpenAI(api_key=api_key)
+            stream = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "あなたはプロのキャリアアドバイザーです。"},
+                    {"role": "user", "content": prompt},
+                ],
+                stream=True,
+                max_tokens=1500,
+                temperature=0.3,
+            )
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    yield "data: {}\n\n".format(json.dumps({"type": "chunk", "text": delta.content}, ensure_ascii=False))
+            yield "data: {}\n\n".format(json.dumps({"type": "done"}, ensure_ascii=False))
+        except Exception as exc:
+            logger.error("review_stream generate error: %s", exc)
+            yield "data: {}\n\n".format(json.dumps({"type": "error", "message": str(exc)}, ensure_ascii=False))
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@app.post("/resume/review", response_model=ReviewResponse)
+def review_resume(request: ReviewRequest) -> ReviewResponse:
+    role_label = request.job_title or "指定なし"
+    retrieved, context_source = _gather_context(request)
 
     report = run_crewai(
         resume_text=request.resume_text,


### PR DESCRIPTION
Closes #147

## 変更内容

### FastAPI (`rag/main.py`)
- コンテキスト収集ロジックを `_gather_context()` ヘルパーに共通化し、既存の `/resume/review` も利用するようリファクタリング
- `/resume/review/stream` SSEエンドポイントを新規追加
  - キャッシュ/DeepResearch/DuckDuckGoによるコンテキスト収集後、OpenAI `chat.completions.create(stream=True)` でレポートを逐次配信
  - 各チャンクを `data: {"type":"chunk","text":"..."}` 形式のSSEで送信
  - 完了時に `{"type":"done"}` を送信、エラー時は `{"type":"error","message":"..."}` を送信

### Go バックエンド
- `buildResumeReviewWithAI` からスコア・指摘事項生成ロジックを **`buildReviewScoreItems`** として分離
  - `companyInfo`（RAGレポート）を外部から渡せる設計に変更
- **`fetchRAGReportStream`**: FastAPIの `/resume/review/stream` を呼び出し `io.ReadCloser` を返す
- **`ReviewDocumentStream`** サービスメソッドを追加
  - PDF前処理（正規化・OCR）→ RAGストリーム中継 → スコア生成 → `complete` イベント送信
- **`relaySSEChunks`** ヘルパーを追加: FastAPIのSSEチャンクをフロントエンドに転送しつつ全文を収集
- `ReviewStream` コントローラハンドラを追加（SSEヘッダー設定）
- `/api/resume/review/stream` ルートを登録

### フロントエンド
- Next.js API route `/api/resume/review/stream` を新規作成（Goバックエンドへのストリームプロキシ）
- `resume/page.tsx` をストリーミング対応に更新
  - `fetch` + `ReadableStream` でSSEを逐次受信
  - `ragReport` stateにチャンクを蓄積し、生成中にリアルタイム表示
  - 生成完了後（`complete` イベント）にスコア・指摘事項を一括表示
  - プログレス表示を「PDF解析中」→「レポート生成中」に動的切り替え