### PR TITLE
Resolve #148: APIコストのリアルタイムモニタリング機能

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -123,9 +123,16 @@ func main() {
 	// GitHub連携
 	githubRepo := repositories.NewGitHubRepository(db)
 	skillScoreRepo := repositories.NewSkillScoreRepository(db)
+	// APIコストモニタリング
+	apiCallLogRepo := repositories.NewAPICallLogRepository(db)
 
 	// サービス層の初期化
 	emailService := services.NewEmailService()
+	apiCostService := services.NewAPICostService(apiCallLogRepo)
+	// OpenAI APIコール時にトークン使用量をロギング
+	aiClient.OnUsage = func(model string, promptTokens, completionTokens int) {
+		apiCostService.LogCall(model, promptTokens, completionTokens)
+	}
 	authService := services.NewAuthService(userRepo, pendingRegistrationRepo, emailService)
 	skillScoreService := services.NewSkillScoreService(skillScoreRepo)
 	githubService := services.NewGitHubService(githubRepo, skillScoreService, aiClient)
@@ -179,6 +186,7 @@ func main() {
 	realtimeController := controllers.NewRealtimeController(interviewService)
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	adminDashboardController := controllers.NewAdminDashboardController(userRepo, interviewSessionRepo, interviewReportRepo)
+	adminCostsController := controllers.NewAdminCostsController(apiCostService)
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
 	githubController := controllers.NewGitHubController(githubService, skillScoreService)
 	esRewriteController := controllers.NewESRewriteController(aiClient)
@@ -191,7 +199,7 @@ func main() {
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, userRepo)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)

--- a/Backend/internal/controllers/admin_costs_controller.go
+++ b/Backend/internal/controllers/admin_costs_controller.go
@@ -1,0 +1,81 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type AdminCostsController struct {
+	costService *services.APICostService
+}
+
+func NewAdminCostsController(costService *services.APICostService) *AdminCostsController {
+	return &AdminCostsController{costService: costService}
+}
+
+// Summary handles GET /api/admin/costs/summary
+func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	monthTotal, err := c.costService.GetCurrentMonthTotal()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	since30d := time.Now().UTC().AddDate(0, 0, -30)
+	modelBreakdown, err := c.costService.GetModelBreakdown(since30d)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"current_month_cost_usd": monthTotal,
+		"model_breakdown":        modelBreakdown,
+	})
+}
+
+// Daily handles GET /api/admin/costs/daily?days=30
+func (c *AdminCostsController) Daily(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	days := parseIntQuery(r, "days", 30)
+	if days > 90 {
+		days = 90
+	}
+	rows, err := c.costService.GetDailyCosts(days)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"daily": rows})
+}
+
+// Monthly handles GET /api/admin/costs/monthly?months=12
+func (c *AdminCostsController) Monthly(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	months := parseIntQuery(r, "months", 12)
+	if months > 24 {
+		months = 24
+	}
+	rows, err := c.costService.GetMonthlyCosts(months)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"monthly": rows})
+}

--- a/Backend/internal/models/api_call_log.go
+++ b/Backend/internal/models/api_call_log.go
@@ -1,0 +1,14 @@
+package models
+
+import "time"
+
+// APICallLog OpenAI APIコール記録
+type APICallLog struct {
+	ID               uint      `gorm:"primaryKey"           json:"id"`
+	Model            string    `gorm:"size:100;not null"    json:"model"`
+	PromptTokens     int       `gorm:"not null;default:0"   json:"prompt_tokens"`
+	CompletionTokens int       `gorm:"not null;default:0"   json:"completion_tokens"`
+	TotalTokens      int       `gorm:"not null;default:0"   json:"total_tokens"`
+	CostUSD          float64   `gorm:"type:decimal(14,8);default:0" json:"cost_usd"`
+	CalledAt         time.Time `gorm:"not null;index"       json:"called_at"`
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -51,6 +51,8 @@ func AutoMigrate(db *gorm.DB) error {
 		&PendingRegistration{},
 		// 選考スケジュール
 		&ScheduleEvent{},
+		// APIコストモニタリング
+		&APICallLog{},
 		// GitHub連携
 		&GitHubProfile{},
 		&GitHubRepo{},

--- a/Backend/internal/openai/client.go
+++ b/Backend/internal/openai/client.go
@@ -15,11 +15,16 @@ import (
 	openai "github.com/sashabaranov/go-openai"
 )
 
+// UsageHook はAPIコール成功時に呼ばれるコールバック。
+// model: 使用モデル名, promptTokens: 入力トークン数, completionTokens: 出力トークン数
+type UsageHook func(model string, promptTokens, completionTokens int)
+
 // Client は go-openai SDK をラップします。
 type Client struct {
 	c            *openai.Client
 	DefaultModel string
 	apiKey       string
+	OnUsage      UsageHook // オプション: コール成功時にトークン使用量を通知
 }
 
 func init() {
@@ -119,9 +124,14 @@ func (cli *Client) callResponsesAPI(ctx context.Context, input interface{}, mode
 	type responsesOutput struct {
 		Content []responsesContent `json:"content"`
 	}
+	type responsesUsage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	}
 	type responsesResponse struct {
 		Output            []responsesOutput `json:"output"`
 		OutputText        string            `json:"output_text"`
+		Usage             responsesUsage    `json:"usage"`
 		IncompleteDetails struct {
 			Reason string `json:"reason"`
 		} `json:"incomplete_details"`
@@ -136,6 +146,9 @@ func (cli *Client) callResponsesAPI(ctx context.Context, input interface{}, mode
 	var parsed responsesResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return "", err
+	}
+	if cli.OnUsage != nil && (parsed.Usage.InputTokens > 0 || parsed.Usage.OutputTokens > 0) {
+		cli.OnUsage(model, parsed.Usage.InputTokens, parsed.Usage.OutputTokens)
 	}
 	if strings.TrimSpace(parsed.OutputText) != "" {
 		return strings.TrimSpace(parsed.OutputText), nil
@@ -442,6 +455,9 @@ func (cli *Client) ChatCompletionJSON(ctx context.Context, systemPrompt, userPro
 		if err == nil && len(resp.Choices) > 0 {
 			content := strings.TrimSpace(resp.Choices[0].Message.Content)
 			if content != "" {
+				if cli.OnUsage != nil {
+					cli.OnUsage(req.Model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+				}
 				return content, nil
 			}
 			lastErr = errors.New("empty response from model")

--- a/Backend/internal/repositories/api_call_log_repository.go
+++ b/Backend/internal/repositories/api_call_log_repository.go
@@ -1,0 +1,98 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type APICallLogRepository struct {
+	db *gorm.DB
+}
+
+func NewAPICallLogRepository(db *gorm.DB) *APICallLogRepository {
+	return &APICallLogRepository{db: db}
+}
+
+func (r *APICallLogRepository) Create(log *models.APICallLog) error {
+	return r.db.Create(log).Error
+}
+
+type DailyCostRow struct {
+	Date             string
+	TotalCostUSD     float64
+	TotalTokens      int64
+	CallCount        int64
+}
+
+type MonthlyCostRow struct {
+	Month            string
+	TotalCostUSD     float64
+	TotalTokens      int64
+	CallCount        int64
+}
+
+type ModelCostRow struct {
+	Model            string
+	TotalCostUSD     float64
+	TotalTokens      int64
+	CallCount        int64
+}
+
+// DailyCosts は過去 nDays 日間の日次集計を返す
+func (r *APICallLogRepository) DailyCosts(nDays int) ([]DailyCostRow, error) {
+	var rows []DailyCostRow
+	since := time.Now().UTC().AddDate(0, 0, -nDays)
+	err := r.db.Raw(`
+		SELECT DATE(called_at) AS date,
+		       SUM(cost_usd) AS total_cost_usd,
+		       SUM(total_tokens) AS total_tokens,
+		       COUNT(*) AS call_count
+		FROM api_call_logs
+		WHERE called_at >= ?
+		GROUP BY DATE(called_at)
+		ORDER BY date ASC`, since).Scan(&rows).Error
+	return rows, err
+}
+
+// MonthlyCosts は過去 nMonths ヶ月間の月次集計を返す
+func (r *APICallLogRepository) MonthlyCosts(nMonths int) ([]MonthlyCostRow, error) {
+	var rows []MonthlyCostRow
+	since := time.Now().UTC().AddDate(0, -nMonths, 0)
+	err := r.db.Raw(`
+		SELECT DATE_FORMAT(called_at, '%Y-%m') AS month,
+		       SUM(cost_usd) AS total_cost_usd,
+		       SUM(total_tokens) AS total_tokens,
+		       COUNT(*) AS call_count
+		FROM api_call_logs
+		WHERE called_at >= ?
+		GROUP BY month
+		ORDER BY month ASC`, since).Scan(&rows).Error
+	return rows, err
+}
+
+// ModelBreakdown はモデル別コスト内訳を返す
+func (r *APICallLogRepository) ModelBreakdown(since time.Time) ([]ModelCostRow, error) {
+	var rows []ModelCostRow
+	err := r.db.Raw(`
+		SELECT model,
+		       SUM(cost_usd) AS total_cost_usd,
+		       SUM(total_tokens) AS total_tokens,
+		       COUNT(*) AS call_count
+		FROM api_call_logs
+		WHERE called_at >= ?
+		GROUP BY model
+		ORDER BY total_cost_usd DESC`, since).Scan(&rows).Error
+	return rows, err
+}
+
+// TotalCostSince は指定日時以降の合計コストを返す
+func (r *APICallLogRepository) TotalCostSince(since time.Time) (float64, error) {
+	var total float64
+	err := r.db.Model(&models.APICallLog{}).
+		Where("called_at >= ?", since).
+		Select("COALESCE(SUM(cost_usd), 0)").
+		Scan(&total).Error
+	return total, err
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -16,6 +16,7 @@ func SetupAdminRoutes(
 	adminCompanyGraphController *controllers.AdminCompanyGraphController,
 	adminInterviewController *controllers.AdminInterviewController,
 	adminDashboardController *controllers.AdminDashboardController,
+	adminCostsController *controllers.AdminCostsController,
 	userRepo *repositories.UserRepository,
 ) {
 	auth := func(f http.HandlerFunc) http.HandlerFunc {
@@ -49,4 +50,9 @@ func SetupAdminRoutes(
 	http.HandleFunc("/api/admin/dashboard/users", auth(adminDashboardController.ListUsers))
 	http.HandleFunc("/api/admin/dashboard/users/", auth(adminDashboardController.UserSessions))
 	http.HandleFunc("/api/admin/dashboard/export/csv", auth(adminDashboardController.ExportCSV))
+
+	// API Cost monitoring
+	http.HandleFunc("/api/admin/costs/summary", auth(adminCostsController.Summary))
+	http.HandleFunc("/api/admin/costs/daily", auth(adminCostsController.Daily))
+	http.HandleFunc("/api/admin/costs/monthly", auth(adminCostsController.Monthly))
 }

--- a/Backend/internal/services/api_cost_service.go
+++ b/Backend/internal/services/api_cost_service.go
@@ -1,0 +1,176 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/repositories"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// モデル別単価テーブル (USD per 1M tokens)
+var modelPricing = map[string][2]float64{
+	// input, output per 1M tokens
+	"gpt-4o":              {2.50, 10.00},
+	"gpt-4o-mini":         {0.15, 0.60},
+	"gpt-4-turbo":         {10.00, 30.00},
+	"gpt-4":               {30.00, 60.00},
+	"gpt-3.5-turbo":       {0.50, 1.50},
+	"gpt-5.2":             {2.50, 10.00},  // treated as gpt-4o class
+	"o1":                  {15.00, 60.00},
+	"o1-mini":             {3.00, 12.00},
+	"o3":                  {10.00, 40.00},
+	"text-embedding-3-small": {0.02, 0.02},
+	"text-embedding-3-large": {0.13, 0.13},
+}
+
+// calculateCost は入力/出力トークン数とモデル名からUSDコストを計算する
+func calculateCost(model string, promptTokens, completionTokens int) float64 {
+	lower := strings.ToLower(strings.TrimSpace(model))
+
+	// prefix match for versioned model names (e.g. gpt-4o-2024-08-06)
+	var pricing [2]float64
+	var found bool
+	for k, v := range modelPricing {
+		if lower == k || strings.HasPrefix(lower, k+"-") || strings.HasPrefix(lower, k+":") {
+			pricing = v
+			found = true
+			break
+		}
+	}
+	if !found {
+		// Default to gpt-4o pricing
+		pricing = [2]float64{2.50, 10.00}
+	}
+
+	inputCost := float64(promptTokens) * pricing[0] / 1_000_000
+	outputCost := float64(completionTokens) * pricing[1] / 1_000_000
+	return inputCost + outputCost
+}
+
+// APICostService はAPIコスト記録・集計を担当する
+type APICostService struct {
+	repo            *repositories.APICallLogRepository
+	alertThresholdUSD float64 // 月額閾値
+}
+
+func NewAPICostService(repo *repositories.APICallLogRepository) *APICostService {
+	threshold := 100.0
+	if v := os.Getenv("API_COST_ALERT_THRESHOLD_USD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			threshold = f
+		}
+	}
+	return &APICostService{repo: repo, alertThresholdUSD: threshold}
+}
+
+// LogCall は非同期でAPIコールログをDBに記録する
+func (s *APICostService) LogCall(model string, promptTokens, completionTokens int) {
+	go func() {
+		cost := calculateCost(model, promptTokens, completionTokens)
+		entry := &models.APICallLog{
+			Model:            model,
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      promptTokens + completionTokens,
+			CostUSD:          cost,
+			CalledAt:         time.Now().UTC(),
+		}
+		if err := s.repo.Create(entry); err != nil {
+			log.Printf("[APICost] failed to log: %v", err)
+		}
+		s.checkThreshold()
+	}()
+}
+
+// checkThreshold は月額閾値を超えていたらログ警告を出す
+func (s *APICostService) checkThreshold() {
+	since := time.Now().UTC().AddDate(0, -1, 0)
+	total, err := s.repo.TotalCostSince(since)
+	if err != nil {
+		return
+	}
+	if total > s.alertThresholdUSD {
+		log.Printf("[APICost] ALERT: Monthly API cost $%.4f exceeds threshold $%.2f", total, s.alertThresholdUSD)
+	}
+}
+
+type DailyCostSummary struct {
+	Date         string  `json:"date"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CallCount    int64   `json:"call_count"`
+}
+
+type MonthlyCostSummary struct {
+	Month        string  `json:"month"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CallCount    int64   `json:"call_count"`
+}
+
+type ModelCostSummary struct {
+	Model        string  `json:"model"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CallCount    int64   `json:"call_count"`
+}
+
+func (s *APICostService) GetDailyCosts(nDays int) ([]DailyCostSummary, error) {
+	rows, err := s.repo.DailyCosts(nDays)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]DailyCostSummary, len(rows))
+	for i, r := range rows {
+		result[i] = DailyCostSummary{
+			Date:         r.Date,
+			TotalCostUSD: r.TotalCostUSD,
+			TotalTokens:  r.TotalTokens,
+			CallCount:    r.CallCount,
+		}
+	}
+	return result, nil
+}
+
+func (s *APICostService) GetMonthlyCosts(nMonths int) ([]MonthlyCostSummary, error) {
+	rows, err := s.repo.MonthlyCosts(nMonths)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]MonthlyCostSummary, len(rows))
+	for i, r := range rows {
+		result[i] = MonthlyCostSummary{
+			Month:        r.Month,
+			TotalCostUSD: r.TotalCostUSD,
+			TotalTokens:  r.TotalTokens,
+			CallCount:    r.CallCount,
+		}
+	}
+	return result, nil
+}
+
+func (s *APICostService) GetModelBreakdown(since time.Time) ([]ModelCostSummary, error) {
+	rows, err := s.repo.ModelBreakdown(since)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]ModelCostSummary, len(rows))
+	for i, r := range rows {
+		result[i] = ModelCostSummary{
+			Model:        r.Model,
+			TotalCostUSD: r.TotalCostUSD,
+			TotalTokens:  r.TotalTokens,
+			CallCount:    r.CallCount,
+		}
+	}
+	return result, nil
+}
+
+func (s *APICostService) GetCurrentMonthTotal() (float64, error) {
+	now := time.Now().UTC()
+	since := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	return s.repo.TotalCostSince(since)
+}

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -1,0 +1,315 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { authService } from '@/lib/auth'
+
+type DailyRow = {
+  date: string
+  total_cost_usd: number
+  total_tokens: number
+  call_count: number
+}
+
+type MonthlyRow = {
+  month: string
+  total_cost_usd: number
+  total_tokens: number
+  call_count: number
+}
+
+type ModelRow = {
+  model: string
+  total_cost_usd: number
+  total_tokens: number
+  call_count: number
+}
+
+type Summary = {
+  current_month_cost_usd: number
+  model_breakdown: ModelRow[]
+}
+
+function CostBar({ value, max }: { value: number; max: number }) {
+  const pct = max > 0 ? Math.min(100, (value / max) * 100) : 0
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{
+        flex: 1, height: 8, bgcolor: '#e0e0e0', borderRadius: 4, overflow: 'hidden',
+      }}>
+        <Box sx={{
+          width: `${pct}%`, height: '100%',
+          bgcolor: pct > 80 ? '#d32f2f' : pct > 50 ? '#f57c00' : '#1976d2',
+          borderRadius: 4, transition: 'width 0.3s',
+        }} />
+      </Box>
+      <Typography variant="body2" sx={{ minWidth: 60, textAlign: 'right' }}>
+        ${value.toFixed(4)}
+      </Typography>
+    </Box>
+  )
+}
+
+function MiniChart({ data, valueKey, labelKey }: {
+  data: any[]
+  valueKey: string
+  labelKey: string
+}) {
+  if (data.length === 0) return (
+    <Typography color="text.secondary" textAlign="center" py={2} fontSize="0.85rem">
+      データなし
+    </Typography>
+  )
+  const max = Math.max(...data.map(d => d[valueKey] as number), 0.0001)
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: '2px', height: 80, mt: 1 }}>
+      {data.map((row, i) => {
+        const h = Math.max(4, ((row[valueKey] as number) / max) * 76)
+        return (
+          <Box key={i} sx={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Box
+              title={`${row[labelKey]}: $${(row[valueKey] as number).toFixed(4)}`}
+              sx={{
+                width: '100%', height: h,
+                bgcolor: '#1976d2', borderRadius: '2px 2px 0 0',
+                cursor: 'default', '&:hover': { bgcolor: '#1565c0' },
+              }}
+            />
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
+export default function AdminCostsPage() {
+  const [adminEmail, setAdminEmail] = useState('')
+  const [summary, setSummary] = useState<Summary | null>(null)
+  const [daily, setDaily] = useState<DailyRow[]>([])
+  const [monthly, setMonthly] = useState<MonthlyRow[]>([])
+  const [dailyDays, setDailyDays] = useState(30)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+      return
+    }
+    setAdminEmail(user.email)
+  }, [])
+
+  const fetchAll = useCallback(async () => {
+    if (!adminEmail) return
+    setLoading(true)
+    setError('')
+    const h = { 'X-Admin-Email': adminEmail }
+    try {
+      const [sumRes, dailyRes, monthlyRes] = await Promise.all([
+        fetch('/api/admin/costs', { headers: h }),
+        fetch(`/api/admin/costs/daily?days=${dailyDays}`, { headers: h }),
+        fetch('/api/admin/costs/monthly?months=12', { headers: h }),
+      ])
+      const [sumData, dailyData, monthlyData] = await Promise.all([
+        sumRes.json(), dailyRes.json(), monthlyRes.json(),
+      ])
+      setSummary(sumData)
+      setDaily(dailyData.daily ?? [])
+      setMonthly(monthlyData.monthly ?? [])
+    } catch (e: any) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [adminEmail, dailyDays])
+
+  useEffect(() => { fetchAll() }, [fetchAll])
+
+  const totalDailyCost = daily.reduce((s, r) => s + r.total_cost_usd, 0)
+  const maxDailyModel = summary?.model_breakdown?.[0]?.total_cost_usd ?? 0.0001
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={2} mb={3}>
+        <IconButton component={Link} href="/admin"><ArrowBackIcon /></IconButton>
+        <Typography variant="h5" fontWeight={700} flex={1}>
+          APIコストモニタリング
+        </Typography>
+        {loading && <CircularProgress size={20} />}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* KPI Cards */}
+      <Stack direction="row" spacing={2} mb={3} flexWrap="wrap">
+        <Card sx={{ flex: 1, minWidth: 200 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">今月の合計コスト</Typography>
+            <Typography variant="h4" fontWeight={700} color={
+              (summary?.current_month_cost_usd ?? 0) > 50 ? 'error.main' :
+              (summary?.current_month_cost_usd ?? 0) > 20 ? 'warning.main' : 'success.main'
+            }>
+              ${(summary?.current_month_cost_usd ?? 0).toFixed(4)}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 200 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              過去{dailyDays}日合計コスト
+            </Typography>
+            <Typography variant="h4" fontWeight={700}>
+              ${totalDailyCost.toFixed(4)}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 200 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              過去{dailyDays}日 APIコール数
+            </Typography>
+            <Typography variant="h4" fontWeight={700}>
+              {daily.reduce((s, r) => s + r.call_count, 0).toLocaleString()}
+            </Typography>
+          </CardContent>
+        </Card>
+      </Stack>
+
+      {/* Daily cost chart */}
+      <Paper elevation={1} sx={{ p: 3, mb: 3, borderRadius: 2 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={2}>
+          <Typography variant="h6" fontWeight={600}>日次コスト推移</Typography>
+          <TextField
+            select size="small" value={dailyDays}
+            onChange={e => setDailyDays(Number(e.target.value))}
+            sx={{ width: 120 }}
+          >
+            <MenuItem value={7}>直近 7 日</MenuItem>
+            <MenuItem value={30}>直近 30 日</MenuItem>
+            <MenuItem value={90}>直近 90 日</MenuItem>
+          </TextField>
+        </Stack>
+        <MiniChart data={daily} valueKey="total_cost_usd" labelKey="date" />
+        <Divider sx={{ my: 2 }} />
+        <TableContainer sx={{ maxHeight: 300 }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow sx={{ bgcolor: '#f5f5f5' }}>
+                <TableCell>日付</TableCell>
+                <TableCell align="right">コスト (USD)</TableCell>
+                <TableCell align="right">トークン数</TableCell>
+                <TableCell align="right">コール数</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {[...daily].reverse().map(row => (
+                <TableRow key={row.date} hover>
+                  <TableCell>{row.date}</TableCell>
+                  <TableCell align="right">${row.total_cost_usd.toFixed(6)}</TableCell>
+                  <TableCell align="right">{row.total_tokens.toLocaleString()}</TableCell>
+                  <TableCell align="right">{row.call_count.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+              {daily.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} align="center" sx={{ color: 'text.secondary', py: 3 }}>
+                    データなし
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {/* Monthly chart */}
+      <Paper elevation={1} sx={{ p: 3, mb: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={600} mb={2}>月次コスト推移（過去12ヶ月）</Typography>
+        <MiniChart data={monthly} valueKey="total_cost_usd" labelKey="month" />
+        <Divider sx={{ my: 2 }} />
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: '#f5f5f5' }}>
+                <TableCell>月</TableCell>
+                <TableCell align="right">コスト (USD)</TableCell>
+                <TableCell align="right">トークン数</TableCell>
+                <TableCell align="right">コール数</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {[...monthly].reverse().map(row => (
+                <TableRow key={row.month} hover>
+                  <TableCell>{row.month}</TableCell>
+                  <TableCell align="right">${row.total_cost_usd.toFixed(4)}</TableCell>
+                  <TableCell align="right">{row.total_tokens.toLocaleString()}</TableCell>
+                  <TableCell align="right">{row.call_count.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+              {monthly.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} align="center" sx={{ color: 'text.secondary', py: 3 }}>
+                    データなし
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {/* Model breakdown */}
+      <Paper elevation={1} sx={{ p: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={600} mb={2}>モデル別コスト内訳（過去30日）</Typography>
+        {(summary?.model_breakdown ?? []).length === 0 ? (
+          <Typography color="text.secondary" textAlign="center" py={3}>データなし</Typography>
+        ) : (
+          <Stack spacing={1.5}>
+            {(summary?.model_breakdown ?? []).map(row => (
+              <Box key={row.model}>
+                <Stack direction="row" justifyContent="space-between" mb={0.5}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Chip label={row.model} size="small" variant="outlined" />
+                    <Typography variant="caption" color="text.secondary">
+                      {row.call_count.toLocaleString()} calls / {row.total_tokens.toLocaleString()} tokens
+                    </Typography>
+                  </Stack>
+                </Stack>
+                <CostBar value={row.total_cost_usd} max={maxDailyModel} />
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </Paper>
+    </Box>
+  )
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -183,6 +183,22 @@ export default function AdminDashboardPage() {
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
+                APIコストモニタリング
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                OpenAI APIの日次・月次コストとモデル別内訳を可視化します。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/costs">
+                コスト管理へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
                 スコアダッシュボード
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>

--- a/frontend/app/api/admin/costs/daily/route.ts
+++ b/frontend/app/api/admin/costs/daily/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const admin = request.headers.get('x-admin-email') || ''
+  const { searchParams } = new URL(request.url)
+  const days = searchParams.get('days') || '30'
+  const res = await fetch(`${BACKEND_URL}/api/admin/costs/daily?days=${days}`, {
+    headers: { 'X-Admin-Email': admin },
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/frontend/app/api/admin/costs/monthly/route.ts
+++ b/frontend/app/api/admin/costs/monthly/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const admin = request.headers.get('x-admin-email') || ''
+  const { searchParams } = new URL(request.url)
+  const months = searchParams.get('months') || '12'
+  const res = await fetch(`${BACKEND_URL}/api/admin/costs/monthly?months=${months}`, {
+    headers: { 'X-Admin-Email': admin },
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/frontend/app/api/admin/costs/route.ts
+++ b/frontend/app/api/admin/costs/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const admin = request.headers.get('x-admin-email') || ''
+  const res = await fetch(`${BACKEND_URL}/api/admin/costs/summary`, {
+    headers: { 'X-Admin-Email': admin },
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}


### PR DESCRIPTION
Closes #148

## 変更内容

### Backend

- **`APICallLog` モデル追加** (`Backend/internal/models/api_call_log.go`)
  - OpenAI APIコールごとに model / prompt_tokens / completion_tokens / cost_usd / called_at を記録
  - `AutoMigrate` に登録

- **`APICallLogRepository` 追加** (`Backend/internal/repositories/api_call_log_repository.go`)
  - `DailyCosts(nDays)`: 過去N日間の日次コスト集計（DATE GROUP BY）
  - `MonthlyCosts(nMonths)`: 過去N月間の月次コスト集計（DATE_FORMAT GROUP BY）
  - `ModelBreakdown(since)`: モデル別コスト・トークン・コール数集計
  - `TotalCostSince(since)`: 指定日時以降の合計コスト取得

- **`APICostService` 追加** (`Backend/internal/services/api_cost_service.go`)
  - モデル別単価テーブル（gpt-4o: $2.50/$10.00、gpt-4o-mini: $0.15/$0.60、o1: $15.00/$60.00 等）
  - `LogCall`: 非同期でDBに記録 + 月額閾値チェック（`API_COST_ALERT_THRESHOLD_USD` 環境変数、デフォルト $100）
  - 閾値超過時は `log.Printf` でアラート出力
  - `GetDailyCosts` / `GetMonthlyCosts` / `GetModelBreakdown` / `GetCurrentMonthTotal`

- **OpenAI Client に `OnUsage` フック追加** (`Backend/internal/openai/client.go`)
  - `Client.OnUsage func(model string, promptTokens, completionTokens int)` フィールド追加
  - `ChatCompletionJSON`: 成功レスポンス取得時に `resp.Usage.PromptTokens` / `CompletionTokens` でフック呼び出し
  - `callResponsesAPI`: レスポンスJSONに `usage.input_tokens` / `output_tokens` フィールドを追加してパースし、フック呼び出し

- **`AdminCostsController` 追加** (`Backend/internal/controllers/admin_costs_controller.go`)
  - `GET /api/admin/costs/summary` — 今月合計コスト + 過去30日モデル別内訳
  - `GET /api/admin/costs/daily?days=30` — 日次コスト集計（最大90日）
  - `GET /api/admin/costs/monthly?months=12` — 月次コスト集計（最大24ヶ月）

- **`admin_routes.go` にコストルート追加**・**`main.go` に依存注入**
  - `OnUsage` フックで `apiCostService.LogCall` を設定（全OpenAIコールを自動記録）

### Frontend

- **Next.js API プロキシ追加**
  - `frontend/app/api/admin/costs/route.ts` — summary プロキシ
  - `frontend/app/api/admin/costs/daily/route.ts` — 日次プロキシ
  - `frontend/app/api/admin/costs/monthly/route.ts` — 月次プロキシ

- **`/admin/costs` ページ新規作成** (`frontend/app/admin/costs/page.tsx`)
  - KPIカード: 今月コスト（閾値別色分け）・期間合計コスト・コール数
  - 日次バーチャート + テーブル（直近7/30/90日切替）
  - 月次バーチャート + テーブル（過去12ヶ月）
  - モデル別コストバー（相対パーセント表示）

- **`/admin` トップに「APIコストモニタリング」カード追加**