### PR TITLE
feat: #138 Realtime APIコスト制御（使用量集計・アラート機能）

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -15,6 +15,16 @@ SERVER_PORT=8080
 OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-4o-mini
 
+# Realtime interview cost controls
+OPENAI_REALTIME_MODEL=gpt-realtime
+OPENAI_REALTIME_TRANSCRIBE_MODEL=gpt-4o-mini-transcribe
+OPENAI_REALTIME_MAX_OUTPUT_TOKENS=120
+INTERVIEW_COST_PER_MIN_USD=0.18
+REALTIME_MAX_CONCURRENT_CONNECTIONS=30
+REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200
+# REALTIME_ALERT_EMAILS=ops@example.com,admin@example.com
+# REALTIME_ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
+
 # RAG Service (rag-review コンテナ)
 # 企業別面接傾向ヒットの web search に使用するモデル
 # 対応モデル: gpt-4o-search-preview, gpt-4o-mini-search-preview

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -125,10 +125,12 @@ func main() {
 	skillScoreRepo := repositories.NewSkillScoreRepository(db)
 	// APIコストモニタリング
 	apiCallLogRepo := repositories.NewAPICallLogRepository(db)
+	realtimeUsageRepo := repositories.NewRealtimeUsageRepository(db)
 
 	// サービス層の初期化
 	emailService := services.NewEmailService()
 	apiCostService := services.NewAPICostService(apiCallLogRepo)
+	realtimeUsageService := services.NewRealtimeUsageService(realtimeUsageRepo, emailService)
 	// OpenAI APIコール時にトークン使用量をロギング
 	aiClient.OnUsage = func(model string, promptTokens, completionTokens int) {
 		apiCostService.LogCall(model, promptTokens, completionTokens)
@@ -153,7 +155,7 @@ func main() {
 		matchRepo,
 		nil,
 	)
-	interviewService := services.NewInterviewService(interviewSessionRepo, interviewUtteranceRepo, interviewReportRepo, userRepo, emailService, aiClient)
+	interviewService := services.NewInterviewService(interviewSessionRepo, interviewUtteranceRepo, interviewReportRepo, userRepo, emailService, aiClient, realtimeUsageService)
 	interviewService.StartWorker()
 
 	// コントローラー層の初期化
@@ -186,7 +188,7 @@ func main() {
 	realtimeController := controllers.NewRealtimeController(interviewService)
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	adminDashboardController := controllers.NewAdminDashboardController(userRepo, interviewSessionRepo, interviewReportRepo)
-	adminCostsController := controllers.NewAdminCostsController(apiCostService)
+	adminCostsController := controllers.NewAdminCostsController(apiCostService, realtimeUsageService)
 	companyEntryController := controllers.NewCompanyEntryController(companyRepo, graduateRepo)
 	githubController := controllers.NewGitHubController(githubService, skillScoreService)
 	esRewriteController := controllers.NewESRewriteController(aiClient)

--- a/Backend/internal/controllers/admin_costs_controller.go
+++ b/Backend/internal/controllers/admin_costs_controller.go
@@ -8,11 +8,15 @@ import (
 )
 
 type AdminCostsController struct {
-	costService *services.APICostService
+	costService          *services.APICostService
+	realtimeUsageService *services.RealtimeUsageService
 }
 
-func NewAdminCostsController(costService *services.APICostService) *AdminCostsController {
-	return &AdminCostsController{costService: costService}
+func NewAdminCostsController(costService *services.APICostService, realtimeUsageService *services.RealtimeUsageService) *AdminCostsController {
+	return &AdminCostsController{
+		costService:          costService,
+		realtimeUsageService: realtimeUsageService,
+	}
 }
 
 // Summary handles GET /api/admin/costs/summary
@@ -27,6 +31,26 @@ func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	realtimeMonthTotal := 0.0
+	activeConnections := int64(0)
+	realtimeUsers := []services.RealtimeUserSummary{}
+	if c.realtimeUsageService != nil {
+		realtimeMonthTotal, err = c.realtimeUsageService.CurrentMonthTotalCost()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		activeConnections, err = c.realtimeUsageService.CurrentActiveCount()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		realtimeUsers, err = c.realtimeUsageService.GetUserBreakdown(30, 20)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 
 	since30d := time.Now().UTC().AddDate(0, 0, -30)
 	modelBreakdown, err := c.costService.GetModelBreakdown(since30d)
@@ -39,6 +63,11 @@ func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"current_month_cost_usd": monthTotal,
 		"model_breakdown":        modelBreakdown,
+		"realtime": map[string]interface{}{
+			"current_month_cost_usd": realtimeMonthTotal,
+			"active_connections":     activeConnections,
+			"user_breakdown":         realtimeUsers,
+		},
 	})
 }
 
@@ -57,8 +86,19 @@ func (c *AdminCostsController) Daily(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	realtimeRows := []services.RealtimeDailySummary{}
+	if c.realtimeUsageService != nil {
+		realtimeRows, err = c.realtimeUsageService.GetDailyUsage(days)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"daily": rows})
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"daily":          rows,
+		"realtime_daily": realtimeRows,
+	})
 }
 
 // Monthly handles GET /api/admin/costs/monthly?months=12
@@ -76,6 +116,17 @@ func (c *AdminCostsController) Monthly(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	realtimeRows := []services.RealtimeMonthlySummary{}
+	if c.realtimeUsageService != nil {
+		realtimeRows, err = c.realtimeUsageService.GetMonthlyUsage(months)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"monthly": rows})
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"monthly":          rows,
+		"realtime_monthly": realtimeRows,
+	})
 }

--- a/Backend/internal/controllers/realtime_controller.go
+++ b/Backend/internal/controllers/realtime_controller.go
@@ -4,6 +4,7 @@ import (
 	"Backend/internal/services"
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 type RealtimeController struct {
@@ -42,6 +43,9 @@ func (c *RealtimeController) Token(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusBadRequest
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
+		}
+		if strings.Contains(err.Error(), "realtime capacity exceeded") {
+			status = http.StatusTooManyRequests
 		}
 		http.Error(w, err.Error(), status)
 		return

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -48,6 +48,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&InterviewUtterance{},
 		&InterviewReport{},
 		&InterviewVideo{},
+		&RealtimeUsageLog{},
 		&PendingRegistration{},
 		// 選考スケジュール
 		&ScheduleEvent{},

--- a/Backend/internal/models/realtime_usage_log.go
+++ b/Backend/internal/models/realtime_usage_log.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// RealtimeUsageLog records usage for OpenAI Realtime interview sessions.
+type RealtimeUsageLog struct {
+	ID                 uint       `gorm:"primaryKey" json:"id"`
+	UserID             uint       `gorm:"index;not null" json:"user_id"`
+	InterviewSessionID uint       `gorm:"index;not null" json:"interview_session_id"`
+	Status             string     `gorm:"size:16;index;not null;default:'active'" json:"status"`
+	StartedAt          time.Time  `gorm:"not null;index" json:"started_at"`
+	EndedAt            *time.Time `gorm:"index" json:"ended_at,omitempty"`
+	DurationSeconds    int        `gorm:"not null;default:0" json:"duration_seconds"`
+	CostUSD            float64    `gorm:"type:decimal(10,4);default:0" json:"cost_usd"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}

--- a/Backend/internal/repositories/realtime_usage_repository.go
+++ b/Backend/internal/repositories/realtime_usage_repository.go
@@ -1,0 +1,155 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type RealtimeUsageRepository struct {
+	db *gorm.DB
+}
+
+func NewRealtimeUsageRepository(db *gorm.DB) *RealtimeUsageRepository {
+	return &RealtimeUsageRepository{db: db}
+}
+
+func (r *RealtimeUsageRepository) FindActiveBySessionID(sessionID uint) (*models.RealtimeUsageLog, error) {
+	var log models.RealtimeUsageLog
+	err := r.db.Where("interview_session_id = ? AND status = ? AND ended_at IS NULL", sessionID, "active").
+		Order("started_at DESC").
+		First(&log).Error
+	if err != nil {
+		return nil, err
+	}
+	return &log, nil
+}
+
+func (r *RealtimeUsageRepository) Create(log *models.RealtimeUsageLog) error {
+	return r.db.Create(log).Error
+}
+
+func (r *RealtimeUsageRepository) Update(log *models.RealtimeUsageLog) error {
+	return r.db.Save(log).Error
+}
+
+func (r *RealtimeUsageRepository) CountActiveSessions() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.RealtimeUsageLog{}).
+		Where("status = ? AND ended_at IS NULL", "active").
+		Count(&count).Error
+	return count, err
+}
+
+type RealtimeDailyRow struct {
+	Date                 string
+	TotalCostUSD         float64
+	TotalDurationSeconds int64
+	SessionCount         int64
+	UserCount            int64
+}
+
+type RealtimeMonthlyRow struct {
+	Month                string
+	TotalCostUSD         float64
+	TotalDurationSeconds int64
+	SessionCount         int64
+	UserCount            int64
+}
+
+type RealtimeUserRow struct {
+	UserID               uint
+	TotalCostUSD         float64
+	TotalDurationSeconds int64
+	SessionCount         int64
+}
+
+func (r *RealtimeUsageRepository) DailyUsage(nDays int, currentRatePerMinute float64) ([]RealtimeDailyRow, error) {
+	var rows []RealtimeDailyRow
+	since := time.Now().UTC().AddDate(0, 0, -nDays)
+	err := r.db.Raw(`
+		SELECT DATE(started_at) AS date,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP()) * (? / 60.0)
+		             ELSE cost_usd
+		           END) AS total_cost_usd,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP())
+		             ELSE duration_seconds
+		           END) AS total_duration_seconds,
+		       COUNT(DISTINCT interview_session_id) AS session_count,
+		       COUNT(DISTINCT user_id) AS user_count
+		FROM realtime_usage_logs
+		WHERE started_at >= ?
+		GROUP BY DATE(started_at)
+		ORDER BY date ASC
+	`, currentRatePerMinute, since).Scan(&rows).Error
+	return rows, err
+}
+
+func (r *RealtimeUsageRepository) MonthlyUsage(nMonths int, currentRatePerMinute float64) ([]RealtimeMonthlyRow, error) {
+	var rows []RealtimeMonthlyRow
+	since := time.Now().UTC().AddDate(0, -nMonths, 0)
+	err := r.db.Raw(`
+		SELECT DATE_FORMAT(started_at, '%Y-%m') AS month,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP()) * (? / 60.0)
+		             ELSE cost_usd
+		           END) AS total_cost_usd,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP())
+		             ELSE duration_seconds
+		           END) AS total_duration_seconds,
+		       COUNT(DISTINCT interview_session_id) AS session_count,
+		       COUNT(DISTINCT user_id) AS user_count
+		FROM realtime_usage_logs
+		WHERE started_at >= ?
+		GROUP BY month
+		ORDER BY month ASC
+	`, currentRatePerMinute, since).Scan(&rows).Error
+	return rows, err
+}
+
+func (r *RealtimeUsageRepository) UserBreakdown(since time.Time, currentRatePerMinute float64, limit int) ([]RealtimeUserRow, error) {
+	var rows []RealtimeUserRow
+	query := r.db.Raw(`
+		SELECT user_id,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP()) * (? / 60.0)
+		             ELSE cost_usd
+		           END) AS total_cost_usd,
+		       SUM(CASE
+		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP())
+		             ELSE duration_seconds
+		           END) AS total_duration_seconds,
+		       COUNT(DISTINCT interview_session_id) AS session_count
+		FROM realtime_usage_logs
+		WHERE started_at >= ?
+		GROUP BY user_id
+		ORDER BY total_cost_usd DESC
+	`, currentRatePerMinute, since)
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	err := query.Scan(&rows).Error
+	return rows, err
+}
+
+func (r *RealtimeUsageRepository) CurrentMonthTotalCostEstimated(currentRatePerMinute float64) (float64, error) {
+	now := time.Now().UTC()
+	since := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	var total float64
+	err := r.db.Raw(`
+		SELECT COALESCE(SUM(
+			CASE
+				WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP()) * (? / 60.0)
+				ELSE cost_usd
+			END
+		), 0) AS total
+		FROM realtime_usage_logs
+		WHERE started_at >= ?
+	`, currentRatePerMinute, since).Scan(&total).Error
+	return total, err
+}

--- a/Backend/internal/services/email_service.go
+++ b/Backend/internal/services/email_service.go
@@ -468,3 +468,23 @@ func (s *EmailService) SendInterviewReport(user *entity.User, data InterviewRepo
 	fmt.Printf("[EmailService] Interview report email sent successfully to %s\n", user.Email)
 	return nil
 }
+
+// SendSystemAlertEmail sends a plain-text operational alert email to multiple recipients.
+func (s *EmailService) SendSystemAlertEmail(recipients []string, subject, body string) error {
+	if len(recipients) == 0 {
+		return nil
+	}
+	if s.host == "" || s.user == "" || s.password == "" || s.from == "" {
+		fmt.Printf("[EmailService] SMTP not configured. Simulating alert send to %v\n", recipients)
+		return nil
+	}
+
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	auth := smtp.PlainAuth("", s.user, s.password, s.host)
+	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		s.from, recipients[0], subject, body)
+	if err := smtp.SendMail(addr, auth, s.from, recipients, []byte(msg)); err != nil {
+		return fmt.Errorf("failed to send alert email: %w", err)
+	}
+	return nil
+}

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -18,14 +18,15 @@ import (
 )
 
 type InterviewService struct {
-	sessionRepo  repository.InterviewSessionRepository
-	utterRepo    repository.InterviewUtteranceRepository
-	reportRepo   repository.InterviewReportRepository
-	userRepo     repository.UserRepository
-	emailService *EmailService
-	openaiClient *openai.Client
-	jobCh        chan uint
-	workerOnce   sync.Once
+	sessionRepo          repository.InterviewSessionRepository
+	utterRepo            repository.InterviewUtteranceRepository
+	reportRepo           repository.InterviewReportRepository
+	userRepo             repository.UserRepository
+	emailService         *EmailService
+	openaiClient         *openai.Client
+	realtimeUsageService *RealtimeUsageService
+	jobCh                chan uint
+	workerOnce           sync.Once
 }
 
 func NewInterviewService(
@@ -35,15 +36,17 @@ func NewInterviewService(
 	userRepo repository.UserRepository,
 	emailService *EmailService,
 	openaiClient *openai.Client,
+	realtimeUsageService *RealtimeUsageService,
 ) *InterviewService {
 	return &InterviewService{
-		sessionRepo:  sessionRepo,
-		utterRepo:    utterRepo,
-		reportRepo:   reportRepo,
-		userRepo:     userRepo,
-		emailService: emailService,
-		openaiClient: openaiClient,
-		jobCh:        make(chan uint, 100),
+		sessionRepo:          sessionRepo,
+		utterRepo:            utterRepo,
+		reportRepo:           reportRepo,
+		userRepo:             userRepo,
+		emailService:         emailService,
+		openaiClient:         openaiClient,
+		realtimeUsageService: realtimeUsageService,
+		jobCh:                make(chan uint, 100),
 	}
 }
 
@@ -142,7 +145,15 @@ func (s *InterviewService) FinishSession(userID uint, sessionID uint) (*Intervie
 		session.EndedAt = &now
 	}
 	session.Status = "finished"
-	session.EstimatedCostUSD = s.estimateCost(session.StartedAt, session.EndedAt)
+	if s.realtimeUsageService != nil {
+		if durationSec, cost, err := s.realtimeUsageService.CloseSession(sessionID, *session.EndedAt); err == nil && durationSec >= 0 {
+			session.EstimatedCostUSD = cost
+		} else {
+			session.EstimatedCostUSD = s.estimateCost(session.StartedAt, session.EndedAt)
+		}
+	} else {
+		session.EstimatedCostUSD = s.estimateCost(session.StartedAt, session.EndedAt)
+	}
 	if err := s.sessionRepo.Update(session); err != nil {
 		return nil, err
 	}
@@ -405,6 +416,15 @@ func (s *InterviewService) CreateRealtimeToken(ctx context.Context, userID uint,
 	if session.Status == "finished" {
 		return "", errors.New("session already finished")
 	}
+	if s.realtimeUsageService != nil {
+		allowed, active, maxAllowed, err := s.realtimeUsageService.CanOpenNewConnection()
+		if err != nil {
+			return "", err
+		}
+		if !allowed {
+			return "", fmt.Errorf("realtime capacity exceeded: active=%d limit=%d", active, maxAllowed)
+		}
+	}
 	lang := session.Language
 	if lang == "" {
 		lang = "ja"
@@ -437,6 +457,11 @@ func (s *InterviewService) CreateRealtimeToken(ctx context.Context, userID uint,
 	resp, err := s.openaiClient.CreateRealtimeClientSecret(ctx, req)
 	if err != nil {
 		return "", err
+	}
+	if s.realtimeUsageService != nil {
+		if err := s.realtimeUsageService.EnsureSessionStarted(userID, sessionID); err != nil {
+			return "", err
+		}
 	}
 	return resp.ClientSecret.Value, nil
 }

--- a/Backend/internal/services/realtime_usage_service.go
+++ b/Backend/internal/services/realtime_usage_service.go
@@ -1,0 +1,258 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/repositories"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type RealtimeDailySummary struct {
+	Date                 string  `json:"date"`
+	TotalCostUSD         float64 `json:"total_cost_usd"`
+	TotalDurationSeconds int64   `json:"total_duration_seconds"`
+	SessionCount         int64   `json:"session_count"`
+	UserCount            int64   `json:"user_count"`
+}
+
+type RealtimeMonthlySummary struct {
+	Month                string  `json:"month"`
+	TotalCostUSD         float64 `json:"total_cost_usd"`
+	TotalDurationSeconds int64   `json:"total_duration_seconds"`
+	SessionCount         int64   `json:"session_count"`
+	UserCount            int64   `json:"user_count"`
+}
+
+type RealtimeUserSummary struct {
+	UserID               uint    `json:"user_id"`
+	TotalCostUSD         float64 `json:"total_cost_usd"`
+	TotalDurationSeconds int64   `json:"total_duration_seconds"`
+	SessionCount         int64   `json:"session_count"`
+}
+
+type RealtimeUsageService struct {
+	repo              *repositories.RealtimeUsageRepository
+	emailService      *EmailService
+	alertThresholdUSD float64
+	maxConcurrent     int64
+	ratePerMinuteUSD  float64
+
+	mu               sync.Mutex
+	lastAlertMonthID string
+}
+
+func NewRealtimeUsageService(repo *repositories.RealtimeUsageRepository, emailService *EmailService) *RealtimeUsageService {
+	threshold := getFloatEnv("REALTIME_MONTHLY_ALERT_THRESHOLD_USD", 200.0)
+	maxConcurrent := int64(getIntEnv("REALTIME_MAX_CONCURRENT_CONNECTIONS", 30))
+	if maxConcurrent <= 0 {
+		maxConcurrent = 30
+	}
+	rate := getFloatEnv("INTERVIEW_COST_PER_MIN_USD", 0.18)
+	return &RealtimeUsageService{
+		repo:              repo,
+		emailService:      emailService,
+		alertThresholdUSD: threshold,
+		maxConcurrent:     maxConcurrent,
+		ratePerMinuteUSD:  rate,
+	}
+}
+
+func (s *RealtimeUsageService) CanOpenNewConnection() (bool, int64, int64, error) {
+	active, err := s.repo.CountActiveSessions()
+	if err != nil {
+		return false, 0, s.maxConcurrent, err
+	}
+	return active < s.maxConcurrent, active, s.maxConcurrent, nil
+}
+
+func (s *RealtimeUsageService) EnsureSessionStarted(userID, sessionID uint) error {
+	if _, err := s.repo.FindActiveBySessionID(sessionID); err == nil {
+		return nil
+	}
+	entry := &models.RealtimeUsageLog{
+		UserID:             userID,
+		InterviewSessionID: sessionID,
+		Status:             "active",
+		StartedAt:          time.Now().UTC(),
+	}
+	if err := s.repo.Create(entry); err != nil {
+		return err
+	}
+	go s.checkAndNotifyThreshold()
+	return nil
+}
+
+func (s *RealtimeUsageService) CloseSession(sessionID uint, endedAt time.Time) (durationSec int64, costUSD float64, err error) {
+	entry, err := s.repo.FindActiveBySessionID(sessionID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return -1, 0, nil
+		}
+		return 0, 0, err
+	}
+	dur := int64(endedAt.Sub(entry.StartedAt).Seconds())
+	if dur < 0 {
+		dur = 0
+	}
+	cost := (float64(dur) / 60.0) * s.ratePerMinuteUSD
+	entry.EndedAt = &endedAt
+	entry.DurationSeconds = int(dur)
+	entry.CostUSD = cost
+	entry.Status = "finished"
+	if err := s.repo.Update(entry); err != nil {
+		return 0, 0, err
+	}
+	go s.checkAndNotifyThreshold()
+	return dur, cost, nil
+}
+
+func (s *RealtimeUsageService) CurrentMonthTotalCost() (float64, error) {
+	return s.repo.CurrentMonthTotalCostEstimated(s.ratePerMinuteUSD)
+}
+
+func (s *RealtimeUsageService) CurrentActiveCount() (int64, error) {
+	return s.repo.CountActiveSessions()
+}
+
+func (s *RealtimeUsageService) GetDailyUsage(nDays int) ([]RealtimeDailySummary, error) {
+	rows, err := s.repo.DailyUsage(nDays, s.ratePerMinuteUSD)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RealtimeDailySummary, len(rows))
+	for i, r := range rows {
+		out[i] = RealtimeDailySummary{
+			Date:                 r.Date,
+			TotalCostUSD:         r.TotalCostUSD,
+			TotalDurationSeconds: r.TotalDurationSeconds,
+			SessionCount:         r.SessionCount,
+			UserCount:            r.UserCount,
+		}
+	}
+	return out, nil
+}
+
+func (s *RealtimeUsageService) GetMonthlyUsage(nMonths int) ([]RealtimeMonthlySummary, error) {
+	rows, err := s.repo.MonthlyUsage(nMonths, s.ratePerMinuteUSD)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RealtimeMonthlySummary, len(rows))
+	for i, r := range rows {
+		out[i] = RealtimeMonthlySummary{
+			Month:                r.Month,
+			TotalCostUSD:         r.TotalCostUSD,
+			TotalDurationSeconds: r.TotalDurationSeconds,
+			SessionCount:         r.SessionCount,
+			UserCount:            r.UserCount,
+		}
+	}
+	return out, nil
+}
+
+func (s *RealtimeUsageService) GetUserBreakdown(days int, limit int) ([]RealtimeUserSummary, error) {
+	if days <= 0 {
+		days = 30
+	}
+	since := time.Now().UTC().AddDate(0, 0, -days)
+	rows, err := s.repo.UserBreakdown(since, s.ratePerMinuteUSD, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RealtimeUserSummary, len(rows))
+	for i, r := range rows {
+		out[i] = RealtimeUserSummary{
+			UserID:               r.UserID,
+			TotalCostUSD:         r.TotalCostUSD,
+			TotalDurationSeconds: r.TotalDurationSeconds,
+			SessionCount:         r.SessionCount,
+		}
+	}
+	return out, nil
+}
+
+func (s *RealtimeUsageService) checkAndNotifyThreshold() {
+	total, err := s.CurrentMonthTotalCost()
+	if err != nil {
+		return
+	}
+	if total < s.alertThresholdUSD {
+		return
+	}
+	monthID := time.Now().UTC().Format("2006-01")
+	s.mu.Lock()
+	if s.lastAlertMonthID == monthID {
+		s.mu.Unlock()
+		return
+	}
+	s.lastAlertMonthID = monthID
+	s.mu.Unlock()
+
+	subject := fmt.Sprintf("[SOC AI] Realtime月額コスト閾値超過 (%s)", monthID)
+	body := fmt.Sprintf(
+		"Realtime API monthly cost exceeded threshold.\nmonth=%s\ntotal_usd=%.4f\nthreshold_usd=%.4f\nactive_limit=%d\n",
+		monthID, total, s.alertThresholdUSD, s.maxConcurrent,
+	)
+	log.Printf("[RealtimeUsage] ALERT %s", strings.ReplaceAll(body, "\n", " "))
+
+	if webhook := strings.TrimSpace(os.Getenv("REALTIME_ALERT_SLACK_WEBHOOK_URL")); webhook != "" {
+		if err := postSlackAlert(webhook, subject+"\n"+body); err != nil {
+			log.Printf("[RealtimeUsage] slack alert failed: %v", err)
+		}
+	}
+
+	if s.emailService != nil {
+		recipients := parseEmailsEnv("REALTIME_ALERT_EMAILS")
+		if len(recipients) > 0 {
+			if err := s.emailService.SendSystemAlertEmail(recipients, subject, body); err != nil {
+				log.Printf("[RealtimeUsage] email alert failed: %v", err)
+			}
+		}
+	}
+}
+
+func postSlackAlert(webhookURL, text string) error {
+	payload := map[string]string{"text": text}
+	b, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 8 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status=%d", resp.StatusCode)
+	}
+	return nil
+}
+
+func parseEmailsEnv(key string) []string {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		addr := strings.TrimSpace(p)
+		if addr != "" {
+			out = append(out, addr)
+		}
+	}
+	return out
+}

--- a/Backend/test/services/interview_phrase_suggestions_test.go
+++ b/Backend/test/services/interview_phrase_suggestions_test.go
@@ -26,11 +26,11 @@ type mockInterviewSessionRepo struct {
 	err     error
 }
 
-func (m *mockInterviewSessionRepo) Create(s *models.InterviewSession) error        { return nil }
+func (m *mockInterviewSessionRepo) Create(s *models.InterviewSession) error { return nil }
 func (m *mockInterviewSessionRepo) FindByID(id uint) (*models.InterviewSession, error) {
 	return m.session, m.err
 }
-func (m *mockInterviewSessionRepo) Update(s *models.InterviewSession) error              { return nil }
+func (m *mockInterviewSessionRepo) Update(s *models.InterviewSession) error { return nil }
 func (m *mockInterviewSessionRepo) ListByUser(userID uint, limit, offset int) ([]models.InterviewSession, error) {
 	return nil, nil
 }
@@ -40,8 +40,8 @@ func (m *mockInterviewSessionRepo) ListAll(limit, offset int) ([]models.Intervie
 func (m *mockInterviewSessionRepo) ListFinishedByUser(userID uint, limit int) ([]models.InterviewSession, error) {
 	return nil, nil
 }
-func (m *mockInterviewSessionRepo) CountByUser(userID uint) (int64, error)  { return 0, nil }
-func (m *mockInterviewSessionRepo) CountAll() (int64, error)                { return 0, nil }
+func (m *mockInterviewSessionRepo) CountByUser(userID uint) (int64, error) { return 0, nil }
+func (m *mockInterviewSessionRepo) CountAll() (int64, error)               { return 0, nil }
 func (m *mockInterviewSessionRepo) CountByUserAndDay(userID uint, day time.Time) (int64, error) {
 	return 0, nil
 }
@@ -62,16 +62,18 @@ type mockUserRepo2 struct {
 	err  error
 }
 
-func (m *mockUserRepo2) GetUserByID(id uint) (*entity.User, error)   { return m.user, m.err }
-func (m *mockUserRepo2) CreateUser(u *entity.User) error             { return nil }
+func (m *mockUserRepo2) GetUserByID(id uint) (*entity.User, error)         { return m.user, m.err }
+func (m *mockUserRepo2) CreateUser(u *entity.User) error                   { return nil }
 func (m *mockUserRepo2) GetUserByEmail(email string) (*entity.User, error) { return nil, nil }
-func (m *mockUserRepo2) ListUsers() ([]entity.User, error)           { return nil, nil }
+func (m *mockUserRepo2) ListUsers() ([]entity.User, error)                 { return nil, nil }
 func (m *mockUserRepo2) ListUsersPaged(limit, offset int, query string) ([]entity.User, int64, error) {
 	return nil, 0, nil
 }
-func (m *mockUserRepo2) UpdateUser(u *entity.User) error                               { return nil }
-func (m *mockUserRepo2) DeleteUser(id uint) error                                      { return nil }
-func (m *mockUserRepo2) GetUserByVerificationToken(token string) (*entity.User, error) { return nil, nil }
+func (m *mockUserRepo2) UpdateUser(u *entity.User) error { return nil }
+func (m *mockUserRepo2) DeleteUser(id uint) error        { return nil }
+func (m *mockUserRepo2) GetUserByVerificationToken(token string) (*entity.User, error) {
+	return nil, nil
+}
 func (m *mockUserRepo2) GetUserByPasswordResetToken(token string) (*entity.User, error) {
 	return nil, nil
 }
@@ -88,7 +90,7 @@ func newTestInterviewService(
 	userRepo *mockUserRepo2,
 	aiClient *openaiPkg.Client,
 ) *services.InterviewService {
-	return services.NewInterviewService(sessionRepo, utterRepo, nil, userRepo, nil, aiClient)
+	return services.NewInterviewService(sessionRepo, utterRepo, nil, userRepo, nil, aiClient, nil)
 }
 
 // newOpenAITestServer はOpenAI Chat Completions レスポンスを返すテストHTTPサーバーを起動する。

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ OPENAI_REALTIME_MODEL=gpt-realtime
 OPENAI_REALTIME_VOICE=alloy
 OPENAI_REALTIME_TRANSCRIBE_MODEL=gpt-4o-mini-transcribe
 OPENAI_REALTIME_MAX_OUTPUT_TOKENS=120
+REALTIME_MAX_CONCURRENT_CONNECTIONS=30
+REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200
+# REALTIME_ALERT_EMAILS=ops@example.com,admin@example.com
+# REALTIME_ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
 
 # 面接レポート
 INTERVIEW_REPORT_MODEL=gpt-4o-mini
@@ -270,7 +274,7 @@ tiktoken==0.7.0
 | 面接 | `POST /api/interviews/{id}/start` | セッション開始 |
 | 面接 | `POST /api/interviews/{id}/upload-video` | 動画 S3 アップロード（32MB 上限） |
 | 面接 | `POST /api/interviews/{id}/send-report` | レポートメール送信 |
-| Realtime | `GET /api/realtime/token` | WebRTC トークン取得 |
+| Realtime | `POST /api/realtime/token` | WebRTC トークン取得 |
 | 職務経歴書 | `POST /api/resume/upload` | 職務経歴書アップロード |
 | 職務経歴書 | `GET /api/resume/review` | RAG レビュー取得 |
 | 企業 | `GET /api/companies` | 企業一覧・検索 |

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -50,6 +50,26 @@ type ModelRow = {
 type Summary = {
   current_month_cost_usd: number
   model_breakdown: ModelRow[]
+  realtime?: {
+    current_month_cost_usd: number
+    active_connections: number
+    user_breakdown: RealtimeUserRow[]
+  }
+}
+
+type RealtimeDailyRow = {
+  date: string
+  total_cost_usd: number
+  total_duration_seconds: number
+  session_count: number
+  user_count: number
+}
+
+type RealtimeUserRow = {
+  user_id: number
+  total_cost_usd: number
+  total_duration_seconds: number
+  session_count: number
 }
 
 function CostBar({ value, max }: { value: number; max: number }) {
@@ -109,6 +129,7 @@ export default function AdminCostsPage() {
   const [summary, setSummary] = useState<Summary | null>(null)
   const [daily, setDaily] = useState<DailyRow[]>([])
   const [monthly, setMonthly] = useState<MonthlyRow[]>([])
+  const [realtimeDaily, setRealtimeDaily] = useState<RealtimeDailyRow[]>([])
   const [dailyDays, setDailyDays] = useState(30)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -139,6 +160,7 @@ export default function AdminCostsPage() {
       setSummary(sumData)
       setDaily(dailyData.daily ?? [])
       setMonthly(monthlyData.monthly ?? [])
+      setRealtimeDaily(dailyData.realtime_daily ?? [])
     } catch (e: any) {
       setError(e.message)
     } finally {
@@ -150,6 +172,7 @@ export default function AdminCostsPage() {
 
   const totalDailyCost = daily.reduce((s, r) => s + r.total_cost_usd, 0)
   const maxDailyModel = summary?.model_breakdown?.[0]?.total_cost_usd ?? 0.0001
+  const realtimeDailyCost = realtimeDaily.reduce((s, r) => s + r.total_cost_usd, 0)
 
   return (
     <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
@@ -199,6 +222,18 @@ export default function AdminCostsPage() {
             </Typography>
             <Typography variant="h4" fontWeight={700}>
               {daily.reduce((s, r) => s + r.call_count, 0).toLocaleString()}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 200 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">Realtime 今月コスト</Typography>
+            <Typography variant="h4" fontWeight={700}>
+              ${(summary?.realtime?.current_month_cost_usd ?? 0).toFixed(4)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              active: {summary?.realtime?.active_connections ?? 0}
             </Typography>
           </CardContent>
         </Card>
@@ -282,6 +317,67 @@ export default function AdminCostsPage() {
                   </TableCell>
                 </TableRow>
               )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {/* Realtime usage */}
+      <Paper elevation={1} sx={{ p: 3, mb: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={600} mb={1}>Realtime 利用状況</Typography>
+        <Typography variant="body2" color="text.secondary" mb={2}>
+          過去{dailyDays}日合計: ${realtimeDailyCost.toFixed(4)}
+        </Typography>
+        <MiniChart data={realtimeDaily} valueKey="total_cost_usd" labelKey="date" />
+        <Divider sx={{ my: 2 }} />
+        <TableContainer sx={{ maxHeight: 280 }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow sx={{ bgcolor: '#f5f5f5' }}>
+                <TableCell>日付</TableCell>
+                <TableCell align="right">コスト (USD)</TableCell>
+                <TableCell align="right">時間 (分)</TableCell>
+                <TableCell align="right">セッション数</TableCell>
+                <TableCell align="right">利用ユーザー数</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {[...realtimeDaily].reverse().map(row => (
+                <TableRow key={row.date} hover>
+                  <TableCell>{row.date}</TableCell>
+                  <TableCell align="right">${row.total_cost_usd.toFixed(4)}</TableCell>
+                  <TableCell align="right">{(row.total_duration_seconds / 60).toFixed(1)}</TableCell>
+                  <TableCell align="right">{row.session_count.toLocaleString()}</TableCell>
+                  <TableCell align="right">{row.user_count.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {/* Realtime users */}
+      <Paper elevation={1} sx={{ p: 3, mb: 3, borderRadius: 2 }}>
+        <Typography variant="h6" fontWeight={600} mb={2}>Realtime ユーザー別利用（過去30日）</Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: '#f5f5f5' }}>
+                <TableCell>User ID</TableCell>
+                <TableCell align="right">コスト (USD)</TableCell>
+                <TableCell align="right">時間 (分)</TableCell>
+                <TableCell align="right">セッション数</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {(summary?.realtime?.user_breakdown ?? []).map(row => (
+                <TableRow key={row.user_id} hover>
+                  <TableCell>{row.user_id}</TableCell>
+                  <TableCell align="right">${row.total_cost_usd.toFixed(4)}</TableCell>
+                  <TableCell align="right">{(row.total_duration_seconds / 60).toFixed(1)}</TableCell>
+                  <TableCell align="right">{row.session_count.toLocaleString()}</TableCell>
+                </TableRow>
+              ))}
             </TableBody>
           </Table>
         </TableContainer>

--- a/frontend/lib/lipsync-manager.ts
+++ b/frontend/lib/lipsync-manager.ts
@@ -46,8 +46,8 @@ export class LipsyncManager {
   private audioContext: AudioContext | null = null
   private analyser: AnalyserNode | null = null
   private sourceNode: MediaStreamAudioSourceNode | null = null
-  private freqData: Uint8Array | null = null
-  private timeData: Uint8Array | null = null
+  private freqData: Uint8Array<ArrayBuffer> | null = null
+  private timeData: Uint8Array<ArrayBuffer> | null = null
   private animationFrameId: number | null = null
 
   // Current viseme state — smoothed toward target each frame

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,9 +27,9 @@
         "react-day-picker": "9.8.0",
         "react-dom": "^19.2.0",
         "reactflow": "^11.11.4",
+        "recharts": "^2.15.3",
         "tailwind-merge": "^2.4.0",
         "three": "^0.165.0",
-        "three-stdlib": "^2.34.0",
         "wawa-lipsync": "^0.0.2"
       },
       "devDependencies": {
@@ -2227,12 +2227,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/draco3d": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
-      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
-      "license": "MIT"
-    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2248,12 +2242,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "license": "MIT"
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -2321,6 +2309,7 @@
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vercel/analytics": {
@@ -2476,6 +2465,18 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -2516,6 +2517,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -2528,11 +2538,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2614,6 +2685,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2634,12 +2711,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/draco3d": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
-      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2659,6 +2730,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/fflate": {
@@ -2741,6 +2827,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2790,6 +2885,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -3055,12 +3156,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "license": "ISC"
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3126,6 +3221,21 @@
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3159,6 +3269,44 @@
         "react": ">=17",
         "react-dom": ">=17"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -3328,27 +3476,10 @@
       "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
       "license": "MIT"
     },
-    "node_modules/three-stdlib": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
-      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/draco3d": "^1.4.0",
-        "@types/offscreencanvas": "^2019.6.4",
-        "@types/webxr": "^0.5.2",
-        "draco3d": "^1.4.1",
-        "fflate": "^0.6.9",
-        "potpack": "^1.0.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.128.0"
-      }
-    },
-    "node_modules/three-stdlib/node_modules/fflate": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -3385,6 +3516,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/wawa-lipsync": {


### PR DESCRIPTION
## 概要
Issue #138 に対応し、Realtime API のコスト可視化・閾値監視・同時接続制御を実装しました。

Closes #138

## 変更内容
- `realtime_usage_logs` モデルを追加し、ユーザー/面接セッション単位の利用時間・コストを記録
- Realtime 利用リポジトリ/サービスを新規追加
  - 日次・月次・ユーザー別集計
  - 月次コスト閾値超過時の Slack / メール通知
  - 同時接続数カウント
- `/api/realtime/token` 発行時に同時接続上限（サーキットブレーカー）を適用
  - 上限超過時は `429 Too Many Requests`
- 面接終了時に Realtime 利用ログをクローズし、利用秒数・コストを確定
- 管理API `/api/admin/costs/summary|daily|monthly` に Realtime 指標を追加
- 管理画面 `/admin/costs` に Realtime KPI/日次/ユーザー別可視化を追加
- 運用用環境変数を `.env.example` と `README` に追記

## 追加/更新した主な環境変数
- `REALTIME_MAX_CONCURRENT_CONNECTIONS`
- `REALTIME_MONTHLY_ALERT_THRESHOLD_USD`
- `REALTIME_ALERT_EMAILS`
- `REALTIME_ALERT_SLACK_WEBHOOK_URL`

## テスト・確認
- `cd Backend && go test ./...` ✅
- `cd frontend && npm run build` ✅
  - 依存不足（`recharts`）を解消
  - 既存 `lipsync-manager.ts` の型不整合を修正