### PR TITLE
Resolve #175: スケジュール取得APIのエラーハンドリング修正

### DIFF
--- a/frontend/app/api/schedule/[id]/route.ts
+++ b/frontend/app/api/schedule/[id]/route.ts
@@ -5,42 +5,78 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-  const { searchParams } = new URL(request.url)
-  const userId = searchParams.get('user_id')
-  if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+  try {
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
 
-  const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`)
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`)
+    if (!res.ok) {
+      const errorText = await res.text()
+      return NextResponse.json({ error: errorText.trim() }, { status: res.status })
+    }
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error) {
+    console.error('[schedule/id] GET error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-  const { searchParams } = new URL(request.url)
-  const userId = searchParams.get('user_id')
-  if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+  try {
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
 
-  const body = await request.text()
-  const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body,
-  })
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    const body = await request.text()
+    const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    if (!res.ok) {
+      const errorText = await res.text()
+      return NextResponse.json({ error: errorText.trim() }, { status: res.status })
+    }
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error) {
+    console.error('[schedule/id] PUT error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-  const { searchParams } = new URL(request.url)
-  const userId = searchParams.get('user_id')
-  if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+  try {
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
 
-  const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`, {
-    method: 'DELETE',
-  })
-  if (res.status === 204) return new NextResponse(null, { status: 204 })
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    const res = await fetch(`${BACKEND_URL}/api/schedule/${id}?user_id=${userId}`, {
+      method: 'DELETE',
+    })
+    if (res.status === 204) return new NextResponse(null, { status: 204 })
+    if (!res.ok) {
+      const errorText = await res.text()
+      return NextResponse.json({ error: errorText.trim() }, { status: res.status })
+    }
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error) {
+    console.error('[schedule/id] DELETE error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
 }

--- a/frontend/app/api/schedule/route.ts
+++ b/frontend/app/api/schedule/route.ts
@@ -5,26 +5,50 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url)
-  const userId = searchParams.get('user_id')
-  if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+  try {
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
 
-  const res = await fetch(`${BACKEND_URL}/api/schedule?user_id=${userId}`)
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    const res = await fetch(`${BACKEND_URL}/api/schedule?user_id=${userId}`)
+    if (!res.ok) {
+      const errorText = await res.text()
+      return NextResponse.json({ error: errorText.trim() }, { status: res.status })
+    }
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error) {
+    console.error('[schedule] GET error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
 }
 
 export async function POST(request: NextRequest) {
-  const { searchParams } = new URL(request.url)
-  const userId = searchParams.get('user_id')
-  if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+  try {
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
 
-  const body = await request.text()
-  const res = await fetch(`${BACKEND_URL}/api/schedule?user_id=${userId}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body,
-  })
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    const body = await request.text()
+    const res = await fetch(`${BACKEND_URL}/api/schedule?user_id=${userId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    if (!res.ok) {
+      const errorText = await res.text()
+      return NextResponse.json({ error: errorText.trim() }, { status: res.status })
+    }
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error) {
+    console.error('[schedule] POST error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
 }


### PR DESCRIPTION
Closes #175

## 変更内容

### 原因
`frontend/app/api/schedule/route.ts` および `frontend/app/api/schedule/[id]/route.ts` にエラーハンドリングが実装されていなかった。

バックエンド（Go）は `http.Error()` でプレーンテキストのエラーレスポンスを返すが、Next.js APIルートが無条件で `res.json()` を呼び出していたため、JSONパースエラー（`SyntaxError`）が発生し、500レスポンスとなっていた。フロントエンドはこの500を `!res.ok` で検知し「スケジュールの取得に失敗しました」を表示していた。

### 修正内容

#### `frontend/app/api/schedule/route.ts`
- `GET` / `POST` ハンドラ全体を `try/catch` で包む
- `!res.ok` の場合は `res.text()` でエラー文字列を取得し、JSON形式で返すよう変更
- `catch` ブロックで詳細なエラーメッセージを含む500レスポンスを返す
- `console.error` でサーバーサイドログを追加

#### `frontend/app/api/schedule/[id]/route.ts`
- `GET` / `PUT` / `DELETE` ハンドラ全体を `try/catch` で包む
- `!res.ok` の場合のエラーハンドリングを追加
- `catch` ブロックで詳細なエラーメッセージを含む500レスポンスを返す
- `console.error` でサーバーサイドログを追加

### 発生条件（修正前に失敗していたケース）
- DBが起動していない / テーブルが存在しない場合
- バリデーションエラー時（`company_name` 未入力など）
- バックエンドへの接続失敗時