### PR TITLE
Resolve #186: マッチング結果カードに「次のアクション」を追加

### DIFF
--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -232,6 +232,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 
 	type CompanyRecommendation struct {
 		ID             int            `json:"id"`
+		MatchID        uint           `json:"match_id"`      // マッチングレコードID（お気に入り操作に使用）
 		CategoryName   string         `json:"category_name"` // 企業名
 		Score          int            `json:"score"`         // マッチスコア
 		Reason         string         `json:"reason"`        // マッチ理由
@@ -240,6 +241,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 		Employees      string         `json:"employees"`
 		TechStack      []string       `json:"tech_stack"`
 		CategoryScores CategoryScores `json:"category_scores"`
+		IsFavorited    bool           `json:"is_favorited"`
 	}
 
 	type RecommendationResponse struct {
@@ -275,6 +277,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 
 		items = append(items, CompanyRecommendation{
 			ID:           int(match.Company.ID),
+			MatchID:      match.ID,
 			CategoryName: match.Company.Name,
 			Score:        int(match.MatchScore),
 			Reason:       services.BuildMatchReason(match, userScores),
@@ -282,6 +285,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 			Location:     match.Company.Location,
 			Employees:    employeeCount,
 			TechStack:    techStack,
+			IsFavorited:  match.IsFavorited,
 			CategoryScores: CategoryScores{
 				Technical:     match.TechnicalMatch,
 				Teamwork:      match.TeamworkMatch,
@@ -305,6 +309,30 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
+}
+
+// ToggleFavorite お気に入りをトグル (POST /api/chat/favorite)
+func (c *ChatController) ToggleFavorite(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		MatchID uint `json:"match_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.MatchID == 0 {
+		http.Error(w, "match_id is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.matchingService.ToggleFavorite(req.MatchID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"ok": true})
 }
 
 // GetAnalysisSummary 4分析スコアと進捗を取得

--- a/Backend/internal/routes/chat_routes.go
+++ b/Backend/internal/routes/chat_routes.go
@@ -15,6 +15,7 @@ func SetupChatRoutes(chatController *controllers.ChatController, questionControl
 	http.HandleFunc("/api/chat/analysis", chatController.GetAnalysisSummary)
 	http.HandleFunc("/api/chat/sessions", chatController.GetSessions)
 	http.HandleFunc("/api/chat/send-report", chatController.SendReport)
+	http.HandleFunc("/api/chat/favorite", chatController.ToggleFavorite)
 
 	// 質問管理エンドポイント
 	http.HandleFunc("/api/questions/generate", questionController.GenerateQuestions)

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -139,6 +139,11 @@ func (s *MatchingService) GetTopMatches(ctx context.Context, userID uint, sessio
 	return s.matchRepo.FindTopMatchesByUserAndSession(userID, sessionID, limit)
 }
 
+// ToggleFavorite お気に入りをトグル
+func (s *MatchingService) ToggleFavorite(matchID uint) error {
+	return s.matchRepo.ToggleFavorite(matchID)
+}
+
 type MatchingDiagnostics struct {
 	UserScoreCount     int64 `json:"user_score_count"`
 	ActiveCompanyCount int64 `json:"active_company_count"`

--- a/frontend/app/api/chat/favorite/route.ts
+++ b/frontend/app/api/chat/favorite/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const response = await fetch(`${BACKEND_URL}/api/chat/favorite`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const text = await response.text()
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: text || 'Failed to toggle favorite' },
+        { status: response.status }
+      )
+    }
+
+    let data
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = { ok: true }
+    }
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('[chat/favorite] POST error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -17,8 +17,10 @@ import {
   Tab,
   Snackbar,
   Alert,
+  IconButton,
+  Tooltip,
 } from '@mui/material'
-import { ArrowBack, LocationOn, People, TrendingUp as TrendingUpIcon, Refresh, Email } from '@mui/icons-material'
+import { ArrowBack, LocationOn, People, TrendingUp as TrendingUpIcon, Refresh, Email, Favorite, FavoriteBorder } from '@mui/icons-material'
 import { sendAnalysisReport } from '@/lib/api'
 import { authService } from '@/lib/auth'
 import ReactFlow, {
@@ -59,6 +61,7 @@ interface CategoryScores {
 
 interface Company {
   id: string
+  matchId?: number
   name: string
   industry: string
   location: string
@@ -68,6 +71,7 @@ interface Company {
   tags: string[]
   techStack: string[]
   categoryScores?: CategoryScores
+  isFavorited?: boolean
 }
 
 const CustomEdge = ({ id, sourceX, sourceY, targetX, targetY, style, markerEnd, label }: any) => {
@@ -159,6 +163,7 @@ function ResultsContent() {
   const [marketInfo, setMarketInfo] = useState<CompanyMarketInfo[]>([])
   const [diagramLoading, setDiagramLoading] = useState(false)
   const [emailSending, setEmailSending] = useState(false)
+  const [favoritingId, setFavoritingId] = useState<number | null>(null)
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
     open: false,
     message: '',
@@ -245,6 +250,7 @@ function ResultsContent() {
             console.log('[Results] Mapping company data:', rec)
             return {
               id: String(rec.id || rec.ID || index + 1),
+              matchId: rec.match_id || undefined,
               name: rec.category_name || rec.name || `企業 ${index + 1}`,
               industry: rec.industry || 'IT・ソフトウェア',
               location: rec.location || '東京都',
@@ -254,6 +260,7 @@ function ResultsContent() {
               tags: rec.tags || [],
               techStack: rec.tech_stack || [],
               categoryScores: rec.category_scores || undefined,
+              isFavorited: rec.is_favorited || false,
             }
           })
           console.log('[Results] Mapped companies:', mappedCompanies)
@@ -324,6 +331,27 @@ function ResultsContent() {
     localStorage.clear()
     sessionStorage.clear()
     router.push('/')
+  }
+
+  const handleToggleFavorite = async (e: React.MouseEvent, company: Company) => {
+    e.stopPropagation()
+    if (!company.matchId || favoritingId !== null) return
+    setFavoritingId(company.matchId)
+    try {
+      const res = await fetch('/api/chat/favorite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ match_id: company.matchId }),
+      })
+      if (res.ok) {
+        setCompanies(prev => prev.map(c =>
+          c.matchId === company.matchId ? { ...c, isFavorited: !c.isFavorited } : c
+        ))
+        setSnackbar({ open: true, message: company.isFavorited ? 'お気に入りを解除しました' : 'お気に入りに追加しました', severity: 'success' })
+      }
+    } finally {
+      setFavoritingId(null)
+    }
   }
 
   // 関係図のノードとエッジを生成
@@ -1001,10 +1029,31 @@ function ResultsContent() {
             </Card>
           )}
 
+          {/* おすすめの次のステップ サマリー */}
+          {companies.length > 0 && (
+            <Card elevation={1} sx={{ mb: 2, border: '1px solid', borderColor: 'primary.light', bgcolor: '#f8f4ff' }}>
+              <CardContent sx={{ py: 2 }}>
+                <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+                  おすすめの次のステップ
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  <Chip label={`面接練習: ${companies[0].name}から始める`} color="primary" size="small" onClick={() => {
+                    const params = new URLSearchParams({ company_id: companies[0].id, company_name: companies[0].name, industry: companies[0].industry })
+                    router.push(`/interview?${params.toString()}`)
+                  }} />
+                  <Chip label="企業詳細を確認する" variant="outlined" size="small" onClick={() => setSelectedCompany(companies[0])} />
+                  {companies.some(c => !c.isFavorited) && (
+                    <Chip label="気になる企業をお気に入り登録" variant="outlined" size="small" color="error" />
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+          )}
+
           <Stack spacing={3}>
             {companies.map((company, index) => (
-              <Card 
-                key={`${company.id}-${index}`} 
+              <Card
+                key={`${company.id}-${index}`}
                 elevation={3} 
                 sx={{ 
                   border: '2px solid', 
@@ -1034,10 +1083,22 @@ function ResultsContent() {
                         </Typography>
                       </Box>
                     </Box>
-                    <Box sx={{ textAlign: 'right' }}>
-                      <Typography variant="h4" color="primary.main" fontWeight="bold">
-                        {company.matchScore}
-                      </Typography>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        <Tooltip title={company.isFavorited ? 'お気に入り解除' : 'お気に入り登録'}>
+                          <IconButton
+                            size="small"
+                            onClick={(e) => handleToggleFavorite(e, company)}
+                            disabled={favoritingId === company.matchId}
+                            sx={{ color: company.isFavorited ? 'error.main' : 'action.disabled' }}
+                          >
+                            {company.isFavorited ? <Favorite fontSize="small" /> : <FavoriteBorder fontSize="small" />}
+                          </IconButton>
+                        </Tooltip>
+                        <Typography variant="h4" color="primary.main" fontWeight="bold">
+                          {company.matchScore}
+                        </Typography>
+                      </Box>
                       <Typography variant="caption" color="text.secondary">
                         適合度
                       </Typography>


### PR DESCRIPTION
Closes #186

## 変更内容

### バックエンド
- `GetRecommendations` レスポンスに `match_id`・`is_favorited` フィールドを追加
- `POST /api/chat/favorite` エンドポイントを追加（`match_id` でお気に入りをトグル）
- `MatchingService.ToggleFavorite()` を追加して既存の `ToggleFavorite` リポジトリメソッドを公開

### フロントエンド
- 企業カードのスコア横にお気に入りボタン（ハートアイコン）を追加
  - トグル可能・即時 UI 反映・Snackbar 通知付き
- 結果一覧上部に「おすすめの次のステップ」サマリーバナーを追加
  - 面接練習/企業詳細/お気に入り登録へのショートカット Chip を表示
- `frontend/app/api/chat/favorite/route.ts` プロキシルートを追加