### PR TITLE
Resolve #180: プライバシー設計と同意フローの実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -136,6 +136,7 @@ func main() {
 		apiCostService.LogCall(model, promptTokens, completionTokens)
 	}
 	authService := services.NewAuthService(userRepo, pendingRegistrationRepo, emailService)
+	authService.SetDB(db)
 	skillScoreService := services.NewSkillScoreService(skillScoreRepo)
 	githubService := services.NewGitHubService(githubRepo, skillScoreService, aiClient)
 	oauthService := services.NewOAuthService(userRepo, oauthConfig, githubService)

--- a/Backend/internal/controllers/auth_controller.go
+++ b/Backend/internal/controllers/auth_controller.go
@@ -274,3 +274,31 @@ func (c *AuthController) VerifyEmail(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "メールアドレスを確認しました。ログインしてください。"})
 }
+
+// DeleteAccount アカウントと全データを削除（個人情報保護法第28条対応）
+// DELETE /api/auth/account?user_id=X
+func (c *AuthController) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userIDStr := r.URL.Query().Get("user_id")
+	if userIDStr == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+	userID, err := strconv.ParseUint(userIDStr, 10, 32)
+	if err != nil {
+		http.Error(w, "Invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.authService.DeleteAccount(uint(userID)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "アカウントを削除しました"})
+}

--- a/Backend/internal/routes/auth_routes.go
+++ b/Backend/internal/routes/auth_routes.go
@@ -18,6 +18,7 @@ func SetupAuthRoutes(authController *controllers.AuthController, oauthController
 	http.HandleFunc("/api/auth/verify-email", authController.VerifyEmail)
 	http.HandleFunc("/api/auth/forgot-password", authController.RequestPasswordReset)
 	http.HandleFunc("/api/auth/reset-password", authController.ResetPassword)
+	http.HandleFunc("/api/auth/account", authController.DeleteAccount)
 
 	// OAuth エンドポイント
 	http.HandleFunc("/api/auth/google", oauthController.GoogleLogin)

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/entity"
 	"Backend/domain/repository"
+	"Backend/internal/models"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -12,16 +13,59 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 type AuthService struct {
 	userRepo     repository.UserRepository
 	pendingRepo  repository.PendingRegistrationRepository
 	emailService *EmailService
+	db           *gorm.DB
 }
 
 func NewAuthService(userRepo repository.UserRepository, pendingRepo repository.PendingRegistrationRepository, emailService *EmailService) *AuthService {
 	return &AuthService{userRepo: userRepo, pendingRepo: pendingRepo, emailService: emailService}
+}
+
+// SetDB はアカウント削除に使用する DB を設定する
+func (s *AuthService) SetDB(db *gorm.DB) {
+	s.db = db
+}
+
+// DeleteAccount ユーザーアカウントとその全データを削除する（個人情報保護法第28条対応）
+func (s *AuthService) DeleteAccount(userID uint) error {
+	if s.db == nil {
+		return errors.New("database not configured")
+	}
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// チャット履歴・重みスコア
+		if err := tx.Where("user_id = ?", userID).Delete(&models.ChatMessage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.UserWeightScore{}).Error; err != nil {
+			return err
+		}
+		// マッチング結果
+		if err := tx.Where("user_id = ?", userID).Delete(&models.UserCompanyMatch{}).Error; err != nil {
+			return err
+		}
+		// 面接セッション・発話・レポート・動画
+		var sessionIDs []uint
+		tx.Model(&models.InterviewSession{}).Where("user_id = ?", userID).Pluck("id", &sessionIDs)
+		if len(sessionIDs) > 0 {
+			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewUtterance{})
+			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewReport{})
+			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewVideo{})
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.InterviewSession{}).Error; err != nil {
+			return err
+		}
+		// ユーザー本体
+		if err := tx.Delete(&models.User{}, userID).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // RegisterRequest ユーザー登録リクエスト

--- a/frontend/app/api/auth/account/route.ts
+++ b/frontend/app/api/auth/account/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) {
+      return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+    }
+
+    const response = await fetch(`${BACKEND_URL}/api/auth/account?user_id=${userId}`, {
+      method: 'DELETE',
+    })
+
+    const text = await response.text()
+    if (!response.ok) {
+      return NextResponse.json({ error: text || 'Failed to delete account' }, { status: response.status })
+    }
+
+    let data
+    try { data = JSON.parse(text) } catch { data = { message: text } }
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('[auth/account] DELETE error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -7,7 +7,13 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Drawer,
+  FormControlLabel,
+  Checkbox,
   IconButton,
   InputBase,
   LinearProgress,
@@ -148,6 +154,8 @@ function InterviewContent() {
   const transcriptEndRef = useRef<HTMLDivElement | null>(null)
   // ハンズフリーVAD用
   const [handsFreeMode, setHandsFreeMode] = useState(false)
+  const [consentDialogOpen, setConsentDialogOpen] = useState(false)
+  const [consentGiven, setConsentGiven] = useState(false)
   const isRecordingRef = useRef(false)
   const turnPendingRef = useRef(false)
   const aiSpeakingRef = useRef(false)
@@ -426,6 +434,14 @@ function InterviewContent() {
       try { await interviewApi.saveUtterance(sessionId, userId, 'ai', aiText) } catch (e) { console.error('[utterance save error]', e) }
     }
     await playAudioBlob(audio)
+  }
+
+  const handleJoinWithConsent = () => {
+    if (!consentGiven) {
+      setConsentDialogOpen(true)
+      return
+    }
+    handleJoin()
   }
 
   const handleJoin = async () => {
@@ -1146,7 +1162,7 @@ function InterviewContent() {
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ width: '100%', maxWidth: 340 }}>
                 <Button
                   variant="contained"
-                  onClick={handleJoin}
+                  onClick={handleJoinWithConsent}
                   sx={{
                     flex: 1,
                     bgcolor: '#1a73e8',
@@ -1637,6 +1653,47 @@ function InterviewContent() {
       </Box>
 
       <audio ref={aiAudioRef} />
+
+      {/* 録画同意ダイアログ */}
+      <Dialog open={consentDialogOpen} onClose={() => setConsentDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>面接練習を開始する前に</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            面接練習では、より良いフィードバックのために以下のデータを収集します。
+          </Typography>
+          <Typography variant="body2" component="ul" sx={{ pl: 2, mb: 2, color: 'text.secondary' }}>
+            <li>音声・動画の録画（フィードバック生成のみに使用）</li>
+            <li>会話のテキスト（評価スコア算出に使用）</li>
+          </Typography>
+          <Typography variant="body2" color="error.main" sx={{ mb: 2 }}>
+            ※ これらのデータは企業には提供されません。サービス内でのみ使用します。
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            録画データは面接セッション終了後90日で自動削除されます。
+            詳細は<Button size="small" sx={{ p: 0, minWidth: 0, textDecoration: 'underline', fontSize: 'inherit' }}
+              onClick={() => window.open('/privacy', '_blank')}>プライバシーポリシー</Button>をご確認ください。
+          </Typography>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={consentGiven}
+                onChange={(e) => setConsentGiven(e.target.checked)}
+              />
+            }
+            label="上記の内容に同意して面接練習を始める"
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setConsentDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            disabled={!consentGiven}
+            onClick={() => { setConsentDialogOpen(false); handleJoin() }}
+          >
+            面接に参加
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Box, Container, Typography, Divider, Button } from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { useRouter } from 'next/navigation'
+
+export default function PrivacyPage() {
+  const router = useRouter()
+
+  return (
+    <Container maxWidth="md" sx={{ py: 6 }}>
+      <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()} sx={{ mb: 3 }}>
+        戻る
+      </Button>
+
+      <Typography variant="h4" fontWeight="bold" gutterBottom>
+        プライバシーポリシー
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        最終更新日: 2025年1月1日
+      </Typography>
+      <Divider sx={{ my: 3 }} />
+
+      <Box sx={{ '& h2': { mt: 4, mb: 1 }, '& p': { mb: 2 }, lineHeight: 1.8 }}>
+        <Typography variant="h6" component="h2" fontWeight="bold">1. 収集する情報</Typography>
+        <Typography variant="body1">
+          当サービスは、以下の個人情報を収集します。
+        </Typography>
+        <Typography variant="body1" component="ul" sx={{ pl: 3 }}>
+          <li>氏名・メールアドレス（アカウント登録時）</li>
+          <li>チャットの会話内容（就職軸の分析に使用）</li>
+          <li>職務経歴書・履歴書（アップロードされた場合）</li>
+          <li>面接練習の録画動画・音声（セッション中に収録）</li>
+          <li>企業マッチングスコア（算出された分析結果）</li>
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">2. 情報の利用目的</Typography>
+        <Typography variant="body1">
+          収集した情報は以下の目的にのみ使用します。
+        </Typography>
+        <Typography variant="body1" component="ul" sx={{ pl: 3 }}>
+          <li>就職軸の分析・企業マッチング機能の提供</li>
+          <li>面接練習のフィードバック生成</li>
+          <li>サービスの改善・不具合対応</li>
+          <li>利用状況の集計（個人を特定しない統計情報として）</li>
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">3. 第三者への提供</Typography>
+        <Typography variant="body1">
+          収集した個人情報を、以下の場合を除き第三者に提供しません。
+        </Typography>
+        <Typography variant="body1" component="ul" sx={{ pl: 3 }}>
+          <li>法令に基づく場合</li>
+          <li>ユーザー本人の同意がある場合</li>
+        </Typography>
+        <Typography variant="body1" color="error.main" fontWeight="bold">
+          ※ 面接動画・職務経歴書は企業に提供しません。当サービス内での分析にのみ使用します。
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">4. データの保持期間</Typography>
+        <Typography variant="body1">
+          アカウントが有効な期間中、データを保持します。アカウント削除後は30日以内にすべてのデータを完全削除します。
+          面接動画は録画後90日で自動削除されます。
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">5. ユーザーの権利（個人情報保護法第28条）</Typography>
+        <Typography variant="body1">
+          ユーザーはいつでも以下の権利を行使できます。
+        </Typography>
+        <Typography variant="body1" component="ul" sx={{ pl: 3 }}>
+          <li>保有する個人データの開示請求</li>
+          <li>個人データの訂正・追加・削除請求</li>
+          <li>アカウントの完全削除（プロフィールページから実行可能）</li>
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">6. セキュリティ</Typography>
+        <Typography variant="body1">
+          個人情報は暗号化して保存・転送します。パスワードはハッシュ化して保管し、平文では保存しません。
+        </Typography>
+
+        <Typography variant="h6" component="h2" fontWeight="bold">7. お問い合わせ</Typography>
+        <Typography variant="body1">
+          プライバシーに関するお問い合わせは、サービス内のお問い合わせフォームよりご連絡ください。
+        </Typography>
+      </Box>
+    </Container>
+  )
+}

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -16,6 +16,10 @@ import {
   Typography,
   Alert,
   Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material'
 import PersonIcon from '@mui/icons-material/Person'
 import SchoolIcon from '@mui/icons-material/School'
@@ -40,6 +44,8 @@ export default function ProfilePage() {
   const [loading, setLoading] = useState(false)
   const [saved, setSaved] = useState(false)
   const [isFirstTime, setIsFirstTime] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   useEffect(() => {
     const storedUser = authService.getStoredUser()
@@ -98,6 +104,24 @@ export default function ProfilePage() {
       setError(err instanceof Error ? err.message : '保存に失敗しました')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleDeleteAccount = async () => {
+    if (!user) return
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/auth/account?user_id=${user.user_id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const err = await res.text()
+        setError(err || 'アカウント削除に失敗しました')
+        return
+      }
+      authService.logout?.()
+      router.replace('/login?deleted=1')
+    } finally {
+      setDeleting(false)
+      setDeleteDialogOpen(false)
     }
   }
 
@@ -330,6 +354,59 @@ export default function ProfilePage() {
           </Box>
         </Box>
       </Container>
+
+      {/* アカウント管理セクション */}
+      <Container maxWidth="lg" sx={{ pb: 6 }}>
+        <Divider sx={{ my: 4 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+          <Box>
+            <Typography variant="body2" color="text.secondary">
+              プライバシーポリシー・データ利用について
+            </Typography>
+            <Button size="small" onClick={() => router.push('/privacy')} sx={{ p: 0, minWidth: 0, textDecoration: 'underline' }}>
+              プライバシーポリシーを確認
+            </Button>
+          </Box>
+          <Button
+            variant="outlined"
+            color="error"
+            size="small"
+            onClick={() => setDeleteDialogOpen(true)}
+          >
+            アカウントを削除する
+          </Button>
+        </Box>
+      </Container>
+
+      {/* アカウント削除確認ダイアログ */}
+      <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>アカウントを削除しますか？</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary">
+            この操作は取り消せません。以下のデータがすべて完全に削除されます。
+          </Typography>
+          <Typography variant="body2" component="ul" sx={{ pl: 2, mt: 1, color: 'text.secondary' }}>
+            <li>チャット履歴・就職軸スコア</li>
+            <li>マッチング結果</li>
+            <li>面接練習の録画・レポート</li>
+            <li>職務経歴書</li>
+            <li>アカウント情報</li>
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDeleteDialogOpen(false)} disabled={deleting}>
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleDeleteAccount}
+            color="error"
+            variant="contained"
+            disabled={deleting}
+          >
+            {deleting ? '削除中...' : '削除する'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* 保存成功トースト */}
       <Snackbar


### PR DESCRIPTION
Closes #180

## 変更内容

### バックエンド
- `AuthService.DeleteAccount(userID)` を追加（DB トランザクションで以下を完全削除）
  - チャット履歴・重みスコア・マッチング結果
  - 面接セッション・発話・レポート・動画
  - ユーザーアカウント本体
- `DELETE /api/auth/account?user_id=X` エンドポイントを追加
- `AuthService.SetDB(db)` で gorm.DB を注入（`main.go` で呼び出し）

### フロントエンド
- `/privacy` ページを新規作成
  - データ利用目的・保持期間・第三者提供方針・削除方法を明示（個人情報保護法第28条対応）
  - 「面接動画・職務経歴書は企業に提供しない」旨を明示
- プロフィールページにアカウント削除セクションを追加
  - 「アカウントを削除する」ボタン＋確認ダイアログ（削除されるデータ一覧を表示）
  - プライバシーポリシーへのリンクも追加
- 面接ページに録画開始前の同意ダイアログを追加
  - 初回「面接に参加」ボタン押下時に表示
  - チェックボックスで同意後に参加可能（以降のセッションは同意済として扱う）
- `/api/auth/account` Next.js プロキシルートを追加