### PR TITLE
Resolve #177: LLM呼び出しを抽象化するアダプターレイヤー

### DIFF
--- a/Backend/domain/ai/llm.go
+++ b/Backend/domain/ai/llm.go
@@ -1,0 +1,35 @@
+// Package ai defines the LLM abstraction layer.
+// サービス層はこのインターフェースを通じてのみ LLM を呼び出す。
+// OpenAI・Claude・Gemini 等の切り替えをアダプター実装で吸収する。
+package ai
+
+import "context"
+
+// TextClient はテキスト生成の抽象インターフェース。
+type TextClient interface {
+	// GenerateText はシステムプロンプトとユーザープロンプトからテキストを生成する。
+	GenerateText(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+
+	// GenerateJSON は JSON 文字列を返すテキスト生成（構造化出力用）。
+	GenerateJSON(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+}
+
+// EmbeddingClient はベクトル埋め込みの抽象インターフェース。
+type EmbeddingClient interface {
+	// GenerateEmbedding はテキストの埋め込みベクトルを返す。
+	GenerateEmbedding(ctx context.Context, text string) ([]float32, error)
+}
+
+// AudioClient は音声処理の抽象インターフェース。
+type AudioClient interface {
+	// TranscribeAudio は音声バイト列をテキストに変換する（Whisper 等）。
+	TranscribeAudio(ctx context.Context, audio []byte, filename string) (string, error)
+}
+
+// LLMClient は全 AI 操作を統合したインターフェース。
+// 大半のユースケースはこれ一つを依存注入すれば足りる。
+type LLMClient interface {
+	TextClient
+	EmbeddingClient
+	AudioClient
+}

--- a/Backend/internal/ai/fallback_adapter.go
+++ b/Backend/internal/ai/fallback_adapter.go
@@ -1,0 +1,33 @@
+package ai
+
+import (
+	"Backend/domain/ai"
+	"context"
+	"errors"
+)
+
+// FallbackAdapter は OpenAI 障害時のフォールバック実装。
+// テキスト生成は固定メッセージを返し、埋め込みはエラーを返す。
+// 本番でのフォールバック運用と単体テストのモック用途を兼ねる。
+type FallbackAdapter struct{}
+
+// NewFallbackAdapter はフォールバックアダプターを返す。
+func NewFallbackAdapter() ai.LLMClient {
+	return &FallbackAdapter{}
+}
+
+func (f *FallbackAdapter) GenerateText(_ context.Context, _, _ string) (string, error) {
+	return "現在 AI サービスが利用できません。しばらくしてから再度お試しください。", nil
+}
+
+func (f *FallbackAdapter) GenerateJSON(_ context.Context, _, _ string) (string, error) {
+	return "{}", nil
+}
+
+func (f *FallbackAdapter) GenerateEmbedding(_ context.Context, _ string) ([]float32, error) {
+	return nil, errors.New("embedding unavailable: AI service is temporarily down")
+}
+
+func (f *FallbackAdapter) TranscribeAudio(_ context.Context, _ []byte, _ string) (string, error) {
+	return "", errors.New("transcription unavailable: AI service is temporarily down")
+}

--- a/Backend/internal/ai/openai_adapter.go
+++ b/Backend/internal/ai/openai_adapter.go
@@ -1,0 +1,39 @@
+// Package ai implements the LLM adapter layer (domain/ai interfaces).
+package ai
+
+import (
+	"Backend/domain/ai"
+	"Backend/internal/openai"
+	"context"
+)
+
+// OpenAIAdapter は openai.Client を domain/ai.LLMClient に適合させるアダプター。
+// 依存注入によって OpenAI 以外の実装に差し替え可能。
+type OpenAIAdapter struct {
+	client *openai.Client
+}
+
+// NewOpenAIAdapter は既存の openai.Client をラップしたアダプターを返す。
+func NewOpenAIAdapter(client *openai.Client) ai.LLMClient {
+	return &OpenAIAdapter{client: client}
+}
+
+// GenerateText はシステムプロンプト＋ユーザープロンプトでテキストを生成する。
+func (a *OpenAIAdapter) GenerateText(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	return a.client.ResponsesWithTemperature(ctx, systemPrompt, userPrompt, 0.7)
+}
+
+// GenerateJSON は JSON 文字列を返すテキスト生成（構造化出力用）。
+func (a *OpenAIAdapter) GenerateJSON(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	return a.client.ChatCompletionJSON(ctx, systemPrompt, userPrompt, 0.0, 4096)
+}
+
+// GenerateEmbedding はテキストの埋め込みベクトルを返す。
+func (a *OpenAIAdapter) GenerateEmbedding(ctx context.Context, text string) ([]float32, error) {
+	return a.client.Embedding(ctx, text)
+}
+
+// TranscribeAudio は音声バイト列をテキストに変換する。
+func (a *OpenAIAdapter) TranscribeAudio(ctx context.Context, audio []byte, filename string) (string, error) {
+	return a.client.Transcribe(ctx, audio, filename)
+}

--- a/Backend/test/services/llm_adapter_test.go
+++ b/Backend/test/services/llm_adapter_test.go
@@ -1,0 +1,63 @@
+package services_test
+
+// LLM アダプターレイヤーのコンパイル時インターフェース適合テスト (Issue #177)
+//
+// 実行: cd Backend && go test ./test/services/... -run LLMAdapter -v
+
+import (
+	"context"
+	"testing"
+
+	domainai "Backend/domain/ai"
+	internalai "Backend/internal/ai"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// コンパイル時に FallbackAdapter が LLMClient インターフェースを満たすことを検証
+var _ domainai.LLMClient = (*internalai.FallbackAdapter)(nil)
+
+func TestFallbackAdapter_GenerateText(t *testing.T) {
+	adapter := internalai.NewFallbackAdapter()
+	text, err := adapter.GenerateText(context.Background(), "system", "user")
+	require.NoError(t, err)
+	assert.NotEmpty(t, text, "フォールバックは空でないメッセージを返すこと")
+}
+
+func TestFallbackAdapter_GenerateJSON(t *testing.T) {
+	adapter := internalai.NewFallbackAdapter()
+	json, err := adapter.GenerateJSON(context.Background(), "system", "user")
+	require.NoError(t, err)
+	assert.NotEmpty(t, json, "フォールバックは有効な JSON を返すこと")
+}
+
+func TestFallbackAdapter_GenerateEmbedding_ReturnsError(t *testing.T) {
+	adapter := internalai.NewFallbackAdapter()
+	embedding, err := adapter.GenerateEmbedding(context.Background(), "test text")
+	assert.Error(t, err, "フォールバックはエンべディングでエラーを返すこと")
+	assert.Nil(t, embedding)
+}
+
+func TestFallbackAdapter_TranscribeAudio_ReturnsError(t *testing.T) {
+	adapter := internalai.NewFallbackAdapter()
+	text, err := adapter.TranscribeAudio(context.Background(), []byte("audio"), "test.wav")
+	assert.Error(t, err, "フォールバックは音声認識でエラーを返すこと")
+	assert.Empty(t, text)
+}
+
+// LLMClient を依存注入で受け取る関数のテスト
+// サービス層がインターフェース経由で AI を呼び出せることを確認
+func TestLLMClientDependencyInjection(t *testing.T) {
+	// FallbackAdapter を LLMClient として注入
+	var client domainai.LLMClient = internalai.NewFallbackAdapter()
+
+	// TextClient として使用
+	text, err := client.GenerateText(context.Background(), "sp", "up")
+	require.NoError(t, err)
+	assert.NotEmpty(t, text)
+
+	// EmbeddingClient として使用（フォールバックはエラーを返す）
+	_, embErr := client.GenerateEmbedding(context.Background(), "test")
+	assert.Error(t, embErr, "フォールバック実装ではエンべディングは利用不可")
+}


### PR DESCRIPTION
Closes #177

## 変更内容

### `domain/ai/llm.go` — インターフェース定義
- `TextClient`: `GenerateText()` / `GenerateJSON()`
- `EmbeddingClient`: `GenerateEmbedding()`
- `AudioClient`: `TranscribeAudio()`
- `LLMClient`: 上記を統合した全機能インターフェース

### `internal/ai/openai_adapter.go` — OpenAI アダプター
- 既存 `openai.Client` を `domain/ai.LLMClient` に適合させる薄いラッパー
- `NewOpenAIAdapter(client)` で生成 — 既存コードへの変更なし

### `internal/ai/fallback_adapter.go` — フォールバック実装
- OpenAI 障害時のフォールバック（テキスト生成は固定メッセージ、エンべディングはエラー）
- 単体テストのモック実装としても利用可能

### `test/services/llm_adapter_test.go` — テスト
- コンパイル時インターフェース適合確認（`var _ LLMClient = (*FallbackAdapter)(nil)`）
- フォールバックアダプターの全メソッドをテスト
- 依存注入でサービス層がインターフェース経由で AI を呼び出せることを確認

## 設計方針
既存の `openai.Client` 依存箇所への変更は最小限とし、新規サービスから順次 `domain/ai.LLMClient` インターフェース経由に移行できる設計。