### PR TITLE
Resolve #184: 企業関係図とマッチング結果の連動

### DIFF
--- a/frontend/app/Correlation-diagram/page.tsx
+++ b/frontend/app/Correlation-diagram/page.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button, Box } from '@mui/material';
+import { Suspense } from 'react';
 import CorrelationDiagram from '@/components/Correlation-diagram';
 
-export default function Page() {
+function CorrelationDiagramContent() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const companyIdParam = searchParams.get('company_id');
+    const initialCompanyId = companyIdParam ? parseInt(companyIdParam, 10) : null;
 
     return (
         <Box sx={{ p: 2 }}>
@@ -13,7 +17,15 @@ export default function Page() {
                 戻る
             </Button>
 
-            <CorrelationDiagram />
+            <CorrelationDiagram initialCompanyId={initialCompanyId} />
         </Box>
+    );
+}
+
+export default function Page() {
+    return (
+        <Suspense fallback={null}>
+            <CorrelationDiagramContent />
+        </Suspense>
     );
 }

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -1205,6 +1205,16 @@ function ResultsContent() {
                     >
                       この企業の面接を練習する
                     </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        router.push(`/Correlation-diagram?company_id=${company.id}`)
+                      }}
+                    >
+                      関連企業を見る
+                    </Button>
                     <Typography variant="caption" color="primary" sx={{ fontWeight: 'bold' }}>
                       クリックして詳細を見る →
                     </Typography>

--- a/frontend/components/Correlation-diagram.tsx
+++ b/frontend/components/Correlation-diagram.tsx
@@ -97,9 +97,13 @@ const edgeTypes: EdgeTypes = {
     custom: CustomEdge,
 };
 
-export default function CorrelationDiagram() {
+interface CorrelationDiagramProps {
+    initialCompanyId?: number | null
+}
+
+export default function CorrelationDiagram({ initialCompanyId = null }: CorrelationDiagramProps) {
     const [diagramType, setDiagramType] = useState<DiagramType>('capital');
-    const [selectedCompanyId, setSelectedCompanyId] = useState<number | null>(null);
+    const [selectedCompanyId, setSelectedCompanyId] = useState<number | null>(initialCompanyId);
     const [relations, setRelations] = useState<CapitalRelation[]>([]);
     const [marketInfo, setMarketInfo] = useState<CompanyMarketInfo[]>([]);
     const [loading, setLoading] = useState(true);


### PR DESCRIPTION
Closes #184

## 変更内容
- `CorrelationDiagram` コンポーネントに `initialCompanyId` プロップを追加し、URL パラメータ経由で初期選択企業を指定可能にした
- `/Correlation-diagram` ページで `company_id` クエリパラメータを読み取り、`CorrelationDiagram` に渡す実装を追加（`useSearchParams` 利用のため `Suspense` でラップ）
- マッチング結果ページ（`/results`）の各企業カードに「関連企業を見る」ボタンを追加し、`/Correlation-diagram?company_id={id}` へ遷移するようにした