### PR TITLE
Resolve #187: 面接コスト上限をUX非公開にし10分セッション制に変更

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -187,7 +187,7 @@ func main() {
 		s3UploadService = nil
 	}
 	interviewController := controllers.NewInterviewController(interviewService, videoRepo, s3UploadService)
-	realtimeController := controllers.NewRealtimeController(interviewService)
+	realtimeController := controllers.NewRealtimeController(interviewService, realtimeUsageService)
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
 	adminDashboardController := controllers.NewAdminDashboardController(userRepo, interviewSessionRepo, interviewReportRepo)
 	adminCostsController := controllers.NewAdminCostsController(apiCostService, realtimeUsageService)

--- a/Backend/internal/controllers/realtime_controller.go
+++ b/Backend/internal/controllers/realtime_controller.go
@@ -8,11 +8,12 @@ import (
 )
 
 type RealtimeController struct {
-	interviewService *services.InterviewService
+	interviewService    *services.InterviewService
+	realtimeUsageService *services.RealtimeUsageService
 }
 
-func NewRealtimeController(interviewService *services.InterviewService) *RealtimeController {
-	return &RealtimeController{interviewService: interviewService}
+func NewRealtimeController(interviewService *services.InterviewService, realtimeUsageService *services.RealtimeUsageService) *RealtimeController {
+	return &RealtimeController{interviewService: interviewService, realtimeUsageService: realtimeUsageService}
 }
 
 type realtimeTokenRequest struct {
@@ -52,4 +53,22 @@ func (c *RealtimeController) Token(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(realtimeTokenResponse{ClientSecret: secret})
+}
+
+type sessionInfoResponse struct {
+	SessionMinutes int `json:"session_minutes"`
+}
+
+// SessionInfo はユーザー向けのセッション時間（分）を返す。コスト情報は含まない。
+func (c *RealtimeController) SessionInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	minutes := 10
+	if c.realtimeUsageService != nil {
+		minutes = c.realtimeUsageService.SessionDurationMinutes()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(sessionInfoResponse{SessionMinutes: minutes})
 }

--- a/Backend/internal/routes/interview_routes.go
+++ b/Backend/internal/routes/interview_routes.go
@@ -12,4 +12,5 @@ func SetupInterviewRoutes(interviewController *controllers.InterviewController, 
 	http.HandleFunc("/api/interviews", interviewController.ListOrCreate)
 	http.HandleFunc("/api/interviews/", interviewController.Route)
 	http.HandleFunc("/api/realtime/token", realtimeController.Token)
+	http.HandleFunc("/api/realtime/session-info", realtimeController.SessionInfo)
 }

--- a/Backend/internal/services/realtime_usage_service.go
+++ b/Backend/internal/services/realtime_usage_service.go
@@ -41,11 +41,12 @@ type RealtimeUserSummary struct {
 }
 
 type RealtimeUsageService struct {
-	repo              *repositories.RealtimeUsageRepository
-	emailService      *EmailService
-	alertThresholdUSD float64
-	maxConcurrent     int64
-	ratePerMinuteUSD  float64
+	repo                    *repositories.RealtimeUsageRepository
+	emailService            *EmailService
+	alertThresholdUSD       float64
+	maxConcurrent           int64
+	ratePerMinuteUSD        float64
+	sessionDurationMinutes  int
 
 	mu               sync.Mutex
 	lastAlertMonthID string
@@ -58,13 +59,24 @@ func NewRealtimeUsageService(repo *repositories.RealtimeUsageRepository, emailSe
 		maxConcurrent = 30
 	}
 	rate := getFloatEnv("INTERVIEW_COST_PER_MIN_USD", 0.18)
-	return &RealtimeUsageService{
-		repo:              repo,
-		emailService:      emailService,
-		alertThresholdUSD: threshold,
-		maxConcurrent:     maxConcurrent,
-		ratePerMinuteUSD:  rate,
+	sessionMinutes := getIntEnv("INTERVIEW_SESSION_MINUTES", 10)
+	if sessionMinutes <= 0 {
+		sessionMinutes = 10
 	}
+	return &RealtimeUsageService{
+		repo:                   repo,
+		emailService:           emailService,
+		alertThresholdUSD:      threshold,
+		maxConcurrent:          maxConcurrent,
+		ratePerMinuteUSD:       rate,
+		sessionDurationMinutes: sessionMinutes,
+	}
+}
+
+// SessionDurationMinutes はユーザー向けのセッション時間（分）を返す。
+// コスト上限は内部管理のみとし、UXには時間として公開する。
+func (s *RealtimeUsageService) SessionDurationMinutes() int {
+	return s.sessionDurationMinutes
 }
 
 func (s *RealtimeUsageService) CanOpenNewConnection() (bool, int64, int64, error) {

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -103,7 +103,7 @@ function InterviewContent() {
   const [partialUser, setPartialUser] = useState('')
   const [partialAi, setPartialAi] = useState('')
   const [remainingSeconds, setRemainingSeconds] = useState(interviewLimits.maxMinutes * 60)
-  const [estimatedCost, setEstimatedCost] = useState(0)
+  const [sessionWarningShown, setSessionWarningShown] = useState(false)
   const [session, setSession] = useState<InterviewSession | null>(null)
   const [report, setReport] = useState<InterviewReport | null>(null)
   const [reportStatus, setReportStatus] = useState<'idle' | 'pending' | 'ready' | 'error'>('idle')
@@ -355,7 +355,7 @@ function InterviewContent() {
       const elapsed = Math.floor((Date.now() - sessionStartRef.current) / 1000)
       const remaining = Math.max(0, interviewLimits.maxMinutes * 60 - elapsed)
       setRemainingSeconds(remaining)
-      setEstimatedCost((elapsed / 60) * interviewLimits.costPerMinuteUSD)
+      if (remaining <= 120 && !sessionWarningShown) setSessionWarningShown(true)
       if (remaining <= 0) handleStop(true)
     }, 1000)
   }
@@ -451,7 +451,7 @@ function InterviewContent() {
     setPartialUser(''); setPartialAi('')
     setReport(null); setReportStatus('idle')
     setRemainingSeconds(interviewLimits.maxMinutes * 60)
-    setEstimatedCost(0)
+    setSessionWarningShown(false)
     setMicEnabled(true); setCameraEnabled(true)
     historyRef.current = []
 
@@ -1155,9 +1155,14 @@ function InterviewContent() {
               <Typography variant="h4" sx={{ fontWeight: 400, color: '#202124', mb: 1 }}>
                 準備はできましたか？
               </Typography>
-              <Typography sx={{ color: 'text.secondary', mb: 4, fontSize: 15 }}>
+              <Typography sx={{ color: 'text.secondary', mb: 1, fontSize: 15 }}>
                 {companyName}
               </Typography>
+              <Box sx={{ mb: 3, px: 2, py: 1, bgcolor: '#e3f2fd', borderRadius: 1, border: '1px solid #90caf9' }}>
+                <Typography sx={{ fontSize: 13, color: '#1565c0' }}>
+                  ⏱ このセッションは最大{interviewLimits.maxMinutes}分です
+                </Typography>
+              </Box>
 
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ width: '100%', maxWidth: 340 }}>
                 <Button
@@ -1324,14 +1329,14 @@ function InterviewContent() {
         </Box>
       </Box>
 
-      {/* ── Cost alert ── */}
-      {isConnected && estimatedCost >= interviewLimits.maxCostUSD * 0.8 && (
+      {/* ── Time warning ── */}
+      {isConnected && sessionWarningShown && (
         <Box sx={{ px: 2, pt: 1, flexShrink: 0 }}>
-          <Box sx={{ bgcolor: estimatedCost >= interviewLimits.maxCostUSD ? 'rgba(234,67,53,0.2)' : 'rgba(251,188,4,0.15)', border: `1px solid ${estimatedCost >= interviewLimits.maxCostUSD ? '#ea4335' : '#fbbc04'}`, borderRadius: 1, px: 2, py: 0.8, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography sx={{ fontSize: 13, color: estimatedCost >= interviewLimits.maxCostUSD ? '#f28b82' : '#fdd663', fontWeight: 600 }}>
-              {estimatedCost >= interviewLimits.maxCostUSD
-                ? '⚠️ コスト上限に達しました。間もなく面接が終了します。'
-                : `⚠️ コスト上限の80%に達しました（$${estimatedCost.toFixed(2)} / $${interviewLimits.maxCostUSD.toFixed(2)}）`}
+          <Box sx={{ bgcolor: remainingSeconds <= 0 ? 'rgba(234,67,53,0.2)' : 'rgba(251,188,4,0.15)', border: `1px solid ${remainingSeconds <= 0 ? '#ea4335' : '#fbbc04'}`, borderRadius: 1, px: 2, py: 0.8, display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography sx={{ fontSize: 13, color: remainingSeconds <= 0 ? '#f28b82' : '#fdd663', fontWeight: 600 }}>
+              {remainingSeconds <= 0
+                ? 'セッションが終了しました。'
+                : `⚠️ 残り約${Math.ceil(remainingSeconds / 60)}分です。セッションがまもなく終了します。`}
             </Typography>
           </Box>
         </Box>
@@ -1647,7 +1652,7 @@ function InterviewContent() {
             </IconButton>
           </Tooltip>
           <Typography variant="caption" sx={{ color: '#5f6368', ml: 1 }}>
-            推定 ${estimatedCost.toFixed(2)}
+            残り {Math.floor(remainingSeconds / 60)}:{String(remainingSeconds % 60).padStart(2, '0')}
           </Typography>
         </Box>
       </Box>

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -218,6 +218,4 @@ export const interviewApi = {
 
 export const interviewLimits = {
   maxMinutes: Number(process.env.NEXT_PUBLIC_INTERVIEW_MAX_MINUTES || 10),
-  maxCostUSD: Number(process.env.NEXT_PUBLIC_INTERVIEW_MAX_COST_USD || 1.8),
-  costPerMinuteUSD: Number(process.env.NEXT_PUBLIC_INTERVIEW_COST_PER_MIN_USD || 0.18),
 }


### PR DESCRIPTION
Closes #187

## 変更内容
- `RealtimeUsageService` に `SessionDurationMinutes()` を追加し、`INTERVIEW_SESSION_MINUTES` 環境変数で時間を制御できるようにした（デフォルト10分）
- `GET /api/realtime/session-info` エンドポイントを追加し、`{"session_minutes": N}` を返すようにした（コスト情報は含まない）
- `NewRealtimeController` に `RealtimeUsageService` を DI で渡すよう変更
- フロントエンドの `interviewLimits` から `maxCostUSD`・`costPerMinuteUSD` を削除し、コスト概念をバックエンド内部に隠蔽
- ロビー画面に「このセッションは最大N分です」を表示
- セッション中のコスト警告を「残り約N分です」という時間ベースの警告に変更
- セッション終了時の「コスト上限に達しました」を「セッションが終了しました」に変更
- ステータスバーの「推定 $X.XX」を「残り MM:SS」カウントダウンに変更