### PR TITLE
Resolve #189: 職務経歴書レビューをマッチング結果と連動

### DIFF
--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -1215,6 +1215,21 @@ function ResultsContent() {
                     >
                       関連企業を見る
                     </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="success"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        const params = new URLSearchParams({
+                          company_name: company.name,
+                          industry: company.industry,
+                        })
+                        router.push(`/resume?${params.toString()}`)
+                      }}
+                    >
+                      ES・職務経歴書を添削
+                    </Button>
                     <Typography variant="caption" color="primary" sx={{ fontWeight: 'bold' }}>
                       クリックして詳細を見る →
                     </Typography>

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
 import {
   Box,
   Button,
@@ -41,7 +42,8 @@ const severityConfig: Record<string, { color: 'error' | 'warning' | 'info'; labe
   info: { color: 'info', label: '情報', borderColor: '#0288d1' },
 }
 
-export default function ResumePage() {
+function ResumeContent() {
+  const searchParams = useSearchParams()
   const [userId, setUserId] = useState('')
   const [sessionId, setSessionId] = useState('')
   const [sourceType, setSourceType] = useState('pdf')
@@ -58,6 +60,9 @@ export default function ResumePage() {
   const [review, setReview] = useState<ReviewResult | null>(null)
   const [ragReport, setRagReport] = useState('')
 
+  const prefilledCompany = searchParams.get('company_name') || ''
+  const prefilledIndustry = searchParams.get('industry') || ''
+
   useEffect(() => {
     const user = authService.getStoredUser()
     if (user?.user_id) {
@@ -71,7 +76,10 @@ export default function ResumePage() {
         ''
       setSessionId(storedSession)
     }
-  }, [])
+    if (prefilledCompany) {
+      setCompanyName(prefilledCompany)
+    }
+  }, [prefilledCompany])
 
   const handleUpload = async () => {
     setUploadError('')
@@ -198,9 +206,19 @@ export default function ResumePage() {
       <Typography variant="h4" fontWeight="bold" gutterBottom>
         履歴書・エントリシート レビュー
       </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: prefilledCompany ? 1.5 : 3 }}>
         PDF/DOCX/Google Docsをアップロードして、注釈付きPDFを生成します。
       </Typography>
+      {prefilledCompany && (
+        <Box sx={{ mb: 3, px: 2, py: 1.5, bgcolor: '#e8f5e9', borderRadius: 1, border: '1px solid #a5d6a7' }}>
+          <Typography sx={{ fontSize: 14, color: '#2e7d32', fontWeight: 600 }}>
+            {prefilledCompany}{prefilledIndustry ? `（${prefilledIndustry}）` : ''}向けに最適化されたフィードバックを提供します
+          </Typography>
+          <Typography sx={{ fontSize: 12, color: '#388e3c', mt: 0.5 }}>
+            企業の求める人材像を踏まえたアドバイスが反映されます
+          </Typography>
+        </Box>
+      )}
 
       <Paper sx={{ p: 3, mb: 3 }} elevation={2}>
         <Stack spacing={2}>
@@ -381,5 +399,13 @@ export default function ResumePage() {
         </Paper>
       )}
     </Box>
+  )
+}
+
+export default function ResumePage() {
+  return (
+    <Suspense fallback={null}>
+      <ResumeContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
Closes #189

## 変更内容
- マッチング結果ページ（`/results`）の各企業カードに「ES・職務経歴書を添削」ボタンを追加
  - クリックで `/resume?company_name=X&industry=Y` に遷移（Option A: 連携維持）
- `/resume` ページで URL パラメータ (`company_name`, `industry`) を読み取るよう変更
  - `useSearchParams` 対応のため `ResumeContent` + `Suspense` ラッパー構造に変更
  - 企業コンテキストが渡された場合、「○○社向けに最適化されたフィードバックを提供します」バナーを表示
  - 企業名フォームにも自動でプリフィル