### PR TITLE
Resolve #201: 選考結果フィードバックループの実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -123,6 +123,8 @@ func main() {
 	// GitHub連携
 	githubRepo := repositories.NewGitHubRepository(db)
 	skillScoreRepo := repositories.NewSkillScoreRepository(db)
+	// 応募・選考ステータス
+	appStatusRepo := repositories.NewUserApplicationStatusRepository(db)
 	// APIコストモニタリング
 	apiCallLogRepo := repositories.NewAPICallLogRepository(db)
 	realtimeUsageRepo := repositories.NewRealtimeUsageRepository(db)
@@ -198,6 +200,8 @@ func main() {
 	scheduleService := services.NewScheduleService(scheduleRepo)
 	scheduleController := controllers.NewScheduleController(scheduleService)
 	esReviewController := controllers.NewESReviewController()
+	appService := services.NewApplicationService(appStatusRepo, matchRepo)
+	appController := controllers.NewApplicationController(appService)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
@@ -209,6 +213,7 @@ func main() {
 	routes.SetupGitHubRoutes(githubController)
 	routes.SetupESRoutes(esRewriteController, esReviewController)
 	routes.SetupScheduleRoutes(scheduleController)
+	routes.SetupApplicationRoutes(appController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
 
 	go crawlService.StartScheduler()

--- a/Backend/domain/entity/company.go
+++ b/Backend/domain/entity/company.go
@@ -33,6 +33,21 @@ type Company struct {
 	UpdatedAt        time.Time
 }
 
+// UserApplicationStatus 応募・選考ステータスエンティティ
+type UserApplicationStatus struct {
+	ID              uint
+	UserID          uint
+	CompanyID       uint
+	Company         *Company
+	MatchID         uint
+	Status          string // applied / document_passed / interview / offered / accepted / declined / rejected
+	Notes           string
+	AppliedAt       *time.Time
+	StatusUpdatedAt *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
 // IsPublished 公開済みかどうか
 func (c *Company) IsPublished() bool {
 	return c.DataStatus == "published" && c.IsActive

--- a/Backend/domain/mapper/company_mapper.go
+++ b/Backend/domain/mapper/company_mapper.go
@@ -41,6 +41,46 @@ func CompanyToEntity(m *models.Company) *entity.Company {
 	}
 }
 
+// UserApplicationStatusToEntity models.UserApplicationStatus を entity.UserApplicationStatus に変換
+func UserApplicationStatusToEntity(m *models.UserApplicationStatus) *entity.UserApplicationStatus {
+	if m == nil {
+		return nil
+	}
+	e := &entity.UserApplicationStatus{
+		ID:              m.ID,
+		UserID:          m.UserID,
+		CompanyID:       m.CompanyID,
+		MatchID:         m.MatchID,
+		Status:          m.Status,
+		Notes:           m.Notes,
+		AppliedAt:       m.AppliedAt,
+		StatusUpdatedAt: m.StatusUpdatedAt,
+		CreatedAt:       m.CreatedAt,
+		UpdatedAt:       m.UpdatedAt,
+	}
+	e.Company = CompanyToEntity(&m.Company)
+	return e
+}
+
+// UserApplicationStatusFromEntity entity.UserApplicationStatus を models.UserApplicationStatus に変換
+func UserApplicationStatusFromEntity(e *entity.UserApplicationStatus) *models.UserApplicationStatus {
+	if e == nil {
+		return nil
+	}
+	return &models.UserApplicationStatus{
+		ID:              e.ID,
+		UserID:          e.UserID,
+		CompanyID:       e.CompanyID,
+		MatchID:         e.MatchID,
+		Status:          e.Status,
+		Notes:           e.Notes,
+		AppliedAt:       e.AppliedAt,
+		StatusUpdatedAt: e.StatusUpdatedAt,
+		CreatedAt:       e.CreatedAt,
+		UpdatedAt:       e.UpdatedAt,
+	}
+}
+
 // UserCompanyMatchToEntity models.UserCompanyMatch を entity.UserCompanyMatch に変換
 func UserCompanyMatchToEntity(m *models.UserCompanyMatch) *entity.UserCompanyMatch {
 	if m == nil {

--- a/Backend/internal/controllers/application_controller.go
+++ b/Backend/internal/controllers/application_controller.go
@@ -1,0 +1,188 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// ApplicationController 応募・選考ステータス管理コントローラー
+type ApplicationController struct {
+	appService *services.ApplicationService
+}
+
+func NewApplicationController(appService *services.ApplicationService) *ApplicationController {
+	return &ApplicationController{appService: appService}
+}
+
+// Apply POST /api/applications - 企業への応募登録
+func (c *ApplicationController) Apply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		UserID    uint `json:"user_id"`
+		CompanyID uint `json:"company_id"`
+		MatchID   uint `json:"match_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.UserID == 0 || req.CompanyID == 0 || req.MatchID == 0 {
+		http.Error(w, "user_id, company_id, match_id は必須です", http.StatusBadRequest)
+		return
+	}
+
+	app, err := c.appService.Apply(req.UserID, req.CompanyID, req.MatchID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":         app.ID,
+		"user_id":    app.UserID,
+		"company_id": app.CompanyID,
+		"match_id":   app.MatchID,
+		"status":     app.Status,
+		"applied_at": app.AppliedAt,
+	})
+}
+
+// UpdateStatus PUT /api/applications/{id} - 選考ステータス更新
+func (c *ApplicationController) UpdateStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// パスから ID を取得: /api/applications/123
+	idStr := r.URL.Path[len("/api/applications/"):]
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		http.Error(w, "Invalid application ID", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		UserID uint   `json:"user_id"`
+		Status string `json:"status"`
+		Notes  string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.UserID == 0 || req.Status == "" {
+		http.Error(w, "user_id と status は必須です", http.StatusBadRequest)
+		return
+	}
+
+	app, err := c.appService.UpdateStatus(uint(id), req.UserID, req.Status, req.Notes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":     app.ID,
+		"status": app.Status,
+		"notes":  app.Notes,
+	})
+}
+
+// List GET /api/applications?user_id=X - ユーザーの応募一覧取得
+func (c *ApplicationController) List(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userIDStr := r.URL.Query().Get("user_id")
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil || userID == 0 {
+		http.Error(w, "user_id は必須です", http.StatusBadRequest)
+		return
+	}
+
+	apps, err := c.appService.GetApplicationsByUser(uint(userID))
+	if err != nil {
+		http.Error(w, "データ取得エラー", http.StatusInternalServerError)
+		return
+	}
+
+	type AppResponse struct {
+		ID              uint        `json:"id"`
+		CompanyID       uint        `json:"company_id"`
+		CompanyName     string      `json:"company_name"`
+		CompanyIndustry string      `json:"company_industry"`
+		MatchID         uint        `json:"match_id"`
+		Status          string      `json:"status"`
+		Notes           string      `json:"notes"`
+		AppliedAt       interface{} `json:"applied_at"`
+		StatusUpdatedAt interface{} `json:"status_updated_at"`
+	}
+
+	resp := make([]AppResponse, len(apps))
+	for i, app := range apps {
+		name := ""
+		industry := ""
+		if app.Company != nil {
+			name = app.Company.Name
+			industry = app.Company.Industry
+		}
+		resp[i] = AppResponse{
+			ID:              app.ID,
+			CompanyID:       app.CompanyID,
+			CompanyName:     name,
+			CompanyIndustry: industry,
+			MatchID:         app.MatchID,
+			Status:          app.Status,
+			Notes:           app.Notes,
+			AppliedAt:       app.AppliedAt,
+			StatusUpdatedAt: app.StatusUpdatedAt,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"applications": resp,
+		"total":        len(resp),
+	})
+}
+
+// GetCorrelation GET /api/applications/correlation?company_id=X - 相関分析データ取得
+func (c *ApplicationController) GetCorrelation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	companyIDStr := r.URL.Query().Get("company_id")
+	var companyID uint
+	if companyIDStr != "" {
+		id, err := strconv.ParseUint(companyIDStr, 10, 64)
+		if err == nil {
+			companyID = uint(id)
+		}
+	}
+
+	data, err := c.appService.GetCorrelation(companyID)
+	if err != nil {
+		http.Error(w, "相関データ取得エラー", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"correlation": data,
+		"total":       len(data),
+	})
+}

--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -242,6 +242,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 		TechStack      []string       `json:"tech_stack"`
 		CategoryScores CategoryScores `json:"category_scores"`
 		IsFavorited    bool           `json:"is_favorited"`
+		IsApplied      bool           `json:"is_applied"`
 	}
 
 	type RecommendationResponse struct {
@@ -286,6 +287,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 			Employees:    employeeCount,
 			TechStack:    techStack,
 			IsFavorited:  match.IsFavorited,
+			IsApplied:    match.IsApplied,
 			CategoryScores: CategoryScores{
 				Technical:     match.TechnicalMatch,
 				Teamwork:      match.TeamworkMatch,

--- a/Backend/internal/models/company.go
+++ b/Backend/internal/models/company.go
@@ -142,6 +142,28 @@ type UserCompanyMatch struct {
 	UpdatedAt time.Time
 }
 
+// UserApplicationStatus ユーザーの応募・選考ステータス管理
+type UserApplicationStatus struct {
+	ID        uint    `gorm:"primaryKey"`
+	UserID    uint    `gorm:"not null;index:idx_user_company_app"`
+	User      User    `gorm:"foreignKey:UserID"`
+	CompanyID uint    `gorm:"not null;index:idx_user_company_app"`
+	Company   Company `gorm:"foreignKey:CompanyID"`
+	MatchID   uint    `gorm:"not null;index"` // UserCompanyMatch との紐付け
+
+	// 選考ステータス
+	// applied: 応募済み / document_passed: 書類通過 / interview: 面接中 /
+	// offered: 内定 / accepted: 内定承諾 / declined: 辞退 / rejected: 不合格
+	Status string `gorm:"type:varchar(50);not null;default:'applied'"`
+	Notes  string `gorm:"type:text"` // メモ・備考
+
+	AppliedAt       *time.Time // 応募日
+	StatusUpdatedAt *time.Time // ステータス最終更新日
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // CompanyReview 企業レビュー（オプション機能）
 type CompanyReview struct {
 	ID        uint    `gorm:"primaryKey"`

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -26,6 +26,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&CompanyJobPosition{},
 		&CompanyWeightProfile{},
 		&UserCompanyMatch{},
+		&UserApplicationStatus{},
 		&CompanyReview{},
 		&CompanyBenefit{},
 		&GBizCompanyProfile{},

--- a/Backend/internal/repositories/user_application_status_repository.go
+++ b/Backend/internal/repositories/user_application_status_repository.go
@@ -1,0 +1,138 @@
+package repositories
+
+import (
+	"Backend/domain/entity"
+	"Backend/domain/mapper"
+	"Backend/internal/models"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type UserApplicationStatusRepository struct {
+	db *gorm.DB
+}
+
+func NewUserApplicationStatusRepository(db *gorm.DB) *UserApplicationStatusRepository {
+	return &UserApplicationStatusRepository{db: db}
+}
+
+// Create 応募ステータスを新規作成
+func (r *UserApplicationStatusRepository) Create(app *entity.UserApplicationStatus) error {
+	m := mapper.UserApplicationStatusFromEntity(app)
+	if err := r.db.Create(m).Error; err != nil {
+		return err
+	}
+	app.ID = m.ID
+	app.CreatedAt = m.CreatedAt
+	app.UpdatedAt = m.UpdatedAt
+	return nil
+}
+
+// FindByUserAndCompany ユーザーIDと企業IDで検索（重複チェック用）
+func (r *UserApplicationStatusRepository) FindByUserAndCompany(userID, companyID uint) (*entity.UserApplicationStatus, error) {
+	var m models.UserApplicationStatus
+	err := r.db.Where("user_id = ? AND company_id = ?", userID, companyID).
+		Preload("Company").
+		First(&m).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return mapper.UserApplicationStatusToEntity(&m), nil
+}
+
+// FindByID IDで取得
+func (r *UserApplicationStatusRepository) FindByID(id uint) (*entity.UserApplicationStatus, error) {
+	var m models.UserApplicationStatus
+	err := r.db.Preload("Company").First(&m, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapper.UserApplicationStatusToEntity(&m), nil
+}
+
+// FindByUserID ユーザーの全応募一覧を取得
+func (r *UserApplicationStatusRepository) FindByUserID(userID uint) ([]*entity.UserApplicationStatus, error) {
+	var ms []*models.UserApplicationStatus
+	err := r.db.Where("user_id = ?", userID).
+		Preload("Company").
+		Order("created_at DESC").
+		Find(&ms).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*entity.UserApplicationStatus, len(ms))
+	for i, m := range ms {
+		result[i] = mapper.UserApplicationStatusToEntity(m)
+	}
+	return result, nil
+}
+
+// UpdateStatus 選考ステータスを更新
+func (r *UserApplicationStatusRepository) UpdateStatus(id uint, status, notes string) error {
+	now := time.Now()
+	return r.db.Model(&models.UserApplicationStatus{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"status":            status,
+			"notes":             notes,
+			"status_updated_at": now,
+			"updated_at":        now,
+		}).Error
+}
+
+// GetCorrelationByCompany 企業ごとのマッチングスコア×選考通過率の相関データを取得
+func (r *UserApplicationStatusRepository) GetCorrelationByCompany(companyID uint) ([]map[string]interface{}, error) {
+	type Row struct {
+		MatchScore float64
+		Status     string
+	}
+	var rows []Row
+	err := r.db.Table("user_application_statuses uas").
+		Select("ucm.match_score, uas.status").
+		Joins("JOIN user_company_matches ucm ON ucm.id = uas.match_id").
+		Where("uas.company_id = ?", companyID).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, len(rows))
+	for i, row := range rows {
+		result[i] = map[string]interface{}{
+			"match_score": row.MatchScore,
+			"status":      row.Status,
+		}
+	}
+	return result, nil
+}
+
+// GetGlobalCorrelation 全企業横断のマッチングスコア×選考結果相関データ
+func (r *UserApplicationStatusRepository) GetGlobalCorrelation() ([]map[string]interface{}, error) {
+	type Row struct {
+		CompanyID  uint
+		MatchScore float64
+		Status     string
+	}
+	var rows []Row
+	err := r.db.Table("user_application_statuses uas").
+		Select("uas.company_id, ucm.match_score, uas.status").
+		Joins("JOIN user_company_matches ucm ON ucm.id = uas.match_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, len(rows))
+	for i, row := range rows {
+		result[i] = map[string]interface{}{
+			"company_id":  row.CompanyID,
+			"match_score": row.MatchScore,
+			"status":      row.Status,
+		}
+	}
+	return result, nil
+}

--- a/Backend/internal/routes/application_routes.go
+++ b/Backend/internal/routes/application_routes.go
@@ -1,0 +1,40 @@
+package routes
+
+import (
+	"Backend/internal/controllers"
+	"net/http"
+	"strings"
+)
+
+// SetupApplicationRoutes 応募・選考ステータス管理のルーティング設定
+func SetupApplicationRoutes(appController *controllers.ApplicationController) {
+	// POST /api/applications       → 応募登録
+	// GET  /api/applications       → 応募一覧取得
+	// GET  /api/applications/correlation → 相関分析データ
+	// PUT  /api/applications/{id}  → ステータス更新
+	http.HandleFunc("/api/applications", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			appController.Apply(w, r)
+		case http.MethodGet:
+			appController.List(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	http.HandleFunc("/api/applications/correlation", appController.GetCorrelation)
+
+	http.HandleFunc("/api/applications/", func(w http.ResponseWriter, r *http.Request) {
+		// /api/applications/correlation は上で処理済みなのでスキップ
+		if strings.HasSuffix(r.URL.Path, "/correlation") {
+			appController.GetCorrelation(w, r)
+			return
+		}
+		if r.Method == http.MethodPut {
+			appController.UpdateStatus(w, r)
+			return
+		}
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	})
+}

--- a/Backend/internal/services/application_service.go
+++ b/Backend/internal/services/application_service.go
@@ -1,0 +1,107 @@
+package services
+
+import (
+	"Backend/domain/entity"
+	"Backend/internal/repositories"
+	"fmt"
+	"time"
+)
+
+// ApplicationService 応募・選考ステータス管理サービス
+type ApplicationService struct {
+	appRepo   *repositories.UserApplicationStatusRepository
+	matchRepo *repositories.UserCompanyMatchRepository
+}
+
+func NewApplicationService(
+	appRepo *repositories.UserApplicationStatusRepository,
+	matchRepo *repositories.UserCompanyMatchRepository,
+) *ApplicationService {
+	return &ApplicationService{appRepo: appRepo, matchRepo: matchRepo}
+}
+
+// ValidStatuses 有効な選考ステータス一覧
+var ValidStatuses = []string{
+	"applied",          // 応募済み
+	"document_passed",  // 書類通過
+	"interview",        // 面接中
+	"offered",          // 内定
+	"accepted",         // 内定承諾
+	"declined",         // 辞退
+	"rejected",         // 不合格
+}
+
+func isValidStatus(status string) bool {
+	for _, s := range ValidStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply 企業への応募を登録する
+func (s *ApplicationService) Apply(userID, companyID, matchID uint) (*entity.UserApplicationStatus, error) {
+	// 重複チェック
+	existing, err := s.appRepo.FindByUserAndCompany(userID, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("重複チェックエラー: %w", err)
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("この企業にはすでに応募済みです")
+	}
+
+	now := time.Now()
+	app := &entity.UserApplicationStatus{
+		UserID:    userID,
+		CompanyID: companyID,
+		MatchID:   matchID,
+		Status:    "applied",
+		AppliedAt: &now,
+	}
+	if err := s.appRepo.Create(app); err != nil {
+		return nil, fmt.Errorf("応募登録エラー: %w", err)
+	}
+
+	// UserCompanyMatch の IsApplied フラグも更新
+	_ = s.matchRepo.MarkAsApplied(matchID)
+
+	return app, nil
+}
+
+// UpdateStatus 選考ステータスを更新する
+func (s *ApplicationService) UpdateStatus(applicationID uint, userID uint, status, notes string) (*entity.UserApplicationStatus, error) {
+	if !isValidStatus(status) {
+		return nil, fmt.Errorf("無効なステータス: %s", status)
+	}
+
+	// 所有権確認
+	app, err := s.appRepo.FindByID(applicationID)
+	if err != nil {
+		return nil, fmt.Errorf("応募データが見つかりません: %w", err)
+	}
+	if app.UserID != userID {
+		return nil, fmt.Errorf("権限がありません")
+	}
+
+	if err := s.appRepo.UpdateStatus(applicationID, status, notes); err != nil {
+		return nil, fmt.Errorf("ステータス更新エラー: %w", err)
+	}
+
+	app.Status = status
+	app.Notes = notes
+	return app, nil
+}
+
+// GetApplicationsByUser ユーザーの応募一覧を取得する
+func (s *ApplicationService) GetApplicationsByUser(userID uint) ([]*entity.UserApplicationStatus, error) {
+	return s.appRepo.FindByUserID(userID)
+}
+
+// GetCorrelation マッチングスコアと選考通過率の相関データを取得する
+func (s *ApplicationService) GetCorrelation(companyID uint) ([]map[string]interface{}, error) {
+	if companyID > 0 {
+		return s.appRepo.GetCorrelationByCompany(companyID)
+	}
+	return s.appRepo.GetGlobalCorrelation()
+}

--- a/frontend/app/api/applications/[id]/route.ts
+++ b/frontend/app/api/applications/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json()
+    const response = await fetch(`${BACKEND_URL}/api/applications/${params.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const text = await response.text()
+    if (!response.ok) {
+      return NextResponse.json({ error: text || 'Failed to update status' }, { status: response.status })
+    }
+    return NextResponse.json(JSON.parse(text))
+  } catch (error) {
+    console.error('[applications/[id]] PUT error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/frontend/app/api/applications/route.ts
+++ b/frontend/app/api/applications/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const response = await fetch(`${BACKEND_URL}/api/applications`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const text = await response.text()
+    if (!response.ok) {
+      return NextResponse.json({ error: text || 'Failed to apply' }, { status: response.status })
+    }
+    return NextResponse.json(JSON.parse(text), { status: 201 })
+  } catch (error) {
+    console.error('[applications] POST error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get('user_id')
+    if (!userId) {
+      return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+    }
+    const response = await fetch(`${BACKEND_URL}/api/applications?user_id=${userId}`)
+    const text = await response.text()
+    if (!response.ok) {
+      return NextResponse.json({ error: text }, { status: response.status })
+    }
+    return NextResponse.json(JSON.parse(text))
+  } catch (error) {
+    console.error('[applications] GET error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/frontend/app/applications/page.tsx
+++ b/frontend/app/applications/page.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState, useEffect, Suspense } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import {
+  Box,
+  Paper,
+  Typography,
+  Button,
+  Card,
+  CardContent,
+  Stack,
+  CircularProgress,
+  Chip,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  TextField,
+  Snackbar,
+  Alert,
+  IconButton,
+} from '@mui/material'
+import { ArrowBack, Edit, Check } from '@mui/icons-material'
+
+const STATUS_LABELS: Record<string, string> = {
+  applied: '応募済み',
+  document_passed: '書類通過',
+  interview: '面接中',
+  offered: '内定',
+  accepted: '内定承諾',
+  declined: '辞退',
+  rejected: '不合格',
+}
+
+const STATUS_COLORS: Record<string, 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'> = {
+  applied: 'default',
+  document_passed: 'info',
+  interview: 'primary',
+  offered: 'success',
+  accepted: 'success',
+  declined: 'default',
+  rejected: 'error',
+}
+
+interface Application {
+  id: number
+  company_id: number
+  company_name: string
+  company_industry: string
+  match_id: number
+  status: string
+  notes: string
+  applied_at: string | null
+  status_updated_at: string | null
+}
+
+function ApplicationsContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const userId = searchParams.get('user_id')
+
+  const [applications, setApplications] = useState<Application[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editStatus, setEditStatus] = useState('')
+  const [editNotes, setEditNotes] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success',
+  })
+
+  useEffect(() => {
+    if (!userId) return
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/applications?user_id=${userId}`)
+        if (!res.ok) throw new Error('取得失敗')
+        const data = await res.json()
+        setApplications(data.applications || [])
+      } catch {
+        setSnackbar({ open: true, message: '応募データの取得に失敗しました', severity: 'error' })
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [userId])
+
+  const startEdit = (app: Application) => {
+    setEditingId(app.id)
+    setEditStatus(app.status)
+    setEditNotes(app.notes || '')
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditStatus('')
+    setEditNotes('')
+  }
+
+  const saveEdit = async (appId: number) => {
+    if (!userId) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/applications/${appId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: Number(userId), status: editStatus, notes: editNotes }),
+      })
+      if (!res.ok) throw new Error('更新失敗')
+      setApplications(prev =>
+        prev.map(a => (a.id === appId ? { ...a, status: editStatus, notes: editNotes } : a))
+      )
+      setSnackbar({ open: true, message: 'ステータスを更新しました', severity: 'success' })
+      cancelEdit()
+    } catch {
+      setSnackbar({ open: true, message: 'ステータスの更新に失敗しました', severity: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ maxWidth: 800, mx: 'auto', p: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+        <IconButton onClick={() => router.back()}>
+          <ArrowBack />
+        </IconButton>
+        <Typography variant="h5" fontWeight="bold">
+          選考管理
+        </Typography>
+      </Stack>
+
+      {applications.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">応募した企業はまだありません</Typography>
+          <Button variant="contained" sx={{ mt: 2 }} onClick={() => router.push(`/results?user_id=${userId}`)}>
+            マッチング結果に戻る
+          </Button>
+        </Paper>
+      ) : (
+        <Stack spacing={2}>
+          {applications.map(app => (
+            <Card key={app.id} variant="outlined">
+              <CardContent>
+                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                  <Box>
+                    <Typography variant="h6" fontWeight="bold">
+                      {app.company_name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {app.company_industry}
+                    </Typography>
+                    {app.applied_at && (
+                      <Typography variant="caption" color="text.secondary">
+                        応募日: {new Date(app.applied_at).toLocaleDateString('ja-JP')}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Chip
+                    label={STATUS_LABELS[app.status] || app.status}
+                    color={STATUS_COLORS[app.status] || 'default'}
+                    size="small"
+                  />
+                </Stack>
+
+                {editingId === app.id ? (
+                  <Box mt={2}>
+                    <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+                      <InputLabel>選考ステータス</InputLabel>
+                      <Select
+                        value={editStatus}
+                        label="選考ステータス"
+                        onChange={e => setEditStatus(e.target.value)}
+                      >
+                        {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                          <MenuItem key={value} value={value}>
+                            {label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      label="メモ"
+                      multiline
+                      rows={2}
+                      value={editNotes}
+                      onChange={e => setEditNotes(e.target.value)}
+                      sx={{ mb: 2 }}
+                    />
+                    <Stack direction="row" spacing={1}>
+                      <Button
+                        variant="contained"
+                        size="small"
+                        startIcon={<Check />}
+                        onClick={() => saveEdit(app.id)}
+                        disabled={saving}
+                      >
+                        保存
+                      </Button>
+                      <Button variant="outlined" size="small" onClick={cancelEdit} disabled={saving}>
+                        キャンセル
+                      </Button>
+                    </Stack>
+                  </Box>
+                ) : (
+                  <Box mt={1}>
+                    {app.notes && (
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                        {app.notes}
+                      </Typography>
+                    )}
+                    <Button
+                      size="small"
+                      startIcon={<Edit />}
+                      onClick={() => startEdit(app)}
+                    >
+                      ステータスを更新
+                    </Button>
+                  </Box>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      )}
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  )
+}
+
+export default function ApplicationsPage() {
+  return (
+    <Suspense fallback={<Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}><CircularProgress /></Box>}>
+      <ApplicationsContent />
+    </Suspense>
+  )
+}

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -72,6 +72,8 @@ interface Company {
   techStack: string[]
   categoryScores?: CategoryScores
   isFavorited?: boolean
+  isApplied?: boolean
+  applicationId?: number
 }
 
 const CustomEdge = ({ id, sourceX, sourceY, targetX, targetY, style, markerEnd, label }: any) => {
@@ -164,6 +166,7 @@ function ResultsContent() {
   const [diagramLoading, setDiagramLoading] = useState(false)
   const [emailSending, setEmailSending] = useState(false)
   const [favoritingId, setFavoritingId] = useState<number | null>(null)
+  const [applyingId, setApplyingId] = useState<number | null>(null)
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
     open: false,
     message: '',
@@ -261,6 +264,8 @@ function ResultsContent() {
               techStack: rec.tech_stack || [],
               categoryScores: rec.category_scores || undefined,
               isFavorited: rec.is_favorited || false,
+            isApplied: rec.is_applied || false,
+            applicationId: rec.application_id || undefined,
             }
           })
           console.log('[Results] Mapped companies:', mappedCompanies)
@@ -351,6 +356,37 @@ function ResultsContent() {
       }
     } finally {
       setFavoritingId(null)
+    }
+  }
+
+  const handleApply = async (e: React.MouseEvent, company: Company) => {
+    e.stopPropagation()
+    if (!company.matchId || company.isApplied || applyingId !== null) return
+    setApplyingId(company.matchId)
+    try {
+      const res = await fetch('/api/applications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: Number(userId),
+          company_id: Number(company.id),
+          match_id: company.matchId,
+        }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setCompanies(prev => prev.map(c =>
+          c.matchId === company.matchId
+            ? { ...c, isApplied: true, applicationId: data.id }
+            : c
+        ))
+        setSnackbar({ open: true, message: `${company.name} に応募しました`, severity: 'success' })
+      } else {
+        const err = await res.json()
+        setSnackbar({ open: true, message: err.error || '応募に失敗しました', severity: 'error' })
+      }
+    } finally {
+      setApplyingId(null)
     }
   }
 
@@ -1230,6 +1266,15 @@ function ResultsContent() {
                     >
                       ES・職務経歴書を添削
                     </Button>
+                    <Button
+                      variant={company.isApplied ? 'contained' : 'outlined'}
+                      size="small"
+                      color="primary"
+                      disabled={company.isApplied || applyingId === company.matchId}
+                      onClick={(e) => handleApply(e, company)}
+                    >
+                      {company.isApplied ? '応募済み' : applyingId === company.matchId ? '応募中...' : '応募する'}
+                    </Button>
                     <Typography variant="caption" color="primary" sx={{ fontWeight: 'bold' }}>
                       クリックして詳細を見る →
                     </Typography>
@@ -1240,9 +1285,16 @@ function ResultsContent() {
           </Stack>
 
           <Box sx={{ textAlign: 'center', mt: 4, mb: 4 }}>
-            <Stack direction="row" spacing={2} justifyContent="center">
+            <Stack direction="row" spacing={2} justifyContent="center" flexWrap="wrap">
               <Button variant="contained" startIcon={<Email />} onClick={handleSendEmail} disabled={emailSending}>
                 {emailSending ? '送信中...' : '結果をメールで受け取る'}
+              </Button>
+              <Button
+                variant="outlined"
+                size="large"
+                onClick={() => router.push(`/applications?user_id=${userId}`)}
+              >
+                選考管理を見る
               </Button>
               <Button variant="outlined" size="large" startIcon={<Refresh />} onClick={handleReset}>
                 最初からやり直す


### PR DESCRIPTION
Closes #201

## 変更内容

### Backend

#### モデル・スキーマ
- `UserApplicationStatus` モデルを追加（選考ステータス管理テーブル）
  - ステータス: `applied` / `document_passed` / `interview` / `offered` / `accepted` / `declined` / `rejected`
  - `UserCompanyMatch` との紐付け（`match_id`）
- `AutoMigrate` に `UserApplicationStatus` を追加

#### ドメイン層
- `entity.UserApplicationStatus` エンティティを追加
- `UserApplicationStatusToEntity` / `UserApplicationStatusFromEntity` マッパーを追加

#### リポジトリ層
- `UserApplicationStatusRepository` を新規作成
  - `Create` / `FindByID` / `FindByUserID` / `FindByUserAndCompany`
  - `UpdateStatus` / `GetCorrelationByCompany` / `GetGlobalCorrelation`（マッチングスコアと選考通過率の相関クエリ）

#### サービス層
- `ApplicationService` を新規作成
  - `Apply`: 重複チェック付き応募登録 + `UserCompanyMatch.IsApplied` フラグ連動
  - `UpdateStatus`: 権限確認付きステータス更新
  - `GetApplicationsByUser`: 応募一覧取得
  - `GetCorrelation`: 企業別・全体の相関分析データ取得

#### コントローラー・ルーティング
- `ApplicationController` を新規作成（4エンドポイント）
  - `POST /api/applications` — 応募登録
  - `GET  /api/applications?user_id=X` — 応募一覧取得
  - `PUT  /api/applications/{id}` — 選考ステータス更新
  - `GET  /api/applications/correlation` — 相関分析データ（管理用）
- `SetupApplicationRoutes` を `main.go` にワイヤリング
- `GetRecommendations` レスポンスに `is_applied` フィールドを追加

### Frontend

- **`/api/applications`** Next.js APIルート（POST・GET）を追加
- **`/api/applications/[id]`** Next.js APIルート（PUT）を追加
- **`/applications`** 選考管理画面を新規作成
  - 応募企業の一覧表示
  - 選考ステータスのドロップダウン更新UI（メモ付き）
  - ステータス別カラーチップ表示
- **マッチング結果画面** に以下を追加
  - 「応募する」ボタン（応募済みは無効化 + 「応募済み」表示）
  - 「選考管理を見る」ボタン

## フライホイールへの貢献

実世界の選考結果（応募・書類通過・内定等）がDBに蓄積されるようになり、 `/api/applications/correlation` により**マッチングスコアと選考通過率の相関分析**が可能になった。これがフライホイールの閉ループ（Issue #202・#203）の基盤となる。