### PR TITLE
Resolve #203: チャット分析スコアの精度検証・改善基盤

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -211,12 +211,15 @@ func main() {
 	appService := services.NewApplicationService(appStatusRepo, matchRepo)
 	appController := controllers.NewApplicationController(appService)
 	integratedProfileController := controllers.NewIntegratedProfileController(crossFeatureService, interviewSessionRepo, resumeRepo)
+	scoreValidationRepo := repositories.NewScoreValidationRepository(db)
+	scoreValidationService := services.NewScoreValidationService(scoreValidationRepo)
+	scoreValidationController := controllers.NewAdminScoreValidationController(scoreValidationService)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, userRepo)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)

--- a/Backend/internal/controllers/admin_score_validation_controller.go
+++ b/Backend/internal/controllers/admin_score_validation_controller.go
@@ -1,0 +1,165 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// AdminScoreValidationController スコア精度検証・A/Bテスト管理API
+type AdminScoreValidationController struct {
+	svc *services.ScoreValidationService
+}
+
+func NewAdminScoreValidationController(svc *services.ScoreValidationService) *AdminScoreValidationController {
+	return &AdminScoreValidationController{svc: svc}
+}
+
+// Route /api/admin/score-validation/* のルーティング
+func (c *AdminScoreValidationController) Route(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/admin/score-validation")
+	path = strings.Trim(path, "/")
+
+	switch {
+	case path == "correlation" && r.Method == http.MethodGet:
+		c.GetCorrelation(w, r)
+	case path == "phase-metrics" && r.Method == http.MethodGet:
+		c.GetPhaseMetrics(w, r)
+	case path == "calibration" && r.Method == http.MethodGet:
+		c.GetCalibration(w, r)
+	case path == "calibration/run" && r.Method == http.MethodPost:
+		c.RunCalibration(w, r)
+	case path == "calibration/history" && r.Method == http.MethodGet:
+		c.GetCalibrationHistory(w, r)
+	case path == "variants" && r.Method == http.MethodGet:
+		c.ListVariants(w, r)
+	case path == "variants" && r.Method == http.MethodPost:
+		c.CreateVariant(w, r)
+	case path == "variants/results" && r.Method == http.MethodGet:
+		c.GetVariantResults(w, r)
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}
+
+// GetCorrelation GET /api/admin/score-validation/correlation
+// カテゴリ別スコアと選考通過率の相関レポート
+func (c *AdminScoreValidationController) GetCorrelation(w http.ResponseWriter, r *http.Request) {
+	report, err := c.svc.GetCorrelationReport()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, report)
+}
+
+// GetPhaseMetrics GET /api/admin/score-validation/phase-metrics
+// フェーズ別予測精度メトリクス
+func (c *AdminScoreValidationController) GetPhaseMetrics(w http.ResponseWriter, r *http.Request) {
+	report, err := c.svc.GetPhasePrecisionReport()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, report)
+}
+
+// GetCalibration GET /api/admin/score-validation/calibration
+// 現在有効なキャリブレーション重みを返す
+func (c *AdminScoreValidationController) GetCalibration(w http.ResponseWriter, r *http.Request) {
+	weights, err := c.svc.GetCurrentCalibration()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{"weights": weights})
+}
+
+// RunCalibration POST /api/admin/score-validation/calibration/run
+// 実績データを元にスコアキャリブレーションを実行
+func (c *AdminScoreValidationController) RunCalibration(w http.ResponseWriter, r *http.Request) {
+	result, err := c.svc.RunCalibration()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, result)
+}
+
+// GetCalibrationHistory GET /api/admin/score-validation/calibration/history?limit=10
+func (c *AdminScoreValidationController) GetCalibrationHistory(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	history, err := c.svc.GetCalibrationHistory(limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{"history": history})
+}
+
+// ListVariants GET /api/admin/score-validation/variants?experiment=xxx
+func (c *AdminScoreValidationController) ListVariants(w http.ResponseWriter, r *http.Request) {
+	experiments, err := c.svc.ListExperiments()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{"experiments": experiments})
+}
+
+// CreateVariant POST /api/admin/score-validation/variants
+func (c *AdminScoreValidationController) CreateVariant(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ExperimentName string  `json:"experiment_name"`
+		VariantName    string  `json:"variant_name"`
+		Description    string  `json:"description"`
+		TrafficRatio   float64 `json:"traffic_ratio"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.ExperimentName == "" || req.VariantName == "" {
+		http.Error(w, "experiment_name and variant_name are required", http.StatusBadRequest)
+		return
+	}
+	if req.TrafficRatio <= 0 || req.TrafficRatio > 1 {
+		req.TrafficRatio = 0.5
+	}
+
+	variant, err := c.svc.CreateVariant(req.ExperimentName, req.VariantName, req.Description, req.TrafficRatio)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, variant)
+}
+
+// GetVariantResults GET /api/admin/score-validation/variants/results?experiment=xxx
+func (c *AdminScoreValidationController) GetVariantResults(w http.ResponseWriter, r *http.Request) {
+	experimentName := r.URL.Query().Get("experiment")
+	if experimentName == "" {
+		http.Error(w, "experiment query parameter is required", http.StatusBadRequest)
+		return
+	}
+	results, err := c.svc.GetVariantResults(experimentName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{"experiment": experimentName, "results": results})
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -56,6 +56,10 @@ func AutoMigrate(db *gorm.DB) error {
 		&ScheduleEvent{},
 		// APIコストモニタリング
 		&APICallLog{},
+		// スコア精度検証・A/Bテスト
+		&QuestionVariant{},
+		&VariantAssignment{},
+		&ScoreCalibrationWeight{},
 		// GitHub連携
 		&GitHubProfile{},
 		&GitHubRepo{},

--- a/Backend/internal/models/score_validation.go
+++ b/Backend/internal/models/score_validation.go
@@ -1,0 +1,42 @@
+package models
+
+import "time"
+
+// QuestionVariant A/Bテスト用の質問セットバリアント定義
+type QuestionVariant struct {
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	ExperimentName string    `gorm:"type:varchar(100);not null;index:idx_exp_variant" json:"experiment_name"` // 実験名（例: "phase1_2024q1"）
+	VariantName    string    `gorm:"type:varchar(50);not null;index:idx_exp_variant" json:"variant_name"`    // バリアント名（例: "control", "treatment_a"）
+	Description    string    `gorm:"type:text" json:"description"`
+	IsActive       bool      `gorm:"default:true" json:"is_active"`
+	TrafficRatio   float64   `gorm:"default:0.5" json:"traffic_ratio"` // 割り当て比率 0-1
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// VariantAssignment セッションへのバリアント割り当て記録
+type VariantAssignment struct {
+	ID              uint             `gorm:"primaryKey" json:"id"`
+	UserID          uint             `gorm:"not null;index:idx_user_session_variant" json:"user_id"`
+	SessionID       string           `gorm:"type:varchar(100);not null;index:idx_user_session_variant" json:"session_id"`
+	VariantID       uint             `gorm:"not null;index" json:"variant_id"`
+	Variant         *QuestionVariant `gorm:"foreignKey:VariantID" json:"variant,omitempty"`
+	ExperimentName  string           `gorm:"type:varchar(100);not null" json:"experiment_name"`
+	AssignedVariant string           `gorm:"type:varchar(50);not null" json:"assigned_variant"`
+	CreatedAt       time.Time        `json:"created_at"`
+}
+
+// ScoreCalibrationWeight スコアキャリブレーション重み
+// 実績データに基づいてカテゴリ別スコアの重要度を調整する
+type ScoreCalibrationWeight struct {
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	Category     string    `gorm:"type:varchar(100);not null;uniqueIndex:idx_cat_version" json:"category"`
+	Version      int       `gorm:"not null;uniqueIndex:idx_cat_version;default:1" json:"version"`
+	Weight       float64   `gorm:"not null;default:1.0" json:"weight"` // 乗数（デフォルト1.0）
+	SampleCount  int       `gorm:"not null;default:0" json:"sample_count"`
+	PassRate     float64   `gorm:"not null;default:0" json:"pass_rate"` // キャリブレーション時の通過率
+	Correlation  float64   `gorm:"not null;default:0" json:"correlation"` // スコアと通過率の相関係数
+	IsActive     bool      `gorm:"default:false" json:"is_active"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/Backend/internal/repositories/score_validation_repository.go
+++ b/Backend/internal/repositories/score_validation_repository.go
@@ -1,0 +1,261 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"fmt"
+	"math"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type ScoreValidationRepository struct {
+	db *gorm.DB
+}
+
+func NewScoreValidationRepository(db *gorm.DB) *ScoreValidationRepository {
+	return &ScoreValidationRepository{db: db}
+}
+
+// ── 相関分析クエリ ────────────────────────────────────────────────────────────
+
+// CategoryCorrelationRow カテゴリ別スコア vs 通過率の相関行データ
+type CategoryCorrelationRow struct {
+	Category    string
+	ScoreBand   string // "0-20", "21-40", "41-60", "61-80", "81-100"
+	TotalCount  int
+	PassCount   int    // document_passed / interview / offered / accepted のいずれか
+	PassRate    float64
+	AvgScore    float64
+}
+
+// GetCategoryPassRateCorrelation カテゴリ別スコア帯と選考通過率の相関を集計する
+// 通過判定: status IN ('document_passed','interview','offered','accepted')
+func (r *ScoreValidationRepository) GetCategoryPassRateCorrelation() ([]CategoryCorrelationRow, error) {
+	type rawRow struct {
+		Category   string
+		ScoreBand  int
+		TotalCount int
+		PassCount  int
+		AvgScore   float64
+	}
+
+	// スコアを20点刻みのバンドに丸める（0→0, 21→1, ... ）
+	rows := []rawRow{}
+	err := r.db.Raw(`
+		SELECT
+			uws.weight_category AS category,
+			FLOOR(uws.score / 20) AS score_band,
+			COUNT(DISTINCT uas.id) AS total_count,
+			SUM(CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN 1 ELSE 0 END) AS pass_count,
+			AVG(uws.score) AS avg_score
+		FROM user_weight_scores uws
+		INNER JOIN user_application_statuses uas ON uas.user_id = uws.user_id
+		WHERE uas.status != ''
+		GROUP BY uws.weight_category, FLOOR(uws.score / 20)
+		ORDER BY uws.weight_category, score_band
+	`).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	bandLabel := func(b int) string {
+		lo := b * 20
+		hi := lo + 20
+		if hi > 100 {
+			hi = 100
+		}
+		return fmt.Sprintf("%d-%d", lo, hi)
+	}
+
+	result := make([]CategoryCorrelationRow, 0, len(rows))
+	for _, row := range rows {
+		passRate := 0.0
+		if row.TotalCount > 0 {
+			passRate = float64(row.PassCount) / float64(row.TotalCount) * 100
+		}
+		result = append(result, CategoryCorrelationRow{
+			Category:   row.Category,
+			ScoreBand:  bandLabel(row.ScoreBand),
+			TotalCount: row.TotalCount,
+			PassCount:  row.PassCount,
+			PassRate:   math.Round(passRate*10) / 10,
+			AvgScore:   math.Round(row.AvgScore*10) / 10,
+		})
+	}
+	return result, nil
+}
+
+// PhasePrecisionRow フェーズ別精度メトリクス行
+type PhasePrecisionRow struct {
+	PhaseName      string
+	SessionCount   int
+	AvgCompletion  float64
+	PassCount      int
+	PassRate       float64
+}
+
+// GetPhasePrecisionMetrics フェーズ別の完了率・通過率相関を集計する
+func (r *ScoreValidationRepository) GetPhasePrecisionMetrics() ([]PhasePrecisionRow, error) {
+	rows := []PhasePrecisionRow{}
+	err := r.db.Raw(`
+		SELECT
+			ap.phase_name,
+			COUNT(DISTINCT uap.session_id) AS session_count,
+			AVG(uap.completion_score) AS avg_completion,
+			COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS pass_count,
+			CASE
+				WHEN COUNT(DISTINCT uap.user_id) = 0 THEN 0
+				ELSE CAST(COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS FLOAT) /
+					COUNT(DISTINCT uap.user_id) * 100
+			END AS pass_rate
+		FROM user_analysis_progress uap
+		INNER JOIN analysis_phases ap ON ap.id = uap.phase_id
+		LEFT JOIN user_application_statuses uas ON uas.user_id = uap.user_id
+		GROUP BY ap.phase_name, ap.phase_order
+		ORDER BY ap.phase_order
+	`).Scan(&rows).Error
+	return rows, err
+}
+
+// ── A/Bテスト バリアント管理 ─────────────────────────────────────────────────
+
+func (r *ScoreValidationRepository) CreateVariant(v *models.QuestionVariant) error {
+	return r.db.Create(v).Error
+}
+
+func (r *ScoreValidationRepository) ListActiveVariants(experimentName string) ([]models.QuestionVariant, error) {
+	var variants []models.QuestionVariant
+	err := r.db.Where("experiment_name = ? AND is_active = ?", experimentName, true).
+		Find(&variants).Error
+	return variants, err
+}
+
+func (r *ScoreValidationRepository) ListAllExperiments() ([]string, error) {
+	var names []string
+	err := r.db.Model(&models.QuestionVariant{}).
+		Distinct("experiment_name").
+		Pluck("experiment_name", &names).Error
+	return names, err
+}
+
+func (r *ScoreValidationRepository) AssignVariant(a *models.VariantAssignment) error {
+	return r.db.Create(a).Error
+}
+
+func (r *ScoreValidationRepository) FindAssignment(userID uint, sessionID string) (*models.VariantAssignment, error) {
+	var a models.VariantAssignment
+	err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).
+		Preload("Variant").First(&a).Error
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// VariantResultRow A/Bテスト結果比較行
+type VariantResultRow struct {
+	ExperimentName  string
+	VariantName     string
+	SessionCount    int
+	PassCount       int
+	PassRate        float64
+	AvgScoreSum     float64
+}
+
+// GetVariantResults 実験バリアント別の通過率を集計する
+func (r *ScoreValidationRepository) GetVariantResults(experimentName string) ([]VariantResultRow, error) {
+	rows := []VariantResultRow{}
+	err := r.db.Raw(`
+		SELECT
+			va.experiment_name,
+			va.assigned_variant AS variant_name,
+			COUNT(DISTINCT va.session_id) AS session_count,
+			COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS pass_count,
+			CASE
+				WHEN COUNT(DISTINCT va.user_id) = 0 THEN 0
+				ELSE CAST(COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS FLOAT) /
+					COUNT(DISTINCT va.user_id) * 100
+			END AS pass_rate
+		FROM variant_assignments va
+		LEFT JOIN user_application_statuses uas ON uas.user_id = va.user_id
+		WHERE va.experiment_name = ?
+		GROUP BY va.experiment_name, va.assigned_variant
+	`, experimentName).Scan(&rows).Error
+	return rows, err
+}
+
+// ── キャリブレーション ────────────────────────────────────────────────────────
+
+func (r *ScoreValidationRepository) GetLatestCalibrationWeights() ([]models.ScoreCalibrationWeight, error) {
+	var weights []models.ScoreCalibrationWeight
+	err := r.db.Where("is_active = ?", true).Find(&weights).Error
+	return weights, err
+}
+
+func (r *ScoreValidationRepository) SaveCalibrationWeights(weights []models.ScoreCalibrationWeight) error {
+	// 現行アクティブ版を非アクティブ化
+	if err := r.db.Model(&models.ScoreCalibrationWeight{}).
+		Where("is_active = ?", true).
+		Update("is_active", false).Error; err != nil {
+		return err
+	}
+	return r.db.Create(&weights).Error
+}
+
+// CategoryPassStats キャリブレーション計算用の生データ
+type CategoryPassStats struct {
+	Category  string
+	AvgScore  float64
+	PassRate  float64
+	SampleN   int
+}
+
+func (r *ScoreValidationRepository) GetCategoryPassStats() ([]CategoryPassStats, error) {
+	rows := []CategoryPassStats{}
+	err := r.db.Raw(`
+		SELECT
+			uws.weight_category AS category,
+			AVG(uws.score) AS avg_score,
+			CASE
+				WHEN COUNT(DISTINCT uas.id) = 0 THEN 0
+				ELSE CAST(SUM(CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN 1 ELSE 0 END) AS FLOAT) /
+					COUNT(DISTINCT uas.id) * 100
+			END AS pass_rate,
+			COUNT(DISTINCT uas.id) AS sample_n
+		FROM user_weight_scores uws
+		INNER JOIN user_application_statuses uas ON uas.user_id = uws.user_id
+		GROUP BY uws.weight_category
+		HAVING COUNT(DISTINCT uas.id) >= 5
+	`).Scan(&rows).Error
+	return rows, err
+}
+
+// ── キャリブレーション重みの取得（バージョン管理） ──────────────────────────
+
+func (r *ScoreValidationRepository) GetNextVersion() (int, error) {
+	var maxVersion int
+	err := r.db.Model(&models.ScoreCalibrationWeight{}).
+		Select("COALESCE(MAX(version), 0)").
+		Scan(&maxVersion).Error
+	return maxVersion + 1, err
+}
+
+// ListCalibrationHistory バージョン一覧（降順）
+func (r *ScoreValidationRepository) ListCalibrationHistory(limit int) ([]models.ScoreCalibrationWeight, error) {
+	var weights []models.ScoreCalibrationWeight
+	err := r.db.Order("version DESC, created_at DESC").
+		Limit(limit).
+		Find(&weights).Error
+	return weights, err
+}
+
+// LastCalibrationAt 最後にキャリブレーションが実行された日時
+func (r *ScoreValidationRepository) LastCalibrationAt() (*time.Time, error) {
+	var w models.ScoreCalibrationWeight
+	err := r.db.Order("created_at DESC").First(&w).Error
+	if err != nil {
+		return nil, err
+	}
+	return &w.CreatedAt, nil
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -18,6 +18,7 @@ func SetupAdminRoutes(
 	adminDashboardController *controllers.AdminDashboardController,
 	adminCostsController *controllers.AdminCostsController,
 	profileRecalcController *controllers.AdminProfileRecalculationController,
+	scoreValidationController *controllers.AdminScoreValidationController,
 	userRepo *repositories.UserRepository,
 ) {
 	auth := func(f http.HandlerFunc) http.HandlerFunc {
@@ -60,4 +61,7 @@ func SetupAdminRoutes(
 	// Profile recalculation
 	http.HandleFunc("/api/admin/profile-recalculation", auth(profileRecalcController.Route))
 	http.HandleFunc("/api/admin/profile-recalculation/", auth(profileRecalcController.Route))
+
+	// Score validation (correlation, calibration, A/B test)
+	http.HandleFunc("/api/admin/score-validation/", auth(scoreValidationController.Route))
 }

--- a/Backend/internal/services/score_validation_service.go
+++ b/Backend/internal/services/score_validation_service.go
@@ -1,0 +1,277 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/repositories"
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+// ScoreValidationService チャット分析スコアの精度検証・改善サービス
+type ScoreValidationService struct {
+	repo *repositories.ScoreValidationRepository
+}
+
+func NewScoreValidationService(repo *repositories.ScoreValidationRepository) *ScoreValidationService {
+	return &ScoreValidationService{repo: repo}
+}
+
+// ── 相関分析レポート ──────────────────────────────────────────────────────────
+
+// CorrelationReport 相関分析レポート
+type CorrelationReport struct {
+	Rows            []repositories.CategoryCorrelationRow `json:"rows"`
+	TopCorrelated   []string                              `json:"top_correlated"`   // 通過率との相関が高いカテゴリ
+	LowCorrelated   []string                              `json:"low_correlated"`   // 相関が低いカテゴリ（改善候補）
+	TotalSamples    int                                   `json:"total_samples"`
+}
+
+// GetCorrelationReport スコアと選考通過率の相関レポートを生成する
+func (s *ScoreValidationService) GetCorrelationReport() (*CorrelationReport, error) {
+	rows, err := s.repo.GetCategoryPassRateCorrelation()
+	if err != nil {
+		return nil, fmt.Errorf("相関集計エラー: %w", err)
+	}
+
+	// カテゴリ別に通過率の分散を計算して相関の高低を判定
+	type catStat struct {
+		passRates []float64
+		totalN    int
+	}
+	catMap := map[string]*catStat{}
+	for _, row := range rows {
+		if _, ok := catMap[row.Category]; !ok {
+			catMap[row.Category] = &catStat{}
+		}
+		catMap[row.Category].passRates = append(catMap[row.Category].passRates, row.PassRate)
+		catMap[row.Category].totalN += row.TotalCount
+	}
+
+	// 分散（スコアが高いほど通過率が上がるか）を計算
+	type catVariance struct {
+		category string
+		variance float64
+	}
+	variances := make([]catVariance, 0, len(catMap))
+	for cat, stat := range catMap {
+		if len(stat.passRates) < 2 {
+			continue
+		}
+		mean := 0.0
+		for _, r := range stat.passRates {
+			mean += r
+		}
+		mean /= float64(len(stat.passRates))
+		variance := 0.0
+		for _, r := range stat.passRates {
+			variance += (r - mean) * (r - mean)
+		}
+		variance /= float64(len(stat.passRates))
+		variances = append(variances, catVariance{cat, variance})
+	}
+
+	// 分散が大きい（スコア帯で通過率の差が大きい）カテゴリを "相関高" とみなす
+	top, low := []string{}, []string{}
+	threshold := 100.0 // 分散閾値（調整可能）
+	for _, v := range variances {
+		if v.variance >= threshold {
+			top = append(top, v.category)
+		} else {
+			low = append(low, v.category)
+		}
+	}
+
+	totalSamples := 0
+	for _, stat := range catMap {
+		totalSamples += stat.totalN
+	}
+
+	return &CorrelationReport{
+		Rows:          rows,
+		TopCorrelated: top,
+		LowCorrelated: low,
+		TotalSamples:  totalSamples,
+	}, nil
+}
+
+// ── フェーズ精度メトリクス ────────────────────────────────────────────────────
+
+// PhasePrecisionReport フェーズ別精度メトリクスレポート
+type PhasePrecisionReport struct {
+	Phases      []repositories.PhasePrecisionRow `json:"phases"`
+	OverallPass float64                          `json:"overall_pass_rate"`
+}
+
+func (s *ScoreValidationService) GetPhasePrecisionReport() (*PhasePrecisionReport, error) {
+	phases, err := s.repo.GetPhasePrecisionMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("フェーズメトリクス集計エラー: %w", err)
+	}
+
+	totalPass, totalSessions := 0.0, 0
+	for _, p := range phases {
+		totalPass += p.PassRate
+		totalSessions++
+	}
+	overallPass := 0.0
+	if totalSessions > 0 {
+		overallPass = math.Round(totalPass/float64(totalSessions)*10) / 10
+	}
+
+	return &PhasePrecisionReport{
+		Phases:      phases,
+		OverallPass: overallPass,
+	}, nil
+}
+
+// ── A/Bテスト バリアント管理 ─────────────────────────────────────────────────
+
+// CreateVariant 新しい質問バリアントを登録する
+func (s *ScoreValidationService) CreateVariant(experimentName, variantName, description string, trafficRatio float64) (*models.QuestionVariant, error) {
+	v := &models.QuestionVariant{
+		ExperimentName: experimentName,
+		VariantName:    variantName,
+		Description:    description,
+		IsActive:       true,
+		TrafficRatio:   trafficRatio,
+	}
+	if err := s.repo.CreateVariant(v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// AssignVariant セッションにバリアントをランダム割り当てする
+func (s *ScoreValidationService) AssignVariant(userID uint, sessionID, experimentName string) (*models.VariantAssignment, error) {
+	// 既存割り当て確認
+	existing, err := s.repo.FindAssignment(userID, sessionID)
+	if err == nil {
+		return existing, nil
+	}
+
+	variants, err := s.repo.ListActiveVariants(experimentName)
+	if err != nil || len(variants) == 0 {
+		return nil, fmt.Errorf("アクティブなバリアントが見つかりません: %s", experimentName)
+	}
+
+	// traffic_ratio に基づく重み付きランダム選択
+	r := rand.Float64()
+	cumulative := 0.0
+	selected := variants[0]
+	for _, v := range variants {
+		cumulative += v.TrafficRatio
+		if r <= cumulative {
+			selected = v
+			break
+		}
+	}
+
+	assignment := &models.VariantAssignment{
+		UserID:          userID,
+		SessionID:       sessionID,
+		VariantID:       selected.ID,
+		ExperimentName:  experimentName,
+		AssignedVariant: selected.VariantName,
+	}
+	if err := s.repo.AssignVariant(assignment); err != nil {
+		return nil, err
+	}
+	return assignment, nil
+}
+
+// GetVariantResults 実験バリアント別の通過率レポートを返す
+func (s *ScoreValidationService) GetVariantResults(experimentName string) ([]repositories.VariantResultRow, error) {
+	return s.repo.GetVariantResults(experimentName)
+}
+
+// ListExperiments 実験名一覧を返す
+func (s *ScoreValidationService) ListExperiments() ([]string, error) {
+	return s.repo.ListAllExperiments()
+}
+
+// ── スコアキャリブレーション ──────────────────────────────────────────────────
+
+// CalibrationResult キャリブレーション実行結果
+type CalibrationResult struct {
+	Version  int                           `json:"version"`
+	Weights  []models.ScoreCalibrationWeight `json:"weights"`
+	Message  string                        `json:"message"`
+}
+
+// RunCalibration 実績データからスコア重みを再計算して保存する
+func (s *ScoreValidationService) RunCalibration() (*CalibrationResult, error) {
+	stats, err := s.repo.GetCategoryPassStats()
+	if err != nil {
+		return nil, fmt.Errorf("統計取得エラー: %w", err)
+	}
+	if len(stats) == 0 {
+		return nil, fmt.Errorf("キャリブレーションに必要なサンプル数が不足しています（各カテゴリ5件以上必要）")
+	}
+
+	// 全体の平均通過率を基準にして重みを計算
+	totalPassRate := 0.0
+	for _, s := range stats {
+		totalPassRate += s.PassRate
+	}
+	avgPassRate := totalPassRate / float64(len(stats))
+	if avgPassRate == 0 {
+		avgPassRate = 1 // ゼロ除算防止
+	}
+
+	nextVersion, err := s.repo.GetNextVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	weights := make([]models.ScoreCalibrationWeight, 0, len(stats))
+	for _, stat := range stats {
+		// 重み = カテゴリの通過率 / 全体平均通過率（1.0が平均）
+		weight := stat.PassRate / avgPassRate
+		weight = math.Round(weight*100) / 100
+
+		// 相関係数の簡易近似（高スコア帯の通過率 / 低スコア帯の通過率の比）
+		correlation := math.Min(weight-1.0, 1.0) // -1～1に簡易正規化
+
+		weights = append(weights, models.ScoreCalibrationWeight{
+			Category:    stat.Category,
+			Version:     nextVersion,
+			Weight:      weight,
+			SampleCount: stat.SampleN,
+			PassRate:    math.Round(stat.PassRate*10) / 10,
+			Correlation: math.Round(correlation*100) / 100,
+			IsActive:    true,
+		})
+	}
+
+	if err := s.repo.SaveCalibrationWeights(weights); err != nil {
+		return nil, fmt.Errorf("重み保存エラー: %w", err)
+	}
+
+	return &CalibrationResult{
+		Version:  nextVersion,
+		Weights:  weights,
+		Message:  fmt.Sprintf("キャリブレーション完了: %d カテゴリ、サンプル合計 %d 件", len(weights), totalSampleCount(stats)),
+	}, nil
+}
+
+// GetCurrentCalibration 現在有効なキャリブレーション重みを返す
+func (s *ScoreValidationService) GetCurrentCalibration() ([]models.ScoreCalibrationWeight, error) {
+	return s.repo.GetLatestCalibrationWeights()
+}
+
+// GetCalibrationHistory キャリブレーション履歴を返す
+func (s *ScoreValidationService) GetCalibrationHistory(limit int) ([]models.ScoreCalibrationWeight, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	return s.repo.ListCalibrationHistory(limit)
+}
+
+func totalSampleCount(stats []repositories.CategoryPassStats) int {
+	total := 0
+	for _, s := range stats {
+		total += s.SampleN
+	}
+	return total
+}


### PR DESCRIPTION
Closes #203

## 変更内容

### モデル（新規）
- **QuestionVariant**: A/Bテスト用の質問セットバリアント定義（実験名・バリアント名・割り当て比率）
- **VariantAssignment**: セッションへのバリアント割り当て記録（再現性のための永続化）
- **ScoreCalibrationWeight**: スコアキャリブレーション重み（バージョン管理付き）

### リポジトリ
- カテゴリ別スコア帯 × 選考通過率の相関集計クエリ
- フェーズ別完了率・通過率の精度メトリクス集計
- A/Bテストバリアントの作成・セッション割り当て・結果集計
- キャリブレーション重みのCRUD（バージョン管理・履歴保持）

### サービス
- **CorrelationReport**: スコアと選考通過率の相関が高い/低いカテゴリを分類
- **PhasePrecisionReport**: 全4フェーズの完了率・通過率・全体平均を集計
- **A/Bテスト**: traffic_ratio による重み付きランダムバリアント割り当て
- **RunCalibration**: 通過率 / 平均通過率 で各カテゴリの重み係数を計算し保存

### 管理API（8エンドポイント）
| エンドポイント | 説明 |
|---|---|
| `GET /api/admin/score-validation/correlation` | スコアvs通過率の相関レポート |
| `GET /api/admin/score-validation/phase-metrics` | フェーズ別予測精度メトリクス |
| `GET /api/admin/score-validation/calibration` | 現在有効なキャリブレーション重み |
| `POST /api/admin/score-validation/calibration/run` | キャリブレーション実行 |
| `GET /api/admin/score-validation/calibration/history` | 重み更新履歴 |
| `GET /api/admin/score-validation/variants` | 実験一覧 |
| `POST /api/admin/score-validation/variants` | バリアント作成 |
| `GET /api/admin/score-validation/variants/results?experiment=xxx` | バリアント別通過率比較 |