### PR TITLE
Resolve #205: ユーザー横断の集合知によるレコメンド改善

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -214,12 +214,15 @@ func main() {
 	scoreValidationRepo := repositories.NewScoreValidationRepository(db)
 	scoreValidationService := services.NewScoreValidationService(scoreValidationRepo)
 	scoreValidationController := controllers.NewAdminScoreValidationController(scoreValidationService)
+	collectiveInsightRepo := repositories.NewCollectiveInsightRepository(db)
+	collectiveInsightService := services.NewCollectiveInsightService(collectiveInsightRepo, userWeightScoreRepo)
+	collectiveInsightController := controllers.NewCollectiveInsightController(collectiveInsightService)
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, userRepo)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, userRepo)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)
@@ -227,6 +230,7 @@ func main() {
 	routes.SetupScheduleRoutes(scheduleController)
 	routes.SetupApplicationRoutes(appController)
 	routes.SetupUserRoutes(integratedProfileController)
+	routes.SetupCollectiveInsightRoutes(collectiveInsightController)
 	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
 
 	go crawlService.StartScheduler()

--- a/Backend/internal/controllers/collective_insight_controller.go
+++ b/Backend/internal/controllers/collective_insight_controller.go
@@ -1,0 +1,177 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// CollectiveInsightController 集合知レコメンドAPI
+type CollectiveInsightController struct {
+	svc *services.CollectiveInsightService
+}
+
+func NewCollectiveInsightController(svc *services.CollectiveInsightService) *CollectiveInsightController {
+	return &CollectiveInsightController{svc: svc}
+}
+
+// Route /api/collective-insights/* のルーティング
+func (c *CollectiveInsightController) Route(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/collective-insights")
+	path = strings.Trim(path, "/")
+
+	switch {
+	case path == "recommendations" && r.Method == http.MethodGet:
+		c.GetRecommendations(w, r)
+	case path == "top-companies" && r.Method == http.MethodGet:
+		c.GetTopPassRateCompanies(w, r)
+	case path == "consent" && r.Method == http.MethodPut:
+		c.UpdateConsent(w, r)
+	case path == "actions" && r.Method == http.MethodPost:
+		c.RecordAction(w, r)
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+	}
+}
+
+// GetRecommendations GET /api/collective-insights/recommendations?user_id=xxx&session_id=xxx
+// 類似スコアプロファイルのユーザーが通過した企業をレコメンドする
+func (c *CollectiveInsightController) GetRecommendations(w http.ResponseWriter, r *http.Request) {
+	userID, sessionID, ok := parseUserAndSession(r)
+	if !ok {
+		http.Error(w, "user_id and session_id are required", http.StatusBadRequest)
+		return
+	}
+
+	// 除外企業IDをオプションで受け取る（カンマ区切り）
+	var excludeIDs []uint
+	if excStr := r.URL.Query().Get("exclude"); excStr != "" {
+		for _, idStr := range strings.Split(excStr, ",") {
+			if id, err := strconv.ParseUint(strings.TrimSpace(idStr), 10, 32); err == nil {
+				excludeIDs = append(excludeIDs, uint(id))
+			}
+		}
+	}
+
+	items, err := c.svc.GetCollectiveRecommendations(userID, sessionID, excludeIDs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if items == nil {
+		items = []services.CollectiveRecommendItem{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"recommendations": items,
+		"count":           len(items),
+	})
+}
+
+// GetTopPassRateCompanies GET /api/collective-insights/top-companies?limit=10
+// 全ユーザー通過率の高い企業ランキング
+func (c *CollectiveInsightController) GetTopPassRateCompanies(w http.ResponseWriter, r *http.Request) {
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	companies, err := c.svc.GetTopPassRateCompanies(limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"companies": companies,
+	})
+}
+
+// UpdateConsent PUT /api/collective-insights/consent
+// ユーザーの集合知参加同意を更新する
+func (c *CollectiveInsightController) UpdateConsent(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		UserID uint `json:"user_id"`
+		Allow  bool `json:"allow"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.UserID == 0 {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.svc.UpdateConsent(req.UserID, req.Allow); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"user_id": req.UserID,
+		"allow":   req.Allow,
+	})
+}
+
+// RecordAction POST /api/collective-insights/actions
+// ユーザー行動を匿名ログとして記録する
+func (c *CollectiveInsightController) RecordAction(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		UserID     uint   `json:"user_id"`
+		SessionID  string `json:"session_id"`
+		CompanyID  uint   `json:"company_id"`
+		ActionType string `json:"action_type"` // viewed / applied / passed / rejected
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.UserID == 0 || req.CompanyID == 0 || req.ActionType == "" {
+		http.Error(w, "user_id, company_id, action_type are required", http.StatusBadRequest)
+		return
+	}
+
+	validActions := map[string]bool{"viewed": true, "applied": true, "passed": true, "rejected": true}
+	if !validActions[req.ActionType] {
+		http.Error(w, "invalid action_type", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.svc.RecordAction(req.UserID, req.SessionID, req.CompanyID, req.ActionType); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"status": "recorded"})
+}
+
+// RebuildSummaries POST /api/admin/collective-insights/rebuild-summaries
+// 全企業の行動サマリーをバッチ再集計する（管理画面用）
+func (c *CollectiveInsightController) RebuildSummaries(w http.ResponseWriter, r *http.Request) {
+	if err := c.svc.RebuildSummaries(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"status": "rebuilt"})
+}
+
+// parseUserAndSession user_id・session_idをクエリから取得するヘルパー
+func parseUserAndSession(r *http.Request) (uint, string, bool) {
+	userIDStr := r.URL.Query().Get("user_id")
+	sessionID := r.URL.Query().Get("session_id")
+	if userIDStr == "" || sessionID == "" {
+		return 0, "", false
+	}
+	uid, err := strconv.ParseUint(userIDStr, 10, 32)
+	if err != nil {
+		return 0, "", false
+	}
+	return uint(uid), sessionID, true
+}

--- a/Backend/internal/models/collective_insight.go
+++ b/Backend/internal/models/collective_insight.go
@@ -1,0 +1,28 @@
+package models
+
+import "time"
+
+// CollectiveInsightLog ユーザー行動の匿名集計ログ
+// userIDはハッシュ化して保存し、個人を特定できないようにする
+type CollectiveInsightLog struct {
+	ID              uint      `gorm:"primaryKey" json:"id"`
+	AnonymousUserID string    `gorm:"type:varchar(64);not null;index" json:"anonymous_user_id"` // SHA-256ハッシュ
+	CompanyID       uint      `gorm:"not null;index" json:"company_id"`
+	ActionType      string    `gorm:"type:varchar(50);not null" json:"action_type"` // viewed / applied / passed / rejected
+	// スコアプロファイルのスナップショット（集合知計算用）
+	ScoreSnapshot   string    `gorm:"type:text" json:"score_snapshot"` // JSON: {"技術志向":80,"チームワーク":60,...}
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// AnonymizedBehaviorSummary 企業別の匿名行動集計サマリー（定期バッチで更新）
+type AnonymizedBehaviorSummary struct {
+	ID              uint      `gorm:"primaryKey" json:"id"`
+	CompanyID       uint      `gorm:"not null;uniqueIndex" json:"company_id"`
+	ViewCount       int       `gorm:"default:0" json:"view_count"`
+	ApplyCount      int       `gorm:"default:0" json:"apply_count"`
+	PassCount       int       `gorm:"default:0" json:"pass_count"`
+	PassRate        float64   `gorm:"default:0" json:"pass_rate"`
+	// 通過ユーザーのスコア平均（JSON）
+	AvgPasserScores string    `gorm:"type:text" json:"avg_passer_scores"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -56,6 +56,9 @@ func AutoMigrate(db *gorm.DB) error {
 		&ScheduleEvent{},
 		// APIコストモニタリング
 		&APICallLog{},
+		// 集合知レコメンド
+		&CollectiveInsightLog{},
+		&AnonymizedBehaviorSummary{},
 		// スコア精度検証・A/Bテスト
 		&QuestionVariant{},
 		&VariantAssignment{},

--- a/Backend/internal/models/user.go
+++ b/Backend/internal/models/user.go
@@ -23,6 +23,7 @@ type User struct {
 	LastLoginAt              *time.Time `gorm:"column:last_login_at"`                        // 最終ログイン日時
 	PasswordResetToken       string     `gorm:"size:255;column:password_reset_token"`        // パスワードリセットトークン
 	PasswordResetExpiresAt   *time.Time `gorm:"column:password_reset_expires_at"`            // パスワードリセットトークン有効期限
+	AllowCollectiveInsight   bool       `gorm:"default:true;column:allow_collective_insight"` // 集合知レコメンドへの参加同意
 	CreatedAt                time.Time
 	UpdatedAt                time.Time
 }

--- a/Backend/internal/repositories/collective_insight_repository.go
+++ b/Backend/internal/repositories/collective_insight_repository.go
@@ -1,0 +1,218 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+	"encoding/json"
+
+	"gorm.io/gorm"
+)
+
+type CollectiveInsightRepository struct {
+	db *gorm.DB
+}
+
+func NewCollectiveInsightRepository(db *gorm.DB) *CollectiveInsightRepository {
+	return &CollectiveInsightRepository{db: db}
+}
+
+// LogAction 行動ログを保存する（同意済みユーザーのみ）
+func (r *CollectiveInsightRepository) LogAction(log *models.CollectiveInsightLog) error {
+	return r.db.Create(log).Error
+}
+
+// IsConsentGiven ユーザーが集合知参加に同意しているか確認する
+func (r *CollectiveInsightRepository) IsConsentGiven(userID uint) (bool, error) {
+	var user models.User
+	err := r.db.Select("allow_collective_insight").First(&user, userID).Error
+	if err != nil {
+		return false, err
+	}
+	return user.AllowCollectiveInsight, nil
+}
+
+// UpdateConsent ユーザーの同意設定を更新する
+func (r *CollectiveInsightRepository) UpdateConsent(userID uint, allow bool) error {
+	return r.db.Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("allow_collective_insight", allow).Error
+}
+
+// SimilarUserPassedCompaniesRow 類似ユーザーの通過企業行
+type SimilarUserPassedCompaniesRow struct {
+	CompanyID       uint
+	CompanyName     string
+	PassCount       int
+	AvgPasserScores string // JSON
+	CollectiveScore float64
+}
+
+// GetPassedCompaniesBySimilarUsers 類似スコアプロファイルのユーザーが通過した企業を返す
+// similarUserHashes: 類似ユーザーの匿名ID一覧
+func (r *CollectiveInsightRepository) GetPassedCompaniesBySimilarUsers(
+	similarUserHashes []string,
+	excludeCompanyIDs []uint,
+) ([]SimilarUserPassedCompaniesRow, error) {
+	if len(similarUserHashes) == 0 {
+		return nil, nil
+	}
+
+	rows := []SimilarUserPassedCompaniesRow{}
+	query := r.db.Raw(`
+		SELECT
+			cil.company_id,
+			c.name AS company_name,
+			COUNT(*) AS pass_count,
+			'' AS avg_passer_scores,
+			CAST(COUNT(*) AS FLOAT) / ? AS collective_score
+		FROM collective_insight_logs cil
+		INNER JOIN companies c ON c.id = cil.company_id
+		WHERE cil.anonymous_user_id IN ?
+		  AND cil.action_type IN ('passed', 'applied')
+		GROUP BY cil.company_id, c.name
+		ORDER BY pass_count DESC
+		LIMIT 20
+	`, len(similarUserHashes), similarUserHashes)
+
+	if len(excludeCompanyIDs) > 0 {
+		query = r.db.Raw(`
+			SELECT
+				cil.company_id,
+				c.name AS company_name,
+				COUNT(*) AS pass_count,
+				'' AS avg_passer_scores,
+				CAST(COUNT(*) AS FLOAT) / ? AS collective_score
+			FROM collective_insight_logs cil
+			INNER JOIN companies c ON c.id = cil.company_id
+			WHERE cil.anonymous_user_id IN ?
+			  AND cil.action_type IN ('passed', 'applied')
+			  AND cil.company_id NOT IN ?
+			GROUP BY cil.company_id, c.name
+			ORDER BY pass_count DESC
+			LIMIT 20
+		`, len(similarUserHashes), similarUserHashes, excludeCompanyIDs)
+	}
+
+	err := query.Scan(&rows).Error
+	return rows, err
+}
+
+// GetUserScoreSnapshots 類似ユーザー検索のためにスコアスナップショットを取得する
+// action_type = 'applied' のログからスコア分布を集める
+func (r *CollectiveInsightRepository) GetUserScoreSnapshots(limit int) ([]models.CollectiveInsightLog, error) {
+	var logs []models.CollectiveInsightLog
+	err := r.db.Where("action_type = ? AND score_snapshot != ''", "applied").
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&logs).Error
+	return logs, err
+}
+
+// UpsertBehaviorSummary 企業別行動サマリーを更新する
+func (r *CollectiveInsightRepository) UpsertBehaviorSummary(summary *models.AnonymizedBehaviorSummary) error {
+	return r.db.Save(summary).Error
+}
+
+// GetBehaviorSummary 企業の行動サマリーを取得する
+func (r *CollectiveInsightRepository) GetBehaviorSummary(companyID uint) (*models.AnonymizedBehaviorSummary, error) {
+	var s models.AnonymizedBehaviorSummary
+	err := r.db.Where("company_id = ?", companyID).First(&s).Error
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// GetTopPassRateCompanies 通過率上位の企業サマリーを返す
+func (r *CollectiveInsightRepository) GetTopPassRateCompanies(limit int) ([]models.AnonymizedBehaviorSummary, error) {
+	var summaries []models.AnonymizedBehaviorSummary
+	err := r.db.Where("apply_count >= 3").
+		Order("pass_rate DESC").
+		Limit(limit).
+		Find(&summaries).Error
+	return summaries, err
+}
+
+// GetAllBehaviorSummaries バッチ集計用: 全企業サマリーを取得
+func (r *CollectiveInsightRepository) GetAllBehaviorSummaries() ([]models.AnonymizedBehaviorSummary, error) {
+	var summaries []models.AnonymizedBehaviorSummary
+	err := r.db.Find(&summaries).Error
+	return summaries, err
+}
+
+// RebuildSummaries 全企業の行動サマリーを再集計する（バッチ用）
+func (r *CollectiveInsightRepository) RebuildSummaries() error {
+	type rawSummary struct {
+		CompanyID   uint
+		ViewCount   int
+		ApplyCount  int
+		PassCount   int
+	}
+
+	var raws []rawSummary
+	err := r.db.Raw(`
+		SELECT
+			company_id,
+			SUM(CASE WHEN action_type = 'viewed' THEN 1 ELSE 0 END) AS view_count,
+			SUM(CASE WHEN action_type = 'applied' THEN 1 ELSE 0 END) AS apply_count,
+			SUM(CASE WHEN action_type = 'passed' THEN 1 ELSE 0 END) AS pass_count
+		FROM collective_insight_logs
+		GROUP BY company_id
+	`).Scan(&raws).Error
+	if err != nil {
+		return err
+	}
+
+	for _, raw := range raws {
+		passRate := 0.0
+		if raw.ApplyCount > 0 {
+			passRate = float64(raw.PassCount) / float64(raw.ApplyCount) * 100
+		}
+
+		// 通過ユーザーの平均スコアを計算
+		avgScores, _ := r.calcAvgPasserScores(raw.CompanyID)
+		avgJSON, _ := json.Marshal(avgScores)
+
+		summary := &models.AnonymizedBehaviorSummary{
+			CompanyID:       raw.CompanyID,
+			ViewCount:       raw.ViewCount,
+			ApplyCount:      raw.ApplyCount,
+			PassCount:       raw.PassCount,
+			PassRate:        passRate,
+			AvgPasserScores: string(avgJSON),
+		}
+
+		r.db.Where("company_id = ?", raw.CompanyID).
+			Assign(summary).
+			FirstOrCreate(summary)
+	}
+	return nil
+}
+
+// calcAvgPasserScores 通過ユーザーのカテゴリ別平均スコアを計算する
+func (r *CollectiveInsightRepository) calcAvgPasserScores(companyID uint) (map[string]float64, error) {
+	var logs []models.CollectiveInsightLog
+	err := r.db.Where("company_id = ? AND action_type = 'passed' AND score_snapshot != ''", companyID).
+		Find(&logs).Error
+	if err != nil || len(logs) == 0 {
+		return nil, err
+	}
+
+	sums := map[string]float64{}
+	counts := map[string]int{}
+	for _, log := range logs {
+		var scores map[string]float64
+		if err := json.Unmarshal([]byte(log.ScoreSnapshot), &scores); err != nil {
+			continue
+		}
+		for cat, score := range scores {
+			sums[cat] += score
+			counts[cat]++
+		}
+	}
+
+	result := map[string]float64{}
+	for cat, sum := range sums {
+		result[cat] = sum / float64(counts[cat])
+	}
+	return result, nil
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -19,6 +19,7 @@ func SetupAdminRoutes(
 	adminCostsController *controllers.AdminCostsController,
 	profileRecalcController *controllers.AdminProfileRecalculationController,
 	scoreValidationController *controllers.AdminScoreValidationController,
+	collectiveInsightController *controllers.CollectiveInsightController,
 	userRepo *repositories.UserRepository,
 ) {
 	auth := func(f http.HandlerFunc) http.HandlerFunc {
@@ -64,4 +65,7 @@ func SetupAdminRoutes(
 
 	// Score validation (correlation, calibration, A/B test)
 	http.HandleFunc("/api/admin/score-validation/", auth(scoreValidationController.Route))
+
+	// Collective insight batch
+	http.HandleFunc("/api/admin/collective-insights/rebuild-summaries", auth(collectiveInsightController.RebuildSummaries))
 }

--- a/Backend/internal/routes/collective_insight_routes.go
+++ b/Backend/internal/routes/collective_insight_routes.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"Backend/internal/controllers"
+	"net/http"
+)
+
+func SetupCollectiveInsightRoutes(controller *controllers.CollectiveInsightController) {
+	http.HandleFunc("/api/collective-insights/recommendations", controller.Route)
+	http.HandleFunc("/api/collective-insights/top-companies", controller.Route)
+	http.HandleFunc("/api/collective-insights/consent", controller.Route)
+	http.HandleFunc("/api/collective-insights/actions", controller.Route)
+}

--- a/Backend/internal/services/collective_insight_service.go
+++ b/Backend/internal/services/collective_insight_service.go
@@ -1,0 +1,217 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/repositories"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+)
+
+// CollectiveInsightService 集合知レコメンドサービス
+type CollectiveInsightService struct {
+	repo            *repositories.CollectiveInsightRepository
+	weightScoreRepo *repositories.UserWeightScoreRepository
+}
+
+func NewCollectiveInsightService(
+	repo *repositories.CollectiveInsightRepository,
+	weightScoreRepo *repositories.UserWeightScoreRepository,
+) *CollectiveInsightService {
+	return &CollectiveInsightService{repo: repo, weightScoreRepo: weightScoreRepo}
+}
+
+// ── 行動ログ記録 ─────────────────────────────────────────────────────────────
+
+// RecordAction ユーザー行動を匿名ログとして記録する
+// 同意していないユーザーの行動は記録しない
+func (s *CollectiveInsightService) RecordAction(userID uint, sessionID string, companyID uint, actionType string) error {
+	consented, err := s.repo.IsConsentGiven(userID)
+	if err != nil || !consented {
+		return nil // 未同意は黙って無視
+	}
+
+	// スコアスナップショット取得
+	scores, _ := s.weightScoreRepo.FindByUserAndSession(userID, sessionID)
+	snapshot := map[string]int{}
+	for _, sc := range scores {
+		snapshot[sc.WeightCategory] = sc.Score
+	}
+	snapJSON, _ := json.Marshal(snapshot)
+
+	log := &models.CollectiveInsightLog{
+		AnonymousUserID: anonymizeUserID(userID),
+		CompanyID:       companyID,
+		ActionType:      actionType,
+		ScoreSnapshot:   string(snapJSON),
+	}
+	return s.repo.LogAction(log)
+}
+
+// UpdateConsent ユーザーの集合知参加同意を更新する
+func (s *CollectiveInsightService) UpdateConsent(userID uint, allow bool) error {
+	return s.repo.UpdateConsent(userID, allow)
+}
+
+// ── 類似ユーザー検索 ─────────────────────────────────────────────────────────
+
+// CollectiveRecommendItem 集合知レコメンドアイテム
+type CollectiveRecommendItem struct {
+	CompanyID       uint    `json:"company_id"`
+	CompanyName     string  `json:"company_name"`
+	PassCount       int     `json:"pass_count"`        // 類似ユーザーの通過人数
+	SimilarUsers    int     `json:"similar_users"`     // 類似ユーザー数
+	CollectiveScore float64 `json:"collective_score"`  // 集合知スコア（0-100）
+	Reason          string  `json:"reason"`
+}
+
+// GetCollectiveRecommendations 類似スコアプロファイルを持つユーザーの通過企業をレコメンドする
+func (s *CollectiveInsightService) GetCollectiveRecommendations(
+	userID uint,
+	sessionID string,
+	excludeCompanyIDs []uint,
+) ([]CollectiveRecommendItem, error) {
+	// 自分のスコアを取得
+	myScores, err := s.weightScoreRepo.FindByUserAndSession(userID, sessionID)
+	if err != nil || len(myScores) == 0 {
+		return nil, nil
+	}
+
+	// スコアマップに変換
+	myScoreMap := map[string]float64{}
+	for _, sc := range myScores {
+		myScoreMap[sc.WeightCategory] = float64(sc.Score)
+	}
+
+	// 過去の行動ログからスナップショットを取得して類似ユーザーを特定
+	logs, err := s.repo.GetUserScoreSnapshots(500)
+	if err != nil {
+		return nil, err
+	}
+
+	similarHashes := findSimilarUsers(myScoreMap, anonymizeUserID(userID), logs, 0.85, 20)
+	if len(similarHashes) == 0 {
+		return nil, nil
+	}
+
+	rows, err := s.repo.GetPassedCompaniesBySimilarUsers(similarHashes, excludeCompanyIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]CollectiveRecommendItem, 0, len(rows))
+	for _, row := range rows {
+		score := math.Min(row.CollectiveScore*100, 100)
+		score = math.Round(score*10) / 10
+		items = append(items, CollectiveRecommendItem{
+			CompanyID:       row.CompanyID,
+			CompanyName:     row.CompanyName,
+			PassCount:       row.PassCount,
+			SimilarUsers:    len(similarHashes),
+			CollectiveScore: score,
+			Reason:          fmt.Sprintf("あなたと似たスコアプロファイルの%d人が通過・応募した企業です", row.PassCount),
+		})
+	}
+	return items, nil
+}
+
+// RebuildSummaries 企業別行動サマリーを再集計する（管理バッチ用）
+func (s *CollectiveInsightService) RebuildSummaries() error {
+	return s.repo.RebuildSummaries()
+}
+
+// GetTopPassRateCompanies 全ユーザー通過率上位の企業を返す
+func (s *CollectiveInsightService) GetTopPassRateCompanies(limit int) ([]models.AnonymizedBehaviorSummary, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	return s.repo.GetTopPassRateCompanies(limit)
+}
+
+// ── ヘルパー ─────────────────────────────────────────────────────────────────
+
+// anonymizeUserID userIDをSHA-256でハッシュ化する
+func anonymizeUserID(userID uint) string {
+	h := sha256.Sum256([]byte(fmt.Sprintf("user:%d:collective", userID)))
+	return fmt.Sprintf("%x", h)
+}
+
+// cosineSimMap 2つのスコアマップのコサイン類似度を計算する
+func cosineSimMap(a, b map[string]float64) float64 {
+	dot, normA, normB := 0.0, 0.0, 0.0
+	for k, va := range a {
+		vb := b[k]
+		dot += va * vb
+		normA += va * va
+	}
+	for _, vb := range b {
+		normB += vb * vb
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+// findSimilarUsers 類似スコアプロファイルを持つ匿名ユーザーIDを返す
+func findSimilarUsers(
+	myScores map[string]float64,
+	myHash string,
+	logs []models.CollectiveInsightLog,
+	threshold float64,
+	maxUsers int,
+) []string {
+	type candidate struct {
+		hash       string
+		similarity float64
+	}
+
+	seen := map[string]float64{}
+	for _, log := range logs {
+		if log.AnonymousUserID == myHash {
+			continue // 自分自身は除外
+		}
+		if log.ScoreSnapshot == "" {
+			continue
+		}
+		var scoreMap map[string]float64
+		if err := json.Unmarshal([]byte(log.ScoreSnapshot), &scoreMap); err != nil {
+			continue
+		}
+		// int→float64 変換が必要な場合のフォールバック
+		if len(scoreMap) == 0 {
+			var intMap map[string]int
+			if err := json.Unmarshal([]byte(log.ScoreSnapshot), &intMap); err == nil {
+				for k, v := range intMap {
+					scoreMap[k] = float64(v)
+				}
+			}
+		}
+
+		sim := cosineSimMap(myScores, scoreMap)
+		if sim >= threshold {
+			if prev, ok := seen[log.AnonymousUserID]; !ok || sim > prev {
+				seen[log.AnonymousUserID] = sim
+			}
+		}
+	}
+
+	candidates := make([]candidate, 0, len(seen))
+	for hash, sim := range seen {
+		candidates = append(candidates, candidate{hash, sim})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].similarity > candidates[j].similarity
+	})
+
+	result := make([]string, 0, maxUsers)
+	for i, c := range candidates {
+		if i >= maxUsers {
+			break
+		}
+		result = append(result, c.hash)
+	}
+	return result
+}


### PR DESCRIPTION
Closes #205

## 変更内容

### モデル（新規）
- **CollectiveInsightLog**: ユーザー行動の匿名集計ログ（SHA-256ハッシュでuserIDを匿名化、スコアスナップショット付き）
- **AnonymizedBehaviorSummary**: 企業別の行動集計サマリー（閲覧数・応募数・通過率・通過ユーザー平均スコア）
- **User.AllowCollectiveInsight**: 集合知参加同意フラグ（デフォルトtrue）

### リポジトリ
- 行動ログ保存・ユーザー同意確認/更新
- 匿名ユーザーハッシュ一覧から通過企業を集計するクエリ
- 企業別行動サマリーのUpsert・全企業バッチ再集計

### サービス
- **RecordAction**: 同意済みユーザーのみ行動をSHA-256匿名化して記録
- **GetCollectiveRecommendations**: コサイン類似度（閾値0.85）で類似ユーザーを最大20人検索し、通過企業を集合知スコア付きでレコメンド
- **RebuildSummaries**: バッチで全企業の通過率・通過ユーザー平均スコアを再集計

### API（5エンドポイント）
| エンドポイント | 説明 |
|---|---|
| `GET /api/collective-insights/recommendations` | 類似ユーザーの通過企業レコメンド |
| `GET /api/collective-insights/top-companies` | 全ユーザー通過率上位企業 |
| `PUT /api/collective-insights/consent` | 集合知参加同意の更新 |
| `POST /api/collective-insights/actions` | 行動ログ記録 |
| `POST /api/admin/collective-insights/rebuild-summaries` | サマリーバッチ再集計（管理画面） |

### プライバシー設計
- userIDはSHA-256ハッシュ化（`user:{id}:collective`）して保存し個人特定不可
- `AllowCollectiveInsight=false`のユーザーの行動は一切記録しない
- 管理画面のバッチAPIは管理者認証必須