### PR TITLE
Resolve #232: 注釈PDF生成失敗時のユーザー向けエラー通知追加

### DIFF
--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -820,19 +820,26 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	}
 
 	// 注釈 PDF を生成して保存
+	annotatedAvailable := false
 	_, annotatedStored, err := s.annotatePDF(pdfPath, doc, review, items)
 	if err != nil {
 		log.Printf("resume_review_stream: annotatePDF failed document_id=%d err=%v", documentID, err)
+		sendEvent(map[string]interface{}{
+			"type":    "annotate_error",
+			"message": "注釈PDFの生成に失敗しました。レビュー結果は表示されますが、PDFダウンロードはご利用いただけません。",
+		})
 	} else {
 		doc.AnnotatedPath = annotatedStored
 		doc.Status = "reviewed"
 		_ = s.repo.UpdateDocument(doc)
+		annotatedAvailable = true
 	}
 
 	sendEvent(map[string]interface{}{
-		"type":   "complete",
-		"review": review,
-		"items":  items,
+		"type":                "complete",
+		"review":              review,
+		"items":               items,
+		"annotated_available": annotatedAvailable,
 	})
 	return nil
 }

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -34,6 +34,7 @@ type ReviewResult = {
     summary: string
   }
   items: ReviewItem[]
+  annotated_available: boolean
 }
 
 const severityConfig: Record<string, { color: 'error' | 'warning' | 'info'; label: string; borderColor: string }> = {
@@ -57,6 +58,7 @@ function ResumeContent() {
   const [reviewLoading, setReviewLoading] = useState(false)
   const [uploadError, setUploadError] = useState('')
   const [reviewError, setReviewError] = useState('')
+  const [annotateError, setAnnotateError] = useState('')
   const [review, setReview] = useState<ReviewResult | null>(null)
   const [ragReport, setRagReport] = useState('')
 
@@ -136,6 +138,7 @@ function ResumeContent() {
       return
     }
     setReviewError('')
+    setAnnotateError('')
     setReview(null)
     setRagReport('')
     setReviewLoading(true)
@@ -175,7 +178,9 @@ function ResumeContent() {
             if (data.type === 'chunk') {
               setRagReport((prev) => prev + data.text)
             } else if (data.type === 'complete') {
-              setReview({ review: data.review, items: data.items })
+              setReview({ review: data.review, items: data.items, annotated_available: data.annotated_available ?? false })
+            } else if (data.type === 'annotate_error') {
+              setAnnotateError(data.message)
             } else if (data.type === 'error') {
               throw new Error(data.message)
             }
@@ -392,9 +397,14 @@ function ResumeContent() {
             })}
           </Stack>
           <Box sx={{ mt: 3 }}>
-            <Button variant="outlined" onClick={handleDownload}>
-              注釈PDFをダウンロード
-            </Button>
+            {annotateError && (
+              <Alert severity="warning" sx={{ mb: 2 }}>{annotateError}</Alert>
+            )}
+            {review.annotated_available && (
+              <Button variant="outlined" onClick={handleDownload}>
+                注釈PDFをダウンロード
+              </Button>
+            )}
           </Box>
         </Paper>
       )}


### PR DESCRIPTION
Closes #232

## 変更内容

### Backend (`Backend/internal/services/resume_service.go`)
- `ReviewDocumentStream` 内の `annotatePDF` 失敗時に `annotate_error` SSEイベントを送信するよう修正
  - エラーメッセージ: 「注釈PDFの生成に失敗しました。レビュー結果は表示されますが、PDFダウンロードはご利用いただけません。」
- `complete` SSEイベントに `annotated_available` フラグ（bool）を追加
  - 成功時: `true`、失敗時: `false`

### Frontend (`frontend/app/resume/page.tsx`)
- `ReviewResult` 型に `annotated_available: boolean` フィールドを追加
- `annotateError` stateを追加し、レビュー開始時にリセット
- SSEストリームで `annotate_error` イベントを受信した場合、警告アラートを表示
- `complete` イベント受信時に `annotated_available` フラグを `ReviewResult` に保存
- `annotated_available: false` の場合はダウンロードボタンを非表示に（エラー時のみ警告アラートを表示）

## 背景

`annotatePDF` 失敗時はログ出力のみで、フロントエンドには `complete` イベントが届いてしまい、ダウンロードボタンが正常に表示される問題があった。本対応により、エラー発生時はユーザーへの通知とUIの適切な制御が行われる。