### PR TITLE
Resolve #239: ゲストアカウント時にGitHub設定セクションを非表示

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -129,6 +129,7 @@ export default function ProfilePage() {
 
   const avatarLetter = name ? name[0].toUpperCase() : user.email[0].toUpperCase()
   const isGitHubUser = user.oauth_provider === 'github'
+  const isGuest = user.is_guest === true
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: '#f5f7fa' }}>
@@ -346,10 +347,12 @@ export default function ProfilePage() {
             </Card>
           </Box>
 
-          {/* 右カラム: GitHub スキル分析 */}
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            <GitHubSkills userId={user.user_id} />
-          </Box>
+          {/* 右カラム: GitHub スキル分析（ゲストアカウントは非表示） */}
+          {!isGuest && (
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <GitHubSkills userId={user.user_id} />
+            </Box>
+          )}
         </Box>
       </Container>
 


### PR DESCRIPTION
Closes #239

## 変更内容

### `frontend/app/profile/page.tsx`
- `isGuest` 変数を追加（`user.is_guest === true` で判定）
- GitHub スキル分析セクション（`<GitHubSkills>` コンポーネント）を `{!isGuest && (...)}` で条件付きレンダリングに変更
  - ゲストアカウントの場合: GitHub 設定セクションを非表示
  - 通常アカウントの場合: 従来どおり表示

## 補足

`User` 型には既に `is_guest: boolean` フィールドが定義されていたため、型変更・API変更は不要。