### PR TITLE
Resolve #246: プロフィール設定後の /onboarding リダイレクト処理を無効化

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -52,11 +52,8 @@ function OAuthCallbackContent() {
         authService.saveAuth(userData)
         localStorage.removeItem('oauth_state')
 
-        const needsOnboarding =
-          (userData.target_level !== '新卒' && userData.target_level !== '中途') ||
-          !userData.school_name
-        // 必須情報が未設定ならオンボーディングへ
-        if (needsOnboarding) {
+        // 名前が未設定の場合のみオンボーディングへ（初回登録ユーザー）
+        if (!userData.name) {
           router.push('/onboarding')
           return
         }

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -164,9 +164,6 @@ function InterviewContent() {
   useEffect(() => {
     const storedUser = authService.getStoredUser()
     if (!storedUser) { router.replace('/login'); return }
-    if (storedUser.target_level !== '新卒' && storedUser.target_level !== '中途') {
-      router.replace('/onboarding'); return
-    }
     setUser(storedUser)
     setLoading(false)
   }, [router])

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -11,10 +11,6 @@ export default function Login() {
   useEffect(() => {
     const storedUser = authService.getStoredUser()
     if (storedUser) {
-      if (storedUser.target_level !== '新卒' && storedUser.target_level !== '中途') {
-        router.replace('/onboarding')
-        return
-      }
       router.replace('/')
     }
   }, [router])

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -18,15 +18,6 @@ export default function Home() {
       router.replace('/login')
       return
     }
-    if (storedUser.target_level !== '新卒' && storedUser.target_level !== '中途') {
-      // 名前が設定済みの場合はプロフィール画面へ、未設定の場合はオンボーディングへ
-      if (storedUser.name) {
-        router.replace('/profile')
-      } else {
-        router.replace('/onboarding')
-      }
-      return
-    }
     setUser(storedUser)
     setLoading(false)
   }, [router])

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -153,8 +153,8 @@ export function MuiChat() {
     const initializeChat = async () => {
       // ユーザー情報を初期化
       const user = authService.getStoredUser()
-      if (!user || !user.name || !user.target_level) {
-        router.replace('/onboarding')
+      if (!user) {
+        router.replace('/login')
         return
       }
       const currentUserId = user.user_id


### PR DESCRIPTION
Closes #246

## 変更内容

### 問題
プロフィール設定を保存した後、各ページで `target_level` や `school_name` の値チェックにより `/onboarding` へ不正にリダイレクトされていた。

### 修正箇所

- **`frontend/app/auth/callback/page.tsx`**
  - `target_level` / `school_name` による `needsOnboarding` 判定を削除
  - `name` 未設定の場合のみ（初回登録ユーザー）`/onboarding` へリダイレクト

- **`frontend/app/page.tsx`**
  - `target_level` チェックによる `/onboarding` および `/profile` へのリダイレクトブロックを削除
  - ログイン済みであれば通常通りホーム画面を表示

- **`frontend/app/login/page.tsx`**
  - `target_level` チェックを削除
  - ログイン済みであれば常に `/` へリダイレクト

- **`frontend/app/interview/page.tsx`**
  - `target_level` による `/onboarding` リダイレクトを削除
  - 未認証のみ `/login` へリダイレクト

- **`frontend/components/mui-chat.tsx`**
  - `name` / `target_level` 未設定チェックによる `/onboarding` リダイレクトを削除
  - 未認証（`user` が null）の場合は `/login` へリダイレクトするよう変更