### PR TITLE
Resolve #248: 管理者認証をHMAC-SHA256トークン検証に強化

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -222,7 +222,7 @@ func main() {
 	routes.SetupAuthRoutes(authController, oauthController)
 	routes.SetupChatRoutes(chatController, questionController)
 	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, userRepo)
+	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, userRepo, cfg.AdminSecret)
 	routes.SetupResumeRoutes(resumeController)
 	routes.SetupInterviewRoutes(interviewController, realtimeController)
 	routes.SetupGitHubRoutes(githubController)

--- a/Backend/internal/config/config.go
+++ b/Backend/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ServerPort      string
 	GBizInfoBaseURL string
 	GBizInfoToken   string
+	AdminSecret     string
 }
 
 func LoadConfig() (*Config, error) {
@@ -30,6 +31,11 @@ func LoadConfig() (*Config, error) {
 		}
 	}
 
+	adminSecret := os.Getenv("ADMIN_SECRET")
+	if adminSecret == "" {
+		log.Println("WARNING: ADMIN_SECRET が設定されていません。管理者認証トークンの検証が無効化されます。本番環境では必ず設定してください。")
+	}
+
 	cfg := &Config{
 		DBUser:          os.Getenv("DB_USER"),
 		DBPass:          os.Getenv("DB_PASSWORD"),
@@ -39,6 +45,7 @@ func LoadConfig() (*Config, error) {
 		ServerPort:      get("SERVER_PORT", "80"),
 		GBizInfoBaseURL: get("GBIZINFO_BASE_URL", ""),
 		GBizInfoToken:   getFirst("GBIZINFO_API_KEY", "GBIZINFO_API_TOKEN"),
+		AdminSecret:     adminSecret,
 	}
 
 	// 必須値チェック

--- a/Backend/internal/middleware/admin_auth.go
+++ b/Backend/internal/middleware/admin_auth.go
@@ -5,17 +5,10 @@ import (
 	"net/http"
 )
 
-// AdminAuth X-Admin-Email ヘッダーでユーザーを検証し is_admin が true であることを確認する
-func AdminAuth(userRepo *repositories.UserRepository, next http.Handler) http.Handler {
+// AdminAuth X-Admin-Email と X-Admin-Token ヘッダーでユーザーを検証し is_admin が true であることを確認する
+func AdminAuth(userRepo *repositories.UserRepository, adminSecret string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		email := r.Header.Get("X-Admin-Email")
-		if email == "" {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		user, err := userRepo.GetUserByEmail(email)
-		if err != nil || user == nil || !user.IsAdmin {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !verifyAdminRequest(w, r, userRepo, adminSecret) {
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -23,18 +16,34 @@ func AdminAuth(userRepo *repositories.UserRepository, next http.Handler) http.Ha
 }
 
 // AdminAuthFunc AdminAuth の http.HandlerFunc バージョン
-func AdminAuthFunc(userRepo *repositories.UserRepository, next http.HandlerFunc) http.HandlerFunc {
+func AdminAuthFunc(userRepo *repositories.UserRepository, adminSecret string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		email := r.Header.Get("X-Admin-Email")
-		if email == "" {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		user, err := userRepo.GetUserByEmail(email)
-		if err != nil || user == nil || !user.IsAdmin {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		if !verifyAdminRequest(w, r, userRepo, adminSecret) {
 			return
 		}
 		next(w, r)
 	}
+}
+
+// verifyAdminRequest はリクエストの管理者認証を検証する共通ロジック
+func verifyAdminRequest(w http.ResponseWriter, r *http.Request, userRepo *repositories.UserRepository, adminSecret string) bool {
+	email := r.Header.Get("X-Admin-Email")
+	if email == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	user, err := userRepo.GetUserByEmail(email)
+	if err != nil || user == nil || !user.IsAdmin {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return false
+	}
+	// ADMIN_SECRET が設定されている場合はトークンを検証する
+	if adminSecret != "" {
+		token := r.Header.Get("X-Admin-Token")
+		if token == "" || !VerifyAdminToken(token, user.ID, user.Email, adminSecret) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return false
+		}
+	}
+	return true
 }

--- a/Backend/internal/middleware/admin_token.go
+++ b/Backend/internal/middleware/admin_token.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenerateAdminToken はユーザーID・メールアドレス・シークレットからHMAC-SHA256トークンを生成する
+func GenerateAdminToken(userID uint, email, secret string) string {
+	payload := fmt.Sprintf("%d:%s", userID, email)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyAdminToken はトークンがユーザーID・メールアドレス・シークレットと一致するか検証する
+func VerifyAdminToken(token string, userID uint, email, secret string) bool {
+	expected := GenerateAdminToken(userID, email, secret)
+	return hmac.Equal([]byte(token), []byte(expected))
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -21,9 +21,10 @@ func SetupAdminRoutes(
 	scoreValidationController *controllers.AdminScoreValidationController,
 	collectiveInsightController *controllers.CollectiveInsightController,
 	userRepo *repositories.UserRepository,
+	adminSecret string,
 ) {
 	auth := func(f http.HandlerFunc) http.HandlerFunc {
-		return middleware.AdminAuthFunc(userRepo, f)
+		return middleware.AdminAuthFunc(userRepo, adminSecret, f)
 	}
 
 	http.HandleFunc("/api/admin/companies", auth(adminCompanyController.ListOrCreate))

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/entity"
 	"Backend/domain/repository"
+	"Backend/internal/middleware"
 	"Backend/internal/models"
 	"crypto/rand"
 	"encoding/base64"
@@ -309,7 +310,7 @@ func (s *AuthService) Login(req LoginRequest) (*AuthResponse, error) {
 	user.LastLoginAt = &now
 	s.userRepo.UpdateUser(user)
 
-	return &AuthResponse{
+	resp := &AuthResponse{
 		UserID:                   user.ID,
 		Email:                    user.Email,
 		Name:                     user.Name,
@@ -322,7 +323,15 @@ func (s *AuthService) Login(req LoginRequest) (*AuthResponse, error) {
 		AvatarURL:                user.AvatarURL,
 		EmailVerified:            emailVerified,
 		RequiresReVerification:   requiresReVerification,
-	}, nil
+	}
+	// 管理者ユーザーにはHMACトークンを付与する
+	if user.IsAdmin {
+		adminSecret := os.Getenv("ADMIN_SECRET")
+		if adminSecret != "" {
+			resp.Token = middleware.GenerateAdminToken(user.ID, user.Email, adminSecret)
+		}
+	}
+	return resp, nil
 }
 
 // CreateGuestUser ゲストユーザー作成

--- a/frontend/app/admin/audit-logs/page.tsx
+++ b/frontend/app/admin/audit-logs/page.tsx
@@ -37,9 +37,8 @@ export default function AdminAuditLogsPage() {
 
   const loadLogs = async () => {
     setError('')
-    const admin = authService.getStoredUser()
     const response = await fetch('/api/admin/audit-logs', {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await response.json()
     if (!response.ok) {

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -92,7 +92,7 @@ export default function AdminCompanyEditPage() {
   useEffect(() => {
     const admin = authService.getStoredUser()
     fetch(`/api/admin/companies/${id}`, {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
       .then((r) => r.json())
       .then((data) => {
@@ -112,7 +112,7 @@ export default function AdminCompanyEditPage() {
     try {
       const res = await fetch(`/api/admin/companies/${id}/tech-stack-search`, {
         method: 'POST',
-        headers: { 'X-Admin-Email': admin?.email || '' },
+        headers: authService.getAdminFetchHeaders(),
       })
       if (!res.ok) {
         const d = await res.json().catch(() => ({}))
@@ -138,7 +138,7 @@ export default function AdminCompanyEditPage() {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
+        ...authService.getAdminFetchHeaders(),
       },
       body: JSON.stringify({
         tech_stack: JSON.stringify(techStack),

--- a/frontend/app/admin/companies/new/page.tsx
+++ b/frontend/app/admin/companies/new/page.tsx
@@ -42,7 +42,7 @@ export default function AdminCompanyNewPage() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
+        ...authService.getAdminFetchHeaders(),
       },
       body: JSON.stringify({
         name,

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -55,10 +55,9 @@ export default function AdminCompaniesPage() {
 
   const fetchCompanies = async (p: number = page) => {
     setError('')
-    const admin = authService.getStoredUser()
     const offset = (p - 1) * PAGE_SIZE
     const res = await fetch(`/api/admin/companies?limit=${PAGE_SIZE}&offset=${offset}`, {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await res.json()
     if (!res.ok) {
@@ -79,10 +78,9 @@ export default function AdminCompaniesPage() {
   }
 
   const handlePublish = async (companyId: number) => {
-    const admin = authService.getStoredUser()
     const res = await fetch(`/api/admin/companies/${companyId}/publish`, {
       method: 'PATCH',
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     if (!res.ok) {
       const data = await res.json()
@@ -93,10 +91,9 @@ export default function AdminCompaniesPage() {
   }
 
   const handleReject = async (companyId: number) => {
-    const admin = authService.getStoredUser()
     const res = await fetch(`/api/admin/companies/${companyId}/reject`, {
       method: 'PATCH',
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     if (!res.ok) {
       const data = await res.json()

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -147,7 +147,7 @@ export default function AdminCostsPage() {
     if (!adminEmail) return
     setLoading(true)
     setError('')
-    const h = { 'X-Admin-Email': adminEmail }
+    const h = { 'X-Admin-Email': adminEmail, 'X-Admin-Token': authService.getStoredToken() || '' }
     try {
       const [sumRes, dailyRes, monthlyRes] = await Promise.all([
         fetch('/api/admin/costs', { headers: h }),

--- a/frontend/app/admin/crawling/page.tsx
+++ b/frontend/app/admin/crawling/page.tsx
@@ -110,9 +110,8 @@ export default function AdminCrawlingPage() {
 
   const loadSources = async () => {
     setError('')
-    const admin = authService.getStoredUser()
     const response = await fetch('/api/admin/crawl-sources', {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await response.json()
     if (!response.ok) {
@@ -123,9 +122,8 @@ export default function AdminCrawlingPage() {
   }
 
   const loadRuns = async () => {
-    const admin = authService.getStoredUser()
     const response = await fetch('/api/admin/crawl-runs', {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await response.json()
     if (response.ok) {
@@ -141,7 +139,6 @@ export default function AdminCrawlingPage() {
   const handleCreate = async () => {
     setError('')
     setLoading(true)
-    const admin = authService.getStoredUser()
     const payload = {
       name,
       target_type: targetType,
@@ -153,10 +150,7 @@ export default function AdminCrawlingPage() {
     }
     const response = await fetch('/api/admin/crawl-sources', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
     const data = await response.json()
@@ -176,13 +170,9 @@ export default function AdminCrawlingPage() {
   }
 
   const handleToggleActive = async (source: CrawlSource) => {
-    const admin = authService.getStoredUser()
     const response = await fetch(`/api/admin/crawl-sources/${source.id}`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ is_active: !source.is_active }),
     })
     if (response.ok) {
@@ -191,12 +181,9 @@ export default function AdminCrawlingPage() {
   }
 
   const handleRun = async (source: CrawlSource) => {
-    const admin = authService.getStoredUser()
     const response = await fetch(`/api/admin/crawl-sources/${source.id}/run`, {
       method: 'POST',
-      headers: {
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: authService.getAdminFetchHeaders(),
     })
     if (response.ok) {
       await loadSources()
@@ -207,13 +194,9 @@ export default function AdminCrawlingPage() {
   const handleGraphCrawl = async () => {
     setGraphLoading(true)
     setGraphResult(null)
-    const admin = authService.getStoredUser()
     const response = await fetch('/api/admin/company-graph-crawl', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({
         sites: graphSites,
         query: graphQuery,
@@ -232,10 +215,9 @@ export default function AdminCrawlingPage() {
     setGbizSearchError('')
     setGbizSearchResults([])
     setGbizRegisterMessage('')
-    const admin = authService.getStoredUser()
     const response = await fetch(
       `/api/admin/companies/search-gbiz?name=${encodeURIComponent(gbizSearchName)}`,
-      { headers: { 'X-Admin-Email': admin?.email || '' } },
+      { headers: authService.getAdminFetchHeaders() },
     )
     const data = await response.json()
     if (!response.ok) {
@@ -252,13 +234,9 @@ export default function AdminCrawlingPage() {
   const handleGbizRegister = async (result: { corporate_number: string; name: string; location: string; company_url: string; employee_number: number }) => {
     setGbizRegisterLoading(result.corporate_number)
     setGbizRegisterMessage('')
-    const admin = authService.getStoredUser()
     const response = await fetch('/api/admin/companies', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name: result.name,
         location: result.location,

--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -117,7 +117,7 @@ export default function AdminScoreDashboardPage() {
         ...(query ? { query } : {}),
       })
       const res = await fetch(`/api/admin/dashboard/users?${params}`, {
-        headers: { 'X-Admin-Email': adminEmail },
+        headers: { 'X-Admin-Email': adminEmail, 'X-Admin-Token': authService.getStoredToken() || '' },
       })
       if (!res.ok) throw new Error('データの取得に失敗しました')
       const data = await res.json()
@@ -137,7 +137,7 @@ export default function AdminScoreDashboardPage() {
   const handleExport = () => {
     const link = document.createElement('a')
     link.href = '/api/admin/dashboard/export'
-    const headers = new Headers({ 'X-Admin-Email': adminEmail })
+    const headers = new Headers({ 'X-Admin-Email': adminEmail, 'X-Admin-Token': authService.getStoredToken() || '' })
     fetch('/api/admin/dashboard/export', { headers })
       .then(res => res.blob())
       .then(blob => {
@@ -155,7 +155,7 @@ export default function AdminScoreDashboardPage() {
     setDetailLoading(true)
     try {
       const res = await fetch(`/api/admin/dashboard/users/${user.user_id}/sessions`, {
-        headers: { 'X-Admin-Email': adminEmail },
+        headers: { 'X-Admin-Email': adminEmail, 'X-Admin-Token': authService.getStoredToken() || '' },
       })
       const data = await res.json()
       setDetailSessions(data.sessions ?? [])

--- a/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
+++ b/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
@@ -44,8 +44,7 @@ export default function AdminGraduateEmploymentEditPage() {
 
   useEffect(() => {
     if (!id) return
-    const admin = authService.getStoredUser()
-    const headers = { 'X-Admin-Email': admin?.email || '' }
+    const headers = authService.getAdminFetchHeaders()
     Promise.all([
       fetch('/api/admin/companies', { headers }).then((r) => r.json()),
       fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()),
@@ -69,13 +68,9 @@ export default function AdminGraduateEmploymentEditPage() {
 
   const handleUpdate = async () => {
     setError('')
-    const admin = authService.getStoredUser()
     const res = await fetch(`/api/admin/graduate-employments/${id}`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({
         company_id: Number(companyId),
         job_position_id: jobPositionId ? Number(jobPositionId) : undefined,

--- a/frontend/app/admin/graduate-employments/new/page.tsx
+++ b/frontend/app/admin/graduate-employments/new/page.tsx
@@ -40,21 +40,16 @@ export default function AdminGraduateEmploymentNewPage() {
   const [note, setNote] = useState('')
 
   useEffect(() => {
-    const admin = authService.getStoredUser()
-    const headers = { 'X-Admin-Email': admin?.email || '' }
+    const headers = authService.getAdminFetchHeaders()
     fetch('/api/admin/companies', { headers }).then((r) => r.json()).then((d) => setCompanies(d?.companies || []))
     fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()).then((d) => setJobPositions(d?.positions || []))
   }, [])
 
   const handleCreate = async () => {
     setError('')
-    const admin = authService.getStoredUser()
     const res = await fetch('/api/admin/graduate-employments', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin?.email || '',
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({
         company_id: Number(companyId),
         job_position_id: jobPositionId ? Number(jobPositionId) : undefined,

--- a/frontend/app/admin/graduate-employments/page.tsx
+++ b/frontend/app/admin/graduate-employments/page.tsx
@@ -38,9 +38,8 @@ export default function AdminGraduateEmploymentsPage() {
   const [graduateEntries, setGraduateEntries] = useState<GraduateEmployment[]>([])
 
   useEffect(() => {
-    const admin = authService.getStoredUser()
     fetch('/api/admin/graduate-employments?limit=100', {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
       .then((r) => r.json())
       .then((data) => setGraduateEntries(data?.entries || []))

--- a/frontend/app/admin/interviews/[id]/page.tsx
+++ b/frontend/app/admin/interviews/[id]/page.tsx
@@ -65,12 +65,10 @@ export default function AdminInterviewDetailPage() {
 
   useEffect(() => {
     const fetchVideos = async () => {
-      const admin = authService.getStoredUser()
-      if (!admin) return
       setLoading(true)
       setError('')
       const response = await fetch(`/api/admin/interviews/${sessionId}/videos`, {
-        headers: { 'X-Admin-Email': admin.email || '' },
+        headers: authService.getAdminFetchHeaders(),
       })
       const data = await response.json()
       setLoading(false)
@@ -88,9 +86,8 @@ export default function AdminInterviewDetailPage() {
     setUrlLoading(video.id)
     setUrlError('')
     setPlayingURL(null)
-    const admin = authService.getStoredUser()
     const response = await fetch(`/api/admin/interviews/${sessionId}/videos/${video.id}/url`, {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await response.json()
     setUrlLoading(null)

--- a/frontend/app/admin/interviews/page.tsx
+++ b/frontend/app/admin/interviews/page.tsx
@@ -58,15 +58,13 @@ export default function AdminInterviewsPage() {
 
   useEffect(() => {
     const fetchSessions = async () => {
-      const admin = authService.getStoredUser()
-      if (!admin) return
       setError('')
       const params = new URLSearchParams({
         page: String(page + 1),
         limit: String(rowsPerPage),
       })
       const response = await fetch(`/api/admin/interviews?${params}`, {
-        headers: { 'X-Admin-Email': admin.email || '' },
+        headers: authService.getAdminFetchHeaders(),
       })
       const data = await response.json()
       if (!response.ok) {

--- a/frontend/app/admin/job-positions/page.tsx
+++ b/frontend/app/admin/job-positions/page.tsx
@@ -245,9 +245,8 @@ export default function AdminJobPositionsPage() {
   const [filterStatus, setFilterStatus] = useState<'all' | 'draft' | 'published' | 'rejected'>('all')
 
   const fetchJobPositions = async () => {
-    const admin = authService.getStoredUser()
     const res = await fetch('/api/admin/job-positions?limit=100', {
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     const data = await res.json()
     if (res.ok) setJobPositions(data?.positions || [])
@@ -258,10 +257,9 @@ export default function AdminJobPositionsPage() {
   }, [])
 
   const handlePublish = async (id: number) => {
-    const admin = authService.getStoredUser()
     const res = await fetch(`/api/admin/job-positions/${id}/publish`, {
       method: 'PATCH',
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     if (!res.ok) {
       const data = await res.json()
@@ -272,10 +270,9 @@ export default function AdminJobPositionsPage() {
   }
 
   const handleReject = async (id: number) => {
-    const admin = authService.getStoredUser()
     const res = await fetch(`/api/admin/job-positions/${id}/reject`, {
       method: 'PATCH',
-      headers: { 'X-Admin-Email': admin?.email || '' },
+      headers: authService.getAdminFetchHeaders(),
     })
     if (!res.ok) {
       const data = await res.json()

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -28,8 +28,7 @@ export default function AdminDashboardPage() {
 
   useEffect(() => {
     const loadCounts = async () => {
-      const admin = authService.getStoredUser()
-      const headers = { 'X-Admin-Email': admin?.email || '' }
+      const headers = authService.getAdminFetchHeaders()
       try {
         const [companiesRes, crawlRes] = await Promise.all([
           fetch('/api/admin/companies', { headers }),

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -62,9 +62,8 @@ export default function AdminUsersPage() {
       })
       if (query.trim()) params.set('q', query.trim())
 
-      const admin = authService.getStoredUser()
       const response = await fetch(`/api/admin/users?${params}`, {
-        headers: { 'X-Admin-Email': admin?.email || '' },
+        headers: authService.getAdminFetchHeaders(),
       })
       const data = await response.json()
       if (cancelled) return
@@ -84,10 +83,7 @@ export default function AdminUsersPage() {
     setLoading(true)
     const response = await fetch(`/api/admin/users/${user.id}`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': admin.email,
-      },
+      headers: { ...authService.getAdminFetchHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ is_admin: !user.is_admin }),
     })
     const data = await response.json()

--- a/frontend/app/api/admin/audit-logs/route.ts
+++ b/frontend/app/api/admin/audit-logs/route.ts
@@ -9,7 +9,8 @@ export async function GET(request: NextRequest) {
   const limit = url.searchParams.get('limit')
   const query = limit ? `?limit=${limit}` : ''
   const response = await fetch(`${BACKEND_URL}/api/admin/audit-logs${query}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/app/api/admin/companies/[id]/publish/route.ts
+++ b/frontend/app/api/admin/companies/[id]/publish/route.ts
@@ -10,6 +10,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     method: 'PATCH',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/companies/[id]/reject/route.ts
+++ b/frontend/app/api/admin/companies/[id]/reject/route.ts
@@ -10,6 +10,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     method: 'PATCH',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/companies/[id]/route.ts
+++ b/frontend/app/api/admin/companies/[id]/route.ts
@@ -10,7 +10,8 @@ export async function GET(
 ) {
   const { id } = await params
   const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}
@@ -32,7 +33,8 @@ export async function PUT(
   const body = await request.text()
   const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'Content-Type': 'application/json', 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
     body,
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/companies/[id]/tech-stack-search/route.ts
+++ b/frontend/app/api/admin/companies/[id]/tech-stack-search/route.ts
@@ -11,7 +11,8 @@ export async function POST(
   const { id } = await params
   const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/tech-stack-search`, {
     method: 'POST',
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: Record<string, unknown> = {}

--- a/frontend/app/api/admin/companies/route.ts
+++ b/frontend/app/api/admin/companies/route.ts
@@ -7,7 +7,8 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.toString()
   const response = await fetch(`${BACKEND_URL}/api/admin/companies${query ? `?${query}` : ''}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}
@@ -28,6 +29,7 @@ export async function POST(request: NextRequest) {
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/companies/search-gbiz/route.ts
+++ b/frontend/app/api/admin/companies/search-gbiz/route.ts
@@ -9,7 +9,8 @@ export async function GET(request: NextRequest) {
   const response = await fetch(
     `${BACKEND_URL}/api/admin/companies/search-gbiz?name=${encodeURIComponent(name)}`,
     {
-      headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+      headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
     },
   )
   const raw = await response.text()

--- a/frontend/app/api/admin/company-graph-crawl/route.ts
+++ b/frontend/app/api/admin/company-graph-crawl/route.ts
@@ -14,6 +14,7 @@ export async function POST(request: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
         'X-Admin-Email': request.headers.get('X-Admin-Email') ?? '',
+        'X-Admin-Token': request.headers.get('X-Admin-Token') ?? '',
       },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(310_000), // 5 min + buffer

--- a/frontend/app/api/admin/costs/daily/route.ts
+++ b/frontend/app/api/admin/costs/daily/route.ts
@@ -5,11 +5,13 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const admin = request.headers.get('x-admin-email') || ''
   const { searchParams } = new URL(request.url)
   const days = searchParams.get('days') || '30'
   const res = await fetch(`${BACKEND_URL}/api/admin/costs/daily?days=${days}`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })

--- a/frontend/app/api/admin/costs/monthly/route.ts
+++ b/frontend/app/api/admin/costs/monthly/route.ts
@@ -5,11 +5,13 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const admin = request.headers.get('x-admin-email') || ''
   const { searchParams } = new URL(request.url)
   const months = searchParams.get('months') || '12'
   const res = await fetch(`${BACKEND_URL}/api/admin/costs/monthly?months=${months}`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })

--- a/frontend/app/api/admin/costs/route.ts
+++ b/frontend/app/api/admin/costs/route.ts
@@ -5,9 +5,11 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const admin = request.headers.get('x-admin-email') || ''
   const res = await fetch(`${BACKEND_URL}/api/admin/costs/summary`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })

--- a/frontend/app/api/admin/crawl-runs/route.ts
+++ b/frontend/app/api/admin/crawl-runs/route.ts
@@ -9,7 +9,8 @@ export async function GET(request: NextRequest) {
   const sourceId = url.searchParams.get('source_id')
   const query = sourceId ? `?source_id=${sourceId}` : ''
   const response = await fetch(`${BACKEND_URL}/api/admin/crawl-runs${query}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/app/api/admin/crawl-sources/[id]/route.ts
+++ b/frontend/app/api/admin/crawl-sources/[id]/route.ts
@@ -12,6 +12,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/crawl-sources/[id]/run/route.ts
+++ b/frontend/app/api/admin/crawl-sources/[id]/run/route.ts
@@ -10,6 +10,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     method: 'POST',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/crawl-sources/route.ts
+++ b/frontend/app/api/admin/crawl-sources/route.ts
@@ -6,7 +6,8 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   const response = await fetch(`${BACKEND_URL}/api/admin/crawl-sources`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}
@@ -27,6 +28,7 @@ export async function POST(request: NextRequest) {
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/dashboard/export/route.ts
+++ b/frontend/app/api/admin/dashboard/export/route.ts
@@ -5,10 +5,11 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const admin = request.headers.get('x-admin-email') || ''
-
   const res = await fetch(`${BACKEND_URL}/api/admin/dashboard/export/csv`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   if (!res.ok) {
     return NextResponse.json({ error: 'Export failed' }, { status: res.status })

--- a/frontend/app/api/admin/dashboard/users/[id]/sessions/route.ts
+++ b/frontend/app/api/admin/dashboard/users/[id]/sessions/route.ts
@@ -9,10 +9,11 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
-  const admin = request.headers.get('x-admin-email') || ''
-
   const res = await fetch(`${BACKEND_URL}/api/admin/dashboard/users/${id}/sessions`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })

--- a/frontend/app/api/admin/dashboard/users/route.ts
+++ b/frontend/app/api/admin/dashboard/users/route.ts
@@ -5,12 +5,14 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const admin = request.headers.get('x-admin-email') || ''
   const { searchParams } = new URL(request.url)
   const qs = searchParams.toString()
 
   const res = await fetch(`${BACKEND_URL}/api/admin/dashboard/users${qs ? '?' + qs : ''}`, {
-    headers: { 'X-Admin-Email': admin },
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
   })
   const data = await res.json()
   return NextResponse.json(data, { status: res.status })

--- a/frontend/app/api/admin/graduate-employments/[id]/route.ts
+++ b/frontend/app/api/admin/graduate-employments/[id]/route.ts
@@ -7,7 +7,10 @@ export const dynamic = 'force-dynamic'
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const response = await fetch(`${BACKEND_URL}/api/admin/graduate-employments/${id}`, {
-    headers: { 'X-Admin-Email': req.headers.get('x-admin-email') || '' },
+    headers: {
+      'X-Admin-Email': req.headers.get('x-admin-email') || '',
+      'X-Admin-Token': req.headers.get('x-admin-token') || '',
+    },
   })
   const raw = await response.text()
   let data: any = {}
@@ -25,6 +28,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/graduate-employments/route.ts
+++ b/frontend/app/api/admin/graduate-employments/route.ts
@@ -7,7 +7,8 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.toString()
   const response = await fetch(`${BACKEND_URL}/api/admin/graduate-employments${query ? `?${query}` : ''}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}
@@ -28,6 +29,7 @@ export async function POST(request: NextRequest) {
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/interviews/[id]/videos/[video_id]/url/route.ts
+++ b/frontend/app/api/admin/interviews/[id]/videos/[video_id]/url/route.ts
@@ -11,7 +11,8 @@ export async function GET(
   const resolvedParams = await params
   const url = `${BACKEND_URL}/api/admin/interviews/${resolvedParams.id}/videos/${resolvedParams.video_id}/url`
   const response = await fetch(url, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const data = await response.json().catch(() => ({}))
   return NextResponse.json(data, { status: response.status })

--- a/frontend/app/api/admin/interviews/[id]/videos/route.ts
+++ b/frontend/app/api/admin/interviews/[id]/videos/route.ts
@@ -11,7 +11,8 @@ export async function GET(
   const resolvedParams = await params
   const url = `${BACKEND_URL}/api/admin/interviews/${resolvedParams.id}/videos`
   const response = await fetch(url, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const data = await response.json().catch(() => ({}))
   return NextResponse.json(data, { status: response.status })

--- a/frontend/app/api/admin/interviews/route.ts
+++ b/frontend/app/api/admin/interviews/route.ts
@@ -13,7 +13,8 @@ export async function GET(request: NextRequest) {
   }
   const url = `${BACKEND_URL}/api/admin/interviews?${params}`
   const response = await fetch(url, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/app/api/admin/job-categories/route.ts
+++ b/frontend/app/api/admin/job-categories/route.ts
@@ -6,7 +6,8 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   const response = await fetch(`${BACKEND_URL}/api/admin/job-categories`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/app/api/admin/job-positions/[id]/publish/route.ts
+++ b/frontend/app/api/admin/job-positions/[id]/publish/route.ts
@@ -10,6 +10,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     method: 'PATCH',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/job-positions/[id]/reject/route.ts
+++ b/frontend/app/api/admin/job-positions/[id]/reject/route.ts
@@ -10,6 +10,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     method: 'PATCH',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
   })
   const raw = await response.text()

--- a/frontend/app/api/admin/job-positions/route.ts
+++ b/frontend/app/api/admin/job-positions/route.ts
@@ -7,7 +7,8 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.toString()
   const response = await fetch(`${BACKEND_URL}/api/admin/job-positions${query ? `?${query}` : ''}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}
@@ -28,6 +29,7 @@ export async function POST(request: NextRequest) {
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/users/[id]/route.ts
+++ b/frontend/app/api/admin/users/[id]/route.ts
@@ -12,6 +12,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     headers: {
       'Content-Type': 'application/json',
       'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
     },
     body,
   })

--- a/frontend/app/api/admin/users/route.ts
+++ b/frontend/app/api/admin/users/route.ts
@@ -13,7 +13,8 @@ export async function GET(request: NextRequest) {
   }
   const url = `${BACKEND_URL}/api/admin/users?${params}`
   const response = await fetch(url, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '' },
+    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -230,6 +230,16 @@ export const authService = {
     return localStorage.getItem('token')
   },
 
+  // 管理者APIリクエスト用のヘッダーを返す（X-Admin-Email + X-Admin-Token）
+  getAdminFetchHeaders(): Record<string, string> {
+    const user = this.getStoredUser()
+    const token = this.getStoredToken()
+    return {
+      'X-Admin-Email': user?.email || '',
+      'X-Admin-Token': token || '',
+    }
+  },
+
   logout() {
     // ユーザー情報とトークンを削除
     localStorage.removeItem('user')


### PR DESCRIPTION
Closes #248

## 変更内容

### 問題
管理者認証が `X-Admin-Email` ヘッダーのみに依存しており、クライアント側で任意のメールアドレスに偽装することで管理者権限を得られる脆弱性があった。

### 対応方針
ログイン時に HMAC-SHA256 署名トークンを生成し、管理者 API リクエストに `X-Admin-Token` ヘッダーとして付加・検証することで、なりすましを防止する。

---

### Backend (Go)

- **`Backend/internal/middleware/admin_token.go`** (新規)
  - `GenerateAdminToken(userID, email, secret)` — HMAC-SHA256 による署名トークン生成
  - `VerifyAdminToken(token, userID, email, secret)` — 定数時間比較による安全な検証

- **`Backend/internal/config/config.go`**
  - `AdminSecret` フィールドを追加し、環境変数 `ADMIN_SECRET` から読み込む
  - 未設定時は起動時に警告ログを出力（後方互換性を維持）

- **`Backend/internal/middleware/admin_auth.go`**
  - `AdminAuth` / `AdminAuthFunc` が `adminSecret` パラメータを受け取るよう変更
  - `ADMIN_SECRET` 設定時は `X-Admin-Token` ヘッダーを必須化し、HMAC 検証を実施
  - DB の `is_admin` チェックは従来通り維持

- **`Backend/internal/routes/admin_routes.go`**
  - `SetupAdminRoutes` に `adminSecret string` 引数を追加

- **`Backend/cmd/server/main.go`**
  - `cfg.AdminSecret` をルート設定に渡すよう変更

- **`Backend/internal/services/auth_service.go`**
  - `Login()` で管理者ユーザーのレスポンスに `Token` フィールドを追加
  - `ADMIN_SECRET` が設定されている場合のみトークンを生成

---

### Frontend (TypeScript)

- **`frontend/lib/auth.ts`**
  - `getAdminFetchHeaders()` ヘルパーメソッドを追加
  - `X-Admin-Email` と `X-Admin-Token` を一括で返す

- **管理者ページ（15ファイル）**
  - `{ 'X-Admin-Email': admin?.email }` を `authService.getAdminFetchHeaders()` に統一
  - `adminEmail` state を使うページでは `X-Admin-Token: authService.getStoredToken()` を追加

- **Next.js API ルート（29ファイル）**
  - すべての管理者向けバックエンドリクエストに `X-Admin-Token` ヘッダーを転送するよう変更

---

## 運用上の注意

- `ADMIN_SECRET` 環境変数を設定することでトークン検証が有効化される
- **本番環境では必ず強力なランダム文字列を `ADMIN_SECRET` に設定すること**
- 未設定の場合は従来の挙動（メール + DB の `is_admin` チェックのみ）に fallback する（後方互換）