### PR TITLE
feat: #260 AI面接の3分質問切替と進行可視化

### DIFF
--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -369,6 +369,30 @@ func (c *InterviewController) Turn(w http.ResponseWriter, r *http.Request) {
 			remainingSeconds = parsed
 		}
 	}
+	questionIndex := 0
+	if qi := r.FormValue("question_index"); qi != "" {
+		if parsed, err := strconv.Atoi(qi); err == nil && parsed >= 0 {
+			questionIndex = parsed
+		}
+	}
+	totalQuestions := 0
+	if tq := r.FormValue("total_questions"); tq != "" {
+		if parsed, err := strconv.Atoi(tq); err == nil && parsed >= 0 {
+			totalQuestions = parsed
+		}
+	}
+	questionElapsedSeconds := 0
+	if qe := r.FormValue("question_elapsed_seconds"); qe != "" {
+		if parsed, err := strconv.Atoi(qe); err == nil && parsed >= 0 {
+			questionElapsedSeconds = parsed
+		}
+	}
+	questionDurationSeconds := 0
+	if qd := r.FormValue("question_duration_seconds"); qd != "" {
+		if parsed, err := strconv.Atoi(qd); err == nil && parsed >= 0 {
+			questionDurationSeconds = parsed
+		}
+	}
 
 	audioFile, _, err := r.FormFile("audio")
 	if err != nil {
@@ -382,7 +406,24 @@ func (c *InterviewController) Turn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := c.interviewService.Turn(r.Context(), userID, sessionID, audioData, history, companyName, companyReading, position, companyInfo, companyType, turnCount, remainingSeconds)
+	result, err := c.interviewService.Turn(
+		r.Context(),
+		userID,
+		sessionID,
+		audioData,
+		history,
+		companyName,
+		companyReading,
+		position,
+		companyInfo,
+		companyType,
+		turnCount,
+		remainingSeconds,
+		questionIndex,
+		totalQuestions,
+		questionElapsedSeconds,
+		questionDurationSeconds,
+	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -415,16 +456,33 @@ func (c *InterviewController) StartTurn(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req struct {
-		UserID         uint   `json:"user_id"`
-		CompanyName    string `json:"company_name"`
-		CompanyReading string `json:"company_reading"`
-		Position       string `json:"position"`
-		CompanyInfo    string `json:"company_info"`
-		CompanyType    string `json:"company_type"`
+		UserID                  uint   `json:"user_id"`
+		CompanyName             string `json:"company_name"`
+		CompanyReading          string `json:"company_reading"`
+		Position                string `json:"position"`
+		CompanyInfo             string `json:"company_info"`
+		CompanyType             string `json:"company_type"`
+		QuestionIndex           int    `json:"question_index"`
+		TotalQuestions          int    `json:"total_questions"`
+		QuestionElapsedSeconds  int    `json:"question_elapsed_seconds"`
+		QuestionDurationSeconds int    `json:"question_duration_seconds"`
 	}
 	json.NewDecoder(r.Body).Decode(&req)
 
-	result, err := c.interviewService.StartTurn(r.Context(), req.UserID, sessionID, req.CompanyName, req.CompanyReading, req.Position, req.CompanyInfo, req.CompanyType)
+	result, err := c.interviewService.StartTurn(
+		r.Context(),
+		req.UserID,
+		sessionID,
+		req.CompanyName,
+		req.CompanyReading,
+		req.Position,
+		req.CompanyInfo,
+		req.CompanyType,
+		req.QuestionIndex,
+		req.TotalQuestions,
+		req.QuestionElapsedSeconds,
+		req.QuestionDurationSeconds,
+	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -492,7 +492,24 @@ type TurnResult struct {
 }
 
 // Turn はユーザー音声を受け取り、STT→Chat→TTSを実行してTurnResultを返します
-func (s *InterviewService) Turn(ctx context.Context, userID uint, sessionID uint, audioData []byte, history []map[string]string, companyName, companyReading, position, companyInfo, companyType string, turnCount int, remainingSeconds int) (*TurnResult, error) {
+func (s *InterviewService) Turn(
+	ctx context.Context,
+	userID uint,
+	sessionID uint,
+	audioData []byte,
+	history []map[string]string,
+	companyName,
+	companyReading,
+	position,
+	companyInfo,
+	companyType string,
+	turnCount int,
+	remainingSeconds int,
+	questionIndex int,
+	totalQuestions int,
+	questionElapsedSeconds int,
+	questionDurationSeconds int,
+) (*TurnResult, error) {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
 		return nil, err
@@ -524,7 +541,19 @@ func (s *InterviewService) Turn(ctx context.Context, userID uint, sessionID uint
 	history = append(history, map[string]string{"role": "user", "content": userText})
 
 	// Chat: 面接官として返答生成
-	systemPrompt := buildInterviewSystemPrompt(companyName, companyReading, position, companyInfo, companyType, turnCount, remainingSeconds)
+	systemPrompt := buildInterviewSystemPrompt(
+		companyName,
+		companyReading,
+		position,
+		companyInfo,
+		companyType,
+		turnCount,
+		remainingSeconds,
+		questionIndex,
+		totalQuestions,
+		questionElapsedSeconds,
+		questionDurationSeconds,
+	)
 	if s.crossFeature != nil {
 		if profileCtx := s.crossFeature.BuildInterviewContextFromUser(userID); profileCtx != "" {
 			systemPrompt = profileCtx + "\n" + systemPrompt
@@ -546,7 +575,20 @@ func (s *InterviewService) Turn(ctx context.Context, userID uint, sessionID uint
 }
 
 // StartTurn は面接開始の最初のAI発話を生成します
-func (s *InterviewService) StartTurn(ctx context.Context, userID uint, sessionID uint, companyName, companyReading, position, companyInfo, companyType string) (*TurnResult, error) {
+func (s *InterviewService) StartTurn(
+	ctx context.Context,
+	userID uint,
+	sessionID uint,
+	companyName,
+	companyReading,
+	position,
+	companyInfo,
+	companyType string,
+	questionIndex int,
+	totalQuestions int,
+	questionElapsedSeconds int,
+	questionDurationSeconds int,
+) (*TurnResult, error) {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
 		return nil, err
@@ -565,7 +607,19 @@ func (s *InterviewService) StartTurn(ctx context.Context, userID uint, sessionID
 		companyInfo = s.lookupCompanyProfile(ctx, companyName)
 	}
 
-	systemPromptStart := buildInterviewSystemPrompt(companyName, companyReading, position, companyInfo, companyType, 0, 0)
+	systemPromptStart := buildInterviewSystemPrompt(
+		companyName,
+		companyReading,
+		position,
+		companyInfo,
+		companyType,
+		0,
+		0,
+		questionIndex,
+		totalQuestions,
+		questionElapsedSeconds,
+		questionDurationSeconds,
+	)
 	if s.crossFeature != nil {
 		if profileCtx := s.crossFeature.BuildInterviewContextFromUser(userID); profileCtx != "" {
 			systemPromptStart = profileCtx + "\n" + systemPromptStart
@@ -633,7 +687,38 @@ var interviewTopics = []string{
 // maxTurnsPerTopic は1トピックあたりの最大ターン数（深掘り含む）
 const maxTurnsPerTopic = 3
 
-func buildInterviewSystemPrompt(companyName, companyReading, position, companyInfo, companyType string, turnCount int, remainingSeconds int) string {
+func buildInterviewSystemPrompt(
+	companyName,
+	companyReading,
+	position,
+	companyInfo,
+	companyType string,
+	turnCount int,
+	remainingSeconds int,
+	questionIndex int,
+	totalQuestions int,
+	questionElapsedSeconds int,
+	questionDurationSeconds int,
+) string {
+	if questionDurationSeconds <= 0 {
+		questionDurationSeconds = 180
+	}
+	if totalQuestions <= 0 {
+		totalQuestions = 1
+	}
+	if questionIndex <= 0 {
+		questionIndex = 1
+	}
+	if questionIndex > totalQuestions {
+		questionIndex = totalQuestions
+	}
+	if questionElapsedSeconds < 0 {
+		questionElapsedSeconds = 0
+	}
+	if questionElapsedSeconds > questionDurationSeconds {
+		questionElapsedSeconds = questionDurationSeconds
+	}
+
 	// ターン数からトピックインデックスと当該トピック内のターン数を計算
 	topicIndex := 0
 	turnsOnTopic := 0
@@ -658,6 +743,15 @@ func buildInterviewSystemPrompt(companyName, companyReading, position, companyIn
 	// 現在のトピックと進行状況を明示
 	base += fmt.Sprintf("\n\n【現在の面接状況】\n現在のトピック: %s（%d/%d）\n現在のトピックでの質問回数: %d/%d回",
 		currentTopic, topicIndex+1, len(interviewTopics), turnsOnTopic, maxTurnsPerTopic)
+	base += fmt.Sprintf(
+		"\n\n【質問タイムボックス】\n1質問あたりの目安: 約%d分（%d秒）\n現在の質問番号: %d/%d\nこの質問の経過時間: %d秒\nこの質問の残り目安: %d秒",
+		questionDurationSeconds/60,
+		questionDurationSeconds,
+		questionIndex,
+		totalQuestions,
+		questionElapsedSeconds,
+		questionDurationSeconds-questionElapsedSeconds,
+	)
 
 	if remainingSeconds > 0 {
 		remainingMinutes := remainingSeconds / 60
@@ -681,6 +775,7 @@ func buildInterviewSystemPrompt(companyName, companyReading, position, companyIn
 - 応募者の回答が抽象的・表面的な場合のみ深掘りしてください
 - 採用判断に有益な情報（具体的エピソード・数値・自分の行動・結果）が得られた場合は次のトピックへ移行してください
 - 同一トピックへの深掘りは最大2回までとし、現在のトピックでの質問回数が3回に達したら必ず次のトピックへ移行してください
+- 1つの質問は約3分を目安にし、目安時間に達したら自然に次の質問へ移行してください
 - トピックを移行する際は「ありがとうございます。次に〜についてお聞きします。」と自然につないでください`
 
 	if companyName != "" || position != "" {

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -103,6 +103,9 @@ function InterviewContent() {
   const [partialUser, setPartialUser] = useState('')
   const [partialAi, setPartialAi] = useState('')
   const [remainingSeconds, setRemainingSeconds] = useState(interviewLimits.maxMinutes * 60)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(1)
+  const [questionElapsedSeconds, setQuestionElapsedSeconds] = useState(0)
   const [sessionWarningShown, setSessionWarningShown] = useState(false)
   const [session, setSession] = useState<InterviewSession | null>(null)
   const [report, setReport] = useState<InterviewReport | null>(null)
@@ -348,13 +351,27 @@ function InterviewContent() {
     setIsRecording(false); setTurnPending(false); setAiSpeaking(false)
   }
 
-  const startTimer = () => {
+  const startTimer = (totalQuestions: number) => {
     sessionStartRef.current = Date.now()
     timerRef.current = setInterval(() => {
       if (!sessionStartRef.current) return
       const elapsed = Math.floor((Date.now() - sessionStartRef.current) / 1000)
       const remaining = Math.max(0, interviewLimits.maxMinutes * 60 - elapsed)
+      const safeQuestionDuration = Math.max(60, interviewLimits.questionDurationSeconds || 180)
+      const safeTotalQuestions = Math.max(1, totalQuestions)
+      const nextQuestionIndex = Math.min(
+        safeTotalQuestions,
+        Math.floor(elapsed / safeQuestionDuration) + 1,
+      )
+      const questionElapsed = Math.min(
+        safeQuestionDuration,
+        Math.max(0, elapsed - (nextQuestionIndex - 1) * safeQuestionDuration),
+      )
+
+      setElapsedSeconds(elapsed)
       setRemainingSeconds(remaining)
+      setCurrentQuestionIndex(nextQuestionIndex)
+      setQuestionElapsedSeconds(questionElapsed)
       if (remaining <= 120 && !sessionWarningShown) setSessionWarningShown(true)
       if (remaining <= 0) handleStop(true)
     }, 1000)
@@ -423,6 +440,10 @@ function InterviewContent() {
         position: selectedPosition?.title || '',
         company_info: [interviewCompany?.description, interviewCompany?.main_business].filter(Boolean).join(' / '),
         company_type: selectedPosition?.category || 'general',
+        question_index: 1,
+        total_questions: Math.max(1, selectedPosition?.questions || 1),
+        question_elapsed_seconds: 0,
+        question_duration_seconds: Math.max(60, interviewLimits.questionDurationSeconds || 180),
       }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -451,6 +472,9 @@ function InterviewContent() {
     setPartialUser(''); setPartialAi('')
     setReport(null); setReportStatus('idle')
     setRemainingSeconds(interviewLimits.maxMinutes * 60)
+    setElapsedSeconds(0)
+    setCurrentQuestionIndex(1)
+    setQuestionElapsedSeconds(0)
     setSessionWarningShown(false)
     setMicEnabled(true); setCameraEnabled(true)
     historyRef.current = []
@@ -496,7 +520,7 @@ function InterviewContent() {
         } catch { /* camera unavailable — skip recording */ }
       }
 
-      startTimer()
+      startTimer(selectedPosition.questions)
       await doStartTurn(created.id, user.user_id)
     } catch (error: any) {
       setStatus('error')
@@ -604,6 +628,10 @@ function InterviewContent() {
     formData.append('history', JSON.stringify(historyRef.current))
     formData.append('turn_count', String(Math.floor(historyRef.current.length / 2) + 1))
     formData.append('remaining_seconds', String(remainingSeconds))
+    formData.append('question_index', String(currentQuestionIndex))
+    formData.append('total_questions', String(Math.max(1, selectedPosition.questions)))
+    formData.append('question_elapsed_seconds', String(questionElapsedSeconds))
+    formData.append('question_duration_seconds', String(Math.max(60, interviewLimits.questionDurationSeconds || 180)))
     formData.append('company_name', interviewCompany?.name || '')
     formData.append('company_reading', interviewCompany?.name_reading || '')
     formData.append('position', selectedPosition?.title || '')
@@ -655,6 +683,10 @@ function InterviewContent() {
 
   const isActive = status === 'connecting' || status === 'connected'
   const isConnected = status === 'connected'
+  const questionDurationSeconds = Math.max(60, interviewLimits.questionDurationSeconds || 180)
+  const totalQuestionCount = Math.max(1, selectedPosition.questions)
+  const questionProgress = Math.min(100, Math.round((questionElapsedSeconds / questionDurationSeconds) * 100))
+  const questionRemainingSeconds = Math.max(0, questionDurationSeconds - questionElapsedSeconds)
   const progress = Math.min(100, Math.round(((interviewLimits.maxMinutes * 60 - remainingSeconds) / (interviewLimits.maxMinutes * 60)) * 100))
   const isFemale = avatarGender === 'female'
   const companyName = interviewCompany?.name || 'AI面接練習'
@@ -1369,6 +1401,13 @@ function InterviewContent() {
               <Typography sx={{ fontSize: 13, color: '#e8eaed', fontWeight: 500 }}>{formatSeconds(remainingSeconds)}</Typography>
             </Box>
           )}
+          {isActive && (
+            <Box sx={{ display: 'flex', alignItems: 'center', px: 1.5, py: 0.6, borderRadius: 9999, bgcolor: 'rgba(236,91,19,0.2)', border: `1px solid ${PRIMARY}66` }}>
+              <Typography sx={{ fontSize: 12, color: '#ffd8c2', fontWeight: 700 }}>
+                質問 {currentQuestionIndex}/{totalQuestionCount}
+              </Typography>
+            </Box>
+          )}
           {isConnected && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
               <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: '#34a853', animation: 'pulse 2s infinite', '@keyframes pulse': { '0%,100%': { opacity: 1 }, '50%': { opacity: 0.4 } } }} />
@@ -1388,6 +1427,27 @@ function InterviewContent() {
                 : `⚠️ 残り約${Math.ceil(remainingSeconds / 60)}分です。セッションがまもなく終了します。`}
             </Typography>
           </Box>
+        </Box>
+      )}
+
+      {/* ── Question progress ── */}
+      {isConnected && (
+        <Box sx={{ px: 2, pt: 1, flexShrink: 0 }}>
+          <Paper sx={{ bgcolor: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 2, p: 1.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Typography sx={{ fontSize: 13, color: '#e8eaed', fontWeight: 700 }}>
+                質問 {currentQuestionIndex}/{totalQuestionCount}
+              </Typography>
+              <Typography sx={{ fontSize: 12, color: '#cdd1d5' }}>
+                全体経過 {formatSeconds(elapsedSeconds)} • 質問内 {formatSeconds(questionElapsedSeconds)} / 残り目安 {formatSeconds(questionRemainingSeconds)}
+              </Typography>
+            </Box>
+            <LinearProgress
+              variant="determinate"
+              value={questionProgress}
+              sx={{ height: 7, borderRadius: 9999, bgcolor: 'rgba(255,255,255,0.12)', '& .MuiLinearProgress-bar': { bgcolor: PRIMARY } }}
+            />
+          </Paper>
         </Box>
       )}
 
@@ -1701,7 +1761,7 @@ function InterviewContent() {
             </IconButton>
           </Tooltip>
           <Typography variant="caption" sx={{ color: '#5f6368', ml: 1 }}>
-            残り {Math.floor(remainingSeconds / 60)}:{String(remainingSeconds % 60).padStart(2, '0')}
+            質問 {currentQuestionIndex}/{totalQuestionCount} • 残り {Math.floor(remainingSeconds / 60)}:{String(remainingSeconds % 60).padStart(2, '0')}
           </Typography>
         </Box>
       </Box>

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -218,4 +218,5 @@ export const interviewApi = {
 
 export const interviewLimits = {
   maxMinutes: Number(process.env.NEXT_PUBLIC_INTERVIEW_MAX_MINUTES || 10),
+  questionDurationSeconds: Number(process.env.NEXT_PUBLIC_INTERVIEW_QUESTION_DURATION_SECONDS || 180),
 }


### PR DESCRIPTION
## 概要
AI面接機能に、1質問あたり約3分で進行するタイムボックス制御と質問進行の可視化を追加しました。

Closes #260

## 変更内容
- 面接中の質問進行状態とタイマー更新処理を追加
- ヘッダー、下部バー、進行カードで質問番号と時間情報を可視化
- TurnとStartTurnに質問進行パラメータを追加
- Backendで質問進行パラメータを受け取り、面接プロンプトに反映
- 質問は約3分で次へ移行する指示をプロンプトに追加
- 環境変数 NEXT_PUBLIC_INTERVIEW_QUESTION_DURATION_SECONDS を追加（デフォルト180秒）