### PR TITLE
Resolve #249: 本番環境CORSを許可オリジン制限へ変更

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -10,6 +10,8 @@ DB_NAME=app_db
 
 # Server Configuration
 SERVER_PORT=8080
+# CORS 許可オリジン（カンマ区切り）
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key-here

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -12,15 +12,49 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 )
 
+func buildAllowedOrigins() map[string]struct{} {
+	allowedOrigins := make(map[string]struct{})
+	raw := os.Getenv("ALLOWED_ORIGINS")
+
+	for _, origin := range strings.Split(raw, ",") {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed == "" {
+			continue
+		}
+		allowedOrigins[trimmed] = struct{}{}
+	}
+
+	if len(allowedOrigins) == 0 && os.Getenv("APP_ENV") != "production" {
+		allowedOrigins["http://localhost:3000"] = struct{}{}
+		allowedOrigins["http://127.0.0.1:3000"] = struct{}{}
+		log.Println("WARNING: ALLOWED_ORIGINS が未設定のため、開発用デフォルト（localhost:3000）のみ許可します。")
+	}
+
+	return allowedOrigins
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
+	allowedOrigins := buildAllowedOrigins()
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		_, isAllowedOrigin := allowedOrigins[origin]
+
+		w.Header().Add("Vary", "Origin")
+		if isAllowedOrigin {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		if r.Method == "OPTIONS" {
+			if origin != "" && !isAllowedOrigin {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			return
 		}

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ INTERVIEW_MAX_MINUTES=10
 INTERVIEW_MAX_COST_USD=1.8
 INTERVIEW_COST_PER_MIN_USD=0.18
 
+# CORS 許可オリジン（カンマ区切り）
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
 # gBizINFO
 GBIZINFO_BASE_URL=https://api.biz-info.go.jp
 GBIZINFO_API_KEY=xxxxxxxxxxxxxxxx


### PR DESCRIPTION
Closes #249

## 変更内容
- CORS の `Access-Control-Allow-Origin` を `*` 固定から、`ALLOWED_ORIGINS` 環境変数のホワイトリスト判定へ変更
- リクエスト `Origin` が許可済みの場合のみ `Access-Control-Allow-Origin` を返す実装に変更し、`Vary: Origin` を付与
- `OPTIONS` プリフライトで未許可オリジンを `403 Forbidden` で拒否するように修正
- `Backend/.env.example` と `README.md` に `ALLOWED_ORIGINS` 設定例を追加
- `APP_ENV != production` かつ `ALLOWED_ORIGINS` 未設定時は、開発用として `localhost:3000` / `127.0.0.1:3000` を許可
