### PR TITLE
Resolve #250: 内部エラーメッセージ露出の防止

### DIFF
--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -16,9 +16,9 @@ import (
 )
 
 type AdminCompanyController struct {
-	repo        repository.CompanyRepository
-	audit       *services.AuditLogService
-	gbiz        *services.GBizInfoService
+	repo         repository.CompanyRepository
+	audit        *services.AuditLogService
+	gbiz         *services.GBizInfoService
 	openaiClient *openai.Client
 }
 
@@ -247,7 +247,7 @@ func (c *AdminCompanyController) searchGBiz(w http.ResponseWriter, r *http.Reque
 	}
 	results, err := c.gbiz.SearchByName(r.Context(), name)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -320,7 +320,7 @@ func (c *AdminCompanyController) fetchTechStack(w http.ResponseWriter, r *http.R
 
 	text, err := c.openaiClient.WebSearchQuery(ctx, prompt)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("web search failed: %v", err), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -122,12 +122,12 @@ func (c *AdminCompanyGraphController) Crawl(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"ok":            true,
-		"logs":          logs,
-		"nodes":         len(nodes),
-		"saved":         saved,
-		"skipped":       skipped,
-		"target_year":   targetYear,
+		"ok":               true,
+		"logs":             logs,
+		"nodes":            len(nodes),
+		"saved":            saved,
+		"skipped":          skipped,
+		"target_year":      targetYear,
 		"relations_synced": relSynced,
 	})
 
@@ -173,10 +173,10 @@ func (c *AdminCompanyGraphController) crawlViaService(
 	body, _ := io.ReadAll(resp.Body)
 
 	var result struct {
-		OK         bool                          `json:"ok"`
-		Error      string                        `json:"error"`
-		Logs       string                        `json:"logs"`
-		TargetYear int                           `json:"target_year"`
+		OK         bool                            `json:"ok"`
+		Error      string                          `json:"error"`
+		Logs       string                          `json:"logs"`
+		TargetYear int                             `json:"target_year"`
 		Nodes      map[string]*scraper.CompanyNode `json:"nodes"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {

--- a/Backend/internal/controllers/admin_costs_controller.go
+++ b/Backend/internal/controllers/admin_costs_controller.go
@@ -28,7 +28,7 @@ func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
 
 	monthTotal, err := c.costService.GetCurrentMonthTotal()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	realtimeMonthTotal := 0.0
@@ -37,17 +37,17 @@ func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
 	if c.realtimeUsageService != nil {
 		realtimeMonthTotal, err = c.realtimeUsageService.CurrentMonthTotalCost()
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeInternalServerError(w, err)
 			return
 		}
 		activeConnections, err = c.realtimeUsageService.CurrentActiveCount()
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeInternalServerError(w, err)
 			return
 		}
 		realtimeUsers, err = c.realtimeUsageService.GetUserBreakdown(30, 20)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeInternalServerError(w, err)
 			return
 		}
 	}
@@ -55,7 +55,7 @@ func (c *AdminCostsController) Summary(w http.ResponseWriter, r *http.Request) {
 	since30d := time.Now().UTC().AddDate(0, 0, -30)
 	modelBreakdown, err := c.costService.GetModelBreakdown(since30d)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -83,14 +83,14 @@ func (c *AdminCostsController) Daily(w http.ResponseWriter, r *http.Request) {
 	}
 	rows, err := c.costService.GetDailyCosts(days)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	realtimeRows := []services.RealtimeDailySummary{}
 	if c.realtimeUsageService != nil {
 		realtimeRows, err = c.realtimeUsageService.GetDailyUsage(days)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeInternalServerError(w, err)
 			return
 		}
 	}
@@ -113,14 +113,14 @@ func (c *AdminCostsController) Monthly(w http.ResponseWriter, r *http.Request) {
 	}
 	rows, err := c.costService.GetMonthlyCosts(months)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	realtimeRows := []services.RealtimeMonthlySummary{}
 	if c.realtimeUsageService != nil {
 		realtimeRows, err = c.realtimeUsageService.GetMonthlyUsage(months)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeInternalServerError(w, err)
 			return
 		}
 	}

--- a/Backend/internal/controllers/admin_dashboard_controller.go
+++ b/Backend/internal/controllers/admin_dashboard_controller.go
@@ -41,9 +41,9 @@ type UserScoreSummary struct {
 }
 
 type SessionScoreEntry struct {
-	SessionID uint       `json:"session_id"`
-	EndedAt   *time.Time `json:"ended_at,omitempty"`
-	AvgScore  *float64   `json:"avg_score,omitempty"`
+	SessionID uint               `json:"session_id"`
+	EndedAt   *time.Time         `json:"ended_at,omitempty"`
+	AvgScore  *float64           `json:"avg_score,omitempty"`
 	Scores    map[string]float64 `json:"scores,omitempty"`
 }
 
@@ -88,7 +88,7 @@ func (c *AdminDashboardController) ListUsers(w http.ResponseWriter, r *http.Requ
 
 	users, total, err := c.userRepo.ListUsersPaged(limit, offset, query)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (c *AdminDashboardController) ListUsers(w http.ResponseWriter, r *http.Requ
 
 	statMap, err := c.sessionRepo.GetUserStatsBatch(userIDs)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -120,7 +120,7 @@ func (c *AdminDashboardController) ListUsers(w http.ResponseWriter, r *http.Requ
 
 	reports, err := c.reportRepo.FindBySessionIDs(allSessionIDs)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -218,13 +218,13 @@ func (c *AdminDashboardController) UserSessions(w http.ResponseWriter, r *http.R
 
 	sessionIDs, err := c.sessionRepo.ListFinishedSessionIDsByUser(userID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
 	reports, err := c.reportRepo.FindBySessionIDs(sessionIDs)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	reportBySession := map[uint]*models.InterviewReport{}
@@ -234,7 +234,7 @@ func (c *AdminDashboardController) UserSessions(w http.ResponseWriter, r *http.R
 
 	sessions, err := c.sessionRepo.ListFinishedByUser(userID, 0)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -262,7 +262,7 @@ func (c *AdminDashboardController) ExportCSV(w http.ResponseWriter, r *http.Requ
 
 	users, _, err := c.userRepo.ListUsersPaged(10000, 0, "")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	userIDs := make([]uint, len(users))

--- a/Backend/internal/controllers/admin_interview_controller.go
+++ b/Backend/internal/controllers/admin_interview_controller.go
@@ -46,7 +46,7 @@ func (c *AdminInterviewController) ListSessions(w http.ResponseWriter, r *http.R
 
 	sessions, total, err := c.interviewService.ListAllSessionsAdmin(limit, offset)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -122,7 +122,7 @@ func (c *AdminInterviewController) VideoURL(w http.ResponseWriter, r *http.Reque
 	expires := 15 * time.Minute
 	presignedURL, err := c.s3Service.PresignGetURL(r.Context(), video.DriveFileID, expires)
 	if err != nil {
-		http.Error(w, "Failed to generate video URL: "+err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/admin_profile_recalculation_controller.go
+++ b/Backend/internal/controllers/admin_profile_recalculation_controller.go
@@ -65,7 +65,7 @@ func (c *AdminProfileRecalculationController) RecalculateAll(w http.ResponseWrit
 
 	results, err := c.service.RecalculateAll(req.MinSamples)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (c *AdminProfileRecalculationController) RecalculateOne(w http.ResponseWrit
 
 	result, err := c.service.RecalculateCompany(companyID, req.MinSamples)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -124,7 +124,7 @@ func (c *AdminProfileRecalculationController) Rollback(w http.ResponseWriter, r 
 func (c *AdminProfileRecalculationController) GetHistory(w http.ResponseWriter, r *http.Request, companyID uint) {
 	histories, err := c.service.GetHistory(companyID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/admin_score_validation_controller.go
+++ b/Backend/internal/controllers/admin_score_validation_controller.go
@@ -49,7 +49,7 @@ func (c *AdminScoreValidationController) Route(w http.ResponseWriter, r *http.Re
 func (c *AdminScoreValidationController) GetCorrelation(w http.ResponseWriter, r *http.Request) {
 	report, err := c.svc.GetCorrelationReport()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, report)
@@ -60,7 +60,7 @@ func (c *AdminScoreValidationController) GetCorrelation(w http.ResponseWriter, r
 func (c *AdminScoreValidationController) GetPhaseMetrics(w http.ResponseWriter, r *http.Request) {
 	report, err := c.svc.GetPhasePrecisionReport()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, report)
@@ -71,7 +71,7 @@ func (c *AdminScoreValidationController) GetPhaseMetrics(w http.ResponseWriter, 
 func (c *AdminScoreValidationController) GetCalibration(w http.ResponseWriter, r *http.Request) {
 	weights, err := c.svc.GetCurrentCalibration()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, map[string]interface{}{"weights": weights})
@@ -99,7 +99,7 @@ func (c *AdminScoreValidationController) GetCalibrationHistory(w http.ResponseWr
 	}
 	history, err := c.svc.GetCalibrationHistory(limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, map[string]interface{}{"history": history})
@@ -109,7 +109,7 @@ func (c *AdminScoreValidationController) GetCalibrationHistory(w http.ResponseWr
 func (c *AdminScoreValidationController) ListVariants(w http.ResponseWriter, r *http.Request) {
 	experiments, err := c.svc.ListExperiments()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, map[string]interface{}{"experiments": experiments})
@@ -137,7 +137,7 @@ func (c *AdminScoreValidationController) CreateVariant(w http.ResponseWriter, r 
 
 	variant, err := c.svc.CreateVariant(req.ExperimentName, req.VariantName, req.Description, req.TrafficRatio)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -153,7 +153,7 @@ func (c *AdminScoreValidationController) GetVariantResults(w http.ResponseWriter
 	}
 	results, err := c.svc.GetVariantResults(experimentName)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	writeJSON(w, map[string]interface{}{"experiment": experimentName, "results": results})

--- a/Backend/internal/controllers/auth_controller.go
+++ b/Backend/internal/controllers/auth_controller.go
@@ -86,7 +86,7 @@ func (c *AuthController) CreateGuest(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := c.authService.CreateGuestUser()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -120,7 +120,7 @@ func (c *AuthController) GetUser(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -295,7 +295,7 @@ func (c *AuthController) DeleteAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := c.authService.DeleteAccount(uint(userID)); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -63,9 +63,7 @@ func (c *ChatController) Chat(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := c.chatService.ProcessChat(r.Context(), req)
 	if err != nil {
-		// エラーログを詳細に出力
-		println("Error in ProcessChat:", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -97,7 +95,7 @@ func (c *ChatController) GetHistory(w http.ResponseWriter, r *http.Request) {
 
 	history, err := c.chatService.GetChatHistory(sessionID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -128,7 +126,7 @@ func (c *ChatController) GetScores(w http.ResponseWriter, r *http.Request) {
 
 	scores, err := c.chatService.GetUserScores(uint(userID), sessionID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -329,7 +327,7 @@ func (c *ChatController) ToggleFavorite(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := c.matchingService.ToggleFavorite(req.MatchID); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -364,7 +362,7 @@ func (c *ChatController) GetAnalysisSummary(w http.ResponseWriter, r *http.Reque
 
 	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), uint(userID), sessionID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -501,7 +499,7 @@ func (c *ChatController) SendReport(w http.ResponseWriter, r *http.Request) {
 	// 分析サマリー取得
 	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), req.UserID, req.SessionID)
 	if err != nil {
-		http.Error(w, "Failed to build analysis summary: "+err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -556,7 +554,7 @@ func (c *ChatController) GetSessions(w http.ResponseWriter, r *http.Request) {
 
 	sessions, err := c.chatService.GetUserChatSessions(uint(userID))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/collective_insight_controller.go
+++ b/Backend/internal/controllers/collective_insight_controller.go
@@ -57,7 +57,7 @@ func (c *CollectiveInsightController) GetRecommendations(w http.ResponseWriter, 
 
 	items, err := c.svc.GetCollectiveRecommendations(userID, sessionID, excludeIDs)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	if items == nil {
@@ -83,7 +83,7 @@ func (c *CollectiveInsightController) GetTopPassRateCompanies(w http.ResponseWri
 
 	companies, err := c.svc.GetTopPassRateCompanies(limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -106,7 +106,7 @@ func (c *CollectiveInsightController) UpdateConsent(w http.ResponseWriter, r *ht
 	}
 
 	if err := c.svc.UpdateConsent(req.UserID, req.Allow); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (c *CollectiveInsightController) RecordAction(w http.ResponseWriter, r *htt
 	}
 
 	if err := c.svc.RecordAction(req.UserID, req.SessionID, req.CompanyID, req.ActionType); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (c *CollectiveInsightController) RecordAction(w http.ResponseWriter, r *htt
 // 全企業の行動サマリーをバッチ再集計する（管理画面用）
 func (c *CollectiveInsightController) RebuildSummaries(w http.ResponseWriter, r *http.Request) {
 	if err := c.svc.RebuildSummaries(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/Backend/internal/controllers/company_relation_controller.go
+++ b/Backend/internal/controllers/company_relation_controller.go
@@ -13,7 +13,7 @@ import (
 )
 
 type CompanyRelationController struct {
-	repo        repository.CompanyRelationQueryRepository
+	repo         repository.CompanyRelationQueryRepository
 	openaiClient *openai.Client
 }
 

--- a/Backend/internal/controllers/error_response.go
+++ b/Backend/internal/controllers/error_response.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+	"path/filepath"
+	"runtime"
+)
+
+const internalServerErrorMessage = "内部エラーが発生しました"
+
+func writeInternalServerError(w http.ResponseWriter, err error) {
+	if err != nil {
+		if _, file, line, ok := runtime.Caller(1); ok {
+			log.Printf("[ERROR] %s:%d %v", filepath.Base(file), line, err)
+		} else {
+			log.Printf("[ERROR] %v", err)
+		}
+	}
+	http.Error(w, internalServerErrorMessage, http.StatusInternalServerError)
+}
+
+func writeErrorByStatus(w http.ResponseWriter, status int, err error) {
+	if status >= http.StatusInternalServerError {
+		writeInternalServerError(w, err)
+		return
+	}
+	if err != nil {
+		writeErrorByStatus(w, status, err)
+		return
+	}
+	http.Error(w, http.StatusText(status), status)
+}

--- a/Backend/internal/controllers/es_rewrite_controller.go
+++ b/Backend/internal/controllers/es_rewrite_controller.go
@@ -89,7 +89,7 @@ JSONのみで返してください。`
 
 	raw, err := c.openaiClient.ChatCompletionJSON(context.Background(), systemPrompt, userPrompt, 0.7, 1500)
 	if err != nil {
-		http.Error(w, "AI generation failed: "+err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -118,7 +118,7 @@ func (c *GitHubController) SyncAndWait(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
-		http.Error(w, "sync failed: "+err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -202,7 +202,7 @@ func (c *GitHubController) SummarizeRepo(w http.ResponseWriter, r *http.Request)
 
 	summary, err := c.githubService.SummarizeRepo(r.Context(), userID, body.FullName, body.ForceRefresh)
 	if err != nil {
-		http.Error(w, "summarize failed: "+err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/integrated_profile_controller.go
+++ b/Backend/internal/controllers/integrated_profile_controller.go
@@ -71,7 +71,7 @@ func (c *IntegratedProfileController) GetProfile(w http.ResponseWriter, r *http.
 
 	profile, err := c.crossFeature.BuildIntegratedProfile(userID, sessionID, interviewCount, resumeReviewDone)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -123,7 +123,7 @@ func (c *InterviewController) GetTrend(w http.ResponseWriter, r *http.Request) {
 	}
 	points, err := c.interviewService.GetTrend(uint(userID), limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -158,7 +158,7 @@ func (c *InterviewController) GetReport(w http.ResponseWriter, r *http.Request) 
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	if report == nil {
@@ -195,7 +195,7 @@ func (c *InterviewController) GetPhraseSuggestions(w http.ResponseWriter, r *htt
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -229,7 +229,7 @@ func (c *InterviewController) SendReport(w http.ResponseWriter, r *http.Request)
 		if err.Error() == "guest users cannot receive email reports" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -425,7 +425,7 @@ func (c *InterviewController) Turn(w http.ResponseWriter, r *http.Request) {
 		questionDurationSeconds,
 	)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -484,7 +484,7 @@ func (c *InterviewController) StartTurn(w http.ResponseWriter, r *http.Request) 
 		req.QuestionDurationSeconds,
 	)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -547,7 +547,7 @@ func (c *InterviewController) Start(w http.ResponseWriter, r *http.Request) {
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -579,7 +579,7 @@ func (c *InterviewController) Finish(w http.ResponseWriter, r *http.Request) {
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -614,7 +614,7 @@ func (c *InterviewController) List(w http.ResponseWriter, r *http.Request) {
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -656,7 +656,7 @@ func (c *InterviewController) Get(w http.ResponseWriter, r *http.Request) {
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -687,7 +687,7 @@ func (c *InterviewController) AddUtterance(w http.ResponseWriter, r *http.Reques
 		if err.Error() == "forbidden" {
 			status = http.StatusForbidden
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/Backend/internal/controllers/question_controller.go
+++ b/Backend/internal/controllers/question_controller.go
@@ -39,7 +39,7 @@ func (c *QuestionController) GenerateQuestions(w http.ResponseWriter, r *http.Re
 
 	questions, err := c.questionService.GenerateAndSaveQuestions(r.Context(), req)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -70,7 +70,7 @@ func (c *QuestionController) CreateQuestion(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := c.questionService.CreateQuestion(&qw); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (c *QuestionController) GetQuestionsByCategory(w http.ResponseWriter, r *ht
 
 	questions, err := c.questionService.GetQuestionsByCategory(category)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 

--- a/Backend/internal/controllers/realtime_controller.go
+++ b/Backend/internal/controllers/realtime_controller.go
@@ -8,7 +8,7 @@ import (
 )
 
 type RealtimeController struct {
-	interviewService    *services.InterviewService
+	interviewService     *services.InterviewService
 	realtimeUsageService *services.RealtimeUsageService
 }
 
@@ -48,7 +48,7 @@ func (c *RealtimeController) Token(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(err.Error(), "realtime capacity exceeded") {
 			status = http.StatusTooManyRequests
 		}
-		http.Error(w, err.Error(), status)
+		writeErrorByStatus(w, status, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/Backend/internal/controllers/resume_controller.go
+++ b/Backend/internal/controllers/resume_controller.go
@@ -54,7 +54,7 @@ func (c *ResumeController) Upload(w http.ResponseWriter, r *http.Request) {
 
 	result, err := c.resumeService.Upload(uint(userID), sessionID, sourceType, sourceURL, fileHeader)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 
@@ -107,7 +107,7 @@ func (c *ResumeController) Review(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ve.Message, http.StatusUnprocessableEntity)
 			return
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	log.Printf("resume_review: completed document_id=%d score=%d items=%d", docID, review.Score, len(items))

--- a/Backend/internal/controllers/schedule_controller.go
+++ b/Backend/internal/controllers/schedule_controller.go
@@ -67,7 +67,7 @@ func (c *ScheduleController) List(w http.ResponseWriter, r *http.Request) {
 	}
 	events, err := c.service.List(userID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -242,7 +242,7 @@ func (c *ScheduleController) ExportICS(w http.ResponseWriter, r *http.Request) {
 	}
 	ics, err := c.service.ExportICS(userID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeInternalServerError(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")


### PR DESCRIPTION
Closes #250

## 変更内容
- `Backend/internal/controllers/error_response.go` を追加し、内部エラー用の共通レスポンス処理を実装
- 500系エラーはクライアントへ固定文言（`内部エラーが発生しました`）を返し、詳細はサーバーログに記録するよう統一
- `http.Error(w, err.Error(), http.StatusInternalServerError)` のパターンを各コントローラーで共通ヘルパーへ置換
- `status` 変数経由のエラーレスポンスも `status >= 500` の場合は詳細を返さないよう統一
- `err.Error()` を連結していた500系レスポンスを除去し、内部実装情報の露出を防止
