### PR TITLE
Resolve #272: 職種選択の番号回答を職種名へ正規化

### DIFF
--- a/Backend/internal/services/job_category_validator.go
+++ b/Backend/internal/services/job_category_validator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -33,6 +34,12 @@ type JobValidationResult struct {
 
 // ValidateJobCategory ユーザーの職種回答を判定
 func (v *JobCategoryValidator) ValidateJobCategory(ctx context.Context, userAnswer string) (*JobValidationResult, error) {
+	normalizedAnswer, err := v.normalizeNumericAnswer(userAnswer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize numeric answer: %w", err)
+	}
+	userAnswer = normalizedAnswer
+
 	// 1. すべての職種を取得
 	allCategories, err := v.jobCategoryRepo.FindAll()
 	if err != nil {
@@ -169,6 +176,31 @@ JSONのみを返してください。説明は不要です。`, userAnswer, stri
 		SuggestedQuestion:  aiResponse.SuggestedQuestion,
 		NeedsClarification: aiResponse.NeedsClarification,
 	}, nil
+}
+
+func (v *JobCategoryValidator) normalizeNumericAnswer(userAnswer string) (string, error) {
+	trimmed := strings.TrimSpace(userAnswer)
+	if trimmed == "" {
+		return userAnswer, nil
+	}
+
+	choice, err := strconv.Atoi(trimmed)
+	if err != nil || choice <= 0 {
+		return userAnswer, nil
+	}
+
+	topCategories, err := v.jobCategoryRepo.GetTopCategories()
+	if err != nil {
+		return "", err
+	}
+
+	if choice <= len(topCategories) {
+		return topCategories[choice-1].Name, nil
+	}
+	if choice == len(topCategories)+1 {
+		return "まだ決めていない", nil
+	}
+	return userAnswer, nil
 }
 
 // GenerateJobSelectionQuestion 職種選択の質問を生成

--- a/Backend/internal/services/job_category_validator_test.go
+++ b/Backend/internal/services/job_category_validator_test.go
@@ -1,0 +1,118 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"errors"
+	"testing"
+)
+
+type jobCategoryRepoMock struct {
+	topCategories    []models.JobCategory
+	topCategoriesErr error
+}
+
+func (m *jobCategoryRepoMock) FindAll() ([]models.JobCategory, error) {
+	return nil, nil
+}
+
+func (m *jobCategoryRepoMock) FindByID(id uint) (*models.JobCategory, error) {
+	return nil, nil
+}
+
+func (m *jobCategoryRepoMock) FindByName(name string) ([]models.JobCategory, error) {
+	return nil, nil
+}
+
+func (m *jobCategoryRepoMock) FindByIndustry(industryID uint) ([]models.JobCategory, error) {
+	return nil, nil
+}
+
+func (m *jobCategoryRepoMock) GetTopCategories() ([]models.JobCategory, error) {
+	if m.topCategoriesErr != nil {
+		return nil, m.topCategoriesErr
+	}
+	return m.topCategories, nil
+}
+
+func TestNormalizeNumericAnswer_mapsTopCategory(t *testing.T) {
+	v := &JobCategoryValidator{
+		jobCategoryRepo: &jobCategoryRepoMock{
+			topCategories: []models.JobCategory{
+				{Name: "エンジニア"},
+				{Name: "営業"},
+			},
+		},
+	}
+
+	got, err := v.normalizeNumericAnswer("1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "エンジニア" {
+		t.Fatalf("want エンジニア, got %s", got)
+	}
+}
+
+func TestNormalizeNumericAnswer_mapsUndecidedOption(t *testing.T) {
+	v := &JobCategoryValidator{
+		jobCategoryRepo: &jobCategoryRepoMock{
+			topCategories: []models.JobCategory{
+				{Name: "エンジニア"},
+				{Name: "営業"},
+			},
+		},
+	}
+
+	got, err := v.normalizeNumericAnswer("3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "まだ決めていない" {
+		t.Fatalf("want まだ決めていない, got %s", got)
+	}
+}
+
+func TestNormalizeNumericAnswer_keepsOriginalForOutOfRange(t *testing.T) {
+	v := &JobCategoryValidator{
+		jobCategoryRepo: &jobCategoryRepoMock{
+			topCategories: []models.JobCategory{
+				{Name: "エンジニア"},
+				{Name: "営業"},
+			},
+		},
+	}
+
+	got, err := v.normalizeNumericAnswer("9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "9" {
+		t.Fatalf("want 9, got %s", got)
+	}
+}
+
+func TestNormalizeNumericAnswer_keepsOriginalForText(t *testing.T) {
+	v := &JobCategoryValidator{
+		jobCategoryRepo: &jobCategoryRepoMock{},
+	}
+
+	got, err := v.normalizeNumericAnswer("エンジニア")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "エンジニア" {
+		t.Fatalf("want エンジニア, got %s", got)
+	}
+}
+
+func TestNormalizeNumericAnswer_returnsErrorOnTopCategoryFetchFailure(t *testing.T) {
+	v := &JobCategoryValidator{
+		jobCategoryRepo: &jobCategoryRepoMock{
+			topCategoriesErr: errors.New("db error"),
+		},
+	}
+
+	if _, err := v.normalizeNumericAnswer("1"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
Closes #272

## 変更内容
- `JobCategoryValidator` に `normalizeNumericAnswer` を追加し、`ValidateJobCategory` 実行前に番号回答を職種名へ正規化するように変更
- `GetTopCategories()` の表示順に基づいて `1..N` を職種名へ、`N+1` を「まだ決めていない」へ変換
- 範囲外の番号やテキスト回答は既存挙動のまま維持
- `job_category_validator_test.go` を追加し、番号変換・未決定選択肢・範囲外/テキスト維持・取得失敗時エラーをテスト
