### PR TITLE
Resolve #255: アカウント削除時の関連データ削除を網羅化

### DIFF
--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -39,34 +39,214 @@ func (s *AuthService) DeleteAccount(userID uint) error {
 		return errors.New("database not configured")
 	}
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		// チャット履歴・重みスコア
+		var user models.User
+		if err := tx.First(&user, userID).Error; err != nil {
+			return err
+		}
+
+		sessionIDs, err := collectUserSessionIDs(tx, userID)
+		if err != nil {
+			return err
+		}
+		if len(sessionIDs) > 0 {
+			if err := tx.Where("session_id IN ?", sessionIDs).Delete(&models.SessionValidation{}).Error; err != nil {
+				return err
+			}
+		}
+
+		interviewSessionIDs, err := collectInterviewSessionIDs(tx, userID)
+		if err != nil {
+			return err
+		}
+		if len(interviewSessionIDs) > 0 {
+			if err := tx.Where("interview_session_id IN ?", interviewSessionIDs).Delete(&models.RealtimeUsageLog{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("session_id IN ?", interviewSessionIDs).Delete(&models.InterviewUtterance{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("session_id IN ?", interviewSessionIDs).Delete(&models.InterviewReport{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("session_id IN ?", interviewSessionIDs).Delete(&models.InterviewVideo{}).Error; err != nil {
+				return err
+			}
+		}
+
+		resumeDocumentIDs, err := collectResumeDocumentIDs(tx, userID)
+		if err != nil {
+			return err
+		}
+		if len(resumeDocumentIDs) > 0 {
+			resumeReviewIDs, err := collectResumeReviewIDs(tx, resumeDocumentIDs)
+			if err != nil {
+				return err
+			}
+			if len(resumeReviewIDs) > 0 {
+				if err := tx.Where("review_id IN ?", resumeReviewIDs).Delete(&models.ResumeReviewItem{}).Error; err != nil {
+					return err
+				}
+			}
+			if err := tx.Where("document_id IN ?", resumeDocumentIDs).Delete(&models.ResumeTextBlock{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Where("document_id IN ?", resumeDocumentIDs).Delete(&models.ResumeReview{}).Error; err != nil {
+				return err
+			}
+		}
+
 		if err := tx.Where("user_id = ?", userID).Delete(&models.ChatMessage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.AIGeneratedQuestion{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.ConversationContext{}).Error; err != nil {
 			return err
 		}
 		if err := tx.Where("user_id = ?", userID).Delete(&models.UserWeightScore{}).Error; err != nil {
 			return err
 		}
-		// マッチング結果
+		if err := tx.Where("user_id = ?", userID).Delete(&models.UserAnalysisProgress{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.UserEmbedding{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.VariantAssignment{}).Error; err != nil {
+			return err
+		}
 		if err := tx.Where("user_id = ?", userID).Delete(&models.UserCompanyMatch{}).Error; err != nil {
 			return err
 		}
-		// 面接セッション・発話・レポート・動画
-		var sessionIDs []uint
-		tx.Model(&models.InterviewSession{}).Where("user_id = ?", userID).Pluck("id", &sessionIDs)
-		if len(sessionIDs) > 0 {
-			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewUtterance{})
-			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewReport{})
-			tx.Where("session_id IN ?", sessionIDs).Delete(&models.InterviewVideo{})
+		if err := tx.Where("user_id = ?", userID).Delete(&models.UserApplicationStatus{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.CompanyReview{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.ResumeDocument{}).Error; err != nil {
+			return err
 		}
 		if err := tx.Where("user_id = ?", userID).Delete(&models.InterviewSession{}).Error; err != nil {
 			return err
 		}
-		// ユーザー本体
+		if err := tx.Where("user_id = ?", userID).Delete(&models.InterviewVideo{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.RealtimeUsageLog{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.ScheduleEvent{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.SkillScore{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubRepoSummary{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubLanguageStat{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubRepo{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", userID).Delete(&models.GitHubProfile{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("email = ?", user.Email).Delete(&models.PendingRegistration{}).Error; err != nil {
+			return err
+		}
+
 		if err := tx.Delete(&models.User{}, userID).Error; err != nil {
 			return err
 		}
 		return nil
 	})
+}
+
+func collectUserSessionIDs(tx *gorm.DB, userID uint) ([]string, error) {
+	sessions := map[string]struct{}{}
+	collect := func(model any) error {
+		var ids []string
+		if err := tx.Model(model).
+			Where("user_id = ?", userID).
+			Distinct().
+			Pluck("session_id", &ids).Error; err != nil {
+			return err
+		}
+		for _, id := range ids {
+			if id != "" {
+				sessions[id] = struct{}{}
+			}
+		}
+		return nil
+	}
+
+	if err := collect(&models.ChatMessage{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.UserWeightScore{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.ConversationContext{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.AIGeneratedQuestion{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.UserAnalysisProgress{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.UserEmbedding{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.UserCompanyMatch{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.VariantAssignment{}); err != nil {
+		return nil, err
+	}
+	if err := collect(&models.ResumeDocument{}); err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(sessions))
+	for id := range sessions {
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+func collectInterviewSessionIDs(tx *gorm.DB, userID uint) ([]uint, error) {
+	var sessionIDs []uint
+	if err := tx.Model(&models.InterviewSession{}).
+		Where("user_id = ?", userID).
+		Pluck("id", &sessionIDs).Error; err != nil {
+		return nil, err
+	}
+	return sessionIDs, nil
+}
+
+func collectResumeDocumentIDs(tx *gorm.DB, userID uint) ([]uint, error) {
+	var documentIDs []uint
+	if err := tx.Model(&models.ResumeDocument{}).
+		Where("user_id = ?", userID).
+		Pluck("id", &documentIDs).Error; err != nil {
+		return nil, err
+	}
+	return documentIDs, nil
+}
+
+func collectResumeReviewIDs(tx *gorm.DB, documentIDs []uint) ([]uint, error) {
+	var reviewIDs []uint
+	if err := tx.Model(&models.ResumeReview{}).
+		Where("document_id IN ?", documentIDs).
+		Pluck("id", &reviewIDs).Error; err != nil {
+		return nil, err
+	}
+	return reviewIDs, nil
 }
 
 // RegisterRequest ユーザー登録リクエスト

--- a/Backend/internal/services/auth_service_test.go
+++ b/Backend/internal/services/auth_service_test.go
@@ -1,0 +1,152 @@
+package services
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newAuthServiceTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+
+	dialector := mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	})
+	db, err := gorm.Open(dialector, &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm db: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+	return db, mock
+}
+
+func expectSessionIDPluck(mock sqlmock.Sqlmock, table string) {
+	mock.ExpectQuery("SELECT DISTINCT `session_id` FROM `" + table + "` WHERE user_id = \\?").
+		WithArgs(uint(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id"}))
+}
+
+func expectDeleteByUserID(mock sqlmock.Sqlmock, table string) {
+	mock.ExpectExec("DELETE FROM `" + table + "` WHERE user_id = \\?").
+		WithArgs(uint(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func TestDeleteAccount_DBNotConfigured(t *testing.T) {
+	svc := &AuthService{}
+	if err := svc.DeleteAccount(1); err == nil {
+		t.Fatal("expected error when db is not configured")
+	}
+}
+
+func TestDeleteAccount_CascadeDeleteQueries(t *testing.T) {
+	db, mock := newAuthServiceTestDB(t)
+	svc := &AuthService{db: db}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT \\* FROM `users` WHERE `users`.`id` = \\? ORDER BY `users`.`id` LIMIT \\?").
+		WithArgs(uint(1), 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}).AddRow(1, "user@example.com"))
+
+	// collectUserSessionIDs
+	mock.ExpectQuery("SELECT DISTINCT `session_id` FROM `chat_messages` WHERE user_id = \\?").
+		WithArgs(uint(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"session_id"}).AddRow("session-1"))
+	expectSessionIDPluck(mock, "user_weight_scores")
+	expectSessionIDPluck(mock, "conversation_contexts")
+	expectSessionIDPluck(mock, "ai_generated_questions")
+	expectSessionIDPluck(mock, "user_analysis_progress")
+	expectSessionIDPluck(mock, "user_embeddings")
+	expectSessionIDPluck(mock, "user_company_matches")
+	expectSessionIDPluck(mock, "variant_assignments")
+	expectSessionIDPluck(mock, "resume_documents")
+
+	mock.ExpectExec("DELETE FROM `session_validations` WHERE session_id IN \\(\\?\\)").
+		WithArgs("session-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// interview cascade
+	mock.ExpectQuery("SELECT `id` FROM `interview_sessions` WHERE user_id = \\?").
+		WithArgs(uint(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(10))
+	mock.ExpectExec("DELETE FROM `realtime_usage_logs` WHERE interview_session_id IN \\(\\?\\)").
+		WithArgs(10).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `interview_utterances` WHERE session_id IN \\(\\?\\)").
+		WithArgs(10).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `interview_reports` WHERE session_id IN \\(\\?\\)").
+		WithArgs(10).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `interview_videos` WHERE session_id IN \\(\\?\\)").
+		WithArgs(10).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// resume cascade
+	mock.ExpectQuery("SELECT `id` FROM `resume_documents` WHERE user_id = \\?").
+		WithArgs(uint(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(20))
+	mock.ExpectQuery("SELECT `id` FROM `resume_reviews` WHERE document_id IN \\(\\?\\)").
+		WithArgs(20).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(30))
+	mock.ExpectExec("DELETE FROM `resume_review_items` WHERE review_id IN \\(\\?\\)").
+		WithArgs(30).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `resume_text_blocks` WHERE document_id IN \\(\\?\\)").
+		WithArgs(20).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `resume_reviews` WHERE document_id IN \\(\\?\\)").
+		WithArgs(20).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// user-linked tables
+	expectDeleteByUserID(mock, "chat_messages")
+	expectDeleteByUserID(mock, "ai_generated_questions")
+	expectDeleteByUserID(mock, "conversation_contexts")
+	expectDeleteByUserID(mock, "user_weight_scores")
+	expectDeleteByUserID(mock, "user_analysis_progress")
+	expectDeleteByUserID(mock, "user_embeddings")
+	expectDeleteByUserID(mock, "variant_assignments")
+	expectDeleteByUserID(mock, "user_company_matches")
+	expectDeleteByUserID(mock, "user_application_statuses")
+	expectDeleteByUserID(mock, "company_reviews")
+	expectDeleteByUserID(mock, "resume_documents")
+	expectDeleteByUserID(mock, "interview_sessions")
+	expectDeleteByUserID(mock, "interview_videos")
+	expectDeleteByUserID(mock, "realtime_usage_logs")
+	expectDeleteByUserID(mock, "schedule_events")
+	expectDeleteByUserID(mock, "skill_scores")
+	expectDeleteByUserID(mock, "git_hub_repo_summaries")
+	expectDeleteByUserID(mock, "git_hub_language_stats")
+	expectDeleteByUserID(mock, "git_hub_repos")
+	expectDeleteByUserID(mock, "git_hub_profiles")
+
+	mock.ExpectExec("DELETE FROM `pending_registrations` WHERE email = \\?").
+		WithArgs("user@example.com").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `users` WHERE `users`.`id` = \\?").
+		WithArgs(uint(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := svc.DeleteAccount(1); err != nil {
+		t.Fatalf("DeleteAccount returned error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #255

## 変更内容
- `AuthService.DeleteAccount` をトランザクション内で拡張し、ユーザー関連データの削除対象を網羅化
- セッションIDを収集して `session_validations` を削除し、面接セッションID/職務経歴書ドキュメントIDを使って子テーブル（`interview_*`, `realtime_usage_logs`, `resume_*`）を先に削除
- `chat_messages`, `user_weight_scores`, `user_company_matches` に加え、`conversation_contexts`, `user_analysis_progress`, `user_embeddings`, `variant_assignments`, `user_application_statuses`, `github_*`, `schedule_events`, `skill_scores`, `pending_registrations` なども削除対象に追加
- すべての削除処理でエラーを明示的に返すようにし、途中失敗時はロールバックされるよう統一
- `auth_service_test.go` を追加し、SQLモックでカスケード削除クエリが実行されることを検証

## 補足
- フロントエンドの削除確認ダイアログは既存実装済みのため、今回の変更はバックエンド削除保証とテスト強化が中心
