### PR TITLE
Resolve #271: ハードコーディングを定数・環境変数へ統一

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_HINTS_MODEL=gpt-4o-search-preview
 # ヒットの JSON 構造化抽出に使用するモデル（search-preview モデルは json_object 非対応のため分離）
 OPENAI_HINTS_PARSE_MODEL=gpt-4o
+RAG_HINTS_PARSE_MAX_TOKENS=600
+RAG_REVIEW_RESUME_CHAR_LIMIT=10000
+RAG_CHROMA_DATA_DIR=/app/chroma_db
 
 # ログ設定
 LOG_MAX_SIZE=10m

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -37,6 +37,10 @@ OPENAI_HINTS_PARSE_MODEL=gpt-4o
 
 # Base URL (for OAuth callbacks)
 BASE_URL=http://localhost:8080
+APP_URL=http://localhost:3000
+COMPANY_GRAPH_THRESHOLD=0.75
+DEFAULT_SCHOOL_NAME=学校法人岩崎学園情報科学専門学校
+GUEST_EMAIL_DOMAIN=temp.local
 
 # Google OAuth
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -28,8 +28,9 @@ func buildAllowedOrigins() map[string]struct{} {
 	}
 
 	if len(allowedOrigins) == 0 && os.Getenv("APP_ENV") != "production" {
-		allowedOrigins["http://localhost:3000"] = struct{}{}
-		allowedOrigins["http://127.0.0.1:3000"] = struct{}{}
+		for _, origin := range config.DevAllowedOrigins() {
+			allowedOrigins[origin] = struct{}{}
+		}
 		log.Println("WARNING: ALLOWED_ORIGINS が未設定のため、開発用デフォルト（localhost:3000）のみ許可します。")
 	}
 
@@ -217,7 +218,7 @@ func main() {
 	gbizToken := os.Getenv("GBIZINFO_API_TOKEN")
 	companyGraphPipeline := &scraper.Pipeline{
 		GBiz:      scraper.NewGBizClient("", gbizToken),
-		Threshold: 0.75,
+		Threshold: config.CompanyGraphThreshold(),
 	}
 	adminCompanyGraphController := controllers.NewAdminCompanyGraphController(companyGraphPipeline, companyRepo, companyRelationRepo, auditLogService)
 	resumeController := controllers.NewResumeController(resumeService)

--- a/Backend/internal/config/constants.go
+++ b/Backend/internal/config/constants.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	DefaultOAuthBaseURL            = "http://localhost:8080"
+	DefaultAppURL                  = "http://localhost:3000"
+	DefaultGuestEmailDomain        = "temp.local"
+	DefaultSchoolName              = "学校法人岩崎学園情報科学専門学校"
+	DefaultCompanyGraphThreshold   = 0.75
+	PendingRegistrationTokenTTL    = 24 * time.Hour
+	ReVerificationInactiveDuration = 10 * 24 * time.Hour
+	PasswordResetTokenTTL          = time.Hour
+)
+
+func OAuthBaseURL() string {
+	return get("BASE_URL", DefaultOAuthBaseURL)
+}
+
+func AppURL() string {
+	return get("APP_URL", DefaultAppURL)
+}
+
+func GuestEmailDomain() string {
+	return get("GUEST_EMAIL_DOMAIN", DefaultGuestEmailDomain)
+}
+
+func SchoolName() string {
+	return get("DEFAULT_SCHOOL_NAME", DefaultSchoolName)
+}
+
+func CompanyGraphThreshold() float64 {
+	raw := os.Getenv("COMPANY_GRAPH_THRESHOLD")
+	if raw == "" {
+		return DefaultCompanyGraphThreshold
+	}
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil || value <= 0 {
+		return DefaultCompanyGraphThreshold
+	}
+	return value
+}
+
+func DevAllowedOrigins() []string {
+	return []string{
+		"http://localhost:3000",
+		"http://127.0.0.1:3000",
+	}
+}

--- a/Backend/internal/config/oauth.go
+++ b/Backend/internal/config/oauth.go
@@ -14,10 +14,7 @@ type OAuthConfig struct {
 }
 
 func LoadOAuthConfig() *OAuthConfig {
-	baseURL := os.Getenv("BASE_URL")
-	if baseURL == "" {
-		baseURL = "http://localhost:8080"
-	}
+	baseURL := OAuthBaseURL()
 
 	return &OAuthConfig{
 		Google: &oauth2.Config{
@@ -37,8 +34,8 @@ func LoadOAuthConfig() *OAuthConfig {
 			Scopes: []string{
 				"user:email",
 				"read:user",
-				"repo",      // プライベートリポジトリ・組織リポジトリへのアクセスに必要
-				"read:org",  // 所属組織のメンバーシップ情報取得に必要
+				"repo",     // プライベートリポジトリ・組織リポジトリへのアクセスに必要
+				"read:org", // 所属組織のメンバーシップ情報取得に必要
 			},
 			Endpoint: github.Endpoint,
 		},

--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"Backend/domain/repository"
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"Backend/internal/scraper"
 	"Backend/internal/services"
@@ -64,7 +65,7 @@ func (c *AdminCompanyGraphController) Crawl(w http.ResponseWriter, r *http.Reque
 	req.Sites = []string{"rikunabi", "career_tasu"}
 	req.Query = "IT"
 	req.Pages = 2
-	req.Threshold = 0.75
+	req.Threshold = config.CompanyGraphThreshold()
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
 		http.Error(w, "invalid request body", http.StatusBadRequest)

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/entity"
 	"Backend/domain/repository"
+	"Backend/internal/config"
 	"Backend/internal/middleware"
 	"Backend/internal/models"
 	"crypto/rand"
@@ -323,7 +324,7 @@ func (s *AuthService) RequestRegistration(email string) error {
 	pending := &entity.PendingRegistration{
 		Token:     token,
 		Email:     email,
-		ExpiresAt: time.Now().Add(24 * time.Hour),
+		ExpiresAt: time.Now().Add(config.PendingRegistrationTokenTTL),
 	}
 	if err := s.pendingRepo.Create(pending); err != nil {
 		return fmt.Errorf("failed to save pending registration: %w", err)
@@ -370,7 +371,7 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 		return nil, errors.New("target_level must be '新卒' or '中途'")
 	}
 	if strings.TrimSpace(req.SchoolName) == "" {
-		req.SchoolName = "学校法人岩崎学園情報科学専門学校"
+		req.SchoolName = config.SchoolName()
 	}
 
 	// 既存ユーザーチェック
@@ -411,10 +412,7 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 	}
 
 	// 認証メール送信（失敗しても登録は成功扱い）
-	appURL := os.Getenv("APP_URL")
-	if appURL == "" {
-		appURL = "http://localhost:3000"
-	}
+	appURL := config.AppURL()
 	go s.emailService.SendVerificationEmail(user, user.EmailVerificationToken, appURL)
 
 	return &AuthResponse{
@@ -469,16 +467,13 @@ func (s *AuthService) Login(req LoginRequest) (*AuthResponse, error) {
 		}
 
 		// 10日以上ログインなし → 再認証
-		if user.LastLoginAt != nil && time.Since(*user.LastLoginAt) > 10*24*time.Hour {
+		if user.LastLoginAt != nil && time.Since(*user.LastLoginAt) > config.ReVerificationInactiveDuration {
 			tokenBytes := make([]byte, 24)
 			rand.Read(tokenBytes)
 			user.EmailVerificationToken = base64.URLEncoding.EncodeToString(tokenBytes)
 			user.EmailVerifiedAt = nil
 			s.userRepo.UpdateUser(user)
-			appURL := os.Getenv("APP_URL")
-			if appURL == "" {
-				appURL = "http://localhost:3000"
-			}
+			appURL := config.AppURL()
 			go s.emailService.SendReVerificationEmail(user, user.EmailVerificationToken, appURL)
 			requiresReVerification = true
 			return nil, errors.New("re_verification_required")
@@ -524,12 +519,12 @@ func (s *AuthService) CreateGuestUser() (*AuthResponse, error) {
 	guestID := base64.URLEncoding.EncodeToString(randomBytes)
 
 	user := &entity.User{
-		Email:       fmt.Sprintf("guest_%s@temp.local", guestID),
+		Email:       fmt.Sprintf("guest_%s@%s", guestID, config.GuestEmailDomain()),
 		Password:    "", // ゲストユーザーはパスワード不要
 		Name:        fmt.Sprintf("Guest_%s", guestID[:8]),
 		IsGuest:     true,
 		TargetLevel: "未設定",
-		SchoolName:  "学校法人岩崎学園情報科学専門学校",
+		SchoolName:  config.SchoolName(),
 	}
 
 	if err := s.userRepo.CreateUser(user); err != nil {
@@ -639,7 +634,7 @@ func (s *AuthService) RequestPasswordReset(email string) error {
 	}
 	token := base64.URLEncoding.EncodeToString(b)
 
-	expiresAt := time.Now().Add(1 * time.Hour)
+	expiresAt := time.Now().Add(config.PasswordResetTokenTTL)
 	user.PasswordResetToken = token
 	user.PasswordResetExpiresAt = &expiresAt
 
@@ -647,10 +642,7 @@ func (s *AuthService) RequestPasswordReset(email string) error {
 		return fmt.Errorf("failed to update user: %w", err)
 	}
 
-	appURL := os.Getenv("APP_URL")
-	if appURL == "" {
-		appURL = "http://localhost:3000"
-	}
+	appURL := config.AppURL()
 	return s.emailService.SendPasswordResetEmail(user.Email, token, appURL)
 }
 

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Box, CircularProgress, Typography, Alert } from '@mui/material'
 import { authService } from '@/lib/auth'
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from '@/lib/backend-url'
 
 function OAuthCallbackContent() {
   const router = useRouter()

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Box, Container, Typography, Paper, List, ListItem, ListItemButton, ListItemText, Divider, CircularProgress, Button } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { authService } from '@/lib/auth'
+import { BACKEND_URL } from '@/lib/backend-url'
 import ChatIcon from '@mui/icons-material/Chat'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 
@@ -31,7 +32,7 @@ export default function ChatHistoryPage() {
 
   const fetchSessions = async (userId: number) => {
     try {
-      const response = await fetch(`http://localhost:8080/api/chat/sessions?user_id=${userId}`)
+      const response = await fetch(`${BACKEND_URL}/api/chat/sessions?user_id=${userId}`)
       if (!response.ok) {
         throw new Error('Failed to fetch sessions')
       }

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -23,8 +23,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import EditNoteIcon from '@mui/icons-material/EditNote'
 import RateReviewIcon from '@mui/icons-material/RateReview'
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from '@/lib/backend-url'
 const PRIMARY = '#ec5b13'
 
 const QUESTION_TYPES = ['志望動機', '自己PR', '学チカ', 'ガクチカ', 'その他']

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -39,6 +39,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ApartmentIcon from '@mui/icons-material/Apartment'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { BACKEND_URL } from '@/lib/backend-url'
 import { authService, User } from '@/lib/auth'
 import { interviewApi, interviewLimits, InterviewReport, InterviewSession } from '@/lib/interview'
 import { formatSeconds, parseJsonSafe, parseMediaError, parseMultipartResponse } from '@/lib/interview-utils'
@@ -426,8 +427,7 @@ function InterviewContent() {
   }
 
   const doStartTurn = async (sessionId: number, userId: number) => {
-    const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
-    const res = await fetch(`${BACKEND}/api/interviews/${sessionId}/start-turn`, {
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/start-turn`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -635,8 +635,7 @@ function InterviewContent() {
     formData.append('company_info', [interviewCompany?.description, interviewCompany?.main_business].filter(Boolean).join(' / '))
     formData.append('company_type', selectedPosition?.category || 'general')
     try {
-      const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
-      const res = await fetch(`${BACKEND}/api/interviews/${session.id}/turn`, {
+      const res = await fetch(`${BACKEND_URL}/api/interviews/${session.id}/turn`, {
         method: 'POST',
         body: formData,
       })

--- a/frontend/app/verify-email/page.tsx
+++ b/frontend/app/verify-email/page.tsx
@@ -6,8 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { Box, Button, CircularProgress, Paper, Typography } from '@mui/material'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ErrorIcon from '@mui/icons-material/Error'
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from '@/lib/backend-url'
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams()

--- a/frontend/app/verify-registration/page.tsx
+++ b/frontend/app/verify-registration/page.tsx
@@ -15,9 +15,8 @@ import {
   MenuItem,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { BACKEND_URL } from '@/lib/backend-url'
 import { CERTIFICATION_OPTIONS, joinCertifications } from '@/lib/profile'
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
 
 function VerifyRegistrationContent() {
   const searchParams = useSearchParams()

--- a/frontend/components/github-skills.tsx
+++ b/frontend/components/github-skills.tsx
@@ -6,8 +6,7 @@ import GitHubIcon from '@mui/icons-material/GitHub'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from '@/lib/backend-url'
 
 interface SkillScore {
   ID: number

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,4 +1,4 @@
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from './backend-url'
 const AUTH_USER_KEY = 'user'
 const AUTH_TOKEN_KEY = 'token'
 

--- a/frontend/lib/backend-url.ts
+++ b/frontend/lib/backend-url.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_BACKEND_URL = 'http://localhost:8080'
+
+export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || DEFAULT_BACKEND_URL

--- a/frontend/lib/company-data.ts
+++ b/frontend/lib/company-data.ts
@@ -1,3 +1,5 @@
+import { BACKEND_URL } from './backend-url';
+
 // 企業データの型定義
 export type MarketType = 'prime' | 'standard' | 'growth' | 'unlisted';
 export type RelationType = 'subsidiary' | 'affiliate'; // 子会社 or 関連会社
@@ -36,7 +38,7 @@ export interface CompanyMarketInfo {
 // APIから企業関係データを取得
 export async function fetchCompanyRelations(): Promise<CapitalRelation[]> {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080'}/api/companies/relations`);
+    const response = await fetch(`${BACKEND_URL}/api/companies/relations`);
     if (!response.ok) {
       console.warn('Failed to fetch company relations');
       return [];
@@ -51,7 +53,7 @@ export async function fetchCompanyRelations(): Promise<CapitalRelation[]> {
 // APIから企業市場情報を取得
 export async function fetchCompanyMarketInfo(): Promise<CompanyMarketInfo[]> {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080'}/api/companies/market-info`);
+    const response = await fetch(`${BACKEND_URL}/api/companies/market-info`);
     if (!response.ok) {
       console.warn('Failed to fetch market info');
       return [];

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -1,4 +1,7 @@
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:80'
+import { BACKEND_URL } from './backend-url'
+
+const DEFAULT_INTERVIEW_MAX_MINUTES = 10
+const DEFAULT_INTERVIEW_QUESTION_DURATION_SECONDS = 180
 
 export type InterviewSession = {
   id: number
@@ -217,6 +220,6 @@ export const interviewApi = {
 }
 
 export const interviewLimits = {
-  maxMinutes: Number(process.env.NEXT_PUBLIC_INTERVIEW_MAX_MINUTES || 10),
-  questionDurationSeconds: Number(process.env.NEXT_PUBLIC_INTERVIEW_QUESTION_DURATION_SECONDS || 180),
+  maxMinutes: Number(process.env.NEXT_PUBLIC_INTERVIEW_MAX_MINUTES || DEFAULT_INTERVIEW_MAX_MINUTES),
+  questionDurationSeconds: Number(process.env.NEXT_PUBLIC_INTERVIEW_QUESTION_DURATION_SECONDS || DEFAULT_INTERVIEW_QUESTION_DURATION_SECONDS),
 }

--- a/rag/main.py
+++ b/rag/main.py
@@ -25,14 +25,23 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 # ── 環境変数 ────────────────────────────────────────────────────────────────
-CACHE_TTL_SECONDS = int(os.getenv("RAG_SEARCH_CACHE_TTL_SECONDS", "86400"))
+DEFAULT_CACHE_TTL_SECONDS = 86400
+DEFAULT_MAX_EMBED_TOKENS = 8191
+DEFAULT_EMBED_MAX_RETRIES = 3
+DEFAULT_CHROMA_DATA_DIR = "/app/chroma_db"
+DEFAULT_HINTS_PARSE_MAX_TOKENS = 600
+DEFAULT_RESUME_REVIEW_INPUT_CHAR_LIMIT = 10000
+
+CACHE_TTL_SECONDS = int(os.getenv("RAG_SEARCH_CACHE_TTL_SECONDS", str(DEFAULT_CACHE_TTL_SECONDS)))
 USE_DEEP_RESEARCH = os.getenv("RAG_USE_DEEP_RESEARCH", "true").lower() == "true"
 ALLOW_DDG_FALLBACK = os.getenv("RAG_ALLOW_DUCKDUCKGO_FALLBACK", "true").lower() == "true"
 STRICT_DEEP_RESEARCH = os.getenv("RAG_DEEP_RESEARCH_STRICT", "false").lower() == "true"
 CREWAI_VERBOSE = os.getenv("RAG_CREWAI_VERBOSE", "false").lower() == "true"
-MAX_EMBED_TOKENS = int(os.getenv("RAG_MAX_EMBED_TOKENS", "8191"))
-EMBED_MAX_RETRIES = int(os.getenv("RAG_EMBED_MAX_RETRIES", "3"))
-CHROMA_DATA_DIR = os.getenv("RAG_CHROMA_DATA_DIR", "/app/chroma_db")
+MAX_EMBED_TOKENS = int(os.getenv("RAG_MAX_EMBED_TOKENS", str(DEFAULT_MAX_EMBED_TOKENS)))
+EMBED_MAX_RETRIES = int(os.getenv("RAG_EMBED_MAX_RETRIES", str(DEFAULT_EMBED_MAX_RETRIES)))
+CHROMA_DATA_DIR = os.getenv("RAG_CHROMA_DATA_DIR", DEFAULT_CHROMA_DATA_DIR)
+HINTS_PARSE_MAX_TOKENS = int(os.getenv("RAG_HINTS_PARSE_MAX_TOKENS", str(DEFAULT_HINTS_PARSE_MAX_TOKENS)))
+RESUME_REVIEW_INPUT_CHAR_LIMIT = int(os.getenv("RAG_REVIEW_RESUME_CHAR_LIMIT", str(DEFAULT_RESUME_REVIEW_INPUT_CHAR_LIMIT)))
 
 # ── Chromadb 永続ベクトルストア ────────────────────────────────────────────
 _chroma_client: Optional[chromadb.PersistentClient] = None
@@ -483,7 +492,7 @@ def _parse_hints_from_text(company_name: str, position: str, research_text: str)
                 {"role": "user", "content": user_prompt},
             ],
             temperature=0.2,
-            max_tokens=600,
+            max_tokens=HINTS_PARSE_MAX_TOKENS,
             response_format={"type": "json_object"},
         )
         raw = resp.choices[0].message.content or "{}"
@@ -643,7 +652,7 @@ def review_resume_stream(request: ReviewRequest) -> StreamingResponse:
             company=request.company_name,
             role=role_label,
             context=context_block,
-            resume=request.resume_text[:10000],
+            resume=request.resume_text[:RESUME_REVIEW_INPUT_CHAR_LIMIT],
             source=source_label,
         )
 


### PR DESCRIPTION
Closes #271

## 変更内容
- Frontend に `lib/backend-url.ts` を追加し、`NEXT_PUBLIC_BACKEND_URL` の参照を一元化（`localhost:80` / `localhost:8080` 混在を解消）
- `chat-history/page.tsx` と `lib/company-data.ts` の `localhost` 直書きを共通 `BACKEND_URL` 参照へ変更
- `lib/auth.ts`, `lib/interview.ts`, `app/interview/page.tsx` などのフォールバックURLを統一
- Backend に `internal/config/constants.go` を追加し、OAuth/App URL・認証TTL・学校名・ゲストメールドメイン・会社グラフ閾値を集約
- `oauth.go`, `auth_service.go`, `cmd/server/main.go`, `admin_company_graph_controller.go` のハードコードを設定値参照へ置換
- RAG (`rag/main.py`) の主要数値リテラル（キャッシュTTL、埋め込み設定、ヒント抽出トークン上限、履歴書文字数上限）を定数化し、環境変数で上書き可能に統一
- `.env.example` / `Backend/.env.example` に新規設定値を追記
