### PR TITLE
Resolve #274: フロントエンドの共通コンポーネント化と環境変数参照の統一

### DIFF
--- a/frontend/app/admin/audit-logs/page.tsx
+++ b/frontend/app/admin/audit-logs/page.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import {
-  Alert,
-  Box,
   Card,
   CardContent,
   Divider,
@@ -12,6 +10,9 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { AdminListCard } from '@/components/admin/AdminListCard'
 
 type AuditLog = {
   id: number
@@ -71,7 +72,7 @@ export default function AdminAuditLogsPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
+    <PageContainer maxWidth={1100}>
       <Typography variant="h4" fontWeight="bold" gutterBottom>
         監査ログ
       </Typography>
@@ -79,11 +80,7 @@ export default function AdminAuditLogsPage() {
         管理者操作の履歴を確認できます。
       </Typography>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
 
       <Card sx={{ mb: 3 }}>
         <CardContent>
@@ -109,7 +106,7 @@ export default function AdminAuditLogsPage() {
               </Typography>
             )}
             {filtered.map((log) => (
-              <Box key={log.id} sx={{ border: '1px solid #eee', borderRadius: 1, p: 2 }}>
+              <AdminListCard key={log.id}>
                 <Stack spacing={0.5}>
                   <Typography variant="subtitle2" fontWeight="bold">
                     {log.action}
@@ -124,11 +121,11 @@ export default function AdminAuditLogsPage() {
                     {log.created_at}
                   </Typography>
                 </Stack>
-              </Box>
+              </AdminListCard>
             ))}
           </Stack>
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -6,8 +6,6 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   Chip,
   Divider,
   MenuItem,
@@ -16,6 +14,8 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
 
 const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
 
@@ -156,66 +156,59 @@ export default function AdminCompanyEditPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
-      <Button variant="text" onClick={() => router.back()} sx={{ mb: 2 }}>
-        ← 戻る
-      </Button>
-      <Typography variant="h5" fontWeight="bold" sx={{ mb: 3 }}>
-        技術スタック編集: {name}
-      </Typography>
-
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+    <AdminFormContainer
+      title={`技術スタック編集: ${name}`}
+      maxWidth={800}
+      backLabel="← 戻る"
+      onBack={() => router.back()}
+    >
+      <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+      <Stack spacing={3}>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={handleAiFill}
+          disabled={aiLoading}
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          {aiLoading ? 'AI検索中...' : '🤖 AI自動入力（OpenAI WebSearch）'}
+        </Button>
 
-      <Card>
-        <CardContent>
-          <Stack spacing={3}>
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={handleAiFill}
-              disabled={aiLoading}
-              sx={{ alignSelf: 'flex-start' }}
-            >
-              {aiLoading ? 'AI検索中...' : '🤖 AI自動入力（OpenAI WebSearch）'}
-            </Button>
+        <Divider />
 
-            <Divider />
+        <ChipEditor
+          label="言語・フレームワーク（例: Go, React, TypeScript）"
+          values={techStack}
+          onChange={setTechStack}
+        />
+        <ChipEditor
+          label="インフラ（例: AWS, GCP, Azure, オンプレ）"
+          values={infraStack}
+          onChange={setInfraStack}
+        />
+        <ChipEditor
+          label="CI/CDツール（例: GitHub Actions, Jenkins, CircleCI）"
+          values={cicdTools}
+          onChange={setCicdTools}
+        />
+        <TextField
+          select
+          label="開発手法"
+          value={devStyle}
+          onChange={(e) => setDevStyle(e.target.value)}
+          size="small"
+        >
+          <MenuItem value="">未設定</MenuItem>
+          {DEV_STYLES.map((s) => (
+            <MenuItem key={s} value={s}>{s}</MenuItem>
+          ))}
+        </TextField>
 
-            <ChipEditor
-              label="言語・フレームワーク（例: Go, React, TypeScript）"
-              values={techStack}
-              onChange={setTechStack}
-            />
-            <ChipEditor
-              label="インフラ（例: AWS, GCP, Azure, オンプレ）"
-              values={infraStack}
-              onChange={setInfraStack}
-            />
-            <ChipEditor
-              label="CI/CDツール（例: GitHub Actions, Jenkins, CircleCI）"
-              values={cicdTools}
-              onChange={setCicdTools}
-            />
-            <TextField
-              select
-              label="開発手法"
-              value={devStyle}
-              onChange={(e) => setDevStyle(e.target.value)}
-              size="small"
-            >
-              <MenuItem value="">未設定</MenuItem>
-              {DEV_STYLES.map((s) => (
-                <MenuItem key={s} value={s}>{s}</MenuItem>
-              ))}
-            </TextField>
-
-            <Button variant="contained" onClick={handleSave} sx={{ alignSelf: 'flex-end' }}>
-              保存
-            </Button>
-          </Stack>
-        </CardContent>
-      </Card>
-    </Box>
+        <Button variant="contained" onClick={handleSave} sx={{ alignSelf: 'flex-end' }}>
+          保存
+        </Button>
+      </Stack>
+    </AdminFormContainer>
   )
 }

--- a/frontend/app/admin/companies/new/page.tsx
+++ b/frontend/app/admin/companies/new/page.tsx
@@ -3,17 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
-  Alert,
-  Box,
   Button,
-  Card,
-  CardContent,
   MenuItem,
-  Stack,
   TextField,
-  Typography,
+  Stack,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
 
 export default function AdminCompanyNewPage() {
   const router = useRouter()
@@ -64,54 +61,36 @@ export default function AdminCompanyNewPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 700, mx: 'auto' }}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
-        <Typography variant="h4" fontWeight="bold">
-          企業の追加
-        </Typography>
-        <Button variant="outlined" size="small" onClick={() => router.push('/admin/companies')}>
-          一覧に戻る
+    <AdminFormContainer title="企業の追加" maxWidth={700} backHref="/admin/companies" backLabel="一覧に戻る">
+      <ErrorAlert error={error} />
+      <Stack spacing={2}>
+        <TextField label="企業名" value={name} onChange={(e) => setName(e.target.value)} required />
+        <TextField label="業種" value={industry} onChange={(e) => setIndustry(e.target.value)} />
+        <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
+        <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
+        <TextField select label="出典タイプ" value={sourceType} onChange={(e) => setSourceType(e.target.value)}>
+          <MenuItem value="official">公式サイト</MenuItem>
+          <MenuItem value="job_site">就活/転職サイト</MenuItem>
+          <MenuItem value="manual">手入力</MenuItem>
+        </TextField>
+        <TextField label="出典URL" value={sourceUrl} onChange={(e) => setSourceUrl(e.target.value)} />
+        <TextField select label="ステータス" value={dataStatus} onChange={(e) => setDataStatus(e.target.value)}>
+          <MenuItem value="draft">下書き</MenuItem>
+          <MenuItem value="published">公開</MenuItem>
+        </TextField>
+        <TextField
+          select
+          label="暫定データ"
+          value={isProvisional ? 'yes' : 'no'}
+          onChange={(e) => setIsProvisional(e.target.value === 'yes')}
+        >
+          <MenuItem value="yes">暫定</MenuItem>
+          <MenuItem value="no">確定</MenuItem>
+        </TextField>
+        <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>
+          追加する
         </Button>
       </Stack>
-
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      <Card>
-        <CardContent>
-          <Stack spacing={2}>
-            <TextField label="企業名" value={name} onChange={(e) => setName(e.target.value)} required />
-            <TextField label="業種" value={industry} onChange={(e) => setIndustry(e.target.value)} />
-            <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
-            <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
-            <TextField select label="出典タイプ" value={sourceType} onChange={(e) => setSourceType(e.target.value)}>
-              <MenuItem value="official">公式サイト</MenuItem>
-              <MenuItem value="job_site">就活/転職サイト</MenuItem>
-              <MenuItem value="manual">手入力</MenuItem>
-            </TextField>
-            <TextField label="出典URL" value={sourceUrl} onChange={(e) => setSourceUrl(e.target.value)} />
-            <TextField select label="ステータス" value={dataStatus} onChange={(e) => setDataStatus(e.target.value)}>
-              <MenuItem value="draft">下書き</MenuItem>
-              <MenuItem value="published">公開</MenuItem>
-            </TextField>
-            <TextField
-              select
-              label="暫定データ"
-              value={isProvisional ? 'yes' : 'no'}
-              onChange={(e) => setIsProvisional(e.target.value === 'yes')}
-            >
-              <MenuItem value="yes">暫定</MenuItem>
-              <MenuItem value="no">確定</MenuItem>
-            </TextField>
-            <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>
-              追加する
-            </Button>
-          </Stack>
-        </CardContent>
-      </Card>
-    </Box>
+    </AdminFormContainer>
   )
 }

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -15,6 +14,10 @@ import {
   Pagination,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { AdminListCard } from '@/components/admin/AdminListCard'
+import { StatusBadge } from '@/components/admin/StatusBadge'
 
 const PAGE_SIZE = 50
 
@@ -26,11 +29,6 @@ type Company = {
   source_type?: string
   is_provisional?: boolean
   data_status?: string
-}
-
-const statusBadge = (status?: string) => {
-  if (status === 'published') return <Chip label="公開" color="success" size="small" />
-  return <Chip label="下書き" color="warning" size="small" />
 }
 
 const sourceLabel = (sourceType?: string) => {
@@ -111,7 +109,7 @@ export default function AdminCompaniesPage() {
   const pageCount = Math.ceil(total / PAGE_SIZE)
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1000, mx: 'auto' }}>
+    <PageContainer maxWidth={1000}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Typography variant="h4" fontWeight="bold">
           企業管理
@@ -132,11 +130,7 @@ export default function AdminCompaniesPage() {
         企業情報の公開ステータスを管理します。（全 {total.toLocaleString()} 件）
       </Typography>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
 
       <Card>
         <CardContent>
@@ -158,14 +152,14 @@ export default function AdminCompaniesPage() {
           <Divider sx={{ mb: 2 }} />
           <Stack spacing={1}>
             {filteredCompanies.map((company) => (
-              <Box key={company.id} sx={{ border: '1px solid #eee', borderRadius: 1, p: 2 }}>
+              <AdminListCard key={company.id}>
                 <Stack direction="row" alignItems="center" justifyContent="space-between">
                   <Box>
                     <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
                       <Typography variant="subtitle1" fontWeight="bold">
                         {company.name}
                       </Typography>
-                      {statusBadge(company.data_status)}
+                      <StatusBadge status={company.data_status} />
                       <Chip label={sourceLabel(company.source_type)} size="small" variant="outlined" />
                       {company.is_provisional && (
                         <Chip label="暫定" size="small" color="default" variant="outlined" />
@@ -206,7 +200,7 @@ export default function AdminCompaniesPage() {
                     )}
                   </Stack>
                 </Stack>
-              </Box>
+              </AdminListCard>
             ))}
           </Stack>
 
@@ -222,6 +216,6 @@ export default function AdminCompaniesPage() {
           )}
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/graduate-employments/new/page.tsx
+++ b/frontend/app/admin/graduate-employments/new/page.tsx
@@ -3,17 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
-  Alert,
-  Box,
   Button,
-  Card,
-  CardContent,
   MenuItem,
   Stack,
   TextField,
-  Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
 
 type Company = { id: number; name: string }
 type JobPosition = { id: number; title: string; company?: Company }
@@ -70,44 +67,35 @@ export default function AdminGraduateEmploymentNewPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 700, mx: 'auto' }}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
-        <Typography variant="h4" fontWeight="bold">
-          就職情報の登録
-        </Typography>
-        <Button variant="outlined" size="small" onClick={() => router.push('/admin/graduate-employments')}>
-          一覧に戻る
+    <AdminFormContainer
+      title="就職情報の登録"
+      maxWidth={700}
+      backHref="/admin/graduate-employments"
+      backLabel="一覧に戻る"
+    >
+      <ErrorAlert error={error} />
+      <Stack spacing={2}>
+        <TextField select label="企業" value={companyId} onChange={(e) => setCompanyId(e.target.value)} required>
+          {companies.map((c) => (
+            <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
+          ))}
+        </TextField>
+        <TextField select label="応募職種" value={jobPositionId} onChange={(e) => setJobPositionId(e.target.value)}>
+          <MenuItem value="">未設定</MenuItem>
+          {jobPositions.map((p) => (
+            <MenuItem key={p.id} value={p.id}>{p.title} ({p.company?.name || '企業未設定'})</MenuItem>
+          ))}
+        </TextField>
+        <TextField label="卒業生氏名" value={graduateName} onChange={(e) => setGraduateName(e.target.value)} />
+        <TextField label="卒業年度" value={graduationYear} onChange={(e) => setGraduationYear(e.target.value)} type="number" />
+        <TextField label="学校名" value={schoolName} onChange={(e) => setSchoolName(e.target.value)} />
+        <TextField label="学科/専攻" value={department} onChange={(e) => setDepartment(e.target.value)} />
+        <TextField label="就職日 (YYYY-MM-DD)" value={hiredAt} onChange={(e) => setHiredAt(e.target.value)} />
+        <TextField label="メモ" value={note} onChange={(e) => setNote(e.target.value)} multiline minRows={2} />
+        <Button variant="contained" onClick={handleCreate} disabled={!companyId}>
+          登録する
         </Button>
       </Stack>
-
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-
-      <Card>
-        <CardContent>
-          <Stack spacing={2}>
-            <TextField select label="企業" value={companyId} onChange={(e) => setCompanyId(e.target.value)} required>
-              {companies.map((c) => (
-                <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
-              ))}
-            </TextField>
-            <TextField select label="応募職種" value={jobPositionId} onChange={(e) => setJobPositionId(e.target.value)}>
-              <MenuItem value="">未設定</MenuItem>
-              {jobPositions.map((p) => (
-                <MenuItem key={p.id} value={p.id}>{p.title} ({p.company?.name || '企業未設定'})</MenuItem>
-              ))}
-            </TextField>
-            <TextField label="卒業生氏名" value={graduateName} onChange={(e) => setGraduateName(e.target.value)} />
-            <TextField label="卒業年度" value={graduationYear} onChange={(e) => setGraduationYear(e.target.value)} type="number" />
-            <TextField label="学校名" value={schoolName} onChange={(e) => setSchoolName(e.target.value)} />
-            <TextField label="学科/専攻" value={department} onChange={(e) => setDepartment(e.target.value)} />
-            <TextField label="就職日 (YYYY-MM-DD)" value={hiredAt} onChange={(e) => setHiredAt(e.target.value)} />
-            <TextField label="メモ" value={note} onChange={(e) => setNote(e.target.value)} multiline minRows={2} />
-            <Button variant="contained" onClick={handleCreate} disabled={!companyId}>
-              登録する
-            </Button>
-          </Stack>
-        </CardContent>
-      </Card>
-    </Box>
+    </AdminFormContainer>
   )
 }

--- a/frontend/app/admin/graduate-employments/page.tsx
+++ b/frontend/app/admin/graduate-employments/page.tsx
@@ -12,6 +12,8 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { AdminListCard } from '@/components/admin/AdminListCard'
 
 type GraduateEmployment = {
   id: number
@@ -47,7 +49,7 @@ export default function AdminGraduateEmploymentsPage() {
   }, [])
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1000, mx: 'auto' }}>
+    <PageContainer maxWidth={1000}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Typography variant="h4" fontWeight="bold">
           卒業生の就職情報管理
@@ -81,7 +83,7 @@ export default function AdminGraduateEmploymentsPage() {
               </Typography>
             ) : (
               graduateEntries.map((entry) => (
-                <Box key={entry.id} sx={{ border: '1px solid #eee', borderRadius: 1, p: 2 }}>
+                <AdminListCard key={entry.id}>
                   <Stack direction="row" alignItems="center" justifyContent="space-between">
                     <Box>
                       <Typography variant="subtitle2" fontWeight="bold">
@@ -106,12 +108,12 @@ export default function AdminGraduateEmploymentsPage() {
                       編集
                     </Button>
                   </Stack>
-                </Box>
+                </AdminListCard>
               ))
             )}
           </Stack>
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/interviews/page.tsx
+++ b/frontend/app/admin/interviews/page.tsx
@@ -3,23 +3,22 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import {
-  Alert,
-  Box,
   Button,
   Card,
   CardContent,
-  Chip,
   Divider,
-  Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TablePagination,
   TableRow,
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { AdminTableWrapper } from '@/components/admin/AdminTableWrapper'
+import { StatusBadge } from '@/components/admin/StatusBadge'
 
 type InterviewSession = {
   id: number
@@ -84,7 +83,7 @@ export default function AdminInterviewsPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1200, mx: 'auto' }}>
+    <PageContainer maxWidth={1200}>
       <Typography variant="h4" fontWeight="bold" gutterBottom>
         面接管理
       </Typography>
@@ -92,11 +91,7 @@ export default function AdminInterviewsPage() {
         全ユーザーの面接セッション一覧です。動画を確認するには詳細ページを開いてください。
       </Typography>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
 
       <Card>
         <CardContent>
@@ -110,8 +105,7 @@ export default function AdminInterviewsPage() {
             </Typography>
           ) : (
             <>
-              <TableContainer>
-                <Table size="small">
+              <AdminTableWrapper>
                   <TableHead>
                     <TableRow>
                       <TableCell>ID</TableCell>
@@ -134,7 +128,7 @@ export default function AdminInterviewsPage() {
                           <TableCell>{session.company_name || '—'}</TableCell>
                           <TableCell>{session.position || '—'}</TableCell>
                           <TableCell>
-                            <Chip label={st.label} color={st.color} size="small" />
+                            <StatusBadge status={session.status} fallbackLabel={st.label} />
                           </TableCell>
                           <TableCell>
                             {session.started_at
@@ -158,8 +152,7 @@ export default function AdminInterviewsPage() {
                       )
                     })}
                   </TableBody>
-                </Table>
-              </TableContainer>
+              </AdminTableWrapper>
               <TablePagination
                 component="div"
                 count={total}
@@ -175,6 +168,6 @@ export default function AdminInterviewsPage() {
           )}
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/job-positions/page.tsx
+++ b/frontend/app/admin/job-positions/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -20,6 +19,10 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { AdminListCard } from '@/components/admin/AdminListCard'
+import { StatusBadge } from '@/components/admin/StatusBadge'
 
 type JobPosition = {
   id: number
@@ -44,12 +47,6 @@ type JobPosition = {
     is_provisional?: boolean
   }
   job_category?: { id: number; name: string }
-}
-
-const statusBadge = (status?: string) => {
-  if (status === 'published') return <Chip label="公開" color="success" size="small" />
-  if (status === 'rejected') return <Chip label="却下" color="error" size="small" />
-  return <Chip label="審査中" color="warning" size="small" />
 }
 
 const formatDate = (dateStr?: string) => {
@@ -84,14 +81,14 @@ function JobPositionCard({
   const hasCrawlInfo = !!(position.company?.source_url || position.company?.source_fetched_at || position.description || position.min_salary || reqSkills.length || prefSkills.length)
 
   return (
-    <Box sx={{ border: '1px solid #e0e0e0', borderRadius: 1, p: 2 }}>
+    <AdminListCard>
       <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1}>
         <Box flex={1} minWidth={0}>
           <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ mb: 0.5 }}>
             <Typography variant="subtitle1" fontWeight="bold">
               {position.title}
             </Typography>
-            {statusBadge(position.data_status)}
+            <StatusBadge status={position.data_status || 'draft'} fallbackLabel="審査中" />
             {position.company?.is_provisional && (
               <Chip label="仮登録" size="small" variant="outlined" color="warning" />
             )}
@@ -228,7 +225,7 @@ function JobPositionCard({
           )}
         </Stack>
       </Collapse>
-    </Box>
+    </AdminListCard>
   )
 }
 
@@ -288,7 +285,7 @@ export default function AdminJobPositionsPage() {
   })
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1000, mx: 'auto' }}>
+    <PageContainer maxWidth={1000}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Typography variant="h4" fontWeight="bold">
           求人管理
@@ -309,11 +306,7 @@ export default function AdminJobPositionsPage() {
         クローリングで取得した求人情報を審査・公開します。各求人の▼ボタンでクロール元URL・スキル・職務内容を確認できます。
       </Typography>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
 
       <Card>
         <CardContent>
@@ -356,6 +349,6 @@ export default function AdminJobPositionsPage() {
           </Stack>
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -2,18 +2,14 @@
 
 import { useEffect, useState } from 'react'
 import {
-  Alert,
-  Box,
   Button,
   Card,
   CardContent,
   Chip,
   Divider,
   Stack,
-  Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TablePagination,
   TableRow,
@@ -21,6 +17,9 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { PageContainer } from '@/components/admin/PageContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { AdminTableWrapper } from '@/components/admin/AdminTableWrapper'
 
 type AdminUser = {
   id: number
@@ -109,7 +108,7 @@ export default function AdminUsersPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
+    <PageContainer maxWidth={1100}>
       <Typography variant="h4" fontWeight="bold" gutterBottom>
         ユーザー管理
       </Typography>
@@ -117,11 +116,7 @@ export default function AdminUsersPage() {
         管理者権限の付与やユーザー情報の確認を行います。
       </Typography>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
 
       <Card sx={{ mb: 3 }}>
         <CardContent>
@@ -148,8 +143,7 @@ export default function AdminUsersPage() {
             </Typography>
           ) : (
             <>
-              <TableContainer>
-                <Table size="small">
+              <AdminTableWrapper>
                   <TableHead>
                     <TableRow>
                       <TableCell>ユーザー</TableCell>
@@ -194,8 +188,7 @@ export default function AdminUsersPage() {
                       </TableRow>
                     ))}
                   </TableBody>
-                </Table>
-              </TableContainer>
+              </AdminTableWrapper>
               <TablePagination
                 component="div"
                 count={total}
@@ -211,6 +204,6 @@ export default function AdminUsersPage() {
           )}
         </CardContent>
       </Card>
-    </Box>
+    </PageContainer>
   )
 }

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { Box, Container, Typography, Paper, List, ListItem, ListItemButton, ListItemText, Divider, CircularProgress, Button } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { authService } from '@/lib/auth'
-import { BACKEND_URL } from '@/lib/backend-url'
+import { BACKEND_URL } from '@/lib/config'
 import ChatIcon from '@mui/icons-material/Chat'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 

--- a/frontend/components/admin/AdminFormContainer.tsx
+++ b/frontend/components/admin/AdminFormContainer.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import { Button, Card, CardContent, Stack, Typography } from '@mui/material'
+import { type ReactNode } from 'react'
+import { PageContainer } from './PageContainer'
+
+type AdminFormContainerProps = {
+  title: string
+  children: ReactNode
+  maxWidth?: number
+  backHref?: string
+  backLabel?: string
+  onBack?: () => void
+}
+
+export function AdminFormContainer({
+  title,
+  children,
+  maxWidth = 700,
+  backHref,
+  backLabel = '一覧に戻る',
+  onBack,
+}: AdminFormContainerProps) {
+  return (
+    <PageContainer maxWidth={maxWidth}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
+        <Typography variant="h4" fontWeight="bold">
+          {title}
+        </Typography>
+        {onBack ? (
+          <Button variant="outlined" size="small" onClick={onBack}>
+            {backLabel}
+          </Button>
+        ) : (
+          backHref && (
+            <Button variant="outlined" size="small" component={Link} href={backHref}>
+              {backLabel}
+            </Button>
+          )
+        )}
+      </Stack>
+      <Card>
+        <CardContent>{children}</CardContent>
+      </Card>
+    </PageContainer>
+  )
+}
+

--- a/frontend/components/admin/AdminListCard.tsx
+++ b/frontend/components/admin/AdminListCard.tsx
@@ -1,0 +1,21 @@
+import { Box, type BoxProps } from '@mui/material'
+
+export const ADMIN_CARD_BORDER = '1px solid #e0e0e0'
+
+type AdminListCardProps = BoxProps
+
+export function AdminListCard({ sx, children, ...rest }: AdminListCardProps) {
+  const sxList = Array.isArray(sx) ? sx : [sx]
+  return (
+    <Box
+      {...rest}
+      sx={[
+        { border: ADMIN_CARD_BORDER, borderRadius: 1, p: 2 },
+        ...sxList,
+      ]}
+    >
+      {children}
+    </Box>
+  )
+}
+

--- a/frontend/components/admin/AdminTableWrapper.tsx
+++ b/frontend/components/admin/AdminTableWrapper.tsx
@@ -1,0 +1,19 @@
+import { Table, TableContainer, type TableContainerProps, type TableProps } from '@mui/material'
+import { type ReactNode } from 'react'
+
+type AdminTableWrapperProps = {
+  children: ReactNode
+  tableProps?: TableProps
+  containerProps?: TableContainerProps
+}
+
+export function AdminTableWrapper({ children, tableProps, containerProps }: AdminTableWrapperProps) {
+  return (
+    <TableContainer {...containerProps}>
+      <Table size="small" {...tableProps}>
+        {children}
+      </Table>
+    </TableContainer>
+  )
+}
+

--- a/frontend/components/admin/PageContainer.tsx
+++ b/frontend/components/admin/PageContainer.tsx
@@ -1,0 +1,21 @@
+import { Box, type BoxProps } from '@mui/material'
+
+type PageContainerProps = Omit<BoxProps, 'maxWidth'> & {
+  maxWidth?: number | string
+}
+
+export function PageContainer({ maxWidth = 1000, sx, children, ...rest }: PageContainerProps) {
+  const sxList = Array.isArray(sx) ? sx : [sx]
+  return (
+    <Box
+      {...rest}
+      sx={[
+        { p: 4, maxWidth, mx: 'auto' },
+        ...sxList,
+      ]}
+    >
+      {children}
+    </Box>
+  )
+}
+

--- a/frontend/components/admin/StatusBadge.tsx
+++ b/frontend/components/admin/StatusBadge.tsx
@@ -1,0 +1,21 @@
+import { Chip } from '@mui/material'
+
+const STATUS_CONFIG: Record<string, { label: string; color: 'default' | 'primary' | 'success' | 'warning' | 'error' }> = {
+  draft: { label: '下書き', color: 'warning' },
+  published: { label: '公開', color: 'success' },
+  rejected: { label: '却下', color: 'error' },
+  created: { label: '作成済み', color: 'default' },
+  started: { label: '進行中', color: 'primary' },
+  finished: { label: '完了', color: 'success' },
+  error: { label: 'エラー', color: 'error' },
+}
+
+export function StatusBadge({ status, fallbackLabel = '下書き' }: { status?: string; fallbackLabel?: string }) {
+  const normalized = status ?? 'draft'
+  const config = STATUS_CONFIG[normalized]
+  if (config) {
+    return <Chip label={config.label} color={config.color} size="small" />
+  }
+  return <Chip label={status || fallbackLabel} color="default" size="small" />
+}
+

--- a/frontend/components/common/ErrorAlert.tsx
+++ b/frontend/components/common/ErrorAlert.tsx
@@ -1,0 +1,16 @@
+import { Alert, type AlertProps } from '@mui/material'
+
+type ErrorAlertProps = Omit<AlertProps, 'severity' | 'children'> & {
+  error?: string | null
+}
+
+export function ErrorAlert({ error, sx, ...rest }: ErrorAlertProps) {
+  if (!error) return null
+  const sxList = Array.isArray(sx) ? sx : [sx]
+  return (
+    <Alert severity="error" {...rest} sx={[{ mb: 2 }, ...sxList]}>
+      {error}
+    </Alert>
+  )
+}
+

--- a/frontend/lib/backend-url.ts
+++ b/frontend/lib/backend-url.ts
@@ -1,3 +1,1 @@
-export const DEFAULT_BACKEND_URL = 'http://localhost:8080'
-
-export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || DEFAULT_BACKEND_URL
+export { BACKEND_URL, DEFAULT_BACKEND_URL } from './config'

--- a/frontend/lib/company-data.ts
+++ b/frontend/lib/company-data.ts
@@ -1,4 +1,4 @@
-import { BACKEND_URL } from './backend-url';
+import { BACKEND_URL } from './config';
 
 // 企業データの型定義
 export type MarketType = 'prime' | 'standard' | 'growth' | 'unlisted';

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_BACKEND_URL = 'http://localhost:8080'
+
+export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || DEFAULT_BACKEND_URL
+


### PR DESCRIPTION
Closes #274

## 変更内容
- 管理画面の重複UIを共通コンポーネント化しました（`PageContainer`、`AdminListCard`、`AdminFormContainer`、`StatusBadge`、`AdminTableWrapper`、`ErrorAlert` を追加）。
- `admin/companies`、`admin/job-positions`、`admin/graduate-employments`、`admin/users`、`admin/interviews`、`admin/audit-logs` および新規作成/編集フォームで共通コンポーネントを適用し、同一パターンの実装を整理しました。
- 環境変数参照を `frontend/lib/config.ts` に集約し、`backend-url.ts` は再エクスポートに変更しました。
- `chat-history` と `company-data` のバックエンドURL参照を `config` 経由に統一しました。
