### PR TITLE
fix: 共有ショートカットを他環境でも使えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [環境変数](#環境変数)
 - [ローカル開発](#ローカル開発)
 - [Docker Compose](#docker-compose)
+- [Copilot カスタムコマンド共有](#copilot-カスタムコマンド共有)
 - [主要APIエンドポイント](#主要apiエンドポイント)
 - [品質管理](#品質管理)
 - [よくあるトラブル](#よくあるトラブル)
@@ -267,6 +268,36 @@ docker compose --profile rag up -d rag-review
 | `frontend` | Next.js | 3000 |
 | `rag-review` | 職務経歴書 RAG | 9000 |
 | `company-graph` | 企業スクレイピング | 9100 |
+
+---
+
+## Copilot カスタムコマンド共有
+
+チームで同じCopilotカスタムコマンドを使う場合は、リポジトリ内の以下を共通利用します。
+
+- Prompt定義: `.github/prompts/*.prompt.md`
+- 呼び出しスクリプト: `scripts/copilot-shortcuts.sh`
+
+### 初回セットアップ
+
+方法1（推奨）: 関数として読み込む
+
+```sh
+source scripts/copilot-shortcuts.sh
+```
+
+方法2: 直接実行する（`source` 不要）
+
+```sh
+./scripts/copilot-shortcuts.sh issue "管理者画面に監査ログ検索を追加したい"
+./scripts/copilot-shortcuts.sh implement "123"
+./scripts/copilot-shortcuts.sh pr "123"
+```
+
+### うまく動かない場合
+
+- `cissue: command not found`: `source scripts/copilot-shortcuts.sh` が未実行です。
+- `Permission denied`: `chmod +x scripts/copilot-shortcuts.sh` を実行してください。
 
 ---
 

--- a/scripts/copilot-shortcuts.sh
+++ b/scripts/copilot-shortcuts.sh
@@ -1,36 +1,110 @@
 #!/usr/bin/env bash
 
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PROMPT_DIR="$PROJECT_ROOT/.copilot/prompts"
+get_script_path() {
+  if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    printf '%s\n' "${BASH_SOURCE[0]}"
+  elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    printf '%s\n' "${(%):-%N}"
+  else
+    printf '%s\n' "$0"
+  fi
+}
+
+SCRIPT_PATH="$(get_script_path)"
+PROJECT_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
+PROMPT_DIR="$PROJECT_ROOT/.github/prompts"
+
+copilot_shortcuts_usage() {
+  cat <<'EOF'
+Usage:
+  source scripts/copilot-shortcuts.sh
+  cissue "..."
+  cimpl "123"
+  cpr "123"
+
+Or run directly:
+  ./scripts/copilot-shortcuts.sh issue "..."
+  ./scripts/copilot-shortcuts.sh implement "123"
+  ./scripts/copilot-shortcuts.sh pr "123"
+EOF
+}
+
+run_copilot_prompt() {
+  local prompt_file="$1"
+  local header="$2"
+  local task="$3"
+
+  if ! command -v copilot >/dev/null 2>&1; then
+    echo "copilot command not found. Install GitHub Copilot CLI first." >&2
+    return 1
+  fi
+
+  if [[ ! -f "$PROMPT_DIR/$prompt_file" ]]; then
+    echo "Prompt file not found: $PROMPT_DIR/$prompt_file" >&2
+    return 1
+  fi
+
+  copilot -p "$(cat "$PROMPT_DIR/$prompt_file")
+
+$header:
+$task"
+}
 
 cplan() {
-  local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/plan.md")
-
-対象タスク:
-$task"
+  local task="${*:-対象タスクを入力してください。}"
+  run_copilot_prompt "plan.prompt.md" "対象タスク" "$task"
 }
 
 creview() {
   local task="${*:-現在の変更内容をレビューしてください。}"
-  copilot -p "$(cat "$PROMPT_DIR/pr-review.md")
-
-レビュー対象:
-$task"
+  run_copilot_prompt "pr-review.prompt.md" "レビュー対象" "$task"
 }
 
 cissue() {
   local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/issue.md")
-
-Issue化したい内容:
-$task"
+  run_copilot_prompt "issue.prompt.md" "Issue化したい内容" "$task"
 }
 
 cimpl() {
   local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/implement.md")
-
-実装したい内容:
-$task"
+  run_copilot_prompt "implement.prompt.md" "実装したい内容" "$task"
 }
+
+cpr() {
+  local task="$*"
+  run_copilot_prompt "pr.prompt.md" "PR作成したいIssue番号" "$task"
+}
+
+copilot_shortcuts_main() {
+  local subcommand="$1"
+  if [[ $# -gt 0 ]]; then
+    shift
+  fi
+
+  case "$subcommand" in
+    issue) cissue "$*" ;;
+    implement) cimpl "$*" ;;
+    pr) cpr "$*" ;;
+    plan) cplan "$*" ;;
+    review) creview "$*" ;;
+    ""|-h|--help|help)
+      copilot_shortcuts_usage
+      ;;
+    *)
+      echo "Unknown subcommand: $subcommand" >&2
+      copilot_shortcuts_usage >&2
+      return 1
+      ;;
+  esac
+}
+
+is_sourced=0
+if [[ -n "${ZSH_VERSION:-}" ]]; then
+  [[ "${ZSH_EVAL_CONTEXT:-}" == *:file* ]] && is_sourced=1
+elif [[ -n "${BASH_VERSION:-}" ]]; then
+  [[ "${BASH_SOURCE[0]}" != "$0" ]] && is_sourced=1
+fi
+
+if [[ "$is_sourced" -eq 0 ]]; then
+  copilot_shortcuts_main "$@"
+fi


### PR DESCRIPTION
## 変更内容
- `scripts/copilot-shortcuts.sh` を `.github/prompts/*.prompt.md` を参照するよう修正
- `cpr` を追加し、`issue` / `implement` / `pr` の直接実行に対応
- `source` 利用時（bash/zsh）でも関数定義のみ行われるよう判定処理を追加
- `copilot` 未導入時とPrompt未存在時のエラーメッセージを追加
- スクリプトに実行権限を付与（`100755`）
- `README.md` にチーム共有手順（source方式 / 直接実行方式 / トラブルシュート）を追記
- `README.md` のトラブルシュートに「source しても使えない場合」の原因（bash/zsh以外・別プロセス実行）と確認手順を追加
