### PR TITLE
docs: Copilot CLI向けカスタム指示運用を明確化

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# SOC AI Agent - Repository-wide Copilot instructions
+
+このリポジトリでは、以下を優先して提案・実装してください。
+
+## 基本方針
+- 既存の構成と規約を尊重し、変更は最小限かつ根本原因に対処する。
+- コメント・コミットメッセージは日本語を基本とする。
+- 文字コードは UTF-8 / 改行は LF。
+
+## アーキテクチャ理解
+- FE(Next.js) -> BE(Go) -> RAG(Python) の構成。
+- Backend は DDD 構成（Controller -> Service -> Repository -> GORM Model）を維持する。
+
+## 実装時の規約
+- Go/TypeScript は camelCase、Python は snake_case。
+- Frontend は型安全を優先し、`any` を避ける。
+- RAG 実装は型ヒント、Pydantic、`logging` を使う。
+- APIキー等の秘密情報はコードやログに出力しない。
+
+## 主要コマンド
+- Backend: `cd Backend && go run ./cmd/server`
+- Frontend: `cd frontend && npm run dev`
+- RAG: `cd rag && pip install -r constraints.txt && python3 main.py`
+- Docker: `docker compose up -d`（必要に応じて `--profile rag`）
+
+## レビュー観点
+- 仕様との整合性、型安全性、エラーハンドリング、既存テストへの影響を重視する。
+- 関連ドキュメント（README / docs/wiki）を必要に応じて更新する。

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "Backend/**/*.go"
+---
+
+Backend の変更では、DDD の層分離（Controller / Service / Repository / Model）を維持してください。
+ユースケース実装は Service 層に寄せ、Repository 層にビジネスロジックを混在させないでください。
+エラー処理は `errors.Is/As` を意識し、曖昧な握りつぶしを避けてください。
+

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "frontend/**/*.{ts,tsx}"
+---
+
+Frontend の変更では型安全を最優先し、`any` は避けてください。
+Next.js App Router と既存の MUI ベースUIのパターンに合わせて実装してください。
+副作用は Hooks に閉じ込め、表示ロジックとデータ処理を分離してください。
+

--- a/.github/instructions/rag.instructions.md
+++ b/.github/instructions/rag.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "rag/**/*.py"
+---
+
+RAG 側の変更では Python 3.10+ の型ヒントを付与してください。
+入力/出力の検証は Pydantic を優先し、ログは `logging` を利用してください。
+依存関係追加時は `rag/constraints.txt` を前提に整合性を保ってください。
+

--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ source scripts/copilot-shortcuts.sh
 ### うまく動かない場合
 
 - `cissue: command not found`: `source scripts/copilot-shortcuts.sh` が未実行です。
+- `source` したのに `cissue` が見つからない:
+  - `echo $SHELL` で bash / zsh 以外（例: fish）の場合、`source` で関数が読み込まれません。
+  - `bash -c "source ..."` のように別プロセスで実行すると、現在のシェルには反映されません。
+  - 同じターミナルで次を順に実行して確認してください。
+    ```sh
+    source scripts/copilot-shortcuts.sh
+    type cissue
+    ```
 - `Permission denied`: `chmod +x scripts/copilot-shortcuts.sh scripts/cissue scripts/cimpl scripts/cpr` を実行してください。
 
 ---

--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ docker compose --profile rag up -d rag-review
 
 - Prompt定義: `.github/prompts/*.prompt.md`
 - 呼び出しスクリプト: `scripts/copilot-shortcuts.sh`
+- Copilot共通指示: `.github/copilot-instructions.md`
+- パス別指示: `.github/instructions/*.instructions.md`
+
+> **注意 (Copilot CLI)**  
+> 現在の Copilot CLI では、任意の `.github/prompts/*` を `/issue` のような**独自スラッシュコマンドとして `/` メニューに表示する機能はありません**。  
+> そのため本リポジトリでは、`scripts/cissue` / `scripts/cimpl` / `scripts/cpr` を共通実行入口として提供しています。
 
 ### 初回セットアップ
 
@@ -302,6 +308,14 @@ source scripts/copilot-shortcuts.sh
 ./scripts/cpr "123"
 ```
 
+WSL ユーザーは実行権限の差異を避けるため、次の形式を推奨します。
+
+```sh
+bash scripts/cissue "管理者画面に監査ログ検索を追加したい"
+bash scripts/cimpl "123"
+bash scripts/cpr "123"
+```
+
 ### うまく動かない場合
 
 - `cissue: command not found`: `source scripts/copilot-shortcuts.sh` が未実行です。
@@ -314,6 +328,13 @@ source scripts/copilot-shortcuts.sh
     type cissue
     ```
 - `Permission denied`: `chmod +x scripts/copilot-shortcuts.sh scripts/cissue scripts/cimpl scripts/cpr` を実行してください。
+- WSL で `./scripts/...` が失敗する: 実行権限やマウント設定の影響があるため、`bash scripts/cissue "..."` 形式で実行してください。
+
+### Copilotカスタム指示（どの環境でも共通化）
+
+- 本リポジトリでは GitHub 公式仕様に合わせて `.github/copilot-instructions.md` を配置しています。
+- 追加で、`Backend` / `frontend` / `rag` 向けのパス別指示を `.github/instructions/*.instructions.md` に配置しています。
+- これらはリポジトリに含まれるため、`git pull` 後の各環境で同じ指示が自動的に使われます。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -294,10 +294,18 @@ source scripts/copilot-shortcuts.sh
 ./scripts/copilot-shortcuts.sh pr "123"
 ```
 
+方法3: pull 後にすぐ使えるラッパーを実行する（`source` 不要）
+
+```sh
+./scripts/cissue "管理者画面に監査ログ検索を追加したい"
+./scripts/cimpl "123"
+./scripts/cpr "123"
+```
+
 ### うまく動かない場合
 
 - `cissue: command not found`: `source scripts/copilot-shortcuts.sh` が未実行です。
-- `Permission denied`: `chmod +x scripts/copilot-shortcuts.sh` を実行してください。
+- `Permission denied`: `chmod +x scripts/copilot-shortcuts.sh scripts/cissue scripts/cimpl scripts/cpr` を実行してください。
 
 ---
 

--- a/scripts/cimpl
+++ b/scripts/cimpl
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/copilot-shortcuts.sh" implement "$@"

--- a/scripts/cissue
+++ b/scripts/cissue
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/copilot-shortcuts.sh" issue "$@"

--- a/scripts/cpr
+++ b/scripts/cpr
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/copilot-shortcuts.sh" pr "$@"


### PR DESCRIPTION
## 変更内容
- `.github/copilot-instructions.md` を追加し、リポジトリ全体の Copilot CLI 指示を明文化
- `.github/instructions/*.instructions.md` を追加し、Backend / frontend / rag のパス別指示を整備
- `.gitattributes` に `*.sh text eol=lf` を追加し、WSL 含む環境差分を抑制
- `README.md` に Copilot CLI の仕様（`.github/prompts` は独自 `/` コマンドとしては表示されない）を明記
- `README.md` に WSL 向け実行方法とトラブルシュートを追記
