### PR TITLE
Resolve #269: 履歴書レビュー画面で注釈PDFのダウンロードボタンが表示されない

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ docker compose --profile rag up -d rag-review
 
 ### 初回セットアップ
 
+方法1（推奨）: シェルに読み込んで関数として使う
+
 ```sh
 source scripts/copilot-shortcuts.sh
 ```
@@ -290,6 +292,14 @@ source scripts/copilot-shortcuts.sh
 echo 'source /absolute/path/to/soc-ai-agent-mock/scripts/copilot-shortcuts.sh' >> ~/.zshrc
 ```
 
+方法2: 直接実行する（`source` 不要）
+
+```sh
+./scripts/copilot-shortcuts.sh issue "管理者画面に監査ログ検索を追加したい"
+./scripts/copilot-shortcuts.sh implement "123"
+./scripts/copilot-shortcuts.sh pr "123"
+```
+
 ### 利用例
 
 ```sh
@@ -297,6 +307,11 @@ cissue "管理者画面に監査ログ検索を追加したい"
 cimpl "123"
 cpr "123"
 ```
+
+### うまく動かない場合
+
+- `cissue: command not found` が出る場合: `source scripts/copilot-shortcuts.sh` が未実行です（またはシェル再起動後に未読込）。
+- 直接実行する場合は `./scripts/copilot-shortcuts.sh ...` の形式で実行してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [環境変数](#環境変数)
 - [ローカル開発](#ローカル開発)
 - [Docker Compose](#docker-compose)
+- [Copilot カスタムコマンド共有](#copilot-カスタムコマンド共有)
 - [主要APIエンドポイント](#主要apiエンドポイント)
 - [品質管理](#品質管理)
 - [よくあるトラブル](#よくあるトラブル)
@@ -267,6 +268,35 @@ docker compose --profile rag up -d rag-review
 | `frontend` | Next.js | 3000 |
 | `rag-review` | 職務経歴書 RAG | 9000 |
 | `company-graph` | 企業スクレイピング | 9100 |
+
+---
+
+## Copilot カスタムコマンド共有
+
+チームで同じCopilotカスタムコマンドを使う場合は、リポジトリ内の以下を共通利用します。
+
+- Prompt定義: `.github/prompts/*.prompt.md`
+- 呼び出し関数: `scripts/copilot-shortcuts.sh`
+
+### 初回セットアップ
+
+```sh
+source scripts/copilot-shortcuts.sh
+```
+
+毎回読み込む場合は、`~/.zshrc` などに追記します。
+
+```sh
+echo 'source /absolute/path/to/soc-ai-agent-mock/scripts/copilot-shortcuts.sh' >> ~/.zshrc
+```
+
+### 利用例
+
+```sh
+cissue "管理者画面に監査ログ検索を追加したい"
+cimpl "123"
+cpr "123"
+```
 
 ---
 

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -68,8 +68,14 @@ function ResumeContent() {
         headers: { Range: 'bytes=0-0' },
       })
       if (!response.ok) return false
-      const contentType = response.headers.get('content-type') || ''
-      return contentType.includes('application/pdf')
+      const contentType = (response.headers.get('content-type') || '').toLowerCase()
+      if (contentType.includes('application/pdf')) return true
+
+      const contentDisposition = (response.headers.get('content-disposition') || '').toLowerCase()
+      if (contentDisposition.includes('.pdf')) return true
+
+      // Content-Type が application/octet-stream でも、Range リクエスト成功なら実体ありとみなす。
+      return response.status === 206 || response.status === 200
     } catch {
       return false
     }

--- a/scripts/copilot-shortcuts.sh
+++ b/scripts/copilot-shortcuts.sh
@@ -1,36 +1,45 @@
 #!/usr/bin/env bash
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PROMPT_DIR="$PROJECT_ROOT/.copilot/prompts"
+PROMPT_DIR="$PROJECT_ROOT/.github/prompts"
 
-cplan() {
-  local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/plan.md")
+run_copilot_prompt() {
+  local prompt_file="$1"
+  local header="$2"
+  local task="$3"
 
-対象タスク:
-$task"
-}
+  if [[ ! -f "$PROMPT_DIR/$prompt_file" ]]; then
+    echo "Prompt file not found: $PROMPT_DIR/$prompt_file" >&2
+    return 1
+  fi
 
-creview() {
-  local task="${*:-現在の変更内容をレビューしてください。}"
-  copilot -p "$(cat "$PROMPT_DIR/pr-review.md")
+  copilot -p "$(cat "$PROMPT_DIR/$prompt_file")
 
-レビュー対象:
+$header:
 $task"
 }
 
 cissue() {
   local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/issue.md")
-
-Issue化したい内容:
-$task"
+  run_copilot_prompt "issue.prompt.md" "Issue化したい内容" "$task"
 }
 
 cimpl() {
   local task="$*"
-  copilot -p "$(cat "$PROMPT_DIR/implement.md")
+  run_copilot_prompt "implement.prompt.md" "実装したい内容" "$task"
+}
 
-実装したい内容:
-$task"
+cpr() {
+  local task="$*"
+  run_copilot_prompt "pr.prompt.md" "PR作成したいIssue番号" "$task"
+}
+
+cplan() {
+  local task="${*:-対象タスクを入力してください。}"
+  run_copilot_prompt "plan.prompt.md" "対象タスク" "$task"
+}
+
+creview() {
+  local task="${*:-現在の変更内容をレビューしてください。}"
+  run_copilot_prompt "pr-review.prompt.md" "レビュー対象" "$task"
 }

--- a/scripts/copilot-shortcuts.sh
+++ b/scripts/copilot-shortcuts.sh
@@ -3,10 +3,30 @@
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROMPT_DIR="$PROJECT_ROOT/.github/prompts"
 
+copilot_shortcuts_usage() {
+  cat <<'EOF'
+Usage:
+  source scripts/copilot-shortcuts.sh
+  cissue "..."
+  cimpl "123"
+  cpr "123"
+
+Or run directly:
+  ./scripts/copilot-shortcuts.sh issue "..."
+  ./scripts/copilot-shortcuts.sh implement "123"
+  ./scripts/copilot-shortcuts.sh pr "123"
+EOF
+}
+
 run_copilot_prompt() {
   local prompt_file="$1"
   local header="$2"
   local task="$3"
+
+  if ! command -v copilot >/dev/null 2>&1; then
+    echo "copilot command not found. Install GitHub Copilot CLI first." >&2
+    return 1
+  fi
 
   if [[ ! -f "$PROMPT_DIR/$prompt_file" ]]; then
     echo "Prompt file not found: $PROMPT_DIR/$prompt_file" >&2
@@ -43,3 +63,28 @@ creview() {
   local task="${*:-現在の変更内容をレビューしてください。}"
   run_copilot_prompt "pr-review.prompt.md" "レビュー対象" "$task"
 }
+
+copilot_shortcuts_main() {
+  local subcommand="$1"
+  shift || true
+
+  case "$subcommand" in
+    issue) cissue "$*" ;;
+    implement) cimpl "$*" ;;
+    pr) cpr "$*" ;;
+    plan) cplan "$*" ;;
+    review) creview "$*" ;;
+    ""|-h|--help|help)
+      copilot_shortcuts_usage
+      ;;
+    *)
+      echo "Unknown subcommand: $subcommand" >&2
+      copilot_shortcuts_usage >&2
+      return 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  copilot_shortcuts_main "$@"
+fi


### PR DESCRIPTION
Closes #269

## 変更内容
- 履歴書レビュー完了後の注釈PDF存在チェックを改善
- `Content-Type` が `application/pdf` 以外でも、`Content-Disposition` または Range 成功 (`200/206`) をもとに注釈PDFありと判定
- 注釈PDFが実在するケースで「注釈PDFをダウンロード」ボタンが表示されるよう修正
