### PR TITLE
Resolve #287: chat_phase_manager.go のエラー戻り値無視を修正

### DIFF
--- a/Backend/internal/services/chat_phase_manager.go
+++ b/Backend/internal/services/chat_phase_manager.go
@@ -15,7 +15,10 @@ func (s *ChatService) getCurrentOrNextPhase(ctx context.Context, userID uint, se
 		return nil, err
 	}
 
-	progresses, _ := s.progressRepo.FindByUserAndSession(userID, sessionID)
+	progresses, err := s.progressRepo.FindByUserAndSession(userID, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	progressMap := make(map[uint]*entity.UserAnalysisProgress, len(progresses))
 	for i := range progresses {
 		progressMap[progresses[i].PhaseID] = &progresses[i]
@@ -75,7 +78,10 @@ func (s *ChatService) updatePhaseProgress(progress *entity.UserAnalysisProgress,
 
 // buildPhaseProgressResponse フェーズ進捗レスポンスを構築
 func (s *ChatService) buildPhaseProgressResponse(userID uint, sessionID string) ([]PhaseProgress, *PhaseProgress, error) {
-	progresses, _ := s.progressRepo.FindByUserAndSession(userID, sessionID)
+	progresses, err := s.progressRepo.FindByUserAndSession(userID, sessionID)
+	if err != nil {
+		return nil, nil, err
+	}
 	allPhases, err := s.phaseRepo.FindAll()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Closes #287

## 変更内容

`Backend/internal/services/chat_phase_manager.go` において、`progressRepo.FindByUserAndSession` の呼び出し結果のエラーが `_` で無視されていた箇所を修正。

### 修正箇所

- **`getCurrentOrNextPhase`**: `progresses, _ :=` → `progresses, err :=` に変更し、エラー発生時は `return nil, err` で呼び出し元へ伝播
- **`buildPhaseProgressResponse`**: `progresses, _ :=` → `progresses, err :=` に変更し、エラー発生時は `return nil, nil, err` で呼び出し元へ伝播

### 修正の効果

- DBクエリ失敗時に不完全なデータ（空スライス）で処理が続行されることを防止
- エラーが上位のハンドラまで伝播し、適切なエラーレスポンスをクライアントへ返せるようになる