### PR TITLE
Resolve #292: RAG Deep Research 失敗時のエラーログを改善

### DIFF
--- a/rag/main.py
+++ b/rag/main.py
@@ -573,7 +573,7 @@ def _gather_context(request: ReviewRequest) -> Tuple[List[str], str]:
                 else:
                     logger.warning("deep research returned empty result")
             except Exception as exc:
-                logger.warning("deep research failed error=%s", exc)
+                logger.error("deep research failed error=%s", exc, exc_info=True)
                 if STRICT_DEEP_RESEARCH and not ALLOW_DDG_FALLBACK:
                     raise HTTPException(status_code=502, detail="Deep Research failed")
 


### PR DESCRIPTION
Closes #292

## 変更内容

`rag/main.py` の Deep Research 失敗時の例外ハンドリングを改善。

### 修正箇所

- **`logger.warning` → `logger.error` に変更**: 例外発生は WARNING ではなく ERROR レベルで記録すべきであるため修正
- **`exc_info=True` を追加**: スタックトレース全体がログに出力されるようになり、障害発生時の原因調査が容易になる

### 設計上の判断

`ALLOW_DDG_FALLBACK=true` 時に DuckDuckGo へフォールバックする動作は意図的なグレースフルデグラデーションであるため維持。エラーが発生しても上位レイヤーへの伝播は `STRICT_DEEP_RESEARCH=true` 時のみ行う既存の動作を保持しつつ、可観測性のみを向上させた。