### PR TITLE
Resolve #288: Backend ログシステムを構造化ログに統一

### DIFF
--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -225,20 +225,20 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 	}
 
 	// 既存のマッチング結果を取得（事前計算済みを想定）
-	fmt.Printf("[GetRecommendations] Fetching pre-calculated matches for user %d, session %s\n", userID, sessionID)
+	log.Printf("[GetRecommendations] Fetching pre-calculated matches for user %d, session %s\n", userID, sessionID)
 	matches, err := c.matchingService.GetTopMatches(r.Context(), uint(userID), sessionID, limit)
-	fmt.Printf("[GetRecommendations] Retrieved %d matches in fast mode\n", len(matches))
+	log.Printf("[GetRecommendations] Retrieved %d matches in fast mode\n", len(matches))
 
 	if err != nil || len(matches) == 0 {
-		fmt.Printf("[GetRecommendations] No matching results found, returning empty result\n")
+		log.Printf("[GetRecommendations] No matching results found, returning empty result\n")
 		diagnostics, diagErr := c.matchingService.GetDiagnostics(uint(userID), sessionID)
 		if diagErr != nil {
-			fmt.Printf("[GetRecommendations] Diagnostics error: %v\n", diagErr)
+			log.Printf("[GetRecommendations] Diagnostics error: %v\n", diagErr)
 		}
 
 		userScores, scoreErr := c.chatService.GetUserScores(uint(userID), sessionID)
 		if scoreErr != nil {
-			fmt.Printf("[GetRecommendations] Failed to load user scores for provisional status: %v\n", scoreErr)
+			log.Printf("[GetRecommendations] Failed to load user scores for provisional status: %v\n", scoreErr)
 			userScores = []entity.UserWeightScore{}
 		}
 
@@ -311,7 +311,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 
 	userScores, err := c.chatService.GetUserScores(uint(userID), sessionID)
 	if err != nil {
-		fmt.Printf("[GetRecommendations] Failed to load user scores: %v\n", err)
+		log.Printf("[GetRecommendations] Failed to load user scores: %v\n", err)
 		userScores = []entity.UserWeightScore{}
 	}
 	evaluatedCategories := countEvaluatedCategories(userScores)
@@ -582,7 +582,7 @@ func (c *ChatController) SendReport(w http.ResponseWriter, r *http.Request) {
 
 	// メール送信
 	if err := c.emailService.SendAnalysisReport(user, summary, companies, req.SessionID); err != nil {
-		fmt.Printf("[SendReport] Failed to send email: %v\n", err)
+		log.Printf("[SendReport] Failed to send email: %v\n", err)
 		http.Error(w, "Failed to send email", http.StatusInternalServerError)
 		return
 	}

--- a/Backend/internal/models/seed_large_data.go
+++ b/Backend/internal/models/seed_large_data.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"time"
 
@@ -16,11 +17,11 @@ func SeedLargeCompanyData(db *gorm.DB) error {
 
 	if count >= 40000 {
 		// すでに4万社以上ある場合はスキップ
-		fmt.Printf("Company data already exists (%d records), skipping large seed\n", count)
+		slog.Info("Company data already exists, skipping large seed", "records", count)
 		return nil
 	}
 
-	fmt.Println("Starting to seed 40,000 companies with relationships...")
+	slog.Info("Starting to seed companies with relationships", "target_companies", 40000)
 	startTime := time.Now()
 
 	// ランダムシードを初期化
@@ -122,11 +123,11 @@ func SeedLargeCompanyData(db *gorm.DB) error {
 		}
 
 		if (i/batchSize)%10 == 0 {
-			fmt.Printf("Inserted %d / %d companies...\n", end, totalCompanies)
+			slog.Info("Inserted companies", "inserted", end, "total", totalCompanies)
 		}
 	}
 
-	fmt.Printf("Successfully inserted %d companies in %v\n", totalCompanies, time.Since(startTime))
+	slog.Info("Successfully inserted companies", "count", totalCompanies, "duration", time.Since(startTime))
 	return nil
 }
 
@@ -136,11 +137,11 @@ func SeedLargeCompanyMarketInfo(db *gorm.DB) error {
 	db.Model(&CompanyMarketInfo{}).Count(&count)
 
 	if count >= 100 {
-		fmt.Printf("Market info already exists (%d records), skipping\n", count)
+		slog.Info("Market info already exists, skipping", "records", count)
 		return nil
 	}
 
-	fmt.Println("Seeding market info for companies...")
+	slog.Info("Seeding market info for companies")
 	startTime := time.Now()
 
 	marketTypes := []string{"prime", "standard", "growth", "unlisted"}
@@ -194,11 +195,11 @@ func SeedLargeCompanyMarketInfo(db *gorm.DB) error {
 		}
 
 		if (i/batchSize)%10 == 0 {
-			fmt.Printf("Inserted %d / %d market info...\n", end, len(companyIDs))
+			slog.Info("Inserted market info", "inserted", end, "total", len(companyIDs))
 		}
 	}
 
-	fmt.Printf("Successfully inserted market info in %v\n", time.Since(startTime))
+	slog.Info("Successfully inserted market info", "duration", time.Since(startTime))
 	return nil
 }
 
@@ -208,11 +209,11 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 	db.Model(&CompanyRelation{}).Count(&count)
 
 	if count >= 50000 {
-		fmt.Printf("Relations already exist (%d records), skipping\n", count)
+		slog.Info("Relations already exist, skipping", "records", count)
 		return nil
 	}
 
-	fmt.Println("Seeding company relations (capital & business) with enhanced group structures...")
+	slog.Info("Seeding company relations with enhanced group structures")
 	startTime := time.Now()
 
 	// 全企業IDを取得
@@ -223,7 +224,7 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		return fmt.Errorf("no companies found")
 	}
 
-	fmt.Printf("Generating relations for %d companies...\n", len(companyIDs))
+	slog.Info("Generating relations", "company_count", len(companyIDs))
 
 	// === 企業グループの生成 ===
 	// 約200のグループを作成（各グループ5-20社）
@@ -242,7 +243,7 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 	relations := make([]CompanyRelation, 0, numCapitalRelations+numBusinessRelations)
 
 	// === 企業グループの資本関係生成 ===
-	fmt.Println("Generating corporate groups with capital relations...")
+	slog.Info("Generating corporate groups with capital relations")
 
 	usedCompanies := make(map[uint]bool)
 	groups := make([][]uint, 0, numGroups)
@@ -299,14 +300,14 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		groups = append(groups, group)
 
 		if g%20 == 0 {
-			fmt.Printf("Generated %d corporate groups...\n", g)
+			slog.Info("Generated corporate groups", "count", g)
 		}
 	}
 
-	fmt.Printf("Generated %d corporate groups with total %d capital relations\n", len(groups), len(relations))
+	slog.Info("Generated corporate groups and capital relations", "groups", len(groups), "capital_relations", len(relations))
 
 	// === ビジネス関係の生成（多様な関係タイプ） ===
-	fmt.Println("Generating business relations...")
+	slog.Info("Generating business relations")
 
 	businessRelationTypes := []struct {
 		Type        string
@@ -332,7 +333,7 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 	businessRelationsCount := 0
 
 	// 1. グループ内のビジネス関係（各グループ内で5-10件）
-	fmt.Println("Generating intra-group business relations...")
+	slog.Info("Generating intra-group business relations")
 	for _, group := range groups {
 		if len(group) < 2 {
 			continue
@@ -365,10 +366,10 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		}
 	}
 
-	fmt.Printf("Generated %d intra-group business relations\n", businessRelationsCount)
+	slog.Info("Generated intra-group business relations", "count", businessRelationsCount)
 
 	// 2. グループ間のビジネス関係（各グループが5-15社と取引）
-	fmt.Println("Generating inter-group business relations...")
+	slog.Info("Generating inter-group business relations")
 	interGroupCount := 0
 	for _, group := range groups {
 		if len(group) == 0 {
@@ -418,11 +419,11 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		}
 	}
 
-	fmt.Printf("Generated %d inter-group business relations\n", interGroupCount)
+	slog.Info("Generated inter-group business relations", "count", interGroupCount)
 	businessRelationsCount += interGroupCount
 
 	// 3. ランダムなビジネス関係（エコシステム）
-	fmt.Println("Generating random business ecosystem...")
+	slog.Info("Generating random business ecosystem")
 	randomCount := 0
 	targetRandomRelations := 25000
 
@@ -470,18 +471,18 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		randomCount++
 
 		if randomCount%5000 == 0 {
-			fmt.Printf("Generated %d random business relations...\n", randomCount)
+			slog.Info("Generated random business relations", "count", randomCount)
 		}
 	}
 
 	businessRelationsCount += randomCount
-	fmt.Printf("Generated %d total business relations\n", businessRelationsCount)
-
-	fmt.Printf("\n=== Summary ===\n")
-	fmt.Printf("Total relations generated: %d\n", len(relations))
-	fmt.Printf("  - Capital relations: %d\n", len(relations)-businessRelationsCount)
-	fmt.Printf("  - Business relations: %d\n", businessRelationsCount)
-	fmt.Printf("  - Corporate groups: %d\n", len(groups))
+	slog.Info("Generated total business relations", "count", businessRelationsCount)
+	slog.Info("Relations generation summary",
+		"total_relations", len(relations),
+		"capital_relations", len(relations)-businessRelationsCount,
+		"business_relations", businessRelationsCount,
+		"corporate_groups", len(groups),
+	)
 
 	// バッチ挿入
 	batchSize := 1000
@@ -496,11 +497,11 @@ func SeedLargeCompanyRelations(db *gorm.DB) error {
 		}
 
 		if (i/batchSize)%5 == 0 {
-			fmt.Printf("Inserted %d / %d relations...\n", end, len(relations))
+			slog.Info("Inserted relations", "inserted", end, "total", len(relations))
 		}
 	}
 
-	fmt.Printf("Successfully inserted %d relations in %v\n", len(relations), time.Since(startTime))
+	slog.Info("Successfully inserted relations", "count", len(relations), "duration", time.Since(startTime))
 	return nil
 }
 
@@ -510,11 +511,11 @@ func SeedLargeCompanyProfiles(db *gorm.DB) error {
 	db.Model(&CompanyWeightProfile{}).Count(&count)
 
 	if count >= 40000 {
-		fmt.Printf("Profiles already exist (%d records), skipping\n", count)
+		slog.Info("Profiles already exist, skipping", "records", count)
 		return nil
 	}
 
-	fmt.Println("Seeding company weight profiles for all companies...")
+	slog.Info("Seeding company weight profiles for all companies")
 	startTime := time.Now()
 
 	// 全企業IDを取得
@@ -558,11 +559,11 @@ func SeedLargeCompanyProfiles(db *gorm.DB) error {
 		}
 
 		if (i/batchSize)%10 == 0 {
-			fmt.Printf("Inserted %d / %d profiles...\n", end, len(companyIDs))
+			slog.Info("Inserted company profiles", "inserted", end, "total", len(companyIDs))
 		}
 	}
 
-	fmt.Printf("Successfully inserted %d profiles in %v\n", len(companyIDs), time.Since(startTime))
+	slog.Info("Successfully inserted company profiles", "count", len(companyIDs), "duration", time.Since(startTime))
 	return nil
 }
 

--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -41,35 +42,35 @@ func (s *ChatService) checkAnswerValidity(ctx context.Context, history []models.
 	isValid, err := s.validateAnswerRelevance(ctx, questionText, userMessage)
 	if err != nil {
 		// AI判定エラー時は基本的な検証のみ
-		fmt.Printf("[Validation] AI validation failed: %v, using basic validation\n", err)
+		log.Printf("[Validation] AI validation failed: %v, using basic validation\n", err)
 		isValid = isLikelyAnswer(userMessage, questionText)
-		fmt.Printf("[Validation] Basic validation result: %v for message: %s\n", isValid, userMessage)
+		log.Printf("[Validation] Basic validation result: %v for message: %s\n", isValid, userMessage)
 	} else {
-		fmt.Printf("[Validation] AI validation result: %v for message: %s\n", isValid, userMessage)
+		log.Printf("[Validation] AI validation result: %v for message: %s\n", isValid, userMessage)
 	}
 
 	if isValid {
 		// 有効な回答と判断 -> カウントをリセットして既存の処理に進める
-		fmt.Printf("[Validation] Valid answer detected, resetting invalid count for session: %s\n", sessionID)
+		log.Printf("[Validation] Valid answer detected, resetting invalid count for session: %s\n", sessionID)
 		if err := s.sessionValidationRepo.ResetInvalidCount(sessionID); err != nil {
-			fmt.Printf("Warning: failed to reset invalid count: %v\n", err)
+			log.Printf("Warning: failed to reset invalid count: %v\n", err)
 		}
 		return false, "", nil
 	}
 
 	// 無効な回答と判断 -> カウントをインクリメント
-	fmt.Printf("[Validation] Invalid answer detected for message: %s\n", userMessage)
+	log.Printf("[Validation] Invalid answer detected for message: %s\n", userMessage)
 	validation, err := s.sessionValidationRepo.IncrementInvalidCount(sessionID)
 	if err != nil {
 		return true, "", fmt.Errorf("failed to increment invalid count: %w", err)
 	}
-	fmt.Printf("[Validation] Invalid count incremented to: %d/3\n", validation.InvalidAnswerCount)
+	log.Printf("[Validation] Invalid count incremented to: %d/3\n", validation.InvalidAnswerCount)
 
 	var assistantText string
 	if validation.InvalidAnswerCount >= 3 {
 		// 3回目の無効回答 -> セッションを強制終了
 		if err := s.sessionValidationRepo.TerminateSession(sessionID); err != nil {
-			fmt.Printf("Warning: failed to terminate session: %v\n", err)
+			log.Printf("Warning: failed to terminate session: %v\n", err)
 		}
 		assistantText = "申し訳ございませんが、質問と関係のない内容が3回続いたため、チャットを終了させていただきます。新しいセッションで最初からやり直してください。"
 	} else {
@@ -96,12 +97,12 @@ func (s *ChatService) validateAnswerRelevance(ctx context.Context, question, ans
 
 	if isTextQuestion {
 		// 文章系の質問: キーワードベースで柔軟に判定
-		fmt.Printf("[Validation] Text-based question detected, using keyword-based validation\n")
+		log.Printf("[Validation] Text-based question detected, using keyword-based validation\n")
 		return isLikelyAnswer(answer, question), nil
 	}
 
 	// 選択肢型の質問: AI判定を使用
-	fmt.Printf("[Validation] Choice-based question detected, using AI validation\n")
+	log.Printf("[Validation] Choice-based question detected, using AI validation\n")
 
 	systemPrompt := prompts.AnswerValidationSystemPrompt
 	userPrompt := prompts.BuildAnswerValidationUserPrompt(question, answer)
@@ -127,7 +128,7 @@ func (s *ChatService) validateAnswerRelevance(ctx context.Context, question, ans
 	var result ValidationResult
 	if err := json.Unmarshal([]byte(response), &result); err != nil {
 		// JSONパースに失敗した場合は無効とみなす
-		fmt.Printf("Warning: Failed to parse AI validation response: %v, response: %s\n", err, response)
+		log.Printf("Warning: Failed to parse AI validation response: %v, response: %s\n", err, response)
 		return false, nil
 	}
 
@@ -229,7 +230,7 @@ func isLikelyAnswer(answer, question string) bool {
 
 	// 十分に長い回答（15文字超）は内容があるとみなし有効
 	if len([]rune(a)) > 15 {
-		fmt.Printf("[Validation] Fallback: Long answer accepted as valid (%d chars)\n", len([]rune(a)))
+		log.Printf("[Validation] Fallback: Long answer accepted as valid (%d chars)\n", len([]rune(a)))
 		return true
 	}
 
@@ -238,7 +239,7 @@ func isLikelyAnswer(answer, question string) bool {
 
 	// 記号のみの回答（A, B, 1, 2など）は有効
 	if len([]rune(a)) <= 3 && strings.ContainsAny(a, "ABCDEabcde12345①②③④⑤") {
-		fmt.Printf("[Validation] Fallback: Valid choice symbol: %s\n", a)
+		log.Printf("[Validation] Fallback: Valid choice symbol: %s\n", a)
 		return true
 	}
 
@@ -253,7 +254,7 @@ func isLikelyAnswer(answer, question string) bool {
 	}
 	for _, pattern := range noAnswerPatterns {
 		if answerLowerStripped == pattern {
-			fmt.Printf("[Validation] Fallback: No-answer pattern detected: %s\n", a)
+			log.Printf("[Validation] Fallback: No-answer pattern detected: %s\n", a)
 			return false
 		}
 	}
@@ -270,25 +271,25 @@ func isLikelyAnswer(answer, question string) bool {
 	}
 	for _, valid := range shortValidAnswers {
 		if answerLowerStripped == valid {
-			fmt.Printf("[Validation] Fallback: Valid short answer: %s\n", a)
+			log.Printf("[Validation] Fallback: Valid short answer: %s\n", a)
 			return true
 		}
 	}
 
 	// 2文字未満は無効（選択肢記号・短答キーワードは上で判定済み）
 	if len([]rune(a)) < 2 {
-		fmt.Printf("[Validation] Fallback: Too short (< 2 chars): %s\n", a)
+		log.Printf("[Validation] Fallback: Too short (< 2 chars): %s\n", a)
 		return false
 	}
 
 	// 挨拶・感謝などの雑談パターンは無効
 	if containsGreeting(a) {
-		fmt.Printf("[Validation] Fallback: Contains greeting: %s\n", a)
+		log.Printf("[Validation] Fallback: Contains greeting: %s\n", a)
 		return false
 	}
 
 	if !isJobSelection && looksLikeKeywordList(a) {
-		fmt.Printf("[Validation] Fallback: Keyword-only list detected: %s\n", a)
+		log.Printf("[Validation] Fallback: Keyword-only list detected: %s\n", a)
 		return false
 	}
 
@@ -312,14 +313,14 @@ func isLikelyAnswer(answer, question string) bool {
 	// 質問文に選択肢や具体例が含まれている場合、回答側に数字や選択肢文字があれば回答とみなす
 	if strings.Contains(question, "A)") || strings.Contains(question, "A：") || strings.Contains(question, "A、") {
 		if strings.ContainsAny(a, "ABCDabcd1-5①②③④") {
-			fmt.Printf("[Validation] Fallback: Contains choice character: %s\n", a)
+			log.Printf("[Validation] Fallback: Contains choice character: %s\n", a)
 			return true
 		}
 	}
 
 	// IT関連キーワードを含む、または5文字以上なら有効（緩和）
 	if hasITKeyword || len([]rune(a)) >= 5 {
-		fmt.Printf("[Validation] Fallback: Valid answer (IT keyword or >= 5 chars): %s\n", a)
+		log.Printf("[Validation] Fallback: Valid answer (IT keyword or >= 5 chars): %s\n", a)
 		return true
 	}
 
@@ -335,12 +336,12 @@ func isLikelyAnswer(answer, question string) bool {
 
 	// 共通キーワードが1つ以上あれば回答とみなす（緩和）
 	if common >= 1 {
-		fmt.Printf("[Validation] Fallback: Common keywords >= 1: %s\n", a)
+		log.Printf("[Validation] Fallback: Common keywords >= 1: %s\n", a)
 		return true
 	}
 
 	// デフォルトは無効（厳格に判断）
-	fmt.Printf("[Validation] Fallback: Default INVALID for: %s\n", a)
+	log.Printf("[Validation] Fallback: Default INVALID for: %s\n", a)
 	return false
 }
 

--- a/Backend/internal/services/chat_getters.go
+++ b/Backend/internal/services/chat_getters.go
@@ -5,7 +5,7 @@ import (
 	"Backend/internal/models"
 	"context"
 	"errors"
-	"fmt"
+	"log"
 	"strings"
 	"time"
 )
@@ -44,7 +44,7 @@ func (s *ChatService) aiCallWithRetries(ctx context.Context, prompt string) (str
 			err = errors.New("empty response")
 		}
 		// log and wait before retry
-		fmt.Printf("Warning: AI call failed or empty response (attempt %d): %v\n", i+1, err)
+		log.Printf("Warning: AI call failed or empty response (attempt %d): %v\n", i+1, err)
 		if i == len(backoffs)-1 {
 			break
 		}

--- a/Backend/internal/services/chat_phase_manager.go
+++ b/Backend/internal/services/chat_phase_manager.go
@@ -5,6 +5,7 @@ import (
 	"Backend/internal/models"
 	"context"
 	"fmt"
+	"log"
 	"time"
 )
 
@@ -63,7 +64,7 @@ func (s *ChatService) updatePhaseProgress(progress *entity.UserAnalysisProgress,
 					phaseLabel = progress.Phase.PhaseName
 				}
 			}
-			fmt.Printf("%sが完了しました。\n", phaseLabel)
+			log.Printf("%sが完了しました。\n", phaseLabel)
 		}
 	} else {
 		progress.CompletedAt = nil

--- a/Backend/internal/services/chat_phase_manager.go
+++ b/Backend/internal/services/chat_phase_manager.go
@@ -5,7 +5,7 @@ import (
 	"Backend/internal/models"
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -64,7 +64,7 @@ func (s *ChatService) updatePhaseProgress(progress *entity.UserAnalysisProgress,
 					phaseLabel = progress.Phase.PhaseName
 				}
 			}
-			log.Printf("%sが完了しました。\n", phaseLabel)
+			slog.Info("分析フェーズが完了しました", "phase", phaseLabel)
 		}
 	} else {
 		progress.CompletedAt = nil

--- a/Backend/internal/services/chat_question_generator.go
+++ b/Backend/internal/services/chat_question_generator.go
@@ -6,12 +6,13 @@ import (
 	"Backend/internal/services/prompts"
 	"context"
 	"fmt"
+	"log"
 	"strings"
 )
 
 // handleSessionStart セッション開始時の初回質問を生成
 func (s *ChatService) handleSessionStart(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
-	fmt.Printf("Starting new session: %s\n", req.SessionID)
+	log.Printf("Starting new session: %s\n", req.SessionID)
 
 	// ユーザー情報を取得
 	user, err := s.userRepo.GetUserByID(req.UserID)
@@ -317,7 +318,7 @@ func (s *ChatService) generateStrategicQuestion(ctx context.Context, history []m
 			break // 重複なし、使用可能
 		}
 
-		fmt.Printf("Retry %d: Duplicate detected (%s)\n", attempt+1, duplicateReason)
+		log.Printf("Retry %d: Duplicate detected (%s)\n", attempt+1, duplicateReason)
 
 		// 再生成プロンプト
 		retryPrompt := fmt.Sprintf(`以下の質問は既に聞いているか類似しています：
@@ -350,14 +351,14 @@ func (s *ChatService) generateStrategicQuestion(ctx context.Context, history []m
 
 		// 最後の試行で重複してもそのまま使用（無限ループ防止）
 		if attempt == maxRetries-1 {
-			fmt.Printf("Max retries reached, using question anyway: %s\n", questionText)
+			log.Printf("Max retries reached, using question anyway: %s\n", questionText)
 		}
 	}
 
 	// AI生成質問をデータベースに保存（空文字は保存しない）
 	questionText = strings.TrimSpace(questionText)
 	if questionText == "" {
-		fmt.Printf("Warning: AI generated empty question even after fallback, not saving. user=%d session=%s\n", userID, sessionID)
+		log.Printf("Warning: AI generated empty question even after fallback, not saving. user=%d session=%s\n", userID, sessionID)
 		return "", 0, fmt.Errorf("ai returned empty question")
 	}
 
@@ -409,7 +410,7 @@ func (s *ChatService) generateQuestionWithAI(ctx context.Context, history []mode
 	// 現在のスコアを取得して、まだ評価が不十分な領域を特定
 	scores, err := s.userWeightScoreRepo.FindByUserAndSession(userID, sessionID)
 	if err != nil {
-		fmt.Printf("Warning: failed to get scores for question generation: %v\n", err)
+		log.Printf("Warning: failed to get scores for question generation: %v\n", err)
 	}
 
 	// スコア分布を分析

--- a/Backend/internal/services/chat_score_updater.go
+++ b/Backend/internal/services/chat_score_updater.go
@@ -4,6 +4,7 @@ import (
 	"Backend/internal/models"
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"strings"
 )
@@ -13,7 +14,7 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 	// 会話履歴から直近の質問を取得
 	history, err := s.chatMessageRepo.FindRecentBySessionID(sessionID, 5)
 	if err != nil {
-		fmt.Printf("Warning: failed to get history for analysis: %v\n", err)
+		log.Printf("Warning: failed to get history for analysis: %v\n", err)
 		history = []models.ChatMessage{}
 	}
 
@@ -26,11 +27,11 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 	}
 
 	if strings.TrimSpace(lastQuestion) == "" {
-		fmt.Printf("Warning: no previous question found for scoring\n")
+		log.Printf("Warning: no previous question found for scoring\n")
 		return nil
 	}
 	if s.isJobSelectionQuestion(lastQuestion) {
-		fmt.Printf("Skipping analysis for job selection question\n")
+		log.Printf("Skipping analysis for job selection question\n")
 		return nil
 	}
 
@@ -39,11 +40,11 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 
 	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, message, isChoice, jobCategoryID != 0, nil)
 	if result.Action != PrecheckScore {
-		fmt.Printf("Skipping scoring due to precheck: %s\n", result.Reason)
+		log.Printf("Skipping scoring due to precheck: %s\n", result.Reason)
 		return nil
 	}
 	if result.Score <= 0 {
-		fmt.Printf("No human score applied (score=%d)\n", result.Score)
+		log.Printf("No human score applied (score=%d)\n", result.Score)
 		return nil
 	}
 
@@ -67,7 +68,7 @@ func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sess
 		return fmt.Errorf("no previous question found")
 	}
 	if s.isJobSelectionQuestion(lastQuestion) {
-		fmt.Printf("[Choice Answer] Skipping score update for job selection question\n")
+		log.Printf("[Choice Answer] Skipping score update for job selection question\n")
 		return nil
 	}
 
@@ -92,11 +93,11 @@ func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sess
 		targetCategory = s.inferCategoryFromQuestion(lastQuestion)
 	}
 
-	fmt.Printf("[Choice Answer] Processing choice '%s' for category: %s\n", answer, targetCategory)
+	log.Printf("[Choice Answer] Processing choice '%s' for category: %s\n", answer, targetCategory)
 
 	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, answer, true, jobCategoryID != 0, nil)
 	if result.Action != PrecheckScore {
-		fmt.Printf("Skipping choice scoring due to precheck: %s\n", result.Reason)
+		log.Printf("Skipping choice scoring due to precheck: %s\n", result.Reason)
 		return nil
 	}
 	score := result.Score
@@ -161,19 +162,19 @@ func (s *ChatService) updateCategoryScore(userID uint, sessionID, category strin
 		if err := s.userWeightScoreRepo.UpdateScore(userID, sessionID, category, score); err != nil {
 			return fmt.Errorf("failed to create score: %w", err)
 		}
-		fmt.Printf("[Choice Answer] Created new score: %s = %d\n", category, score)
+		log.Printf("[Choice Answer] Created new score: %s = %d\n", category, score)
 	} else {
 		// 移動平均で更新（直近回答の影響を反映）
 		newScore := int(math.Round(float64(existingScore.Score)*0.7 + float64(score)*0.3))
 		delta := newScore - existingScore.Score
 		if delta == 0 {
-			fmt.Printf("[Choice Answer] Score unchanged: %s = %d\n", category, existingScore.Score)
+			log.Printf("[Choice Answer] Score unchanged: %s = %d\n", category, existingScore.Score)
 			return nil
 		}
 		if err := s.userWeightScoreRepo.UpdateScore(userID, sessionID, category, delta); err != nil {
 			return fmt.Errorf("failed to update score: %w", err)
 		}
-		fmt.Printf("[Choice Answer] Updated score: %s = %d (average)\n", category, newScore)
+		log.Printf("[Choice Answer] Updated score: %s = %d (average)\n", category, newScore)
 	}
 
 	return nil

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -7,6 +7,7 @@ import (
 	"Backend/internal/openai"
 	"context"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -124,7 +125,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 			Content:   terminationMsg,
 		}
 		if err := s.chatMessageRepo.Create(assistantMsg); err != nil {
-			fmt.Printf("Warning: failed to save termination message: %v\n", err)
+			log.Printf("Warning: failed to save termination message: %v\n", err)
 		}
 		return &ChatResponse{
 			Response:     terminationMsg,
@@ -163,31 +164,31 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	}
 	if jobCategoryID != 0 && s.conversationContextRepo != nil && storedJobCategoryID != jobCategoryID {
 		if err := s.conversationContextRepo.SetJobCategoryID(req.UserID, req.SessionID, jobCategoryID); err != nil {
-			fmt.Printf("Warning: failed to store job category: %v\n", err)
+			log.Printf("Warning: failed to store job category: %v\n", err)
 		}
 	}
 
 	jobJustResolved := false
 	if jobCategoryID == 0 && s.shouldValidateJobCategory(history) {
-		fmt.Printf("[JobValidation] Validating job category answer: %s\n", req.Message)
+		log.Printf("[JobValidation] Validating job category answer: %s\n", req.Message)
 		jobValidation, err := s.jobValidator.ValidateJobCategory(ctx, req.Message)
 		if err != nil {
-			fmt.Printf("[JobValidation] Error: %v\n", err)
+			log.Printf("[JobValidation] Error: %v\n", err)
 			// エラーでも続行
 		} else if jobValidation != nil {
 			if jobValidation.IsValid && len(jobValidation.MatchedCategories) > 0 {
 				// 明確に職種が特定できた場合
-				fmt.Printf("[JobValidation] Valid job category matched: %d categories\n", len(jobValidation.MatchedCategories))
+				log.Printf("[JobValidation] Valid job category matched: %d categories\n", len(jobValidation.MatchedCategories))
 				jobCategoryID = jobValidation.MatchedCategories[0].ID
 				jobJustResolved = true
 				if s.conversationContextRepo != nil {
 					if err := s.conversationContextRepo.SetJobCategoryID(req.UserID, req.SessionID, jobCategoryID); err != nil {
-						fmt.Printf("Warning: failed to store job category: %v\n", err)
+						log.Printf("Warning: failed to store job category: %v\n", err)
 					}
 				}
 			} else if jobValidation.NeedsClarification && jobValidation.SuggestedQuestion != "" {
 				// 職種が曖昧な場合は選択肢を提示
-				fmt.Printf("[JobValidation] Needs clarification, presenting options\n")
+				log.Printf("[JobValidation] Needs clarification, presenting options\n")
 
 				assistantMsg := &models.ChatMessage{
 					SessionID: req.SessionID,
@@ -196,7 +197,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 					Content:   jobValidation.SuggestedQuestion,
 				}
 				if err := s.chatMessageRepo.Create(assistantMsg); err != nil {
-					fmt.Printf("Warning: failed to save assistant message: %v\n", err)
+					log.Printf("Warning: failed to save assistant message: %v\n", err)
 				}
 
 				return &ChatResponse{
@@ -211,7 +212,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 
 	if jobCategoryID != 0 {
 		if err := s.completeJobAnalysisPhase(req.UserID, req.SessionID); err != nil {
-			fmt.Printf("Warning: failed to complete job analysis phase: %v\n", err)
+			log.Printf("Warning: failed to complete job analysis phase: %v\n", err)
 		}
 	}
 
@@ -226,13 +227,13 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 		currentPhase, phaseErr := s.getCurrentOrNextPhase(ctx, req.UserID, req.SessionID)
 		if phaseErr == nil {
 			if err := s.updatePhaseProgress(currentPhase, false); err != nil {
-				fmt.Printf("Warning: failed to update phase progress for invalid answer: %v\n", err)
+				log.Printf("Warning: failed to update phase progress for invalid answer: %v\n", err)
 			}
 		}
 
 		validation, err := s.sessionValidationRepo.GetOrCreate(req.SessionID)
 		if err != nil {
-			fmt.Printf("Warning: failed to get validation: %v\n", err)
+			log.Printf("Warning: failed to get validation: %v\n", err)
 		}
 
 		allPhases, currentPhaseInfo, _ := s.buildPhaseProgressResponse(req.UserID, req.SessionID)
@@ -274,7 +275,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 				Content:   completionMsg,
 			}
 			if err := s.chatMessageRepo.Create(assistantMsg); err != nil {
-				fmt.Printf("Warning: failed to save completion message: %v\n", err)
+				log.Printf("Warning: failed to save completion message: %v\n", err)
 			}
 
 			allPhases, currentPhaseInfo, _ := s.buildPhaseProgressResponse(req.UserID, req.SessionID)
@@ -294,7 +295,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 
 	allPhases, err := s.phaseRepo.FindAll()
 	if err != nil {
-		fmt.Printf("Warning: failed to get phases: %v\n", err)
+		log.Printf("Warning: failed to get phases: %v\n", err)
 	}
 	completedProgresses, _ := s.progressRepo.FindByUserAndSession(req.UserID, req.SessionID)
 	completedPhaseCount := 0
@@ -320,13 +321,13 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 			Content:   completionMsg,
 		}
 		if err := s.chatMessageRepo.Create(assistantMsg); err != nil {
-			fmt.Printf("Warning: failed to save completion message: %v\n", err)
+			log.Printf("Warning: failed to save completion message: %v\n", err)
 		}
 		allPhasesInfo, currentPhaseInfo, _ := s.buildPhaseProgressResponse(req.UserID, req.SessionID)
 		evaluatedCategoriesCount := 0
 		scores, err := s.userWeightScoreRepo.FindByUserAndSession(req.UserID, req.SessionID)
 		if err != nil {
-			fmt.Printf("Warning: failed to get scores for completion response: %v\n", err)
+			log.Printf("Warning: failed to get scores for completion response: %v\n", err)
 		} else {
 			seenCategories := make(map[string]bool)
 			for _, score := range scores {
@@ -360,22 +361,22 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	// 3. ユーザーの回答から重み係数を判定・更新し、結果に応じてフェーズ進捗を更新
 	// スコア更新に成功した場合のみ有効回答としてカウントする
 	trimmedAnswer := strings.TrimSpace(req.Message)
-	fmt.Printf("[ProcessChat] Checking if choice answer: '%s' (len=%d)\n", trimmedAnswer, len(trimmedAnswer))
+	log.Printf("[ProcessChat] Checking if choice answer: '%s' (len=%d)\n", trimmedAnswer, len(trimmedAnswer))
 	scoreUpdated := false
 	if len(trimmedAnswer) <= 3 && s.isChoiceAnswer(trimmedAnswer) {
-		fmt.Printf("[ProcessChat] Processing as choice answer\n")
+		log.Printf("[ProcessChat] Processing as choice answer\n")
 		// 選択肢回答の場合は直接スコアを計算
 		if err := s.processChoiceAnswer(ctx, req.UserID, req.SessionID, trimmedAnswer, history, jobCategoryID); err != nil {
-			fmt.Printf("Warning: failed to process choice answer: %v\n", err)
+			log.Printf("Warning: failed to process choice answer: %v\n", err)
 		} else {
 			scoreUpdated = true
 		}
 	} else {
-		fmt.Printf("[ProcessChat] Processing as text answer\n")
+		log.Printf("[ProcessChat] Processing as text answer\n")
 		// 通常の回答分析
 		if err := s.analyzeAndUpdateWeights(ctx, req.UserID, req.SessionID, req.Message, jobCategoryID); err != nil {
 			// ログに記録するが、処理は継続
-			fmt.Printf("Warning: failed to update weights: %v\n", err)
+			log.Printf("Warning: failed to update weights: %v\n", err)
 		} else {
 			scoreUpdated = true
 		}
@@ -383,7 +384,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 
 	// フェーズ進捗を更新（スコア更新成功時のみ有効カウント）
 	if err := s.updatePhaseProgress(currentPhase, scoreUpdated); err != nil {
-		fmt.Printf("Warning: failed to update phase progress: %v\n", err)
+		log.Printf("Warning: failed to update phase progress: %v\n", err)
 	}
 
 	// 4. 既に聞いた質問を全て収集（重複防止を徹底）
@@ -392,7 +393,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	// 4-1. AI生成質問テーブルから取得
 	askedQuestions, err := s.aiGeneratedQuestionRepo.FindByUserAndSession(req.UserID, req.SessionID)
 	if err != nil {
-		fmt.Printf("Warning: failed to get asked questions: %v\n", err)
+		log.Printf("Warning: failed to get asked questions: %v\n", err)
 		askedQuestions = []models.AIGeneratedQuestion{}
 	}
 	for _, q := range askedQuestions {
@@ -415,13 +416,13 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 		}
 	}
 
-	fmt.Printf("Total asked questions for duplicate check: %d\n", len(askedTexts))
+	log.Printf("Total asked questions for duplicate check: %d\n", len(askedTexts))
 
 	// 5. 現在のスコアを分析して、次に評価すべきカテゴリを決定
 	targetLevel := s.getUserTargetLevel(req.UserID)
 	scores, err := s.userWeightScoreRepo.FindByUserAndSession(req.UserID, req.SessionID)
 	if err != nil {
-		fmt.Printf("Warning: failed to get scores for question selection: %v\n", err)
+		log.Printf("Warning: failed to get scores for question selection: %v\n", err)
 	}
 
 	// スコア分布を分析
@@ -454,10 +455,10 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 
 	if len(unevaluatedCategories) > 0 {
 		targetCategory = unevaluatedCategories[0]
-		fmt.Printf("Targeting unevaluated category: %s\n", targetCategory)
+		log.Printf("Targeting unevaluated category: %s\n", targetCategory)
 	} else if len(weaklyEvaluatedCategories) > 0 {
 		targetCategory = weaklyEvaluatedCategories[0]
-		fmt.Printf("Targeting weakly evaluated category: %s (score: %d)\n", targetCategory, scoreMap[targetCategory])
+		log.Printf("Targeting weakly evaluated category: %s (score: %d)\n", targetCategory, scoreMap[targetCategory])
 	} else {
 		// 全カテゴリ評価済みなら、最もスコアが極端なものを深掘り
 		maxAbsScore := 0
@@ -471,7 +472,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 				targetCategory = cat
 			}
 		}
-		fmt.Printf("All categories evaluated, deepening strongest: %s (score: %d)\n", targetCategory, scoreMap[targetCategory])
+		log.Printf("All categories evaluated, deepening strongest: %s (score: %d)\n", targetCategory, scoreMap[targetCategory])
 	}
 
 	// 常にまずルールベース質問を試し、なければAIで生成
@@ -485,7 +486,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	}
 
 	// まず、ルールベース質問から選択を試みる
-	fmt.Printf("[RuleBased] Attempting to get predefined question for category: %s\n", targetCategory)
+	log.Printf("[RuleBased] Attempting to get predefined question for category: %s\n", targetCategory)
 	currentPhaseName := ""
 	if currentPhase != nil && currentPhase.Phase != nil {
 		currentPhaseName = currentPhase.Phase.PhaseName
@@ -493,16 +494,16 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	predefinedQ, err := s.tryGetPredefinedQuestion(req.UserID, req.SessionID, targetCategory, req.IndustryID, jobCategoryID, targetLevel, askedTexts, currentPhaseName)
 
 	if err == nil && predefinedQ != nil {
-		fmt.Printf("[RuleBased] Using predefined question (ID: %d) for category: %s\n", predefinedQ.ID, predefinedQ.Category)
+		log.Printf("[RuleBased] Using predefined question (ID: %d) for category: %s\n", predefinedQ.ID, predefinedQ.Category)
 		aiResponse = predefinedQ.QuestionText
 		questionWeightID = predefinedQ.ID
 	} else {
 		// ルールベース質問がない場合、AIで生成
-		fmt.Printf("[AI] No predefined question available, generating with AI for category: %s (asked: %d questions)\n", targetCategory, len(askedTexts))
+		log.Printf("[AI] No predefined question available, generating with AI for category: %s (asked: %d questions)\n", targetCategory, len(askedTexts))
 		aiResponse, _, err = s.generateStrategicQuestion(ctx, recentHistory, req.UserID, req.SessionID, scoreMap, allCategories, askedTexts, req.IndustryID, jobCategoryID, targetLevel, currentPhase)
 		if err != nil {
 			// エラーは致命的にせずフォールバック質問を設定
-			fmt.Printf("Warning: failed to generate question via AI: %v\n", err)
+			log.Printf("Warning: failed to generate question via AI: %v\n", err)
 			fallbackQuestion := s.selectFallbackQuestion(targetCategory, jobCategoryID, targetLevel, askedTexts)
 			if fallbackQuestion != "" {
 				aiResponse = fallbackQuestion
@@ -537,7 +538,7 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	// 完了判定: 全フェーズが完了していれば終了
 	isComplete := completedPhaseCount == len(allPhases)
 
-	fmt.Printf("Diagnosis progress: %d phases completed out of %d, %d questions asked, %d/10 categories evaluated, complete: %v\n",
+	log.Printf("Diagnosis progress: %d phases completed out of %d, %d questions asked, %d/10 categories evaluated, complete: %v\n",
 		completedPhaseCount, len(allPhases), answeredCount, len(evaluatedCategories), isComplete)
 
 	// 診断完了時のメッセージは追加しない（次の回答時に完了判定する）
@@ -571,18 +572,18 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 			QuestionWeightID: questionWeightID,
 		}
 		if err := s.chatMessageRepo.Create(assistantMsg); err != nil {
-			fmt.Printf("Warning: failed to save assistant message: %v\n", err)
+			log.Printf("Warning: failed to save assistant message: %v\n", err)
 			// 続行は可能にする
 		}
 	} else {
 		// フォールバック: 空のAI応答の場合は簡易質問を返す
-		fmt.Printf("Warning: skipped saving empty assistant message for session %s user %d\n", req.SessionID, req.UserID)
+		log.Printf("Warning: skipped saving empty assistant message for session %s user %d\n", req.SessionID, req.UserID)
 		aiResponse = "すみません、質問を生成できませんでした。少し時間をおいてからもう一度お試しください。"
 	}
 
 	if isComplete {
 		if err := s.ensureEmbeddings(ctx, req.UserID, req.SessionID, jobCategoryID); err != nil {
-			fmt.Printf("Warning: failed to ensure embeddings: %v\n", err)
+			log.Printf("Warning: failed to ensure embeddings: %v\n", err)
 		}
 	}
 

--- a/Backend/internal/services/cross_feature_integration_service.go
+++ b/Backend/internal/services/cross_feature_integration_service.go
@@ -6,6 +6,7 @@ import (
 	"Backend/internal/repositories"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 )
 
@@ -65,7 +66,7 @@ func (s *CrossFeatureIntegrationService) UpdateScoresFromInterviewReport(
 		for _, category := range mapping.categories {
 			if err := s.applyMovingAverage(userID, chatSessionID, category, normalized); err != nil {
 				// 更新失敗は警告ログのみ（処理継続）
-				fmt.Printf("[CrossFeature] interview→score update failed (cat=%s): %v\n", category, err)
+				log.Printf("[CrossFeature] interview→score update failed (cat=%s): %v\n", category, err)
 			}
 		}
 	}
@@ -101,7 +102,7 @@ func (s *CrossFeatureIntegrationService) UpdateScoresFromResumeReview(
 		bonus := int(math.Round(float64(score-70) / 3)) // 最大 +10
 		for _, category := range []string{"細部志向", "コミュニケーション力", "技術志向"} {
 			if err := s.applyMovingAverage(userID, chatSessionID, category, score+bonus); err != nil {
-				fmt.Printf("[CrossFeature] resume→score bonus failed (cat=%s): %v\n", category, err)
+				log.Printf("[CrossFeature] resume→score bonus failed (cat=%s): %v\n", category, err)
 			}
 		}
 	}
@@ -111,7 +112,7 @@ func (s *CrossFeatureIntegrationService) UpdateScoresFromResumeReview(
 		penalty := clampInt(score-10*criticalCount, 0, 100)
 		for _, category := range []string{"細部志向", "コミュニケーション力"} {
 			if err := s.applyMovingAverage(userID, chatSessionID, category, penalty); err != nil {
-				fmt.Printf("[CrossFeature] resume→score penalty failed (cat=%s): %v\n", category, err)
+				log.Printf("[CrossFeature] resume→score penalty failed (cat=%s): %v\n", category, err)
 			}
 		}
 	}
@@ -238,11 +239,11 @@ func (s *CrossFeatureIntegrationService) BuildResumeContextFromScores(
 
 // UserIntegratedProfile ユーザーの統合プロファイル
 type UserIntegratedProfile struct {
-	UserID        uint                    `json:"user_id"`
-	ChatSessionID string                  `json:"chat_session_id"`
+	UserID        uint                     `json:"user_id"`
+	ChatSessionID string                   `json:"chat_session_id"`
 	WeightScores  []entity.UserWeightScore `json:"weight_scores"`
 	TopCategories []entity.UserWeightScore `json:"top_categories"`
-	SourceSummary ProfileSourceSummary    `json:"source_summary"`
+	SourceSummary ProfileSourceSummary     `json:"source_summary"`
 }
 
 // ProfileSourceSummary 各機能からのデータ取得状況

--- a/Backend/internal/services/email_service.go
+++ b/Backend/internal/services/email_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"log"
 	"net/smtp"
 	"os"
 	"strconv"
@@ -221,7 +222,7 @@ func (s *EmailService) SendAnalysisReport(user *entity.User, summary *AnalysisSu
 
 	// SMTP未設定の場合はログ出力のみ（開発環境向け）
 	if s.host == "" {
-		fmt.Printf("[EmailService] SMTP not configured. Simulating send to %s (body: %d bytes)\n", user.Email, len(htmlBody))
+		log.Printf("[EmailService] SMTP not configured. Simulating send to %s (body: %d bytes)\n", user.Email, len(htmlBody))
 		return nil
 	}
 
@@ -237,7 +238,7 @@ func (s *EmailService) SendAnalysisReport(user *entity.User, summary *AnalysisSu
 		return fmt.Errorf("failed to send email: %w", err)
 	}
 
-	fmt.Printf("[EmailService] Email sent successfully to %s\n", user.Email)
+	log.Printf("[EmailService] Email sent successfully to %s\n", user.Email)
 	return nil
 }
 
@@ -257,7 +258,7 @@ func (s *EmailService) SendVerificationEmail(user *entity.User, token, appURL st
 </body></html>`, user.Name, verifyURL)
 
 	if s.host == "" {
-		fmt.Printf("[EmailService] Verification email for %s: %s\n", user.Email, verifyURL)
+		log.Printf("[EmailService] Verification email for %s: %s\n", user.Email, verifyURL)
 		return nil
 	}
 
@@ -286,7 +287,7 @@ func (s *EmailService) SendReVerificationEmail(user *entity.User, token, appURL 
 </body></html>`, user.Name, verifyURL)
 
 	if s.host == "" {
-		fmt.Printf("[EmailService] Re-verification email for %s: %s\n", user.Email, verifyURL)
+		log.Printf("[EmailService] Re-verification email for %s: %s\n", user.Email, verifyURL)
 		return nil
 	}
 
@@ -393,7 +394,7 @@ func (s *EmailService) SendRegistrationEmail(email, token string) error {
 </body></html>`, registerURL)
 
 	if s.host == "" {
-		fmt.Printf("[EmailService] Registration email for %s: %s\n", email, registerURL)
+		log.Printf("[EmailService] Registration email for %s: %s\n", email, registerURL)
 		return nil
 	}
 
@@ -422,7 +423,7 @@ func (s *EmailService) SendPasswordResetEmail(email, token, appURL string) error
 </body></html>`, resetURL)
 
 	if s.host == "" {
-		fmt.Printf("[EmailService] Password reset email for %s: %s\n", email, resetURL)
+		log.Printf("[EmailService] Password reset email for %s: %s\n", email, resetURL)
 		return nil
 	}
 
@@ -452,7 +453,7 @@ func (s *EmailService) SendInterviewReport(user *entity.User, data InterviewRepo
 	htmlBody := buf.String()
 
 	if s.host == "" {
-		fmt.Printf("[EmailService] SMTP not configured. Simulating interview report send to %s (body: %d bytes)\n", user.Email, len(htmlBody))
+		log.Printf("[EmailService] SMTP not configured. Simulating interview report send to %s (body: %d bytes)\n", user.Email, len(htmlBody))
 		return nil
 	}
 
@@ -465,7 +466,7 @@ func (s *EmailService) SendInterviewReport(user *entity.User, data InterviewRepo
 	if err := smtp.SendMail(addr, auth, s.from, []string{user.Email}, []byte(msg)); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
-	fmt.Printf("[EmailService] Interview report email sent successfully to %s\n", user.Email)
+	log.Printf("[EmailService] Interview report email sent successfully to %s\n", user.Email)
 	return nil
 }
 
@@ -475,7 +476,7 @@ func (s *EmailService) SendSystemAlertEmail(recipients []string, subject, body s
 		return nil
 	}
 	if s.host == "" || s.user == "" || s.password == "" || s.from == "" {
-		fmt.Printf("[EmailService] SMTP not configured. Simulating alert send to %v\n", recipients)
+		log.Printf("[EmailService] SMTP not configured. Simulating alert send to %v\n", recipients)
 		return nil
 	}
 

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -65,10 +66,10 @@ func (s *InterviewService) StartWorker() {
 func (s *InterviewService) runWorker() {
 	for sessionID := range s.jobCh {
 		if err := s.generateReport(context.Background(), sessionID); err != nil {
-			fmt.Printf("[Interview] Report generation failed for session %d: %v\n", sessionID, err)
+			log.Printf("[Interview] Report generation failed for session %d: %v\n", sessionID, err)
 			continue
 		}
-		fmt.Printf("[Interview] Report generation completed for session %d\n", sessionID)
+		log.Printf("[Interview] Report generation completed for session %d\n", sessionID)
 	}
 }
 
@@ -976,7 +977,7 @@ Interview transcript:
 		chatSessionID := fmt.Sprintf("interview-%d", session.UserID)
 		if err := s.crossFeature.UpdateScoresFromInterviewReport(session.UserID, chatSessionID, report); err != nil {
 			// スコア反映失敗はレポート生成を失敗扱いにしない
-			fmt.Printf("[CrossFeature] interview score update failed for session %d: %v\n", sessionID, err)
+			log.Printf("[CrossFeature] interview score update failed for session %d: %v\n", sessionID, err)
 		}
 	}
 	return nil

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -9,6 +9,7 @@ import (
 	"Backend/internal/services/prompts"
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"strings"
@@ -37,7 +38,7 @@ func NewMatchingService(
 
 // CalculateMatching ユーザーと企業のマッチングを計算
 func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, sessionID string) error {
-	fmt.Printf("[CalculateMatching] Starting matching calculation for user %d, session %s\n", userID, sessionID)
+	log.Printf("[CalculateMatching] Starting matching calculation for user %d, session %s\n", userID, sessionID)
 
 	// 1. ユーザーのスコアを取得
 	userScores, err := s.userWeightScoreRepo.FindByUserAndSession(userID, sessionID)
@@ -46,7 +47,7 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 	}
 
 	if len(userScores) == 0 {
-		fmt.Printf("[CalculateMatching] No user scores found for user %d, session %s\n", userID, sessionID)
+		log.Printf("[CalculateMatching] No user scores found for user %d, session %s\n", userID, sessionID)
 		return nil
 	}
 
@@ -56,7 +57,7 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 		scoreMap[score.WeightCategory] = float64(score.Score)
 	}
 
-	fmt.Printf("[CalculateMatching] User scores: %v\n", scoreMap)
+	log.Printf("[CalculateMatching] User scores: %v\n", scoreMap)
 
 	// 2. 全企業のプロファイルを取得
 	companies, err := s.companyRepo.FindAllActive(10000, 0)
@@ -64,7 +65,7 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 		return fmt.Errorf("failed to get companies: %w", err)
 	}
 
-	fmt.Printf("[CalculateMatching] Found %d active companies\n", len(companies))
+	log.Printf("[CalculateMatching] Found %d active companies\n", len(companies))
 
 	// 3. 各企業とのマッチングを計算
 	matchCount := 0
@@ -72,7 +73,7 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 		// 企業のweightプロファイルを取得
 		profile, err := s.companyRepo.GetWeightProfile(company.ID, nil)
 		if err != nil {
-			fmt.Printf("[CalculateMatching] Warning: No profile for company %d: %v\n", company.ID, err)
+			log.Printf("[CalculateMatching] Warning: No profile for company %d: %v\n", company.ID, err)
 			continue
 		}
 
@@ -85,20 +86,20 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 
 		reason, err := s.GenerateMatchReason(ctx, match, userScores)
 		if err != nil {
-			fmt.Printf("[CalculateMatching] Warning: Failed to generate AI reason for company %d: %v\n", company.ID, err)
+			log.Printf("[CalculateMatching] Warning: Failed to generate AI reason for company %d: %v\n", company.ID, err)
 			reason = BuildMatchReason(match, userScores)
 		}
 		match.MatchReason = reason
 
 		// マッチング結果を保存
 		if err := s.matchRepo.CreateOrUpdate(match); err != nil {
-			fmt.Printf("[CalculateMatching] Warning: Failed to save match for company %d: %v\n", company.ID, err)
+			log.Printf("[CalculateMatching] Warning: Failed to save match for company %d: %v\n", company.ID, err)
 			continue
 		}
 		matchCount++
 	}
 
-	fmt.Printf("[CalculateMatching] Completed: %d matches created for user %d, session %s\n", matchCount, userID, sessionID)
+	log.Printf("[CalculateMatching] Completed: %d matches created for user %d, session %s\n", matchCount, userID, sessionID)
 	return nil
 }
 

--- a/Backend/internal/services/oauth_service.go
+++ b/Backend/internal/services/oauth_service.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -252,7 +253,7 @@ func (s *OAuthService) HandleGitHubCallback(ctx context.Context, code string) (*
 		accessToken := token.AccessToken
 		if err := s.githubService.StoreAccessToken(user.ID, userInfo.Login, accessToken); err != nil {
 			// トークン保存失敗はログのみ（ログイン自体は成功扱い）
-			fmt.Printf("[OAuthService] failed to store github access token for user %d: %v\n", user.ID, err)
+			log.Printf("[OAuthService] failed to store github access token for user %d: %v\n", user.ID, err)
 		} else {
 			s.githubService.TriggerAsyncSync(user.ID, false)
 		}

--- a/Backend/internal/services/question_generator_service.go
+++ b/Backend/internal/services/question_generator_service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -97,7 +98,7 @@ func (s *QuestionGeneratorService) GenerateAndSaveQuestions(ctx context.Context,
 		if err != nil {
 			// 重複エラーの場合はスキップ
 			if strings.Contains(err.Error(), "既に存在") {
-				fmt.Printf("Question already exists, skipping: %s\n", gq.Question)
+				log.Printf("Question already exists, skipping: %s\n", gq.Question)
 				continue
 			}
 			return nil, fmt.Errorf("failed to save question: %w", err)

--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -190,7 +190,7 @@ func (s *ResumeService) ReviewDocument(documentID uint, companyName string, jobT
 	// スコア更新（クロス機能連携）
 	if s.crossFeature != nil {
 		if err := s.crossFeature.UpdateScoresFromResumeReview(doc.UserID, doc.SessionID, review, items); err != nil {
-			fmt.Printf("[Resume] crossFeature score update failed: %v\n", err)
+			log.Printf("[Resume] crossFeature score update failed: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
Closes #288

## 変更内容
- `Backend/internal/services/chat_phase_manager.go` のフェーズ完了ログを `log.Printf` から `slog.Info` へ変更し、`phase` を構造化フィールドで出力するように統一
- `Backend/internal/models/seed_large_data.go` の `fmt.Printf` / `fmt.Println` による進捗ログを `slog.Info` ベースへ移行
- 大量データシード時のログを、件数・合計・処理時間などの属性を持つ構造化ログへ整理

## 確認内容
- `cd Backend && go test ./internal/...`
