### PR TITLE
Resolve #316-320: Low バグ修正とテストカバレッジ追加

### DIFF
--- a/Backend/internal/models/seed_large_data.go
+++ b/Backend/internal/models/seed_large_data.go
@@ -24,9 +24,6 @@ func SeedLargeCompanyData(db *gorm.DB) error {
 	slog.Info("Starting to seed companies with relationships", "target_companies", 40000)
 	startTime := time.Now()
 
-	// ランダムシードを初期化
-	rand.Seed(time.Now().UnixNano())
-
 	// 業界リスト
 	industries := []string{
 		"IT・ソフトウェア", "製造業", "金融", "商社", "小売",

--- a/Backend/internal/openai/client.go
+++ b/Backend/internal/openai/client.go
@@ -28,10 +28,6 @@ type Client struct {
 	OnUsage      UsageHook // オプション: コール成功時にトークン使用量を通知
 }
 
-func init() {
-	// ジッター用の乱数初期化
-	rand.Seed(time.Now().UnixNano())
-}
 
 func NewFromEnv(optionalModel string) (*Client, error) {
 	key := os.Getenv("OPENAI_API_KEY")

--- a/Backend/internal/services/answer_evaluator.go
+++ b/Backend/internal/services/answer_evaluator.go
@@ -329,10 +329,8 @@ func (e *AnswerEvaluator) precheckHuman(answer string, isChoice bool, jobRoleSet
 		return HumanScoreResult{Action: PrecheckIgnore, Reason: "too_short_ignore"}
 	}
 
-	// skipPhrases は完全一致のみスキップ（Contains だと「資格なし」等が誤ってスキップされるため）
-	skipPhrases = []string{
-		"わからない", "分からない", "わかりません", "特にない", "特になし", "なし",
-	}
+	// skipPhrases（上記と同一スライスを再利用）を非ストリップ形式でも照合
+	// 句読点付き「なし。」等も捕捉するため trailing 記号を含む形でも確認
 	for _, phrase := range skipPhrases {
 		if normalizedAnswer == phrase || normalizedAnswer == phrase+"。" || normalizedAnswer == phrase+"、" {
 			return HumanScoreResult{Action: PrecheckSkip, Reason: "skip_phrase"}

--- a/Backend/internal/services/answer_evaluator_skip_test.go
+++ b/Backend/internal/services/answer_evaluator_skip_test.go
@@ -1,0 +1,43 @@
+package services
+
+// skipPhrases 統合テスト（Issue #317）
+// 実行: cd Backend && go test ./internal/services/... -run TestPrecheckHuman_SkipPhrases -v
+
+import (
+	"testing"
+)
+
+// TestPrecheckHuman_SkipPhrases_UnifiedList は統合された skipPhrases が全フレーズを正しく捕捉することを検証する（#317修正の担保）
+func TestPrecheckHuman_SkipPhrases_UnifiedList(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+		want   PrecheckAction
+	}{
+		// 第1定義にのみあったフレーズ（旧第2定義では脱落していた）
+		{"わかりません", "わかりません", PrecheckSkip},
+		{"分かりません（全角）", "分かりません", PrecheckSkip},
+		// 両定義に存在したフレーズ
+		{"わからない", "わからない", PrecheckSkip},
+		{"分からない", "分からない", PrecheckSkip},
+		{"特にない", "特にない", PrecheckSkip},
+		{"特になし", "特になし", PrecheckSkip},
+		{"なし", "なし", PrecheckSkip},
+		// 句読点付き（第2ループで捕捉）
+		{"なし。", "なし。", PrecheckSkip},
+		{"特にない、", "特にない、", PrecheckSkip},
+		// 通常の回答はスキップされない
+		{"普通の回答", "技術スキルがあります", PrecheckScore},
+		{"資格なし（部分一致はスキップしない）", "資格なし取得予定", PrecheckScore},
+	}
+
+	ev := &AnswerEvaluator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ev.precheckHuman(tc.answer, false, false)
+			if result.Action != tc.want {
+				t.Errorf("answer=%q: got Action=%v, want %v", tc.answer, result.Action, tc.want)
+			}
+		})
+	}
+}

--- a/Backend/internal/services/oauth_service.go
+++ b/Backend/internal/services/oauth_service.go
@@ -131,7 +131,7 @@ func (s *OAuthService) HandleGoogleCallback(ctx context.Context, code string) (*
 				AvatarURL:     userInfo.Picture,
 				IsGuest:       false,
 				TargetLevel:   "未設定",
-				SchoolName:    "学校法人岩崎学園情報科学専門学校",
+				SchoolName:    config.SchoolName(),
 				IsAdmin:       isAdminIdentity(userInfo.Email),
 			}
 			if err := s.userRepo.CreateUser(user); err != nil {
@@ -239,7 +239,7 @@ func (s *OAuthService) HandleGitHubCallback(ctx context.Context, code string) (*
 				AvatarURL:     userInfo.AvatarURL,
 				IsGuest:       false,
 				TargetLevel:   "未設定",
-				SchoolName:    "学校法人岩崎学園情報科学専門学校",
+				SchoolName:    config.SchoolName(),
 				IsAdmin:       isAdminIdentity(email),
 			}
 			if err := s.userRepo.CreateUser(user); err != nil {

--- a/Backend/internal/services/schedule_service.go
+++ b/Backend/internal/services/schedule_service.go
@@ -117,19 +117,37 @@ func (s *ScheduleService) ExportICS(userID uint) (string, error) {
 		uid := fmt.Sprintf("schedule-%d@soc-ai-agent", ev.ID)
 
 		b.WriteString("BEGIN:VEVENT\r\n")
-		fmt.Fprintf(&b, "UID:%s\r\n", uid)
-		fmt.Fprintf(&b, "DTSTART:%s\r\n", dtStart)
-		fmt.Fprintf(&b, "DTEND:%s\r\n", dtEnd)
-		fmt.Fprintf(&b, "SUMMARY:%s\r\n", escapeICS(title))
+		b.WriteString(foldICSLine("UID:" + uid))
+		b.WriteString(foldICSLine("DTSTART:" + dtStart))
+		b.WriteString(foldICSLine("DTEND:" + dtEnd))
+		b.WriteString(foldICSLine("SUMMARY:" + escapeICS(title)))
 		if ev.Notes != "" {
-			fmt.Fprintf(&b, "DESCRIPTION:%s\r\n", escapeICS(ev.Notes))
+			b.WriteString(foldICSLine("DESCRIPTION:" + escapeICS(ev.Notes)))
 		}
-		fmt.Fprintf(&b, "CATEGORIES:%s\r\n", escapeICS(string(ev.Stage)))
+		b.WriteString(foldICSLine("CATEGORIES:" + escapeICS(string(ev.Stage))))
 		b.WriteString("END:VEVENT\r\n")
 	}
 
 	b.WriteString("END:VCALENDAR\r\n")
 	return b.String(), nil
+}
+
+// foldICSLine は RFC 5545 に従い、75オクテット超の行を CRLF + スペースで折り返す
+func foldICSLine(line string) string {
+	const maxOctets = 75
+	var b strings.Builder
+	octets := 0
+	for _, r := range line {
+		encoded := []byte(string(r))
+		if octets+len(encoded) > maxOctets {
+			b.WriteString("\r\n ")
+			octets = 1 // 折り返しの先頭スペース分
+		}
+		b.WriteRune(r)
+		octets += len(encoded)
+	}
+	b.WriteString("\r\n")
+	return b.String()
 }
 
 func escapeICS(s string) string {

--- a/Backend/internal/services/schedule_service_ics_test.go
+++ b/Backend/internal/services/schedule_service_ics_test.go
@@ -1,0 +1,99 @@
+package services
+
+// ICS 行折り返しのテスト（Issue #320）
+// 実行: cd Backend && go test ./internal/services/... -run TestFoldICSLine -v
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFoldICSLine_ShortLine は75オクテット以下の行が折り返されないことを検証する
+func TestFoldICSLine_ShortLine(t *testing.T) {
+	line := "SUMMARY:短いタイトル"
+	result := foldICSLine(line)
+	if !strings.HasSuffix(result, "\r\n") {
+		t.Error("行末に CRLF が付与されていない")
+	}
+	// 折り返しなし: CRLF は末尾の1箇所のみ
+	if strings.Count(result, "\r\n") != 1 {
+		t.Errorf("短い行が折り返された: %q", result)
+	}
+}
+
+// TestFoldICSLine_LongLine は75オクテット超の行が折り返されることを検証する（#320修正の担保）
+func TestFoldICSLine_LongLine(t *testing.T) {
+	// 100文字のASCII行（100オクテット）
+	long := "SUMMARY:" + strings.Repeat("A", 100)
+	result := foldICSLine(long)
+	if strings.Count(result, "\r\n") < 2 {
+		t.Error("長い行が折り返されていない")
+	}
+	// 折り返し後の各行が75オクテット以下であることを確認
+	lines := strings.Split(result, "\r\n")
+	for i, l := range lines {
+		if i == len(lines)-1 && l == "" {
+			continue // 末尾の空行はスキップ
+		}
+		if len([]byte(l)) > 75 {
+			t.Errorf("行 %d が75オクテット超: %d オクテット", i, len([]byte(l)))
+		}
+	}
+}
+
+// TestFoldICSLine_MultiByteLine はマルチバイト文字（日本語）で正しくオクテット数を計算することを検証する
+func TestFoldICSLine_MultiByteLine(t *testing.T) {
+	// 日本語 1文字 = 3オクテット（UTF-8）
+	// "SUMMARY:" = 8オクテット + 日本語22文字 = 8 + 66 = 74オクテット（折り返しなし）
+	shortJP := "SUMMARY:" + strings.Repeat("あ", 22) // 8 + 66 = 74 <= 75
+	result := foldICSLine(shortJP)
+	if strings.Count(result, "\r\n") != 1 {
+		t.Errorf("74オクテットの行が折り返された: %q", result)
+	}
+
+	// "SUMMARY:" = 8オクテット + 日本語23文字 = 8 + 69 = 77オクテット（折り返しあり）
+	longJP := "SUMMARY:" + strings.Repeat("あ", 23) // 8 + 69 = 77 > 75
+	result2 := foldICSLine(longJP)
+	if strings.Count(result2, "\r\n") < 2 {
+		t.Error("77オクテットの日本語行が折り返されていない")
+	}
+
+	// 折り返し後の各行が75オクテット以下
+	lines := strings.Split(result2, "\r\n")
+	for i, l := range lines {
+		if i == len(lines)-1 && l == "" {
+			continue
+		}
+		if len([]byte(l)) > 75 {
+			t.Errorf("行 %d が75オクテット超: %d オクテット", i, len([]byte(l)))
+		}
+	}
+}
+
+// TestFoldICSLine_ContinuationLineStartsWithSpace は折り返し継続行がスペースで始まることを検証する（RFC 5545）
+func TestFoldICSLine_ContinuationLineStartsWithSpace(t *testing.T) {
+	long := "DESCRIPTION:" + strings.Repeat("X", 100)
+	result := foldICSLine(long)
+	lines := strings.Split(result, "\r\n")
+	for i, l := range lines {
+		if i == 0 || (i == len(lines)-1 && l == "") {
+			continue
+		}
+		if !strings.HasPrefix(l, " ") {
+			t.Errorf("継続行 %d がスペースで始まっていない: %q", i, l)
+		}
+	}
+}
+
+// TestFoldICSLine_ContentPreserved は折り返し後に内容が変化しないことを検証する
+func TestFoldICSLine_ContentPreserved(t *testing.T) {
+	original := "SUMMARY:" + strings.Repeat("テスト", 30) // 長い日本語行
+	result := foldICSLine(original)
+
+	// 折り返しを除去して元の内容と一致するか確認
+	unfolded := strings.ReplaceAll(result, "\r\n ", "")
+	unfolded = strings.TrimSuffix(unfolded, "\r\n")
+	if unfolded != original {
+		t.Errorf("折り返し後に内容が変化した\n got:  %q\n want: %q", unfolded, original)
+	}
+}

--- a/rag/main.py
+++ b/rag/main.py
@@ -51,7 +51,7 @@ _chroma_lock = threading.Lock()
 @app.on_event("startup")
 def log_openai_version() -> None:
     version = getattr(openai_module, "__version__", "unknown")
-    has_responses = hasattr(OpenAI(api_key=""), "responses")
+    has_responses = hasattr(openai_module.OpenAI, "responses")
     logger.info("openai version=%s responses_api=%s", version, has_responses)
 
 


### PR DESCRIPTION
## 対象 Issue

Closes #316, Closes #317, Closes #318, Closes #319, Closes #320

## 変更内容

### バグ修正

- **#316** `Backend/internal/openai/client.go`, `Backend/internal/models/seed_large_data.go`  
  非推奨の `rand.Seed(time.Now().UnixNano())` を削除。Go 1.20以降グローバルソースは自動初期化されるため不要。

- **#317** `Backend/internal/services/answer_evaluator.go`  
  `precheckHuman` 内で `skipPhrases` が2重定義されており、2回目の定義で `"わかりません"` / `"分かりません"` が脱落していた問題を修正。2回目の `skipPhrases = []string{...}` 代入を削除し、最初の完全なスライスを両ループで共用するよう統合。

- **#318** `Backend/internal/services/oauth_service.go`  
  Google OAuth（L134）と GitHub OAuth（L242）の新規ユーザー作成で `SchoolName` をハードコードしていた箇所を `config.SchoolName()` に統一。

- **#319** `rag/main.py`  
  起動時の `has_responses = hasattr(OpenAI(api_key=""), "responses")` を `hasattr(openai_module.OpenAI, "responses")` に変更。空キーでインスタンスを生成する不要なオブジェクト生成を解消。

- **#320** `Backend/internal/services/schedule_service.go`  
  RFC 5545 の ICS 行折り返し要件に対応。`foldICSLine` 関数を追加し、75オクテット超の行を `\r\n ` で分割。SUMMARY / DESCRIPTION / CATEGORIES / UID 等の全フィールドに適用。

### テスト追加

| ファイル | 対象 | 内容 |
|---|---|---|
| `answer_evaluator_skip_test.go` | #317 | 統合済み skipPhrases の全フレーズ捕捉・部分一致非スキップ・句読点付き形式の検証 |
| `schedule_service_ics_test.go` | #320 | 短行非折り返し・長行折り返し・マルチバイト(UTF-8オクテット数)・継続行スペース・内容保持の検証 |

## テスト結果

```
ok  Backend/internal/controllers
ok  Backend/internal/middleware
ok  Backend/internal/repositories
ok  Backend/internal/services
```