### PR TITLE
fix: #324 #325 OAuth CSRF対策とレート制限の実装

### DIFF
--- a/Backend/internal/controllers/oauth_controller.go
+++ b/Backend/internal/controllers/oauth_controller.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"Backend/internal/config"
+	"Backend/internal/middleware"
 	"Backend/internal/services"
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
@@ -23,15 +25,18 @@ func (c *OAuthController) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	state := generateStateToken()
-	// 本番環境ではセッションやクッキーに保存してCSRF対策を行う
+	// state を生成して HttpOnly Cookie に保存（CSRF 対策 #324）
+	state, err := middleware.GenerateOAuthState(w)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	url := c.oauthService.GetGoogleAuthURL(state)
 
-	// リダイレクトURLをJSON形式で返す（フロントエンド側でリダイレクト）
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
 		"auth_url": url,
-		"state":    state,
 	})
 }
 
@@ -42,25 +47,29 @@ func (c *OAuthController) GoogleCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// state 検証（CSRF 対策 #324）
+	if !middleware.VerifyOAuthState(w, r) {
+		log.Printf("[OAuth] Google callback: invalid or missing state from %s", r.RemoteAddr)
+		http.Redirect(w, r, config.AppURL()+"?error=auth_failed", http.StatusTemporaryRedirect)
+		return
+	}
+
 	code := r.URL.Query().Get("code")
 	if code == "" {
 		http.Error(w, "Authorization code not found", http.StatusBadRequest)
 		return
 	}
 
-	// 本番環境ではstateの検証を行う
-	// state := r.URL.Query().Get("state")
-
 	resp, err := c.oauthService.HandleGoogleCallback(r.Context(), code)
 	if err != nil {
-		// エラー時はフロントエンドにリダイレクトしてエラーを表示
-		http.Redirect(w, r, "http://localhost:3000?error="+err.Error(), http.StatusTemporaryRedirect)
+		// エラー詳細はサーバーログにのみ記録し、クライアントには汎用コードを返す（#329）
+		log.Printf("[OAuth] Google callback error: %v", err)
+		http.Redirect(w, r, config.AppURL()+"?error=auth_failed", http.StatusTemporaryRedirect)
 		return
 	}
 
-	// 認証成功時はユーザー情報をクエリパラメータとしてフロントエンドに渡してリダイレクト
 	userData, _ := json.Marshal(resp)
-	redirectURL := "http://localhost:3000/auth/callback?provider=google&code=" + code + "&user=" + base64.URLEncoding.EncodeToString(userData)
+	redirectURL := config.AppURL() + "/auth/callback?provider=google&user=" + base64.URLEncoding.EncodeToString(userData)
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
@@ -71,13 +80,18 @@ func (c *OAuthController) GitHubLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	state := generateStateToken()
+	// state を生成して HttpOnly Cookie に保存（CSRF 対策 #324）
+	state, err := middleware.GenerateOAuthState(w)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	url := c.oauthService.GetGitHubAuthURL(state)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
 		"auth_url": url,
-		"state":    state,
 	})
 }
 
@@ -85,6 +99,13 @@ func (c *OAuthController) GitHubLogin(w http.ResponseWriter, r *http.Request) {
 func (c *OAuthController) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// state 検証（CSRF 対策 #324）
+	if !middleware.VerifyOAuthState(w, r) {
+		log.Printf("[OAuth] GitHub callback: invalid or missing state from %s", r.RemoteAddr)
+		http.Redirect(w, r, config.AppURL()+"?error=auth_failed", http.StatusTemporaryRedirect)
 		return
 	}
 
@@ -96,20 +117,13 @@ func (c *OAuthController) GitHubCallback(w http.ResponseWriter, r *http.Request)
 
 	resp, err := c.oauthService.HandleGitHubCallback(r.Context(), code)
 	if err != nil {
-		// エラー時はフロントエンドにリダイレクトしてエラーを表示
-		http.Redirect(w, r, "http://localhost:3000?error="+err.Error(), http.StatusTemporaryRedirect)
+		// エラー詳細はサーバーログにのみ記録し、クライアントには汎用コードを返す（#329）
+		log.Printf("[OAuth] GitHub callback error: %v", err)
+		http.Redirect(w, r, config.AppURL()+"?error=auth_failed", http.StatusTemporaryRedirect)
 		return
 	}
 
-	// 認証成功時はユーザー情報をクエリパラメータとしてフロントエンドに渡してリダイレクト
 	userData, _ := json.Marshal(resp)
-	redirectURL := "http://localhost:3000/auth/callback?provider=github&code=" + code + "&user=" + base64.URLEncoding.EncodeToString(userData)
+	redirectURL := config.AppURL() + "/auth/callback?provider=github&user=" + base64.URLEncoding.EncodeToString(userData)
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
-}
-
-// generateStateToken CSRF対策用のランダムなstateトークンを生成
-func generateStateToken() string {
-	b := make([]byte, 32)
-	rand.Read(b)
-	return base64.URLEncoding.EncodeToString(b)
 }

--- a/Backend/internal/middleware/oauth_state.go
+++ b/Backend/internal/middleware/oauth_state.go
@@ -1,0 +1,82 @@
+package middleware
+
+// OAuth CSRF 対策 - state パラメータの Cookie 保存と検証（Issue #324）
+// state をサーバー側の HttpOnly Cookie に保存し、コールバック時に HMAC 署名付きで検証する。
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	oauthStateCookieName = "oauth_state"
+	oauthStateTTL        = 10 * time.Minute // OAuth フローは10分以内に完了すべき
+)
+
+// GenerateOAuthState はランダムな state 値を生成し、HMAC 署名付き Cookie にセットして state 文字列を返す。
+// state はコールバック時に VerifyOAuthState で検証する。
+func GenerateOAuthState(w http.ResponseWriter) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	state := base64.URLEncoding.EncodeToString(b)
+	signed := signState(state)
+
+	secure := os.Getenv("APP_ENV") == "production"
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    signed,
+		Path:     "/",
+		MaxAge:   int(oauthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return state, nil
+}
+
+// VerifyOAuthState はリクエストの state パラメータと Cookie を比較し、一致しない場合は false を返す。
+// 検証後は Cookie を削除する（使い捨て）。
+func VerifyOAuthState(w http.ResponseWriter, r *http.Request) bool {
+	stateParam := r.URL.Query().Get("state")
+
+	cookie, err := r.Cookie(oauthStateCookieName)
+	// 検証後は Cookie を削除（使い捨て）
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   os.Getenv("APP_ENV") == "production",
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	if err != nil || stateParam == "" {
+		return false
+	}
+
+	// Cookie の値は "state.signature" 形式
+	expected := signState(stateParam)
+	return hmac.Equal([]byte(cookie.Value), []byte(expected))
+}
+
+// signState は state 値を HMAC-SHA256 で署名し "state.signature" 形式の文字列を返す
+func signState(state string) string {
+	secret := os.Getenv("ADMIN_SECRET")
+	if secret == "" {
+		secret = "dev-oauth-state-secret" // 開発環境フォールバック（本番では必ず設定）
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(state))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return strings.Join([]string{state, sig}, ".")
+}

--- a/Backend/internal/middleware/oauth_state_test.go
+++ b/Backend/internal/middleware/oauth_state_test.go
@@ -1,0 +1,129 @@
+package middleware
+
+// OAuth state 検証のテスト（Issue #324）
+// 実行: cd Backend && go test ./internal/middleware/... -run TestOAuthState -v
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGenerateOAuthState_SetsCookie は GenerateOAuthState が HttpOnly Cookie をセットすることを検証する（#324修正の担保）
+func TestGenerateOAuthState_SetsCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+	state, err := GenerateOAuthState(w)
+	if err != nil {
+		t.Fatalf("GenerateOAuthState returned error: %v", err)
+	}
+	if state == "" {
+		t.Fatal("state が空")
+	}
+
+	resp := w.Result()
+	cookies := resp.Cookies()
+	var stateCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == oauthStateCookieName {
+			stateCookie = c
+			break
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("oauth_state Cookie がセットされていない")
+	}
+	if !stateCookie.HttpOnly {
+		t.Error("Cookie は HttpOnly であるべき")
+	}
+	if stateCookie.SameSite != http.SameSiteLaxMode {
+		t.Error("Cookie は SameSite=Lax であるべき")
+	}
+}
+
+// TestVerifyOAuthState_ValidState は正しい state で検証が通ることを検証する（#324修正の担保）
+func TestVerifyOAuthState_ValidState(t *testing.T) {
+	// 1. Login: state 生成して Cookie をセット
+	loginW := httptest.NewRecorder()
+	state, err := GenerateOAuthState(loginW)
+	if err != nil {
+		t.Fatalf("GenerateOAuthState error: %v", err)
+	}
+
+	// 2. Callback: Cookie を引き継いで state パラメータで検証
+	callbackReq := httptest.NewRequest(http.MethodGet, "/callback?state="+state, nil)
+	// loginW にセットされた Cookie をコールバックリクエストに付与
+	for _, c := range loginW.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackW := httptest.NewRecorder()
+
+	if !VerifyOAuthState(callbackW, callbackReq) {
+		t.Error("正しい state は検証を通るべき")
+	}
+}
+
+// TestVerifyOAuthState_InvalidState は改ざんされた state で検証が失敗することを検証する（#324修正の担保）
+func TestVerifyOAuthState_InvalidState(t *testing.T) {
+	loginW := httptest.NewRecorder()
+	_, err := GenerateOAuthState(loginW)
+	if err != nil {
+		t.Fatalf("GenerateOAuthState error: %v", err)
+	}
+
+	// state パラメータを改ざん
+	callbackReq := httptest.NewRequest(http.MethodGet, "/callback?state=tampered-state-value", nil)
+	for _, c := range loginW.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackW := httptest.NewRecorder()
+
+	if VerifyOAuthState(callbackW, callbackReq) {
+		t.Error("改ざんされた state は検証を失敗させるべき")
+	}
+}
+
+// TestVerifyOAuthState_MissingCookie は Cookie なしで検証が失敗することを検証する
+func TestVerifyOAuthState_MissingCookie(t *testing.T) {
+	callbackReq := httptest.NewRequest(http.MethodGet, "/callback?state=somestate", nil)
+	callbackW := httptest.NewRecorder()
+
+	if VerifyOAuthState(callbackW, callbackReq) {
+		t.Error("Cookie がない場合は検証を失敗させるべき")
+	}
+}
+
+// TestVerifyOAuthState_MissingStateParam は state パラメータなしで検証が失敗することを検証する
+func TestVerifyOAuthState_MissingStateParam(t *testing.T) {
+	loginW := httptest.NewRecorder()
+	_, _ = GenerateOAuthState(loginW)
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/callback", nil) // state なし
+	for _, c := range loginW.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackW := httptest.NewRecorder()
+
+	if VerifyOAuthState(callbackW, callbackReq) {
+		t.Error("state パラメータがない場合は検証を失敗させるべき")
+	}
+}
+
+// TestVerifyOAuthState_CookieDeletedAfterVerification は検証後に Cookie が削除されることを検証する（使い捨てトークン）
+func TestVerifyOAuthState_CookieDeletedAfterVerification(t *testing.T) {
+	loginW := httptest.NewRecorder()
+	state, _ := GenerateOAuthState(loginW)
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/callback?state="+state, nil)
+	for _, c := range loginW.Result().Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackW := httptest.NewRecorder()
+	VerifyOAuthState(callbackW, callbackReq)
+
+	// Cookie が削除（MaxAge=-1）されているか確認
+	for _, c := range callbackW.Result().Cookies() {
+		if c.Name == oauthStateCookieName && c.MaxAge > 0 {
+			t.Error("検証後に oauth_state Cookie が削除されていない")
+		}
+	}
+}

--- a/Backend/internal/middleware/rate_limiter.go
+++ b/Backend/internal/middleware/rate_limiter.go
@@ -1,0 +1,137 @@
+package middleware
+
+// インメモリ スライディングウィンドウ方式のレート制限ミドルウェア（Issue #325）
+// 外部依存なし（sync.Map + time）で実装。
+// キー単位（IP:email など）で window 内の試行回数を管理する。
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// rateLimitEntry は1つのキーに対するリクエスト履歴を保持する
+type rateLimitEntry struct {
+	mu        sync.Mutex
+	timestamps []time.Time
+}
+
+// RateLimiter はスライディングウィンドウ方式のレート制限器
+type RateLimiter struct {
+	entries  sync.Map
+	window   time.Duration
+	maxReqs  int
+	// クリーンアップ間隔（ゴルーティンで定期実行）
+}
+
+// NewRateLimiter は新しい RateLimiter を生成する
+// window: 計測ウィンドウ幅, maxReqs: window 内の最大リクエスト数
+func NewRateLimiter(window time.Duration, maxReqs int) *RateLimiter {
+	rl := &RateLimiter{window: window, maxReqs: maxReqs}
+	go rl.cleanupLoop()
+	return rl
+}
+
+// Allow はキーに対して1リクエストを記録し、制限内なら true を返す
+func (rl *RateLimiter) Allow(key string) bool {
+	val, _ := rl.entries.LoadOrStore(key, &rateLimitEntry{})
+	entry := val.(*rateLimitEntry)
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+
+	// 期限切れタイムスタンプを除去
+	valid := entry.timestamps[:0]
+	for _, t := range entry.timestamps {
+		if t.After(cutoff) {
+			valid = append(valid, t)
+		}
+	}
+	entry.timestamps = valid
+
+	if len(entry.timestamps) >= rl.maxReqs {
+		return false
+	}
+	entry.timestamps = append(entry.timestamps, now)
+	return true
+}
+
+// cleanupLoop は期限切れエントリを定期削除してメモリリークを防ぐ
+func (rl *RateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		cutoff := time.Now().Add(-rl.window)
+		rl.entries.Range(func(k, v any) bool {
+			entry := v.(*rateLimitEntry)
+			entry.mu.Lock()
+			valid := entry.timestamps[:0]
+			for _, t := range entry.timestamps {
+				if t.After(cutoff) {
+					valid = append(valid, t)
+				}
+			}
+			entry.timestamps = valid
+			empty := len(entry.timestamps) == 0
+			entry.mu.Unlock()
+			if empty {
+				rl.entries.Delete(k)
+			}
+			return true
+		})
+	}
+}
+
+// getClientIP は X-Forwarded-For / X-Real-IP を優先してクライアントIPを取得する
+func getClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if ip, _, err := net.SplitHostPort(xff); err == nil {
+			return ip
+		}
+		return xff
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// LoginRateLimiter はログイン試行のレート制限器
+// IP単位: 1分間に20回まで（正常ユーザーの誤入力を許容しつつ攻撃を防ぐ）
+var LoginRateLimiter = NewRateLimiter(time.Minute, 20)
+
+// PasswordResetRateLimiter はパスワードリセット要求のレート制限器
+// IP単位: 1時間に5回まで（メールサーバー保護）
+var PasswordResetRateLimiter = NewRateLimiter(time.Hour, 5)
+
+// LoginRateLimit はログインエンドポイントのレート制限ミドルウェア
+func LoginRateLimit(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip := getClientIP(r)
+		if !LoginRateLimiter.Allow(ip) {
+			http.Error(w, "Too Many Requests: お試し回数の上限に達しました。しばらく待ってから再試行してください。", http.StatusTooManyRequests)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// PasswordResetRateLimit はパスワードリセットエンドポイントのレート制限ミドルウェア
+func PasswordResetRateLimit(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip := getClientIP(r)
+		if !PasswordResetRateLimiter.Allow(ip) {
+			http.Error(w, "Too Many Requests: リクエスト上限に達しました。しばらく待ってから再試行してください。", http.StatusTooManyRequests)
+			return
+		}
+		next(w, r)
+	}
+}

--- a/Backend/internal/middleware/rate_limiter_test.go
+++ b/Backend/internal/middleware/rate_limiter_test.go
@@ -1,0 +1,104 @@
+package middleware
+
+// レート制限ミドルウェアのテスト（Issue #325）
+// 実行: cd Backend && go test ./internal/middleware/... -run TestRateLimit -v
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+var okHandlerRL = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+// TestRateLimiter_AllowsUnderLimit はウィンドウ内の上限以下のリクエストが全て通ることを検証する
+func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
+	rl := NewRateLimiter(time.Minute, 5)
+	for i := range 5 {
+		if !rl.Allow("key1") {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+// TestRateLimiter_BlocksOverLimit はウィンドウ内の上限を超えたリクエストがブロックされることを検証する（#325修正の担保）
+func TestRateLimiter_BlocksOverLimit(t *testing.T) {
+	rl := NewRateLimiter(time.Minute, 3)
+	for range 3 {
+		rl.Allow("key2")
+	}
+	if rl.Allow("key2") {
+		t.Error("4回目のリクエストはブロックされるべき")
+	}
+}
+
+// TestRateLimiter_DifferentKeysAreIndependent は異なるキーが独立してカウントされることを検証する
+func TestRateLimiter_DifferentKeysAreIndependent(t *testing.T) {
+	rl := NewRateLimiter(time.Minute, 2)
+	rl.Allow("user-a")
+	rl.Allow("user-a")
+	// user-a は上限到達、user-b はまだ余裕あり
+	if rl.Allow("user-a") {
+		t.Error("user-a の3回目はブロックされるべき")
+	}
+	if !rl.Allow("user-b") {
+		t.Error("user-b の1回目は通るべき")
+	}
+}
+
+// TestLoginRateLimit_Middleware はミドルウェアが 429 を返すことを検証する
+func TestLoginRateLimit_Middleware(t *testing.T) {
+	// テスト用に制限値が低いレート制限器を使用
+	testLimiter := NewRateLimiter(time.Minute, 2)
+	wrapped := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			ip := getClientIP(r)
+			if !testLimiter.Allow(ip) {
+				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+				return
+			}
+			next(w, r)
+		}
+	}
+
+	handler := wrapped(okHandlerRL)
+	for i := 1; i <= 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		w := httptest.NewRecorder()
+		handler(w, req)
+		if i <= 2 {
+			if w.Code != http.StatusOK {
+				t.Errorf("request %d: want 200, got %d", i, w.Code)
+			}
+		} else {
+			if w.Code != http.StatusTooManyRequests {
+				t.Errorf("request %d: want 429, got %d", i, w.Code)
+			}
+		}
+	}
+}
+
+// TestGetClientIP_XForwardedFor は X-Forwarded-For ヘッダーからIPを取得することを検証する
+func TestGetClientIP_XForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.RemoteAddr = "127.0.0.1:8080"
+	ip := getClientIP(req)
+	if ip != "1.2.3.4" {
+		t.Errorf("got %q, want %q", ip, "1.2.3.4")
+	}
+}
+
+// TestGetClientIP_RemoteAddr は X-Forwarded-For がない場合に RemoteAddr を使用することを検証する
+func TestGetClientIP_RemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.1:9999"
+	ip := getClientIP(req)
+	if ip != "192.168.1.1" {
+		t.Errorf("got %q, want %q", ip, "192.168.1.1")
+	}
+}

--- a/Backend/internal/routes/auth_routes.go
+++ b/Backend/internal/routes/auth_routes.go
@@ -17,10 +17,10 @@ func SetupAuthRoutes(authController *controllers.AuthController, oauthController
 	http.HandleFunc("/api/auth/request-registration", authController.RequestRegistration)
 	http.HandleFunc("/api/auth/verify-registration", authController.VerifyRegistration)
 	http.HandleFunc("/api/auth/register", authController.Register)
-	http.HandleFunc("/api/auth/login", authController.Login)
+	http.HandleFunc("/api/auth/login", middleware.LoginRateLimit(authController.Login))
 	http.HandleFunc("/api/auth/guest", authController.CreateGuest)
 	http.HandleFunc("/api/auth/verify-email", authController.VerifyEmail)
-	http.HandleFunc("/api/auth/forgot-password", authController.RequestPasswordReset)
+	http.HandleFunc("/api/auth/forgot-password", middleware.PasswordResetRateLimit(authController.RequestPasswordReset))
 	http.HandleFunc("/api/auth/reset-password", authController.ResetPassword)
 
 	// 認証必須エンドポイント（X-User-ID + X-User-Token ヘッダーが必要）


### PR DESCRIPTION
## 対象 Issue

Closes #324, Closes #325

## 変更内容

### #324 — OAuth CSRF 対策（state パラメータ検証）

**変更ファイル**: `Backend/internal/middleware/oauth_state.go`, `Backend/internal/controllers/oauth_controller.go`

| 修正前 | 修正後 |
|---|---|
| state を JSON でフロントエンドに渡すだけで検証なし | state を HMAC-SHA256 署名付き HttpOnly Cookie に保存 |
| コールバック時の state 検証がコメントアウト | コールバック時に Cookie と state パラメータを照合して検証 |
| エラー詳細が `?error=err.Error()` でURLに露出（#329） | エラーはサーバーログのみ、クライアントには `auth_failed` 固定 |

実装詳細:
- `GenerateOAuthState(w)`: 32バイトのランダム state を生成し `"state.HMAC"` 形式で Cookie にセット
- `VerifyOAuthState(w, r)`: Cookie の署名を検証後、state パラメータと照合（使い捨て）
- Cookie: `HttpOnly=true`, `SameSite=Lax`, `MaxAge=10分`, 本番環境では `Secure=true`

### #325 — ブルートフォース対策（レート制限）

**変更ファイル**: `Backend/internal/middleware/rate_limiter.go`, `Backend/internal/routes/auth_routes.go`

外部依存なし（`sync.Map` + `time`）のインメモリ スライディングウィンドウ方式を実装:

| エンドポイント | 制限 |
|---|---|
| `POST /api/auth/login` | IP単位: 1分間に20回まで |
| `POST /api/auth/forgot-password` | IP単位: 1時間に5回まで |

- `X-Forwarded-For` / `X-Real-IP` ヘッダーによる実IPアドレス取得対応
- 5分毎のバックグラウンドクリーンアップでメモリリークを防止
- 上限超過時は `HTTP 429 Too Many Requests` を返却

## テスト結果

```
ok  Backend/internal/middleware  (全34テストパス)
ok  Backend/internal/controllers
ok  Backend/internal/services
ok  Backend/internal/repositories
```

新規テスト:
- `oauth_state_test.go`: Cookie設定・正常検証・改ざん検知・Cookie未使用・パラメータ欠落・使い捨て確認（6件）
- `rate_limiter_test.go`: 上限内通過・上限超ブロック・キー独立・ミドルウェア動作・IP取得（6件）