### PR TITLE
Resolve #334: docker-compose.yml に rag-review・company-graph サービスを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,10 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 ### RAG (Python)
 - `cd rag && pip install -r constraints.txt && python3 main.py` (9000)
 ### Docker
-- `docker compose up -d` (app/db/fe) / `--profile rag` (rag)
+- `docker compose up -d` (app/db/fe)
+- `docker compose --profile rag up -d` (+ rag-review: ポート9000)
+- `docker compose --profile company-graph up -d` (+ company-graph: ポート9100)
+- `docker compose --profile rag --profile company-graph up -d` (全サービス)
 
 ## アーキテクチャ & フライホイール
 - **構造**: FE(Next.js) -> BE(Go/MySQL/S3) -> RAG(Python/ChromaDB/CrewAI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,7 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 ### RAG (Python)
 - `cd rag && pip install -r constraints.txt && python3 main.py` (9000)
 ### Docker
-- `docker compose up -d` (app/db/fe)
-- `docker compose --profile rag up -d` (+ rag-review: ポート9000)
-- `docker compose --profile company-graph up -d` (+ company-graph: ポート9100)
-- `docker compose --profile rag --profile company-graph up -d` (全サービス)
+- `docker compose up -d` (全サービス: backend/frontend/rag-review/company-graph)
 
 ## アーキテクチャ & フライホイール
 - **構造**: FE(Next.js) -> BE(Go/MySQL/S3) -> RAG(Python/ChromaDB/CrewAI)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
   rag-review:
     image: 970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-rag-review:latest
     restart: unless-stopped
-    profiles:
-      - rag
     ports:
       - "${RAG_REVIEW_PORT:-9000}:9000"
     env_file:
@@ -43,8 +41,6 @@ services:
   company-graph:
     image: 970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-company-graph:latest
     restart: unless-stopped
-    profiles:
-      - company-graph
     ports:
       - "${COMPANY_GRAPH_PORT:-9100}:9100"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,34 @@ services:
     environment:
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
       APP_ENV: production
+      COMPANY_GRAPH_URL: http://company-graph:9100
     depends_on:
       - backend
+
+  # Resume review RAG (DuckDuckGo + CrewAI)
+  rag-review:
+    image: 970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-rag-review:latest
+    restart: unless-stopped
+    profiles:
+      - rag
+    ports:
+      - "${RAG_REVIEW_PORT:-9000}:9000"
+    env_file:
+      - .env
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      OPENAI_HINTS_MODEL: ${OPENAI_HINTS_MODEL:-gpt-4o-search-preview}
+      OPENAI_HINTS_PARSE_MODEL: ${OPENAI_HINTS_PARSE_MODEL:-gpt-4o}
+
+  # Company graph pipeline (マルチソース新卒採用データ × gBizINFO)
+  company-graph:
+    image: 970835573274.dkr.ecr.ap-northeast-1.amazonaws.com/soc-company-graph:latest
+    restart: unless-stopped
+    profiles:
+      - company-graph
+    ports:
+      - "${COMPANY_GRAPH_PORT:-9100}:9100"
+    environment:
+      GBIZINFO_API_KEY: ${GBIZINFO_API_KEY:-}
+      GBIZINFO_BASE_URL: ${GBIZINFO_BASE_URL:-}


### PR DESCRIPTION
Closes #334

## 変更内容

### docker-compose.yml
- `rag-review` サービスを追加（ポート 9000、ECR イメージ使用）
  - `OPENAI_API_KEY` など必要な環境変数を設定
  - `env_file: .env` で秘匿情報を注入
- `company-graph` サービスを追加（ポート 9100、ECR イメージ使用）
  - `GBIZINFO_API_KEY` / `GBIZINFO_BASE_URL` を環境変数として設定
- 両サービスの `profiles` 設定を削除し、`docker compose up -d` のみで全サービスが起動するよう変更

### CLAUDE.md
- Docker 起動コマンドをシンプルな1行に更新
  - 変更前: `--profile rag` / `--profile company-graph` など複数パターン
  - 変更後: `docker compose up -d`（全サービス起動）