### PR TITLE
Resolve #337: UIスマートフォン対応（レスポンシブデザイン）

### DIFF
--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -1,0 +1,25 @@
+/* モバイル用ヘッダー: md(900px)未満のみ表示 */
+.mobileHeader {
+    display: flex;
+}
+
+/* デスクトップでは非表示 */
+@media (min-width: 900px) {
+    .mobileHeader {
+        display: none;
+    }
+}
+
+.mainContent {
+    flex-grow: 1;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.chatWrapper {
+    flex-grow: 1;
+    overflow: hidden;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import { Menu as MenuIcon } from '@mui/icons-material'
 import { AnalysisSidebar } from '@/components/analysis-sidebar'
 import { MuiChat } from '@/components/mui-chat'
 import { authService, User } from '@/lib/auth'
+import styles from './page.module.css'
 
 export default function Home() {
   const router = useRouter()
@@ -42,25 +43,13 @@ export default function Home() {
         mobileOpen={mobileOpen}
         onMobileClose={() => setMobileOpen(false)}
       />
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          height: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          minWidth: 0,
-        }}
-      >
+      <main className={styles.mainContent}>
         {/* モバイル用ヘッダー（ハンバーガーメニュー） */}
         <AppBar
           position="static"
           elevation={0}
-          sx={{
-            display: { xs: 'flex', md: 'none' },
-            backgroundColor: '#fff',
-            borderBottom: '1px solid #e0e0e0',
-          }}
+          className={styles.mobileHeader}
+          sx={{ backgroundColor: '#fff', borderBottom: '1px solid #e0e0e0' }}
         >
           <Toolbar variant="dense" sx={{ minHeight: 48 }}>
             <IconButton
@@ -76,10 +65,10 @@ export default function Home() {
             </Typography>
           </Toolbar>
         </AppBar>
-        <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+        <div className={styles.chatWrapper}>
           <MuiChat />
-        </Box>
-      </Box>
+        </div>
+      </main>
     </Box>
   )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Box } from '@mui/material'
+import { Box, IconButton, AppBar, Toolbar, Typography } from '@mui/material'
+import { Menu as MenuIcon } from '@mui/icons-material'
 import { AnalysisSidebar } from '@/components/analysis-sidebar'
 import { MuiChat } from '@/components/mui-chat'
 import { authService, User } from '@/lib/auth'
@@ -11,6 +12,7 @@ export default function Home() {
   const router = useRouter()
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   useEffect(() => {
     const storedUser = authService.getStoredUser()
@@ -34,15 +36,49 @@ export default function Home() {
 
   return (
     <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-      <AnalysisSidebar user={user} onLogout={handleLogout} />
+      <AnalysisSidebar
+        user={user}
+        onLogout={handleLogout}
+        mobileOpen={mobileOpen}
+        onMobileClose={() => setMobileOpen(false)}
+      />
       <Box
         component="main"
         sx={{
           flexGrow: 1,
           height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          minWidth: 0,
         }}
       >
-        <MuiChat />
+        {/* モバイル用ヘッダー（ハンバーガーメニュー） */}
+        <AppBar
+          position="static"
+          elevation={0}
+          sx={{
+            display: { xs: 'flex', md: 'none' },
+            backgroundColor: '#fff',
+            borderBottom: '1px solid #e0e0e0',
+          }}
+        >
+          <Toolbar variant="dense" sx={{ minHeight: 48 }}>
+            <IconButton
+              edge="start"
+              onClick={() => setMobileOpen(true)}
+              sx={{ mr: 1, color: 'text.primary' }}
+              aria-label="メニューを開く"
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, color: 'text.primary' }}>
+              IT業界キャリアエージェント
+            </Typography>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+          <MuiChat />
+        </Box>
       </Box>
     </Box>
   )

--- a/frontend/components/analysis-sidebar.module.css
+++ b/frontend/components/analysis-sidebar.module.css
@@ -1,0 +1,17 @@
+/* モバイル: Temporary Drawer のみ表示 */
+.drawerMobile {
+    display: block;
+}
+.drawerDesktop {
+    display: none;
+}
+
+/* デスクトップ(md: 900px以上): Permanent Drawer のみ表示 */
+@media (min-width: 900px) {
+    .drawerMobile {
+        display: none;
+    }
+    .drawerDesktop {
+        display: block;
+    }
+}

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, {useState, useEffect} from 'react'
+import styles from './analysis-sidebar.module.css'
 import
 {
     Box,
@@ -500,20 +501,16 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                 open={mobileOpen}
                 onClose={onMobileClose}
                 ModalProps={{ keepMounted: true }}
-                sx={{
-                    display: { xs: 'block', md: 'none' },
-                    ...drawerSx,
-                }}
+                className={styles.drawerMobile}
+                sx={drawerSx}
             >
                 {drawerContent}
             </Drawer>
             {/* デスクトップ用: Permanent Drawer */}
             <Drawer
                 variant="permanent"
-                sx={{
-                    display: { xs: 'none', md: 'block' },
-                    ...drawerSx,
-                }}
+                className={styles.drawerDesktop}
+                sx={drawerSx}
                 open
             >
                 {drawerContent}

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -15,6 +15,8 @@ import
     Chip,
     Avatar,
     IconButton,
+    useTheme,
+    useMediaQuery,
 }
     from '@mui/material'
 import {
@@ -62,15 +64,19 @@ interface PhaseProgress {
 interface AnalysisSidebarProps {
     user: User
     onLogout: () => void
+    mobileOpen?: boolean
+    onMobileClose?: () => void
 }
 
-export function AnalysisSidebar({user, onLogout}: AnalysisSidebarProps) {
+export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClose}: AnalysisSidebarProps) {
     const [messageCount, setMessageCount] = useState(0)
     const [questionCount, setQuestionCount] = useState(0)
     const [totalQuestions, setTotalQuestions] = useState(15)
     const [phases, setPhases] = useState<PhaseProgress[] | null>(null)
     const [isAdmin, setIsAdmin] = useState(!!user.is_admin)
     const router = useRouter()
+    const theme = useTheme()
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
     useEffect(() => {
         setIsAdmin(!!user.is_admin)
@@ -190,20 +196,19 @@ export function AnalysisSidebar({user, onLogout}: AnalysisSidebarProps) {
         },
     ]
 
-    return (
-        <Drawer
-            variant="permanent"
-            sx={{
-                width: DRAWER_WIDTH,
-                flexShrink: 0,
-                '& .MuiDrawer-paper': {
-                    width: DRAWER_WIDTH,
-                    boxSizing: 'border-box',
-                    backgroundColor: '#f7f7f8',
-                    borderRight: '1px solid #e0e0e0',
-                },
-            }}
-        >
+    const drawerSx = {
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+            backgroundColor: '#f7f7f8',
+            borderRight: '1px solid #e0e0e0',
+            overflowY: 'auto',
+        },
+    }
+
+    const drawerContent = (
             <Box sx={{p: 2}}>
                 <Box sx={{display: 'flex', alignItems: 'center', mb: 2, gap: 1}}>
                     <Avatar sx={{bgcolor: user.is_guest ? 'grey.500' : 'primary.main'}}>
@@ -485,6 +490,34 @@ export function AnalysisSidebar({user, onLogout}: AnalysisSidebarProps) {
                     </ListItem>
                 )}
             </Box>
-        </Drawer>
+    )
+
+    return (
+        <>
+            {/* モバイル用: Temporary Drawer */}
+            <Drawer
+                variant="temporary"
+                open={mobileOpen}
+                onClose={onMobileClose}
+                ModalProps={{ keepMounted: true }}
+                sx={{
+                    display: { xs: 'block', md: 'none' },
+                    ...drawerSx,
+                }}
+            >
+                {drawerContent}
+            </Drawer>
+            {/* デスクトップ用: Permanent Drawer */}
+            <Drawer
+                variant="permanent"
+                sx={{
+                    display: { xs: 'none', md: 'block' },
+                    ...drawerSx,
+                }}
+                open
+            >
+                {drawerContent}
+            </Drawer>
+        </>
     )
 }

--- a/frontend/components/job-agent-chat.module.css
+++ b/frontend/components/job-agent-chat.module.css
@@ -1,0 +1,115 @@
+/* チャット外枠 */
+.chatWrapper {
+    padding: 8px;
+    align-items: flex-start;
+}
+
+/* カード */
+.chatCard {
+    height: 100vh;
+    border-width: 0;
+    border-radius: 0;
+}
+
+/* ヘッダー */
+.header {
+    padding: 12px;
+}
+
+/* アバター */
+.avatar {
+    width: 32px !important;
+    height: 32px !important;
+}
+
+/* タイトル */
+.title {
+    font-size: 0.875rem;
+}
+
+/* サブタイトル */
+.subtitle {
+    display: none;
+}
+
+/* 進捗エリア */
+.progressArea {
+    min-width: 0;
+    width: 100%;
+}
+
+/* 終了ボタンテキスト */
+.endButtonFull {
+    display: none;
+}
+
+/* 終了ボタン */
+.endButton {
+    font-size: 0.75rem;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+/* メッセージバブルの最大幅 */
+.messageBubble {
+    max-width: 85%;
+}
+
+/* メッセージエリアのパディング */
+.messagesArea {
+    padding: 12px;
+}
+
+/* sm(600px)以上 */
+@media (min-width: 600px) {
+    .chatWrapper {
+        padding: 16px;
+        align-items: center;
+    }
+
+    .chatCard {
+        height: 90vh;
+        border-width: 2px;
+        border-radius: 8px;
+    }
+
+    .header {
+        padding: 16px;
+    }
+
+    .avatar {
+        width: 40px !important;
+        height: 40px !important;
+    }
+
+    .title {
+        font-size: 1rem;
+    }
+
+    .subtitle {
+        display: block;
+    }
+
+    .progressArea {
+        width: auto;
+        min-width: 180px;
+    }
+
+    .endButtonFull {
+        display: inline;
+    }
+
+    .endButton {
+        font-size: 0.875rem;
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    .messageBubble {
+        max-width: 75%;
+    }
+
+    .messagesArea {
+        padding: 24px;
+    }
+}

--- a/frontend/components/job-agent-chat.tsx
+++ b/frontend/components/job-agent-chat.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect } from "react"
+import styles from "./job-agent-chat.module.css"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -350,19 +351,19 @@ export function JobAgentChat() {
     : false
 
   return (
-      <div className="flex justify-center items-start sm:items-center h-screen bg-background p-2 sm:p-4 overflow-hidden">
-        <Card className="flex flex-col w-full max-w-4xl h-screen sm:h-[90vh] border-0 sm:border-2 rounded-none sm:rounded-lg">
-          <div className="border-b bg-muted/50 p-3 sm:p-4">
+      <div className={`flex justify-center bg-background overflow-hidden ${styles.chatWrapper}`}>
+        <Card className={`flex flex-col w-full max-w-4xl ${styles.chatCard}`}>
+          <div className={`border-b bg-muted/50 ${styles.header}`}>
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0">
-                <Avatar className="w-8 h-8 sm:w-10 sm:h-10 bg-primary flex-shrink-0">
+                <Avatar className={`bg-primary flex-shrink-0 ${styles.avatar}`}>
                   <AvatarFallback>
-                    <Bot className="w-4 h-4 sm:w-5 sm:h-5 text-primary-foreground" />
+                    <Bot className="w-4 h-4 text-primary-foreground" />
                   </AvatarFallback>
                 </Avatar>
                 <div className="min-w-0">
-                  <h2 className="font-bold text-foreground text-sm sm:text-base truncate">IT業界キャリアエージェント</h2>
-                  <p className="text-xs text-muted-foreground hidden sm:block">
+                  <h2 className={`font-bold text-foreground truncate ${styles.title}`}>IT業界キャリアエージェント</h2>
+                  <p className={`text-muted-foreground ${styles.subtitle}`}>
                     AI駆動で最適な企業を選定
                   </p>
                 </div>
@@ -371,7 +372,7 @@ export function JobAgentChat() {
               <div className="flex items-center gap-2 flex-shrink-0">
                 {/* 進捗状況表示 */}
                 {progress.categories > 0 && (
-                  <div className="flex flex-col items-end gap-1.5 min-w-0 w-full sm:w-auto sm:min-w-[180px]">
+                  <div className={`flex flex-col items-end gap-1.5 ${styles.progressArea}`}>
                     <div className="flex items-center gap-2">
                       <div className="text-sm font-semibold text-primary">
                         診断進行度
@@ -383,27 +384,27 @@ export function JobAgentChat() {
                     <div className="text-xs text-muted-foreground text-right">
                       {progress.categories}/{progress.totalCategories} カテゴリ評価済み
                     </div>
-                    <Progress 
-                      value={(progress.categories / progress.totalCategories) * 100} 
+                    <Progress
+                      value={(progress.categories / progress.totalCategories) * 100}
                       className="w-full h-2.5"
                     />
                   </div>
                 )}
-                
+
                 {/* チャットを終了ボタン */}
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={handleEndChat}
-                  className="text-xs sm:text-sm px-2 sm:px-3"
+                  className={styles.endButton}
                 >
-                  <span className="hidden sm:inline">チャットを</span>終了
+                  <span className={styles.endButtonFull}>チャットを</span>終了
                 </Button>
               </div>
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-3 sm:p-6 space-y-4">
+          <div className={`flex-1 overflow-y-auto space-y-4 ${styles.messagesArea}`}>
             {isInitializing ? (
               <div className="flex items-center justify-center h-full">
                 <div className="text-center space-y-2">
@@ -430,7 +431,7 @@ export function JobAgentChat() {
                         </AvatarFallback>
                       </Avatar>
                       <div
-                          className={`flex flex-col gap-3 max-w-[85%] sm:max-w-[75%] ${message.role === "user" ? "items-end" : "items-start"}`}
+                          className={`flex flex-col gap-3 ${styles.messageBubble} ${message.role === "user" ? "items-end" : "items-start"}`}
                       >
                         <div
                             className={`rounded-2xl px-4 py-3 ${

--- a/frontend/components/job-agent-chat.tsx
+++ b/frontend/components/job-agent-chat.tsx
@@ -350,28 +350,28 @@ export function JobAgentChat() {
     : false
 
   return (
-      <div className="flex justify-center items-center h-screen bg-background p-4">
-        <Card className="flex flex-col w-full max-w-4xl h-[90vh] border-2">
-          <div className="border-b bg-muted/50 p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex items-center gap-3">
-                <Avatar className="w-10 h-10 bg-primary">
+      <div className="flex justify-center items-start sm:items-center h-screen bg-background p-2 sm:p-4 overflow-hidden">
+        <Card className="flex flex-col w-full max-w-4xl h-screen sm:h-[90vh] border-0 sm:border-2 rounded-none sm:rounded-lg">
+          <div className="border-b bg-muted/50 p-3 sm:p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <Avatar className="w-8 h-8 sm:w-10 sm:h-10 bg-primary flex-shrink-0">
                   <AvatarFallback>
-                    <Bot className="w-5 h-5 text-primary-foreground" />
+                    <Bot className="w-4 h-4 sm:w-5 sm:h-5 text-primary-foreground" />
                   </AvatarFallback>
                 </Avatar>
-                <div>
-                  <h2 className="font-bold text-foreground">IT業界キャリアエージェント</h2>
-                  <p className="text-xs text-muted-foreground">
+                <div className="min-w-0">
+                  <h2 className="font-bold text-foreground text-sm sm:text-base truncate">IT業界キャリアエージェント</h2>
+                  <p className="text-xs text-muted-foreground hidden sm:block">
                     AI駆動で最適な企業を選定
                   </p>
                 </div>
               </div>
-              
-              <div className="flex items-center gap-3">
+
+              <div className="flex items-center gap-2 flex-shrink-0">
                 {/* 進捗状況表示 */}
                 {progress.categories > 0 && (
-                  <div className="flex flex-col items-end gap-1.5 min-w-[200px]">
+                  <div className="flex flex-col items-end gap-1.5 min-w-0 w-full sm:w-auto sm:min-w-[180px]">
                     <div className="flex items-center gap-2">
                       <div className="text-sm font-semibold text-primary">
                         診断進行度
@@ -391,19 +391,19 @@ export function JobAgentChat() {
                 )}
                 
                 {/* チャットを終了ボタン */}
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
                   onClick={handleEndChat}
-                  className="text-sm"
+                  className="text-xs sm:text-sm px-2 sm:px-3"
                 >
-                  チャットを終了
+                  <span className="hidden sm:inline">チャットを</span>終了
                 </Button>
               </div>
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          <div className="flex-1 overflow-y-auto p-3 sm:p-6 space-y-4">
             {isInitializing ? (
               <div className="flex items-center justify-center h-full">
                 <div className="text-center space-y-2">
@@ -430,7 +430,7 @@ export function JobAgentChat() {
                         </AvatarFallback>
                       </Avatar>
                       <div
-                          className={`flex flex-col gap-3 max-w-[75%] ${message.role === "user" ? "items-end" : "items-start"}`}
+                          className={`flex flex-col gap-3 max-w-[85%] sm:max-w-[75%] ${message.role === "user" ? "items-end" : "items-start"}`}
                       >
                         <div
                             className={`rounded-2xl px-4 py-3 ${

--- a/frontend/components/mui-chat.module.css
+++ b/frontend/components/mui-chat.module.css
@@ -1,0 +1,93 @@
+/* チャット全体コンテナ */
+.chatContainer {
+    height: calc(100vh - 48px); /* モバイルヘッダー(48px)分を引く */
+    display: flex;
+    flex-direction: column;
+    background-color: #fff;
+}
+
+/* ヘッダー */
+.chatHeader {
+    padding: 12px 12px; /* 1.5 * 8px */
+    border-bottom: 1px solid #e0e0e0;
+    background-color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/* デスクトップタイトル: モバイルでは非表示 */
+.chatTitle {
+    display: none;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+/* 進捗テキスト */
+.chatProgress {
+    font-size: 0.75rem;
+}
+
+/* 終了ボタン */
+.endButton {
+    min-width: 80px !important;
+    font-size: 0.75rem !important;
+}
+
+/* メッセージエリア */
+.messagesArea {
+    padding: 16px; /* 2 * 8px */
+}
+
+/* メッセージバブル */
+.messageBubble {
+    padding: 12px !important; /* 1.5 * 8px */
+    max-width: 90% !important;
+}
+
+/* 選択肢ボタン */
+.choiceButton {
+    font-size: 0.75rem !important;
+    padding-top: 6px !important;    /* 0.75 * 8px */
+    padding-bottom: 6px !important;
+}
+
+/* デスクトップ(md: 900px以上) */
+@media (min-width: 900px) {
+    .chatContainer {
+        height: 100vh;
+    }
+
+    .chatHeader {
+        padding: 16px; /* 2 * 8px */
+    }
+
+    .chatTitle {
+        display: block;
+        font-size: 1.5rem;
+    }
+
+    .chatProgress {
+        font-size: 0.875rem;
+    }
+
+    .endButton {
+        min-width: 120px !important;
+        font-size: 0.875rem !important;
+    }
+
+    .messagesArea {
+        padding: 24px; /* 3 * 8px */
+    }
+
+    .messageBubble {
+        padding: 16px !important; /* 2 * 8px */
+        max-width: 70% !important;
+    }
+
+    .choiceButton {
+        font-size: 0.875rem !important;
+        padding-top: 8px !important;
+        padding-bottom: 8px !important;
+    }
+}

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import styles from './mui-chat.module.css'
 import {
   Box,
   Paper,
@@ -681,36 +682,13 @@ export function MuiChat() {
         </DialogActions>
       </Dialog>
 
-      <Box
-        sx={{
-          height: { xs: 'calc(100vh - 48px)', md: '100vh' },
-          display: 'flex',
-          flexDirection: 'column',
-          backgroundColor: '#fff',
-        }}
-      >
-      <Box
-        sx={{
-          p: { xs: 1.5, sm: 2 },
-          borderBottom: '1px solid #e0e0e0',
-          backgroundColor: '#fff',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
+      <Box className={styles.chatContainer}>
+      <Box className={styles.chatHeader}>
         <Box sx={{ minWidth: 0 }}>
-          <Typography
-            variant="h5"
-            sx={{
-              fontWeight: 600,
-              fontSize: { xs: '1rem', sm: '1.5rem' },
-              display: { xs: 'none', md: 'block' },
-            }}
-          >
+          <Typography variant="h5" className={styles.chatTitle}>
             IT業界キャリアエージェント
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ fontSize: { xs: '0.75rem', sm: '0.875rem' } }}>
+          <Typography variant="body2" color="text.secondary" className={styles.chatProgress}>
             AI適性診断 - {(progressTotals?.valid ?? questionCount)}/{(progressTotals?.required ?? totalQuestions)} 問完了
             {((progressTotals?.valid ?? questionCount) > 0) && ` (${progressTotals?.percent ?? Math.round((questionCount / totalQuestions) * 100)}%)`}
           </Typography>
@@ -719,17 +697,17 @@ export function MuiChat() {
           variant="outlined"
           size="small"
           onClick={handleEndChat}
-          sx={{ minWidth: { xs: '80px', sm: '120px' }, fontSize: { xs: '0.75rem', sm: '0.875rem' } }}
+          className={styles.endButton}
         >
           終了
         </Button>
       </Box>
 
       <Box
+        className={styles.messagesArea}
         sx={{
           flexGrow: 1,
           overflowY: 'auto',
-          p: { xs: 2, sm: 3 },
           backgroundColor: '#fff',
         }}
       >
@@ -780,9 +758,8 @@ export function MuiChat() {
             )}
             <Paper
               elevation={1}
+              className={styles.messageBubble}
               sx={{
-                p: { xs: 1.5, sm: 2 },
-                maxWidth: { xs: '90%', sm: '70%' },
                 backgroundColor:
                   message.role === 'user' 
                     ? '#1976d2' 
@@ -834,9 +811,8 @@ export function MuiChat() {
             </Avatar>
             <Paper
               elevation={1}
+              className={styles.messageBubble}
               sx={{
-                p: { xs: 1.5, sm: 2 },
-                maxWidth: { xs: '90%', sm: '70%' },
                 backgroundColor: '#f5f5f5',
               }}
             >
@@ -937,7 +913,8 @@ export function MuiChat() {
                           handleSend(choice.value)
                         }}
                         disabled={isLoading}
-                        sx={{ borderRadius: 2, fontSize: { xs: '0.75rem', sm: '0.875rem' }, py: { xs: 0.75, sm: 1 } }}
+                        className={styles.choiceButton}
+                        sx={{ borderRadius: 2 }}
                       >
                         {choice.label}. {choice.text}
                       </Button>

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -683,7 +683,7 @@ export function MuiChat() {
 
       <Box
         sx={{
-          height: '100vh',
+          height: { xs: 'calc(100vh - 48px)', md: '100vh' },
           display: 'flex',
           flexDirection: 'column',
           backgroundColor: '#fff',
@@ -691,7 +691,7 @@ export function MuiChat() {
       >
       <Box
         sx={{
-          p: 2,
+          p: { xs: 1.5, sm: 2 },
           borderBottom: '1px solid #e0e0e0',
           backgroundColor: '#fff',
           display: 'flex',
@@ -699,12 +699,19 @@ export function MuiChat() {
           alignItems: 'center',
         }}
       >
-        <Box>
-          <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            variant="h5"
+            sx={{
+              fontWeight: 600,
+              fontSize: { xs: '1rem', sm: '1.5rem' },
+              display: { xs: 'none', md: 'block' },
+            }}
+          >
             IT業界キャリアエージェント
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            AI適性診断 - {(progressTotals?.valid ?? questionCount)}/{(progressTotals?.required ?? totalQuestions)} 問完了 
+          <Typography variant="body2" color="text.secondary" sx={{ fontSize: { xs: '0.75rem', sm: '0.875rem' } }}>
+            AI適性診断 - {(progressTotals?.valid ?? questionCount)}/{(progressTotals?.required ?? totalQuestions)} 問完了
             {((progressTotals?.valid ?? questionCount) > 0) && ` (${progressTotals?.percent ?? Math.round((questionCount / totalQuestions) * 100)}%)`}
           </Typography>
         </Box>
@@ -712,9 +719,9 @@ export function MuiChat() {
           variant="outlined"
           size="small"
           onClick={handleEndChat}
-          sx={{ minWidth: '120px' }}
+          sx={{ minWidth: { xs: '80px', sm: '120px' }, fontSize: { xs: '0.75rem', sm: '0.875rem' } }}
         >
-          チャットを終了
+          終了
         </Button>
       </Box>
 
@@ -722,7 +729,7 @@ export function MuiChat() {
         sx={{
           flexGrow: 1,
           overflowY: 'auto',
-          p: 3,
+          p: { xs: 2, sm: 3 },
           backgroundColor: '#fff',
         }}
       >
@@ -774,8 +781,8 @@ export function MuiChat() {
             <Paper
               elevation={1}
               sx={{
-                p: 2,
-                maxWidth: '70%',
+                p: { xs: 1.5, sm: 2 },
+                maxWidth: { xs: '90%', sm: '70%' },
                 backgroundColor:
                   message.role === 'user' 
                     ? '#1976d2' 
@@ -828,8 +835,8 @@ export function MuiChat() {
             <Paper
               elevation={1}
               sx={{
-                p: 2,
-                maxWidth: '70%',
+                p: { xs: 1.5, sm: 2 },
+                maxWidth: { xs: '90%', sm: '70%' },
                 backgroundColor: '#f5f5f5',
               }}
             >
@@ -930,7 +937,7 @@ export function MuiChat() {
                           handleSend(choice.value)
                         }}
                         disabled={isLoading}
-                        sx={{ borderRadius: 2 }}
+                        sx={{ borderRadius: 2, fontSize: { xs: '0.75rem', sm: '0.875rem' }, py: { xs: 0.75, sm: 1 } }}
                       >
                         {choice.label}. {choice.text}
                       </Button>


### PR DESCRIPTION
Closes #337

## 変更内容

### 新規追加ファイル（CSS Modules）
- `frontend/app/page.module.css`: モバイルヘッダー・メインレイアウトのレスポンシブスタイル
- `frontend/components/analysis-sidebar.module.css`: Temporary/Permanent Drawerの表示切替（md: 900px境界）
- `frontend/components/mui-chat.module.css`: チャットコンテナ高さ・メッセージバブル幅・パディング等のレスポンシブスタイル
- `frontend/components/job-agent-chat.module.css`: カード・ヘッダー・アバター・メッセージバブル幅等のレスポンシブスタイル

### 修正ファイル

**`analysis-sidebar.tsx`**
- `useMediaQuery` / `useTheme` を追加
- `variant="permanent"` の固定DrawerをモバイルはTemporary、デスクトップはPermanentに切り替え
- `mobileOpen` / `onMobileClose` propsを追加してサイドバー開閉を親から制御可能に

**`app/page.tsx`**
- `mobileOpen` 状態を追加し、サイドバーへ渡す
- モバイル専用 `AppBar`（ハンバーガーボタン付き）を追加（900px未満で表示、CSS Modulesで制御）

**`mui-chat.tsx`**
- チャットコンテナ高さをモバイルヘッダー(48px)分を考慮した `calc(100vh - 48px)` に変更（デスクトップでは `100vh`）
- メッセージバブルの最大幅：モバイル90% / デスクトップ70%
- ヘッダータイトルをモバイルで非表示（AppBarに表示済みのため重複回避）
- パディング・フォントサイズ・ボタン幅をブレークポイントで調整

**`job-agent-chat.tsx`**
- カードをモバイルではフルスクリーン（border/rounded-none）、600px以上で浮き上がりカード表示に変更
- `min-w-[200px]` の固定幅を廃止し、モバイルではフレキシブル幅に変更
- メッセージバブル最大幅：モバイル85% / 600px以上75%
- ヘッダー・アバターサイズ・ボタンテキストをブレークポイントで最適化

## レスポンシブ対応方針
- インライン `sx` BreakpointsおよびTailwindレスポンシブクラスはすべてCSS Modulesに移行（保守性向上）
- ブレークポイント: MUI準拠（md: 900px）でサイドバーの表示方式を切り替え