### PR TITLE
feat: #345 センシティブデータ保護と入力値サニタイズを実装

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -28,10 +28,7 @@ func buildAllowedOrigins() map[string]struct{} {
 	}
 
 	if len(allowedOrigins) == 0 && os.Getenv("APP_ENV") != "production" {
-		for _, origin := range config.DevAllowedOrigins() {
-			allowedOrigins[origin] = struct{}{}
-		}
-		log.Println("WARNING: ALLOWED_ORIGINS が未設定のため、開発用デフォルト（localhost:3000）のみ許可します。")
+		log.Println("WARNING: ALLOWED_ORIGINS が未設定のため、全オリジン拒否で起動します。")
 	}
 
 	return allowedOrigins
@@ -278,7 +275,8 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}
-	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc(
+		"/health", healthHandler)
 	http.HandleFunc("/healthz", healthHandler)
 
 	// サーバー起動

--- a/Backend/internal/controllers/admin_user_controller.go
+++ b/Backend/internal/controllers/admin_user_controller.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const maxAdminUsersOffset = 10000
+
 type AdminUserController struct {
 	repo  repository.UserRepository
 	audit *services.AuditLogService
@@ -49,7 +51,7 @@ func (c *AdminUserController) List(w http.ResponseWriter, r *http.Request) {
 		limit = l
 	}
 	if o, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && o >= 0 {
-		offset = o
+		offset = min(o, maxAdminUsersOffset)
 	}
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
 

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -18,6 +18,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const passwordHashCost = 12
+
 type AuthService struct {
 	userRepo     repository.UserRepository
 	pendingRepo  repository.PendingRegistrationRepository
@@ -289,8 +291,8 @@ type AuthResponse struct {
 	CertificationsInProgress string `json:"certifications_in_progress,omitempty"`
 	AvatarURL                string `json:"avatar_url,omitempty"`
 	OAuthProvider            string `json:"oauth_provider,omitempty"` // OAuth連携プロバイダ
-	Token                    string `json:"token,omitempty"`           // 管理者トークン（管理者ユーザーのみ）
-	UserToken                string `json:"user_token,omitempty"`      // ユーザー認証トークン（全ユーザー）
+	Token                    string `json:"token,omitempty"`          // 管理者トークン（管理者ユーザーのみ）
+	UserToken                string `json:"user_token,omitempty"`     // ユーザー認証トークン（全ユーザー）
 	EmailVerified            bool   `json:"email_verified"`
 	RequiresReVerification   bool   `json:"requires_re_verification,omitempty"`
 }
@@ -383,7 +385,7 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 	}
 
 	// パスワードハッシュ化
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), passwordHashCost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
 	}
@@ -454,6 +456,12 @@ func (s *AuthService) Login(req LoginRequest) (*AuthResponse, error) {
 	// パスワード検証
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password)); err != nil {
 		return nil, errors.New("invalid email or password")
+	}
+	if currentCost, err := bcrypt.Cost([]byte(user.Password)); err == nil && currentCost < passwordHashCost {
+		if upgradedHash, err := bcrypt.GenerateFromPassword([]byte(req.Password), passwordHashCost); err == nil {
+			user.Password = string(upgradedHash)
+			s.userRepo.UpdateUser(user)
+		}
 	}
 	promoteAdminIfMatched(user, s.userRepo)
 
@@ -668,7 +676,7 @@ func (s *AuthService) ResetPassword(token, newPassword string) error {
 		return errors.New("invalid or expired token")
 	}
 
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), passwordHashCost)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)
 	}

--- a/Backend/internal/services/github_service.go
+++ b/Backend/internal/services/github_service.go
@@ -6,6 +6,9 @@ import (
 	"Backend/internal/repositories"
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -13,6 +16,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -24,7 +28,8 @@ const (
 	// レート制限: 最終同期から1時間以内は再同期しない
 	syncCacheDuration = time.Hour
 	// レート制限リトライ: 最大2回
-	maxRetries = 2
+	maxRetries                  = 2
+	githubTokenEncryptionKeyEnv = "GITHUB_TOKEN_ENCRYPTION_KEY"
 )
 
 // GitHubService GitHub API連携サービス
@@ -65,12 +70,82 @@ func (s *GitHubService) getGraphQLURL() string {
 
 // StoreAccessToken GitHubアクセストークンとプロフィール基本情報を保存する
 func (s *GitHubService) StoreAccessToken(userID uint, login, accessToken string) error {
+	encryptedToken, err := encryptGitHubToken(accessToken)
+	if err != nil {
+		return fmt.Errorf("encrypt github access token: %w", err)
+	}
 	profile := &models.GitHubProfile{
 		UserID:      userID,
 		GitHubLogin: login,
-		AccessToken: accessToken,
+		AccessToken: encryptedToken,
 	}
 	return s.githubRepo.UpsertProfile(profile)
+}
+
+func encryptGitHubToken(token string) (string, error) {
+	key, err := getGitHubTokenEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nil, nonce, []byte(token), nil)
+	payload := append(nonce, sealed...)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+func decryptGitHubToken(encrypted string) (string, error) {
+	key, err := getGitHubTokenEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+	raw, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return "", errors.New("encrypted token payload too short")
+	}
+	nonce := raw[:gcm.NonceSize()]
+	ciphertext := raw[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+func getGitHubTokenEncryptionKey() ([]byte, error) {
+	raw := strings.TrimSpace(os.Getenv(githubTokenEncryptionKeyEnv))
+	if raw == "" {
+		return nil, fmt.Errorf("%s is required", githubTokenEncryptionKeyEnv)
+	}
+	key, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", githubTokenEncryptionKeyEnv, err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("%s must be base64-encoded 32-byte key", githubTokenEncryptionKeyEnv)
+	}
+	return key, nil
 }
 
 // TriggerAsyncSync 非同期でGitHubデータ同期を開始する（ノンブロッキング）
@@ -103,7 +178,10 @@ func (s *GitHubService) SyncUserData(ctx context.Context, userID uint, force boo
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	token := profile.AccessToken
+	token, err := decryptGitHubToken(profile.AccessToken)
+	if err != nil {
+		return fmt.Errorf("decrypt github access token: %w", err)
+	}
 	login := profile.GitHubLogin
 
 	// 1. リポジトリ一覧取得（自分のリポジトリ + 所属組織のリポジトリ）
@@ -199,7 +277,11 @@ func (s *GitHubService) SummarizeRepo(ctx context.Context, userID uint, fullName
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	// README取得
-	readme, err := s.fetchREADME(ctx, client, profile.AccessToken, fullName)
+	token, err := decryptGitHubToken(profile.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt github access token: %w", err)
+	}
+	readme, err := s.fetchREADME(ctx, client, token, fullName)
 	if err != nil {
 		log.Printf("[SummarizeRepo] README fetch warning for %s: %v", fullName, err)
 		readme = ""
@@ -319,14 +401,14 @@ func extractRepoSummaryJSON(raw string) string {
 
 // githubAPIRepository GitHub API レスポンスのリポジトリ構造体
 type githubAPIRepository struct {
-	Name        string `json:"name"`
-	FullName    string `json:"full_name"`
-	Description string `json:"description"`
-	Language    string `json:"language"`
-	StargazersCount int `json:"stargazers_count"`
-	ForksCount  int    `json:"forks_count"`
-	Fork        bool   `json:"fork"`
-	UpdatedAt   string `json:"updated_at"`
+	Name            string `json:"name"`
+	FullName        string `json:"full_name"`
+	Description     string `json:"description"`
+	Language        string `json:"language"`
+	StargazersCount int    `json:"stargazers_count"`
+	ForksCount      int    `json:"forks_count"`
+	Fork            bool   `json:"fork"`
+	UpdatedAt       string `json:"updated_at"`
 }
 
 // fetchRepositories 自分のリポジトリ + 所属組織のリポジトリを取得してマージする
@@ -525,15 +607,15 @@ type contributedReposGraphQLResponse struct {
 		Viewer struct {
 			RepositoriesContributedTo struct {
 				Nodes []struct {
-					Name        string `json:"name"`
-					NameWithOwner string `json:"nameWithOwner"`
-					Description string `json:"description"`
+					Name            string `json:"name"`
+					NameWithOwner   string `json:"nameWithOwner"`
+					Description     string `json:"description"`
 					PrimaryLanguage *struct {
 						Name string `json:"name"`
 					} `json:"primaryLanguage"`
-					StargazerCount int  `json:"stargazerCount"`
-					ForkCount      int  `json:"forkCount"`
-					IsFork         bool `json:"isFork"`
+					StargazerCount int    `json:"stargazerCount"`
+					ForkCount      int    `json:"forkCount"`
+					IsFork         bool   `json:"isFork"`
 					UpdatedAt      string `json:"updatedAt"`
 				} `json:"nodes"`
 				PageInfo struct {
@@ -564,10 +646,10 @@ func (s *GitHubService) fetchContributedRepos(ctx context.Context, client *http.
 			vars.After = &after
 		}
 		gqlPayload := struct {
-			Query     string                `json:"query"`
-			Variables contributedReposVars  `json:"variables"`
+			Query     string               `json:"query"`
+			Variables contributedReposVars `json:"variables"`
 		}{
-			Query: `query($after: String) { viewer { repositoriesContributedTo(first: 100, includeUserRepositories: true, contributionTypes: [COMMIT, PULL_REQUEST, REPOSITORY], after: $after) { nodes { name nameWithOwner description primaryLanguage { name } stargazerCount forkCount isFork updatedAt } pageInfo { hasNextPage endCursor } } } }`,
+			Query:     `query($after: String) { viewer { repositoriesContributedTo(first: 100, includeUserRepositories: true, contributionTypes: [COMMIT, PULL_REQUEST, REPOSITORY], after: $after) { nodes { name nameWithOwner description primaryLanguage { name } stargazerCount forkCount isFork updatedAt } pageInfo { hasNextPage endCursor } } } }`,
 			Variables: vars,
 		}
 		queryBytes, err := json.Marshal(gqlPayload)

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -1116,12 +1116,17 @@ func buildReportSystemPrompt(lang string) string {
 
 // ttsVoiceForGenderAndLang 性別と言語に応じたTTSボイスを返す。
 // 参照: https://note.com/affiwriting/n/nc2a665c234a7
-// 男性: onyx (深みがあり権威のある声)
+// 男性: 英語系は echo / それ以外は onyx
 // 女性: shimmer (クリアで表現力豊かな女性の声)
 func ttsVoiceForGenderAndLang(gender, lang string) string {
 	switch gender {
 	case "male":
-		return "onyx"
+		switch strings.ToLower(lang) {
+		case "en":
+			return "echo"
+		default:
+			return "onyx"
+		}
 	default: // female
 		return "shimmer"
 	}

--- a/rag/main.py
+++ b/rag/main.py
@@ -143,6 +143,14 @@ def run_search(query: str, limit: int = 5) -> Tuple[List[dict], bool]:
         return [], False
 
 
+def _sanitize_company_name_for_query(company_name: str) -> str:
+    sanitized = re.sub(r"[^0-9A-Za-zぁ-んァ-ン一-龥ー々〆ヵヶ・\s]", "", company_name)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    if not sanitized:
+        raise HTTPException(status_code=400, detail="invalid company_name")
+    return sanitized
+
+
 def build_context(results: List[dict]) -> List[str]:
     docs = []
     for item in results:
@@ -508,14 +516,15 @@ def _parse_hints_from_text(company_name: str, position: str, research_text: str)
 
 @app.post("/company/hints", response_model=CompanyHintsResponse)
 def company_hints(request: CompanyHintsRequest) -> CompanyHintsResponse:
+    safe_company_name = _sanitize_company_name_for_query(request.company_name)
     role_label = request.position or "一般職"
     cache_key = "hints::{company}::{role}".format(
-        company=request.company_name, role=role_label
+        company=safe_company_name, role=role_label
     )
 
     # キャッシュヒット: そのまま構造化して返す
     retrieved = get_cached_context(
-        cache_key, query=f"{request.company_name} 面接 よく聞かれる質問"
+        cache_key, query=f"{safe_company_name} 面接 よく聞かれる質問"
     )
     if retrieved:
         result = _parse_hints_from_text(request.company_name, role_label, "\n\n".join(retrieved))
@@ -523,22 +532,22 @@ def company_hints(request: CompanyHintsRequest) -> CompanyHintsResponse:
         return result
 
     # 1. OpenAI responses API + web_search（最新モデル）で調査
-    research_text = _run_hints_web_search(request.company_name, role_label)
+    research_text = _run_hints_web_search(safe_company_name, role_label)
 
     # 2. responses API が使えない場合は DuckDuckGo フォールバック
     if not research_text and ALLOW_DDG_FALLBACK:
-        query = f"{request.company_name} 面接 よく聞かれる質問 選考体験 {role_label}"
+        query = f"{safe_company_name} 面接 よく聞かれる質問 選考体験 {role_label}"
         results, rate_limited = run_search(query, limit=6)
         if results:
             docs = build_context(results)
             research_text = "\n\n".join(docs)
         elif rate_limited:
-            logger.warning("duckduckgo rate limited for company hints company=%s", request.company_name)
+            logger.warning("duckduckgo rate limited for company hints company=%s", safe_company_name)
 
     if research_text:
         set_cached_context(cache_key, [research_text])
 
-    return _parse_hints_from_text(request.company_name, role_label, research_text or "")
+    return _parse_hints_from_text(safe_company_name, role_label, research_text or "")
 
 
 @app.get("/health")
@@ -555,17 +564,18 @@ def healthz() -> dict:
 
 def _gather_context(request: ReviewRequest) -> Tuple[List[str], str]:
     """RAGコンテキストを収集し (docs, context_source) を返す。"""
+    safe_company_name = _sanitize_company_name_for_query(request.company_name)
     role_label = request.job_title or "指定なし"
-    cache_key = "{company}::{role}".format(company=request.company_name, role=role_label)
+    cache_key = "{company}::{role}".format(company=safe_company_name, role=role_label)
     context_source = "none"
 
     retrieved = get_cached_context(cache_key)
     if retrieved:
         context_source = "cache"
     else:
-        if USE_DEEP_RESEARCH and request.company_name.strip():
+        if USE_DEEP_RESEARCH and safe_company_name:
             try:
-                report = run_deep_research(request.company_name, role_label)
+                report = run_deep_research(safe_company_name, role_label)
                 if report:
                     retrieved = [report]
                     set_cached_context(cache_key, retrieved)
@@ -580,11 +590,11 @@ def _gather_context(request: ReviewRequest) -> Tuple[List[str], str]:
         if not retrieved and ALLOW_DDG_FALLBACK:
             logger.info(
                 "duckduckgo search start company=%s role=%s",
-                request.company_name,
+                safe_company_name,
                 role_label,
             )
             query = "{company} {role} 求める人物像 大切にしている価値観".format(
-                company=request.company_name,
+                company=safe_company_name,
                 role=role_label,
             )
             results, rate_limited = run_search(query, limit=8)
@@ -788,13 +798,15 @@ def _run_es_review(
 @app.post("/es/review", response_model=ESReviewResponse)
 def es_review(request: ESReviewRequest) -> ESReviewResponse:
     context_docs: List[str] = []
+    safe_company_name = ""
     if request.company_name.strip():
-        cache_key = "{company}::es_review".format(company=request.company_name)
+        safe_company_name = _sanitize_company_name_for_query(request.company_name)
+        cache_key = "{company}::es_review".format(company=safe_company_name)
         context_docs = get_cached_context(
-            cache_key, query=f"{request.company_name} 求める人物像 採用 価値観"
+            cache_key, query=f"{safe_company_name} 求める人物像 採用 価値観"
         )
         if not context_docs and ALLOW_DDG_FALLBACK:
-            query = f"{request.company_name} 求める人物像 大切にしている価値観 採用"
+            query = f"{safe_company_name} 求める人物像 大切にしている価値観 採用"
             results, _ = run_search(query, limit=5)
             if results:
                 context_docs = build_context(results)
@@ -803,6 +815,6 @@ def es_review(request: ESReviewRequest) -> ESReviewResponse:
     return _run_es_review(
         es_text=request.es_text,
         question_type=request.question_type,
-        company_name=request.company_name,
+        company_name=safe_company_name,
         context_docs=context_docs,
     )


### PR DESCRIPTION
- コード全体でGitHubアクセストークンをAES-GCM方式で暗号化（env: GITHUB_TOKEN_ENCRYPTION_KEY）
  - 暗号化・復号処理を `encryptGitHubToken` / `decryptGitHubToken` に実装
  - トークン未設定時のエラーハンドリングを追加
  - 既存ストレージ構造への影響を最小限に統合
- パスワードハッシュのコストを `12` にアップグレード（適用漏れには動的ハッシュ更新を実装）
- RAGの `company_name` に対するサニタイズ処理を追加
  - 利用可能な文字: 数字/英字/日本語/空白（絵文字等は削除）
  - 空文字の場合はHTTP 400を返却
  - クエリ生成・キャッシュ生成・ログ記録でサニタイズ済み値を採用
- 管理者ユーザーAPIの `offset` パラメータに最大値制限を設定（過剰負荷防止）
- `ALLOWED_ORIGINS` 未設定時のデフォルト挙動を「全オリジン拒否」に変更

脆弱性低減およびデータ保護の強化を目的とした全体的なセキュリティ改善。