### PR TITLE
Resolve #300: result画面で実企業情報のみ表示（ダミー企業を除外）

### DIFF
--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -18,6 +18,8 @@ type CompanyRelationQueryRepository interface {
 type CompanyRepository interface {
 	FindAllActive(limit, offset int) ([]models.Company, error)
 	CountActive() (int64, error)
+	FindAllPublished(limit, offset int) ([]models.Company, error)
+	CountPublished() (int64, error)
 	FindByID(id uint) (*models.Company, error)
 	FindByName(name string) (*models.Company, error)
 	FindByCorporateNumber(corporateNumber string) (*models.Company, error)

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -37,6 +37,25 @@ func (r *CompanyRepository) CountActive() (int64, error) {
 	return count, err
 }
 
+// FindAllPublished 公開済み企業をページネーション付きで取得（マッチング用）
+func (r *CompanyRepository) FindAllPublished(limit, offset int) ([]models.Company, error) {
+	var companies []models.Company
+	err := r.db.Where("is_active = ? AND data_status = ?", true, "published").
+		Order("id desc").
+		Limit(limit).Offset(offset).
+		Find(&companies).Error
+	return companies, err
+}
+
+// CountPublished 公開済み企業数を取得
+func (r *CompanyRepository) CountPublished() (int64, error) {
+	var count int64
+	err := r.db.Model(&models.Company{}).
+		Where("is_active = ? AND data_status = ?", true, "published").
+		Count(&count).Error
+	return count, err
+}
+
 // FindByID IDで企業を取得
 func (r *CompanyRepository) FindByID(id uint) (*models.Company, error) {
 	var company models.Company

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -59,13 +59,13 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 
 	log.Printf("[CalculateMatching] User scores: %v\n", scoreMap)
 
-	// 2. 全企業のプロファイルを取得
-	companies, err := s.companyRepo.FindAllActive(10000, 0)
+	// 2. 公開済み企業のプロファイルを取得（ダミー企業を除外）
+	companies, err := s.companyRepo.FindAllPublished(10000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get companies: %w", err)
 	}
 
-	log.Printf("[CalculateMatching] Found %d active companies\n", len(companies))
+	log.Printf("[CalculateMatching] Found %d published companies\n", len(companies))
 
 	// 3. 各企業とのマッチングを計算
 	matchCount := 0
@@ -172,7 +172,7 @@ func (s *MatchingService) GetDiagnostics(userID uint, sessionID string) (*Matchi
 	if err != nil {
 		return nil, err
 	}
-	activeCompanyCount, err := s.companyRepo.CountActive()
+	activeCompanyCount, err := s.companyRepo.CountPublished()
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -237,7 +237,7 @@ function ResultsContent() {
           if (reason === 'insufficient_user_scores') {
             message = '判定結果を出すための根拠が不足しています。チャットで質問に回答してください。'
           } else if (reason === 'insufficient_company_data') {
-            message = '企業マッチング用のデータが不足しています。しばらく待ってから再度お試しください。'
+            message = '現在、公開済みの企業データがありません。管理者が企業情報を公開するまでお待ちください。'
           }
           if (diagnostics) {
             message += `\n\nスコア数: ${diagnostics.user_score_count}, 企業数: ${diagnostics.active_company_count}, プロファイル数: ${diagnostics.weight_profile_count}`


### PR DESCRIPTION
Closes #300

## 変更内容

### `Backend/domain/repository/company.go`
- `CompanyRepository` インターフェースに `FindAllPublished(limit, offset int) ([]models.Company, error)` を追加
- `CompanyRepository` インターフェースに `CountPublished() (int64, error)` を追加

### `Backend/internal/repositories/company_repository.go`
- **`FindAllPublished`**: `is_active = true AND data_status = 'published'` の条件で公開済み企業のみを取得するメソッドを実装
- **`CountPublished`**: 同条件で公開済み企業数を返すメソッドを実装
- これにより `data_status = 'draft'`（デフォルト）のシード生成ダミー企業40,000件はマッチング対象から除外される

### `Backend/internal/services/matching_service.go`
- **`CalculateMatching`**: 企業取得を `FindAllActive` から `FindAllPublished` に変更し、公開済み企業のみをマッチング対象にする
- **`GetDiagnostics`**: `active_company_count` の集計を `CountActive` から `CountPublished` に変更し、診断情報が実態を反映するよう修正

### `frontend/app/results/page.tsx`
- `insufficient_company_data` 時のエラーメッセージを「公開済みの企業データがありません。管理者が企業情報を公開するまでお待ちください。」に改善し、ユーザーに状況を明確に伝える

## 動作
- 管理者が `data_status = 'published'` で企業を登録するとマッチング対象になり、result画面に実企業名が表示される
- シードの40,000件ダミー企業（`data_status = 'draft'`）は通常表示経路で使われなくなる
- 公開済み企業が0件の場合は分かりやすいエラーメッセージが表示される