### PR TITLE
fix: mynavi_companyをvalidateCrawlSourceに復元（PR #356マージ時の欠落修正）

### DIFF
--- a/Backend/internal/services/crawl_service.go
+++ b/Backend/internal/services/crawl_service.go
@@ -200,6 +200,8 @@ func (s *CrawlService) executeCrawl(source *models.CrawlSource) error {
 		return s.executeJobSiteCompanyCrawl(source)
 	case "job_listing":
 		return s.executeJobListingCrawl(source)
+	case "mynavi_company":
+		return s.executeMynaviCompanyCrawl(source)
 	case "openwork_company":
 		return s.executeOpenworkCompanyCrawl(source)
 	default:
@@ -214,8 +216,8 @@ func validateCrawlSource(source *models.CrawlSource) error {
 	if strings.TrimSpace(source.TargetType) == "" {
 		return errors.New("target_type is required")
 	}
-	if source.TargetType != "company" && source.TargetType != "popular_companies" && source.TargetType != "job_site_company" && source.TargetType != "job_listing" && source.TargetType != "openwork_company" {
-		return errors.New("target_type must be company, popular_companies, job_site_company, job_listing, or openwork_company")
+	if source.TargetType != "company" && source.TargetType != "popular_companies" && source.TargetType != "job_site_company" && source.TargetType != "job_listing" && source.TargetType != "mynavi_company" && source.TargetType != "openwork_company" {
+		return errors.New("target_type must be company, popular_companies, job_site_company, job_listing, mynavi_company, or openwork_company")
 	}
 	if source.TargetType == "popular_companies" && strings.TrimSpace(source.SourceURL) == "" {
 		return errors.New("source_url is required for popular_companies")
@@ -225,6 +227,9 @@ func validateCrawlSource(source *models.CrawlSource) error {
 	}
 	if source.TargetType == "job_listing" && strings.TrimSpace(source.SourceURL) == "" {
 		return errors.New("source_url is required for job_listing")
+	}
+	if source.TargetType == "mynavi_company" && strings.TrimSpace(source.SourceURL) == "" {
+		return errors.New("source_url is required for mynavi_company")
 	}
 	if source.TargetType == "openwork_company" && strings.TrimSpace(source.SourceURL) == "" {
 		return errors.New("source_url is required for openwork_company")


### PR DESCRIPTION
## 概要

PR #356 (`feature/issue-349`) のマージ時に `crawl_service.go` のコンフリクト解消で `mynavi_company` の実装が欠落しました。
その結果、main で `TestValidateCrawlSource_MynaviCompany` が失敗しています。

## 変更内容

- `executeCrawl` に `mynavi_company` → `executeMynaviCompanyCrawl` のケースを追加
- `validateCrawlSource` のallowlistに `mynavi_company` を追加
- `source_url is required for mynavi_company` のバリデーションを追加

## 影響

このPRをマージ後、PR #357 (feature/issue-348) の CI も自動的に通るようになります。