### PR TITLE
Resolve #359: セキュリティ脆弱性の修正（非破壊的変更）

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -36,6 +36,19 @@ func buildAllowedOrigins() map[string]struct{} {
 	return allowedOrigins
 }
 
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+		if r.TLS != nil {
+			w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
 	allowedOrigins := buildAllowedOrigins()
 
@@ -291,7 +304,7 @@ func main() {
 	}
 
 	log.Printf("Starting server on port %s...", port)
-	if err := http.ListenAndServe(":"+port, corsMiddleware(http.DefaultServeMux)); err != nil {
+	if err := http.ListenAndServe(":"+port, securityHeadersMiddleware(corsMiddleware(http.DefaultServeMux))); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -702,6 +703,9 @@ func extractID(path string, prefix string, suffix string) (uint, error) {
 	id, err := strconv.ParseUint(trimmed, 10, 32)
 	if err != nil {
 		return 0, err
+	}
+	if id > math.MaxInt32 {
+		return 0, fmt.Errorf("id %d exceeds maximum allowed value", id)
 	}
 	return uint(id), nil
 }

--- a/Backend/internal/services/auth_service.go
+++ b/Backend/internal/services/auth_service.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -315,7 +316,9 @@ func (s *AuthService) RequestRegistration(email string) error {
 	}
 
 	// 以前の仮登録を削除
-	_ = s.pendingRepo.DeleteByEmail(email)
+	if err := s.pendingRepo.DeleteByEmail(email); err != nil {
+		log.Printf("[AuthService] failed to delete previous pending registration for %s: %v", email, err)
+	}
 
 	// トークン生成
 	b := make([]byte, 32)
@@ -354,6 +357,9 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 	if req.Email == "" || req.Password == "" {
 		return nil, errors.New("email and password are required")
 	}
+	if len(req.Password) < 8 {
+		return nil, errors.New("password must be at least 8 characters")
+	}
 
 	// トークン検証
 	if req.RegistrationToken != "" {
@@ -365,7 +371,9 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 			return nil, errors.New("invalid or expired registration token")
 		}
 		// 使用済みトークンを削除
-		_ = s.pendingRepo.DeleteByEmail(req.Email)
+		if err := s.pendingRepo.DeleteByEmail(req.Email); err != nil {
+			log.Printf("[AuthService] failed to delete used registration token for %s: %v", req.Email, err)
+		}
 	}
 	if req.TargetLevel == "" {
 		req.TargetLevel = "新卒"
@@ -420,7 +428,11 @@ func (s *AuthService) Register(req RegisterRequest) (*AuthResponse, error) {
 
 	// 認証メール送信（失敗しても登録は成功扱い）
 	appURL := config.AppURL()
-	go s.emailService.SendVerificationEmail(user, user.EmailVerificationToken, appURL)
+	go func() {
+		if err := s.emailService.SendVerificationEmail(user, user.EmailVerificationToken, appURL); err != nil {
+			log.Printf("[AuthService] failed to send verification email to %s: %v", user.Email, err)
+		}
+	}()
 
 	return &AuthResponse{
 		UserID:                   user.ID,

--- a/rag/main.py
+++ b/rag/main.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 import openai as openai_module
 from openai import OpenAI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 logging.basicConfig(level=logging.INFO)
@@ -71,9 +71,14 @@ def log_openai_version() -> None:
 
 
 class ReviewRequest(BaseModel):
-    resume_text: str = Field(min_length=1)
+    resume_text: str = Field(min_length=1, max_length=10000)
     company_name: str = Field(min_length=1)
     job_title: str = Field(default="")
+
+    @field_validator("job_title")
+    @classmethod
+    def normalize_job_title(cls, v: str) -> str:
+        return v.strip()
 
 
 class ReviewResponse(BaseModel):


### PR DESCRIPTION
Closes #359

## 変更内容

### 🟠 HIGH
- **パスワードバリデーション強化** (`Backend/internal/services/auth_service.go`)
  - `Register` 関数に最低8文字チェックを追加（OWASP/NIST SP800-63B準拠）
  - 複雑性強制（英字+数字の組み合わせ）は公式ガイドライン非推奨のため不採用

### 🟡 MEDIUM
- **セキュリティHTTPヘッダー追加** (`Backend/cmd/server/main.go`)
  - `securityHeadersMiddleware` を新規追加し、全レスポンスに以下を付与
    - `X-Content-Type-Options: nosniff`
    - `X-Frame-Options: DENY`
    - `Referrer-Policy: strict-origin-when-cross-origin`
    - `Cross-Origin-Opener-Policy: same-origin`
    - `Strict-Transport-Security: max-age=63072000; includeSubDomains`（HTTPS時のみ）
- **RAG resume_text バリデーション** (`rag/main.py`)
  - `max_length=10000` を `Field` に追加し、超過時は422エラーを返す（サイレントトランケート廃止）
  - `job_title` に空白正規化バリデーター（`field_validator`）を追加

### 🟢 LOW
- **エラーログ追加** (`Backend/internal/services/auth_service.go`)
  - 仮登録削除エラー（2箇所）を `log.Printf` で出力
  - メール送信 goroutine のエラーを無名関数でラップしてログ出力
- **ParseUint 境界値チェック** (`Backend/internal/controllers/interview_controller.go`)
  - `extractID` 関数にて `id > math.MaxInt32` の場合はエラーを返すよう修正

## 対象外（別Issue推奨）

| 項目 | 理由 |
|------|------|
| Adminトークンのプレフィックス変更 | 既存セッション破壊のため除外 |
| TOKEN_ENCRYPTION_KEY フェイルクローズ | env未設定環境が起動不能になるため除外 |
| ADMIN_SECRET フェイルクローズ | OAuth破壊のため除外 |
| チャットgoroutineメモリリーク | リファクタリング規模が大きく別Issue化推奨 |
| Realtimeサービスmutexタイムアウト | アーキテクチャ変更が必要で別Issue化推奨 |