### PR TITLE
Resolve #376: フロントエンドセキュリティ強化（CSP・認証情報の安全な管理・CORS）

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -56,6 +56,13 @@ func corsMiddleware(next http.Handler) http.Handler {
 		origin := strings.TrimSpace(r.Header.Get("Origin"))
 		_, isAllowedOrigin := allowedOrigins[origin]
 
+		// Originなしリクエストを拒否（HTMLフォームPOSTなどCSRF的攻撃を防ぐ）
+		// ただしヘルスチェックエンドポイントは除外
+		if origin == "" && r.URL.Path != "/health" && r.URL.Path != "/healthz" {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
 		w.Header().Add("Vary", "Origin")
 		if isAllowedOrigin {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
@@ -64,7 +71,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-User-ID, X-User-Token, X-Admin-Email, X-Admin-Token")
 
 		if r.Method == "OPTIONS" {
-			if origin != "" && !isAllowedOrigin {
+			if !isAllowedOrigin {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}

--- a/Backend/internal/middleware/user_auth.go
+++ b/Backend/internal/middleware/user_auth.go
@@ -58,6 +58,12 @@ func UserAuthFunc(userRepo *repositories.UserRepository, userSecret string, next
 			return
 		}
 
+		// ゲストユーザーは認証が必要なエンドポイントへのアクセスを拒否
+		if user.IsGuest {
+			http.Error(w, "Forbidden: guest users cannot access this resource", http.StatusForbidden)
+			return
+		}
+
 		next(w, r)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      DB_HOST: database-3.cdbaszsalwj8.ap-northeast-1.rds.amazonaws.com
+      DB_HOST: ${DB_HOST:-localhost}
       DB_PORT: "3306"
       APP_ENV: production
     env_file:

--- a/frontend/app/api/auth/session/route.ts
+++ b/frontend/app/api/auth/session/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  path: '/',
+  maxAge: 60 * 60 * 24 * 7, // 7日間
+}
+
+export async function POST(request: NextRequest) {
+  const { userId, userToken } = await request.json()
+  if (!userId || !userToken) {
+    return NextResponse.json({ error: 'userId and userToken are required' }, { status: 400 })
+  }
+
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set('user_id', String(userId), COOKIE_OPTIONS)
+  response.cookies.set('user_token', userToken, COOKIE_OPTIONS)
+  return response
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true })
+  response.cookies.delete('user_id')
+  response.cookies.delete('user_token')
+  return response
+}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -251,6 +251,16 @@ export const authService = {
     getLocalStorage()?.removeItem(AUTH_USER_KEY)
     getLocalStorage()?.removeItem(AUTH_TOKEN_KEY)
     getLocalStorage()?.removeItem(AUTH_USER_TOKEN_KEY)
+
+    // httpOnly CookieにトークンをセットしてDevTools経由の露出を防ぐ
+    if (authResponse.user_token) {
+      const userId = typeof authResponse.user_id === 'string' ? Number(authResponse.user_id) : authResponse.user_id
+      fetch('/api/auth/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, userToken: authResponse.user_token }),
+      }).catch(() => {})
+    }
   },
 
   getStoredUser(): User | null {
@@ -301,12 +311,15 @@ export const authService = {
     getLocalStorage()?.removeItem(AUTH_USER_KEY)
     getLocalStorage()?.removeItem(AUTH_TOKEN_KEY)
     getLocalStorage()?.removeItem(AUTH_USER_TOKEN_KEY)
-    
+
     // チャットキャッシュを削除
     const sessionId = localStorage.getItem('chat_session_id')
     if (sessionId) {
       localStorage.removeItem(`chat_cache_${sessionId}`)
     }
     localStorage.removeItem('chat_session_id')
+
+    // httpOnly Cookieを削除
+    fetch('/api/auth/session', { method: 'DELETE' }).catch(() => {})
   },
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const userId = request.cookies.get('user_id')?.value
+  const userToken = request.cookies.get('user_token')?.value
+
+  const requestHeaders = new Headers(request.headers)
+
+  if (userId && userToken) {
+    // httpOnly CookieからX-User-*ヘッダーを注入（クライアント送信ヘッダーを上書き）
+    requestHeaders.set('X-User-ID', userId)
+    requestHeaders.set('X-User-Token', userToken)
+  }
+
+  return NextResponse.next({
+    request: { headers: requestHeaders },
+  })
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,11 +1,37 @@
 import type { NextConfig } from 'next'
 
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "connect-src 'self' https://api.openai.com",
+      "frame-ancestors 'none'",
+    ].join('; '),
+  },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+]
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   // MUI emotion CSS-in-JS のSSR対応
   compiler: {
     emotion: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ]
   },
 }
 


### PR DESCRIPTION
Closes #376

## 変更内容

### 1. CSPヘッダーの設定 (`frontend/next.config.ts`)
- `Content-Security-Policy`、`X-Frame-Options: DENY`、`X-Content-Type-Options: nosniff`、`Referrer-Policy: strict-origin-when-cross-origin`、`Permissions-Policy` を全ルートに追加
- XSS・クリックジャッキング・MIMEスニッフィング攻撃を防御

### 2. httpOnly Cookie によるトークン管理
- **`frontend/app/api/auth/session/route.ts`（新規）**: `POST` でhttpOnly Cookie（`user_id`・`user_token`）をセット、`DELETE` でクリアするAPIルートを追加
- **`frontend/middleware.ts`（新規）**: `/api/*` 配下のリクエストに対してhttpOnly CookieからX-User-IDとX-User-Tokenヘッダーを注入するNext.jsミドルウェアを追加。クライアント送信ヘッダーをCookieの値で上書きし、DevTools経由のトークン露出を防止
- **`frontend/lib/auth.ts`**: `saveAuth` でhttpOnly Cookieをセット（`POST /api/auth/session` を非同期呼び出し）、`logout` でCookieをクリア

### 3. CORSのOriginなしリクエスト拒否 (`Backend/cmd/server/main.go`)
- `corsMiddleware` に `origin == ""` チェックを追加し、Originヘッダーなしのリクエストを403で拒否
- HTMLフォームPOSTを利用したCSRF的な攻撃を防止
- ヘルスチェックエンドポイント（`/health`・`/healthz`）のみ除外

### 4. docker-compose.yml の本番RDS情報削除 (`docker-compose.yml`)
- `DB_HOST` のハードコードされた本番RDSエンドポイントを `${DB_HOST:-localhost}` に変更
- 本番DBホスト名がリポジトリに露出しないよう修正

### 5. ゲストユーザー権限チェックの統一 (`Backend/internal/middleware/user_auth.go`)
- `UserAuthFunc` に `user.IsGuest` チェックを追加
- ゲストユーザーが認証必須エンドポイントにアクセスした場合、一律403を返すよう統一化