### PR TITLE
Resolve #375: 入力検証不備の修正（ファイルアップロード・SSRF・プロンプトインジェクション）

### DIFF
--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -13,7 +13,9 @@ import (
 	"io"
 	"log"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +31,76 @@ type ValidationError struct {
 func (e *ValidationError) Error() string { return e.Message }
 
 var ErrForbidden = errors.New("forbidden")
+
+// allowedMIMETypes はアップロード可能なファイルタイプ
+var allowedMIMETypes = map[string]bool{
+	"application/pdf":  true,
+	"application/msword": true,
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+}
+
+// pdfMagicBytes はPDFファイルの先頭シグネチャ（%PDF）
+var pdfMagicBytes = []byte{0x25, 0x50, 0x44, 0x46}
+
+// validateFileUpload はMIMEタイプとファイルシグネチャ（magic bytes）を検証する
+func validateFileUpload(fileHeader *multipart.FileHeader) error {
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if !allowedMIMETypes[mimeType] {
+		return &ValidationError{Message: "unsupported file type: only PDF and Word documents are allowed"}
+	}
+
+	f, err := fileHeader.Open()
+	if err != nil {
+		return fmt.Errorf("failed to open uploaded file: %w", err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return &ValidationError{Message: "file too small to validate"}
+	}
+
+	// PDFシグネチャ: %PDF
+	if bytes.HasPrefix(buf, pdfMagicBytes) {
+		return nil
+	}
+	// DOCX/XLSX (ZIP): PK\x03\x04
+	if bytes.HasPrefix(buf, []byte{0x50, 0x4B, 0x03, 0x04}) {
+		return nil
+	}
+	// DOC (OLE2): D0 CF 11 E0
+	if bytes.HasPrefix(buf, []byte{0xD0, 0xCF, 0x11, 0xE0}) {
+		return nil
+	}
+	return &ValidationError{Message: "file content does not match declared type"}
+}
+
+// validateURL はSSRF対策のためURLスキームとIPアドレス範囲を検証する
+func validateURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return &ValidationError{Message: "only http/https URLs are allowed"}
+	}
+	host := parsed.Hostname()
+	ip := net.ParseIP(host)
+	if ip != nil && (ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()) {
+		return &ValidationError{Message: "requests to internal IP addresses are not allowed"}
+	}
+	return nil
+}
+
+// validatePathInDir はpathがdir配下であることを確認する（パストラバーサル対策）
+func validatePathInDir(path, dir string) error {
+	cleanPath := filepath.Clean(path)
+	cleanDir := filepath.Clean(dir)
+	if !strings.HasPrefix(cleanPath, cleanDir+string(filepath.Separator)) && cleanPath != cleanDir {
+		return fmt.Errorf("path %q is outside allowed directory", path)
+	}
+	return nil
+}
 
 type ResumeService struct {
 	repo         repository.ResumeRepository
@@ -91,6 +163,9 @@ func (s *ResumeService) Upload(userID uint, sessionID, sourceType, sourceURL str
 	defer os.RemoveAll(workDir)
 
 	if fileHeader != nil {
+		if err := validateFileUpload(fileHeader); err != nil {
+			return nil, err
+		}
 		doc.OriginalFilename = fileHeader.Filename
 		ext := strings.ToLower(filepath.Ext(fileHeader.Filename))
 		originalPath := filepath.Join(workDir, "original"+ext)
@@ -102,6 +177,9 @@ func (s *ResumeService) Upload(userID uint, sessionID, sourceType, sourceURL str
 		doc.OriginalFilename = "google_doc"
 		doc.StoredPath = ""
 	} else {
+		if err := validateURL(sourceURL); err != nil {
+			return nil, err
+		}
 		downloaded, filename, err := downloadSourceFile(sourceURL, workDir)
 		if err != nil {
 			return nil, err
@@ -159,6 +237,9 @@ func (s *ResumeService) ReviewDocument(documentID uint, requestingUserID uint, c
 		return nil, nil, err
 	}
 
+	if err := validatePathInDir(pdfPath, workDir); err != nil {
+		return nil, nil, fmt.Errorf("invalid pdf path: %w", err)
+	}
 	blocks, err := s.extractTextBlocks(doc, pdfPath)
 	if err != nil {
 		return nil, nil, err
@@ -421,7 +502,8 @@ func (s *ResumeService) annotatePDF(inputPath string, doc *models.ResumeDocument
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", "", fmt.Errorf("annotate failed: %w (%s)", err, stderr.String())
+		log.Printf("annotate script error: %v\nstderr:\n%s", err, stderr.String())
+		return "", "", errors.New("document processing failed")
 	}
 	storedPath, err := s.uploadToS3(context.Background(), doc, outputPath, filepath.Base(outputPath))
 	if err != nil {
@@ -478,6 +560,9 @@ func (s *ResumeService) ensureWorkingDir(docID uint) (string, error) {
 func (s *ResumeService) resolveLocalPath(doc *models.ResumeDocument, workDir string) (string, error) {
 	if !isS3URI(doc.StoredPath) {
 		if strings.TrimSpace(doc.StoredPath) == "" && strings.TrimSpace(doc.SourceURL) != "" {
+			if err := validateURL(doc.SourceURL); err != nil {
+				return "", err
+			}
 			downloaded, _, err := downloadSourceFile(doc.SourceURL, workDir)
 			if err != nil {
 				return "", err
@@ -812,6 +897,10 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	doc.Status = "normalized"
 	_ = s.repo.UpdateDocument(doc)
 
+	if err := validatePathInDir(pdfPath, workDir); err != nil {
+		sendEvent(map[string]any{"type": "error", "message": "document processing failed"})
+		return fmt.Errorf("invalid pdf path: %w", err)
+	}
 	blocks, err := s.extractTextBlocks(doc, pdfPath)
 	if err != nil {
 		sendEvent(map[string]interface{}{"type": "error", "message": err.Error()})

--- a/rag/main.py
+++ b/rag/main.py
@@ -159,6 +159,13 @@ def _sanitize_company_name_for_query(company_name: str) -> str:
     return sanitized
 
 
+def _sanitize_job_title(job_title: str) -> str:
+    """職種名からプロンプトインジェクションに使われうる特殊文字を除去する"""
+    sanitized = re.sub(r"[^\w\s\-（）()／/]", "", job_title, flags=re.UNICODE)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    return sanitized or "指定なし"
+
+
 def _truncate_text(text: str, model: str) -> str:
     """テキストが埋め込みモデルのトークン上限を超えている場合に切り詰める。"""
     try:
@@ -243,8 +250,9 @@ def run_deep_research(company_name: str, job_title: str) -> str:
             status_code=500,
             detail="Deep Research requires OpenAI responses API. Upgrade openai>=1.66 and rebuild the image.",
         )
-    role = job_title or "指定なし"
-    logger.info("deep research start model=%s company=%s role=%s", model, company_name, role)
+    safe_company = _sanitize_company_name_for_query(company_name)
+    role = _sanitize_job_title(job_title) if job_title else "指定なし"
+    logger.info("deep research start model=%s company=%s role=%s", model, safe_company, role)
     prompt = (
         "以下の企業について、採用に関わる価値観・求める人物像・評価軸・事業の特徴を、"
         "一次情報または信頼できる情報に基づいて簡潔に整理してください。"
@@ -252,7 +260,7 @@ def run_deep_research(company_name: str, job_title: str) -> str:
         "企業名: {company}\n"
         "職種: {role}\n"
         "出力は日本語で、箇条書きを含む短いレポート形式にしてください。"
-    ).format(company=company_name, role=role)
+    ).format(company=safe_company, role=role)
     last_err = None
 
     def request_response(use_tools: bool, model_name: str):
@@ -335,6 +343,8 @@ def run_crewai(
     context_docs: List[str],
     context_source: str = "none",
 ) -> str:
+    safe_company = _sanitize_company_name_for_query(company_name)
+    safe_job_title = _sanitize_job_title(job_title) if job_title else "指定なし"
     context_block = "\n\n".join(context_docs)
 
     source_labels = {
@@ -366,7 +376,7 @@ def run_crewai(
             "Company: {company}\n"
             "Role: {role}\n"
             "Context:\n{context}\n"
-        ).format(company=company_name, role=job_title, context=context_block),
+        ).format(company=safe_company, role=safe_job_title, context=context_block),
         expected_output="Bullet keywords",
         agent=researcher,
     )
@@ -397,8 +407,8 @@ def run_crewai(
             "Role: {role}\n"
             "Resume:\n{resume}\n"
         ).format(
-            company=company_name,
-            role=job_title or "指定なし",
+            company=safe_company,
+            role=safe_job_title,
             resume=resume_text,
             source=source_label,
         ),
@@ -426,24 +436,26 @@ def _generate_search_queries(company_name: str, job_title: str) -> List[str]:
     - 最近の事業展開（直近ニュース・IR情報・新規事業）
     """
     api_key = os.getenv("OPENAI_API_KEY")
-    role_text = job_title or "一般職"
+    safe_company = _sanitize_company_name_for_query(company_name)
+    role_text = _sanitize_job_title(job_title) if job_title else "一般職"
     if not api_key:
         return [
-            f"{company_name} {role_text} 採用方針 求める人物像",
-            f"{company_name} {role_text} 面接 選考 特徴",
-            f"{company_name} 最近の事業展開 ニュース IR",
+            f"{safe_company} {role_text} 採用方針 求める人物像",
+            f"{safe_company} {role_text} 面接 選考 特徴",
+            f"{safe_company} 最近の事業展開 ニュース IR",
         ]
     client = OpenAI(api_key=api_key)
     prompt = (
-        f"企業名: {company_name}\n"
-        f"職種: {role_text}\n\n"
-        "この企業と職種について、以下の3軸をカバーする検索クエリを3〜5個生成してください。\n"
+        "以下の企業と職種について、採用情報を調査するための検索クエリを3〜5個生成してください。\n\n"
+        "企業名: {company}\n"
+        "職種: {role}\n\n"
+        "以下の3軸をカバーする検索クエリを生成してください。\n"
         "軸1: 採用方針（採用基準・求める人物像・企業文化）\n"
         "軸2: 選考の特徴（面接スタイル・選考フロー・評価ポイント）\n"
         "軸3: 最近の事業展開（直近のニュース・IR情報・新規事業）\n\n"
         "検索エンジンのヒット率を最大化するため、具体的なキーワードを組み合わせてください。\n"
-        "出力はJSONのみ: {\"queries\": [\"クエリ1\", \"クエリ2\", ...]}"
-    )
+        "出力はJSONのみ: {{\"queries\": [\"クエリ1\", \"クエリ2\", ...]}}"
+    ).format(company=safe_company, role=role_text)
     try:
         resp = client.chat.completions.create(
             model=os.getenv("OPENAI_CHAT_MODEL", "gpt-4o"),
@@ -455,10 +467,10 @@ def _generate_search_queries(company_name: str, job_title: str) -> List[str]:
         data = json.loads(resp.choices[0].message.content or "{}")
         queries = data.get("queries", [])
         if queries:
-            logger.info("generated %d search queries company=%s", len(queries), company_name)
+            logger.info("generated %d search queries company=%s", len(queries), safe_company)
             return queries[:5]
     except Exception as exc:
-        logger.warning("query generation failed company=%s error=%s", company_name, exc)
+        logger.warning("query generation failed company=%s error=%s", safe_company, exc)
     return [
         f"{company_name} {role_text} 採用方針 求める人物像",
         f"{company_name} {role_text} 面接 選考 特徴",
@@ -494,11 +506,13 @@ def _summarize_for_hiring(company_name: str, job_title: str, raw_texts: List[str
     if not api_key:
         return "\n\n".join(raw_texts)
     client = OpenAI(api_key=api_key)
-    role_text = job_title or "一般職"
+    safe_company = _sanitize_company_name_for_query(company_name)
+    role_text = _sanitize_job_title(job_title) if job_title else "一般職"
     combined = "\n\n---\n\n".join(raw_texts)[:6000]
     prompt = (
-        f"企業名: {company_name}\n"
-        f"職種: {role_text}\n\n"
+        "企業名: {company}\n"
+        "職種: {role}\n\n"
+    ).format(company=safe_company, role=role_text) + (
         "以下の検索結果をもとに、採用観点での企業分析サマリーを日本語で作成してください。\n\n"
         "【優先情報ソース（重要度順）】\n"
         "1. 企業公式サイト（採用ページ・企業理念・代表メッセージ）\n"
@@ -612,18 +626,19 @@ def _run_hints_web_search(company_name: str, position: str) -> Optional[str]:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return None
-    role_text = position or "一般職"
+    safe_company = _sanitize_company_name_for_query(company_name)
+    role_text = _sanitize_job_title(position) if position else "一般職"
     # 面接調査に特化した3軸クエリ
     queries = [
-        f"{company_name} {role_text} 面接 選考スタイル 特徴 体験談",
-        f"{company_name} {role_text} 面接 よく聞かれる質問 口コミ",
-        f"{company_name} 採用 求める人物像 評価軸 公式",
+        f"{safe_company} {role_text} 面接 選考スタイル 特徴 体験談",
+        f"{safe_company} {role_text} 面接 よく聞かれる質問 口コミ",
+        f"{safe_company} 採用 求める人物像 評価軸 公式",
     ]
     try:
-        summary = _run_async(_run_hints_web_search_pipeline, company_name, role_text, queries)
+        summary = _run_async(_run_hints_web_search_pipeline, safe_company, role_text, queries)
         return summary if summary else None
     except Exception as exc:
-        logger.warning("hints web search failed company=%s error=%s", company_name, exc)
+        logger.warning("hints web search failed company=%s error=%s", safe_company, exc)
         return None
 
 
@@ -649,9 +664,10 @@ async def _run_hints_web_search_pipeline(
     client = OpenAI(api_key=api_key)
     combined = "\n\n---\n\n".join(raw_results)[:5000]
     prompt = (
-        f"企業名: {company_name}\n"
-        f"職種: {role_text}\n\n"
+        "企業名: {company}\n"
+        "職種: {role}\n\n"
         "以下の検索結果から、面接・選考に関する情報を採用観点で整理してください。\n\n"
+    ).format(company=company_name, role=role_text) + (
         "【優先情報ソース（重要度順）】\n"
         "1. 企業公式採用サイト・説明会レポート\n"
         "2. 実際の選考体験談（一次情報）\n"
@@ -812,7 +828,8 @@ def _gather_context(request: ReviewRequest) -> Tuple[List[str], str]:
 @app.post("/resume/review/stream")
 def review_resume_stream(request: ReviewRequest) -> StreamingResponse:
     """RAGレポートをSSEでストリーミング配信するエンドポイント。"""
-    role_label = request.job_title or "指定なし"
+    safe_company_for_prompt = _sanitize_company_name_for_query(request.company_name)
+    role_label = _sanitize_job_title(request.job_title) if request.job_title else "指定なし"
 
     # コンテキスト収集（キャッシュ/DeepResearch/Web Search）
     retrieved, context_source = _gather_context(request)
@@ -854,7 +871,7 @@ def review_resume_stream(request: ReviewRequest) -> StreamingResponse:
             "- 情報ソース: {source}\n"
             "- 注意: 外部情報に基づく内容は変化する可能性があります。最新情報は企業公式サイトで確認してください。\n"
         ).format(
-            company=request.company_name,
+            company=safe_company_for_prompt,
             role=role_label,
             context=context_block,
             resume=request.resume_text[:RESUME_REVIEW_INPUT_CHAR_LIMIT],


### PR DESCRIPTION
Closes #375

## 変更内容

### 1. ファイルアップロードのMIMEタイプ・magic bytes検証 (`Backend/internal/services/resume_service.go`)
- `validateFileUpload()` を新規追加
- `fileHeader.Header.Get("Content-Type")` によるMIMEタイプ検証（PDF・DOC・DOCXのみ許可）
- ファイル先頭4バイトのシグネチャ検証（PDF: `%PDF`、DOCX/ZIP: `PK\x03\x04`、DOC/OLE2: `D0 CF 11 E0`）
- アップロード処理の入口で `validateFileUpload` を呼び出し、不正ファイルを拒否

### 2. SSRF対策（URL検証） (`Backend/internal/services/resume_service.go`)
- `validateURL()` を新規追加
- `http/https` スキームのみ許可（`file://`, `gopher://` 等を拒否）
- ループバックアドレス・プライベートIPレンジ・リンクローカルアドレスへのアクセスを拒否（AWSメタデータ等への接続を防止）
- `net` / `net/url` パッケージをimportに追加
- `Upload` と `resolveLocalPath` の `downloadSourceFile` 呼び出し前に検証を適用

### 3. プロンプトインジェクション対策 (`rag/main.py`)
- `_sanitize_job_title()` を新規追加（`job_title` から特殊文字・制御文字を除去）
- 以下の全プロンプト生成箇所に `_sanitize_company_name_for_query` と `_sanitize_job_title` を適用:
  - `run_crewai()`: CrewAIタスク記述（task_research・task_review）
  - `run_deep_research()`: Deep Research プロンプト
  - `_generate_search_queries()`: 検索クエリ生成プロンプト
  - `_summarize_for_hiring()`: 採用サマリープロンプト
  - `review_resume_stream()`: ストリームレビュープロンプト
  - `_run_hints_web_search()` / `_run_hints_web_search_pipeline()`: 面接ヒント検索プロンプト
- f-string埋め込みを `.format()` に統一し、ユーザー入力が直接プロンプトに展開されないよう変更

### 4. パスインジェクション対策 (`Backend/internal/services/resume_service.go`)
- `validatePathInDir()` を新規追加（`filepath.Clean` + `strings.HasPrefix` でディレクトリ境界を検証）
- `extractTextBlocks` 呼び出し前に `pdfPath` が `workDir` 配下であることを検証
- `Review` と `ReviewStream` の両フローに適用

### 5. エラーメッセージの汎用化 (`Backend/internal/services/resume_service.go`)
- `annotate_pdf.py` 実行失敗時のエラーを変更: stderrを含む詳細なエラーをサーバーログのみに記録し、クライアントには汎用メッセージ `"document processing failed"` のみを返す