### PR TITLE
Resolve #407: OAuthステート署名の ADMIN_SECRET 共用を廃止し専用シークレットに分離

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DOCKERFILE=Dockerfile
 HOST_PORT=8080
 ADMIN_SECRET=change-me-admin-secret
 USER_SECRET=change-me-user-secret
+# OAuth CSRF 対策用シークレット（ADMIN_SECRET とは独立して設定すること）（#407）
+# 生成例: python3 -c "import secrets; print(secrets.token_hex(32))"
+OAUTH_STATE_SECRET=change-me-oauth-state-secret
 
 # データベース設定
 DB_HOST_BIND=127.0.0.1

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -12,6 +12,9 @@ DB_NAME=app_db
 SERVER_PORT=8080
 ADMIN_SECRET=change-me-admin-secret
 USER_SECRET=change-me-user-secret
+# OAuth CSRF 対策用シークレット（ADMIN_SECRET とは独立して設定すること）（#407）
+# 生成例: python3 -c "import secrets; print(secrets.token_hex(32))"
+OAUTH_STATE_SECRET=change-me-oauth-state-secret
 # CORS 許可オリジン（カンマ区切り）（#327: 未設定時は全オリジン拒否）
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 

--- a/Backend/internal/config/config.go
+++ b/Backend/internal/config/config.go
@@ -9,16 +9,17 @@ import (
 )
 
 type Config struct {
-	DBUser          string
-	DBPass          string
-	DBHost          string
-	DBPort          string
-	DBName          string
-	ServerPort      string
-	GBizInfoBaseURL string
-	GBizInfoToken   string
-	AdminSecret     string
-	UserSecret      string
+	DBUser           string
+	DBPass           string
+	DBHost           string
+	DBPort           string
+	DBName           string
+	ServerPort       string
+	GBizInfoBaseURL  string
+	GBizInfoToken    string
+	AdminSecret      string
+	UserSecret       string
+	OAuthStateSecret string
 }
 
 func LoadConfig() (*Config, error) {
@@ -40,18 +41,23 @@ func LoadConfig() (*Config, error) {
 	if userSecret == "" {
 		log.Println("WARNING: USER_SECRET が設定されていません。ユーザー認証が利用できません。本番環境では必ず設定してください。")
 	}
+	oauthStateSecret := os.Getenv("OAUTH_STATE_SECRET")
+	if oauthStateSecret == "" {
+		log.Fatal("OAUTH_STATE_SECRET が設定されていません。OAuth CSRF 対策が機能しないため起動を中止します。.env に OAUTH_STATE_SECRET を設定してください。")
+	}
 
 	cfg := &Config{
-		DBUser:          os.Getenv("DB_USER"),
-		DBPass:          os.Getenv("DB_PASSWORD"),
-		DBHost:          os.Getenv("DB_HOST"),
-		DBPort:          os.Getenv("DB_PORT"),
-		DBName:          os.Getenv("DB_NAME"),
-		ServerPort:      get("SERVER_PORT", "80"),
-		GBizInfoBaseURL: get("GBIZINFO_BASE_URL", ""),
-		GBizInfoToken:   getFirst("GBIZINFO_API_KEY", "GBIZINFO_API_TOKEN"),
-		AdminSecret:     adminSecret,
-		UserSecret:      userSecret,
+		DBUser:           os.Getenv("DB_USER"),
+		DBPass:           os.Getenv("DB_PASSWORD"),
+		DBHost:           os.Getenv("DB_HOST"),
+		DBPort:           os.Getenv("DB_PORT"),
+		DBName:           os.Getenv("DB_NAME"),
+		ServerPort:       get("SERVER_PORT", "80"),
+		GBizInfoBaseURL:  get("GBIZINFO_BASE_URL", ""),
+		GBizInfoToken:    getFirst("GBIZINFO_API_KEY", "GBIZINFO_API_TOKEN"),
+		AdminSecret:      adminSecret,
+		UserSecret:       userSecret,
+		OAuthStateSecret: oauthStateSecret,
 	}
 
 	// 必須値チェック

--- a/Backend/internal/middleware/oauth_state.go
+++ b/Backend/internal/middleware/oauth_state.go
@@ -71,10 +71,7 @@ func VerifyOAuthState(w http.ResponseWriter, r *http.Request) bool {
 
 // signState は state 値を HMAC-SHA256 で署名し "state.signature" 形式の文字列を返す
 func signState(state string) string {
-	secret := os.Getenv("ADMIN_SECRET")
-	if secret == "" {
-		secret = "dev-oauth-state-secret" // 開発環境フォールバック（本番では必ず設定）
-	}
+	secret := os.Getenv("OAUTH_STATE_SECRET")
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(state))
 	sig := hex.EncodeToString(mac.Sum(nil))


### PR DESCRIPTION
Closes #407

## 概要

OAuthステートパラメータの署名に `ADMIN_SECRET` を流用しており、管理者トークンとシークレットを共有していたセキュリティ上の問題を修正しました。`ADMIN_SECRET` 漏洩時の影響範囲が OAuth フローと管理者権限の両方に及ぶリスクを解消します。

## 変更内容

### `Backend/internal/middleware/oauth_state.go`
- `signState()` が参照する環境変数を `ADMIN_SECRET` → `OAUTH_STATE_SECRET` に変更
- 開発環境フォールバック文字列（`"dev-oauth-state-secret"`）を削除（起動時チェックで代替）

### `Backend/internal/config/config.go`
- `Config` 構造体に `OAuthStateSecret string` フィールドを追加
- `LoadConfig()` 内で `OAUTH_STATE_SECRET` 未設定時に `log.Fatal` でサーバー起動を中止するフェイルセーフを追加

### `Backend/.env.example` / `.env.example`（ルート）
- `OAUTH_STATE_SECRET` エントリと生成コマンドのコメントを追加

## セキュリティ上の効果

- `ADMIN_SECRET` と `OAUTH_STATE_SECRET` が独立したシークレットになり、片方が漏洩しても影響範囲が限定される
- 本番環境で `OAUTH_STATE_SECRET` が未設定のままサーバーが稼働する事故をフェイルセーフで防止

## 動作確認

- `oauth_state.go` が `ADMIN_SECRET` を参照しないことを確認 ✅
- `OAUTH_STATE_SECRET` 未設定時のサーバー起動中止を確認 ✅
- OAuth state の生成・検証・Cookie削除の全テスト（6件）通過 ✅
- `go build ./...` コンパイル成功 ✅
- `go test ./internal/...` 全テスト通過 ✅

## 注意事項

既存の `.env` ファイルに `OAUTH_STATE_SECRET` が未設定の場合、サーバーが起動できません。`.env.example` を参考に以下のコマンドで生成・設定してください。

```bash
python3 -c "import secrets; print(secrets.token_hex(32))"
```