### PR TITLE
feat: #406 チャットエンドポイントの認証バイパス脆弱性を修正

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -270,7 +270,7 @@ func main() {
 
 	// ルーティング設定
 	routes.SetupAuthRoutes(authController, oauthController, userRepo, cfg.UserSecret)
-	routes.SetupChatRoutes(chatController, questionController)
+	routes.SetupChatRoutes(chatController, questionController, userRepo, cfg.UserSecret)
 	routes.SetupCompanyRoutes(relationController)
 	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, scraperSessionController, userRepo, cfg.AdminSecret)
 	routes.SetupResumeRoutes(resumeController, userRepo, cfg.UserSecret)

--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -132,14 +132,22 @@ func (c *ChatController) Chat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	var req services.ChatRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	// バリデーション
-	if req.UserID == 0 || req.SessionID == "" || req.Message == "" {
+	// user_id は認証ヘッダーから設定（リクエストボディの値は無視）
+	req.UserID = userID
+
+	if req.SessionID == "" || req.Message == "" {
 		http.Error(w, "Missing required fields", http.StatusBadRequest)
 		return
 	}
@@ -164,6 +172,12 @@ func (c *ChatController) GetHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	sessionID := r.URL.Query().Get("session_id")
 	if sessionID == "" {
 		http.Error(w, "session_id is required", http.StatusBadRequest)
@@ -173,6 +187,12 @@ func (c *ChatController) GetHistory(w http.ResponseWriter, r *http.Request) {
 	history, err := c.chatService.GetChatHistory(sessionID)
 	if err != nil {
 		writeInternalServerError(w, err)
+		return
+	}
+
+	// セッション所有者チェック：最初のメッセージの UserID と照合
+	if len(history) > 0 && history[0].UserID != 0 && history[0].UserID != userID {
+		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
@@ -187,21 +207,19 @@ func (c *ChatController) GetScores(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userIDStr := r.URL.Query().Get("user_id")
-	sessionID := r.URL.Query().Get("session_id")
-
-	if userIDStr == "" || sessionID == "" {
-		http.Error(w, "user_id and session_id are required", http.StatusBadRequest)
-		return
-	}
-
-	userID, err := strconv.ParseUint(userIDStr, 10, 32)
+	userID, err := authenticatedUserID(r)
 	if err != nil {
-		http.Error(w, "Invalid user_id", http.StatusBadRequest)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	scores, err := c.chatService.GetUserScores(uint(userID), sessionID)
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
+		return
+	}
+
+	scores, err := c.chatService.GetUserScores(userID, sessionID)
 	if err != nil {
 		writeInternalServerError(w, err)
 		return
@@ -218,18 +236,17 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	userIDStr := r.URL.Query().Get("user_id")
-	sessionID := r.URL.Query().Get("session_id")
-	limitStr := r.URL.Query().Get("limit")
-
-	if userIDStr == "" || sessionID == "" {
-		http.Error(w, "user_id and session_id are required", http.StatusBadRequest)
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	userID, err := strconv.ParseUint(userIDStr, 10, 32)
-	if err != nil {
-		http.Error(w, "Invalid user_id", http.StatusBadRequest)
+	sessionID := r.URL.Query().Get("session_id")
+	limitStr := r.URL.Query().Get("limit")
+
+	if sessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
 		return
 	}
 
@@ -243,17 +260,17 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 
 	// 既存のマッチング結果を取得（事前計算済みを想定）
 	log.Printf("[GetRecommendations] Fetching pre-calculated matches for user %d, session %s\n", userID, sessionID)
-	matches, err := c.matchingService.GetTopMatches(r.Context(), uint(userID), sessionID, limit)
+	matches, err := c.matchingService.GetTopMatches(r.Context(), userID, sessionID, limit)
 	log.Printf("[GetRecommendations] Retrieved %d matches in fast mode\n", len(matches))
 
 	if err != nil || len(matches) == 0 {
 		log.Printf("[GetRecommendations] No matching results found, returning empty result\n")
-		diagnostics, diagErr := c.matchingService.GetDiagnostics(uint(userID), sessionID)
+		diagnostics, diagErr := c.matchingService.GetDiagnostics(userID, sessionID)
 		if diagErr != nil {
 			log.Printf("[GetRecommendations] Diagnostics error: %v\n", diagErr)
 		}
 
-		userScores, scoreErr := c.chatService.GetUserScores(uint(userID), sessionID)
+		userScores, scoreErr := c.chatService.GetUserScores(userID, sessionID)
 		if scoreErr != nil {
 			log.Printf("[GetRecommendations] Failed to load user scores for provisional status: %v\n", scoreErr)
 			userScores = []entity.UserWeightScore{}
@@ -326,7 +343,7 @@ func (c *ChatController) GetRecommendations(w http.ResponseWriter, r *http.Reque
 		IsProvisional       bool                    `json:"is_provisional"`
 	}
 
-	userScores, err := c.chatService.GetUserScores(uint(userID), sessionID)
+	userScores, err := c.chatService.GetUserScores(userID, sessionID)
 	if err != nil {
 		log.Printf("[GetRecommendations] Failed to load user scores: %v\n", err)
 		userScores = []entity.UserWeightScore{}
@@ -419,16 +436,15 @@ func (c *ChatController) GetAnalysisSummary(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	userIDStr := r.URL.Query().Get("user_id")
-	sessionID := r.URL.Query().Get("session_id")
-	if userIDStr == "" || sessionID == "" {
-		http.Error(w, "user_id and session_id are required", http.StatusBadRequest)
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	userID, err := strconv.ParseUint(userIDStr, 10, 32)
-	if err != nil {
-		http.Error(w, "Invalid user_id", http.StatusBadRequest)
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
 		return
 	}
 
@@ -437,7 +453,7 @@ func (c *ChatController) GetAnalysisSummary(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), uint(userID), sessionID)
+	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), userID, sessionID)
 	if err != nil {
 		writeInternalServerError(w, err)
 		return
@@ -547,21 +563,26 @@ func (c *ChatController) SendReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	var req struct {
-		UserID    uint   `json:"user_id"`
 		SessionID string `json:"session_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	if req.UserID == 0 || req.SessionID == "" {
-		http.Error(w, "user_id and session_id are required", http.StatusBadRequest)
+	if req.SessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
 		return
 	}
 
 	// ユーザー情報取得
-	user, err := c.userRepo.GetUserByID(req.UserID)
+	user, err := c.userRepo.GetUserByID(userID)
 	if err != nil || user == nil {
 		http.Error(w, "User not found", http.StatusNotFound)
 		return
@@ -574,15 +595,15 @@ func (c *ChatController) SendReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 分析サマリー取得
-	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), req.UserID, req.SessionID)
+	summary, err := c.analysisService.BuildAnalysisSummary(r.Context(), userID, req.SessionID)
 	if err != nil {
 		writeInternalServerError(w, err)
 		return
 	}
 
 	// おすすめ企業取得（最大5件）
-	matches, _ := c.matchingService.GetTopMatches(r.Context(), req.UserID, req.SessionID, 5)
-	userScores, _ := c.chatService.GetUserScores(req.UserID, req.SessionID)
+	matches, _ := c.matchingService.GetTopMatches(r.Context(), userID, req.SessionID, 5)
+	userScores, _ := c.chatService.GetUserScores(userID, req.SessionID)
 
 	var companies []services.EmailReportCompany
 	for i, match := range matches {
@@ -617,19 +638,13 @@ func (c *ChatController) GetSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userIDStr := r.URL.Query().Get("user_id")
-	if userIDStr == "" {
-		http.Error(w, "user_id is required", http.StatusBadRequest)
-		return
-	}
-
-	userID, err := strconv.ParseUint(userIDStr, 10, 32)
+	userID, err := authenticatedUserID(r)
 	if err != nil {
-		http.Error(w, "Invalid user_id", http.StatusBadRequest)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	sessions, err := c.chatService.GetUserChatSessions(uint(userID))
+	sessions, err := c.chatService.GetUserChatSessions(userID)
 	if err != nil {
 		writeInternalServerError(w, err)
 		return

--- a/Backend/internal/routes/chat_routes.go
+++ b/Backend/internal/routes/chat_routes.go
@@ -2,23 +2,29 @@ package routes
 
 import (
 	"Backend/internal/controllers"
+	"Backend/internal/middleware"
+	"Backend/internal/repositories"
 	"net/http"
 )
 
 // SetupChatRoutes チャット関連のルーティング設定
-func SetupChatRoutes(chatController *controllers.ChatController, questionController *controllers.QuestionController) {
-	// チャットエンドポイント
-	http.HandleFunc("/api/chat", chatController.Chat)
-	http.HandleFunc("/api/chat/history", chatController.GetHistory)
-	http.HandleFunc("/api/chat/scores", chatController.GetScores)
-	http.HandleFunc("/api/chat/recommendations", chatController.GetRecommendations)
-	http.HandleFunc("/api/chat/analysis", chatController.GetAnalysisSummary)
-	http.HandleFunc("/api/chat/sessions", chatController.GetSessions)
-	http.HandleFunc("/api/chat/send-report", chatController.SendReport)
-	http.HandleFunc("/api/chat/favorite", chatController.ToggleFavorite)
+func SetupChatRoutes(chatController *controllers.ChatController, questionController *controllers.QuestionController, userRepo *repositories.UserRepository, userSecret string) {
+	userAuth := func(f http.HandlerFunc) http.HandlerFunc {
+		return middleware.UserAuthFunc(userRepo, userSecret, f)
+	}
 
-	// 質問管理エンドポイント
-	http.HandleFunc("/api/questions/generate", questionController.GenerateQuestions)
-	http.HandleFunc("/api/questions/create", questionController.CreateQuestion)
-	http.HandleFunc("/api/questions/list", questionController.GetQuestionsByCategory)
+	// チャットエンドポイント（認証必須）
+	http.HandleFunc("/api/chat", userAuth(chatController.Chat))
+	http.HandleFunc("/api/chat/history", userAuth(chatController.GetHistory))
+	http.HandleFunc("/api/chat/scores", userAuth(chatController.GetScores))
+	http.HandleFunc("/api/chat/recommendations", userAuth(chatController.GetRecommendations))
+	http.HandleFunc("/api/chat/analysis", userAuth(chatController.GetAnalysisSummary))
+	http.HandleFunc("/api/chat/sessions", userAuth(chatController.GetSessions))
+	http.HandleFunc("/api/chat/send-report", userAuth(chatController.SendReport))
+	http.HandleFunc("/api/chat/favorite", userAuth(chatController.ToggleFavorite))
+
+	// 質問管理エンドポイント（認証必須）
+	http.HandleFunc("/api/questions/generate", userAuth(questionController.GenerateQuestions))
+	http.HandleFunc("/api/questions/create", userAuth(questionController.CreateQuestion))
+	http.HandleFunc("/api/questions/list", userAuth(questionController.GetQuestionsByCategory))
 }

--- a/frontend/app/api/chat/analysis/route.ts
+++ b/frontend/app/api/chat/analysis/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -7,11 +8,13 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const params = new URLSearchParams()
-  for (const key of ['user_id', 'session_id']) {
+  for (const key of ['session_id']) {
     const v = searchParams.get(key)
     if (v !== null) params.set(key, v)
   }
-  const response = await fetch(`${BACKEND_URL}/api/chat/analysis?${params}`)
+  const response = await fetch(`${BACKEND_URL}/api/chat/analysis?${params}`, {
+    headers: extractUserAuthHeaders(request),
+  })
   const raw = await response.text()
   let data: any = {}
   if (raw) {

--- a/frontend/app/api/chat/favorite/route.ts
+++ b/frontend/app/api/chat/favorite/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -8,7 +9,7 @@ export async function POST(request: NextRequest) {
 
     const response = await fetch(`${BACKEND_URL}/api/chat/favorite`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...extractUserAuthHeaders(request) },
       body: JSON.stringify(body),
     })
 

--- a/frontend/app/api/chat/history/route.ts
+++ b/frontend/app/api/chat/history/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
       },
     })
     return buildProxyJsonResponse(response)

--- a/frontend/app/api/chat/recommendations/route.ts
+++ b/frontend/app/api/chat/recommendations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -8,23 +8,23 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const userId = searchParams.get('user_id')
     const sessionId = searchParams.get('session_id')
     const limit = searchParams.get('limit') || '5'
-    
-    if (!userId || !sessionId) {
+
+    if (!sessionId) {
       return NextResponse.json(
-        { error: 'user_id and session_id are required' },
+        { error: 'session_id is required' },
         { status: 400 }
       )
     }
 
     const response = await fetch(
-      `${BACKEND_URL}/api/chat/recommendations?user_id=${userId}&session_id=${sessionId}&limit=${limit}`,
+      `${BACKEND_URL}/api/chat/recommendations?session_id=${sessionId}&limit=${limit}`,
       {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          ...extractUserAuthHeaders(request),
         },
       }
     )

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -11,6 +11,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
       },
       body: JSON.stringify(body),
     })

--- a/frontend/app/api/chat/scores/route.ts
+++ b/frontend/app/api/chat/scores/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -8,22 +8,22 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const userId = searchParams.get('user_id')
     const sessionId = searchParams.get('session_id')
-    
-    if (!userId || !sessionId) {
+
+    if (!sessionId) {
       return NextResponse.json(
-        { error: 'user_id and session_id are required' },
+        { error: 'session_id is required' },
         { status: 400 }
       )
     }
 
     const response = await fetch(
-      `${BACKEND_URL}/api/chat/scores?user_id=${userId}&session_id=${sessionId}`,
+      `${BACKEND_URL}/api/chat/scores?session_id=${sessionId}`,
       {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          ...extractUserAuthHeaders(request),
         },
       }
     )

--- a/frontend/app/api/chat/send-report/route.ts
+++ b/frontend/app/api/chat/send-report/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
@@ -11,6 +11,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
       },
       body: JSON.stringify(body),
     })

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -32,7 +32,9 @@ export default function ChatHistoryPage() {
 
   const fetchSessions = async (userId: number) => {
     try {
-      const response = await fetch(`${BACKEND_URL}/api/chat/sessions?user_id=${userId}`)
+      const response = await fetch(`${BACKEND_URL}/api/chat/sessions`, {
+        headers: authService.getUserFetchHeaders(),
+      })
       if (!response.ok) {
         throw new Error('Failed to fetch sessions')
       }

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -195,7 +195,7 @@ function ResultsContent() {
         console.log('[Results] Fetching recommendations for user:', userId, 'session:', sessionId)
 
         // 職種適性コメントを取得
-        fetch(`/api/chat/analysis?user_id=${userId}&session_id=${sessionId}`)
+        fetch(`/api/chat/analysis?session_id=${sessionId}`, { headers: authService.getUserFetchHeaders() })
           .then(r => r.ok ? r.json() : null)
           .then(data => {
             if (data?.job_suitability_comment) {
@@ -218,7 +218,7 @@ function ResultsContent() {
           })
           .catch(() => {/* サイレント失敗 */})
 
-        const response = await fetch(`/api/chat/recommendations?user_id=${userId}&session_id=${sessionId}&limit=10`)
+        const response = await fetch(`/api/chat/recommendations?session_id=${sessionId}&limit=10`, { headers: authService.getUserFetchHeaders() })
         
         if (!response.ok) {
           throw new Error('企業データの取得に失敗しました')
@@ -345,7 +345,7 @@ function ResultsContent() {
     try {
       const res = await fetch('/api/chat/favorite', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
         body: JSON.stringify({ match_id: company.matchId }),
       })
       if (res.ok) {

--- a/frontend/components/company-results.tsx
+++ b/frontend/components/company-results.tsx
@@ -462,7 +462,9 @@ export function CompanyResults({ userData, onResetAction }: { userData: UserData
         }
 
         // バックエンドから推奨企業を取得
-        const response = await fetch(`/api/chat/recommendations?user_id=1&session_id=${sessionId}&limit=10`)
+        const response = await fetch(`/api/chat/recommendations?session_id=${sessionId}&limit=10`, {
+          headers: authService.getUserFetchHeaders(),
+        })
         
         if (response.ok) {
           const data = await response.json()

--- a/frontend/lib/api-proxy.ts
+++ b/frontend/lib/api-proxy.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { parseProxyResponse, type ProxyResponseData } from '@/lib/proxy-response'
 
 export interface ProxyErrorBody {
@@ -26,6 +26,15 @@ function getDetailText(data: ProxyResponseData, raw: string): string | undefined
     getString(data.message) ??
     getString(raw)
   return detail
+}
+
+export function extractUserAuthHeaders(request: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = {}
+  const xUserId = request.headers.get('X-User-ID')
+  const xUserToken = request.headers.get('X-User-Token')
+  if (xUserId) headers['X-User-ID'] = xUserId
+  if (xUserToken) headers['X-User-Token'] = xUserToken
+  return headers
 }
 
 export async function buildProxyJsonResponse(response: Response): Promise<NextResponse> {


### PR DESCRIPTION
- chat_routes.go: 全エンドポイントに userAuth ミドルウェアを適用 /api/chat, /api/chat/history, /api/chat/scores, /api/chat/recommendations, /api/chat/analysis, /api/chat/sessions, /api/chat/send-report, /api/chat/favorite, /api/questions/* を userAuth でラップ
- chat_controller.go: user_id の取得元をクエリパラメータ/ボディから X-User-ID ヘッダー（authenticatedUserID）に変更
  - Chat: ボディの user_id を無視し認証ヘッダーから設定
  - GetHistory: authenticatedUserID + セッション所有者チェックを追加
  - GetScores / GetRecommendations / GetAnalysisSummary / GetSessions: クエリパラメータ user_id を廃止
  - SendReport: ボディの user_id を廃止
- main.go: SetupChatRoutes に userRepo / cfg.UserSecret を追加