### PR TITLE
Resolve #409: GoバックエンドルーティングをEcho v4 e.Group()パターンに移行

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/labstack/echo/v4"
 )
 
 func buildAllowedOrigins() map[string]struct{} {
@@ -49,31 +51,34 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
+// buildCORSMiddleware は許可オリジンを一度だけ構築してCORSミドルウェアを返す
+func buildCORSMiddleware() func(http.Handler) http.Handler {
 	allowedOrigins := buildAllowedOrigins()
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := strings.TrimSpace(r.Header.Get("Origin"))
-		_, isAllowedOrigin := allowedOrigins[origin]
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := strings.TrimSpace(r.Header.Get("Origin"))
+			_, isAllowedOrigin := allowedOrigins[origin]
 
-		w.Header().Add("Vary", "Origin")
-		if isAllowedOrigin {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-		}
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-User-ID, X-User-Token, X-Admin-Email, X-Admin-Token")
+			w.Header().Add("Vary", "Origin")
+			if isAllowedOrigin {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-User-ID, X-User-Token, X-Admin-Email, X-Admin-Token")
 
-		if r.Method == "OPTIONS" {
-			if origin != "" && !isAllowedOrigin {
-				w.WriteHeader(http.StatusForbidden)
+			if r.Method == "OPTIONS" {
+				if origin != "" && !isAllowedOrigin {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
 				return
 			}
-			w.WriteHeader(http.StatusOK)
-			return
-		}
 
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // checkAnnotationFont はサーバー起動時に PDF アノテーション用フォントの存在を確認し、
@@ -268,22 +273,13 @@ func main() {
 	scraperSessionService := services.NewScraperSessionService(scraperSessionRepo)
 	scraperSessionController := controllers.NewAdminScraperSessionController(scraperSessionService)
 
-	// ルーティング設定
-	routes.SetupAuthRoutes(authController, oauthController, userRepo, cfg.UserSecret)
-	routes.SetupChatRoutes(chatController, questionController, userRepo, cfg.UserSecret)
-	routes.SetupCompanyRoutes(relationController)
-	routes.SetupAdminRoutes(adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, scraperSessionController, userRepo, cfg.AdminSecret)
-	routes.SetupResumeRoutes(resumeController, userRepo, cfg.UserSecret)
-	routes.SetupInterviewRoutes(interviewController, realtimeController)
-	routes.SetupGitHubRoutes(githubController)
-	routes.SetupESRoutes(esRewriteController, esReviewController)
-	routes.SetupScheduleRoutes(scheduleController)
-	routes.SetupApplicationRoutes(appController)
-	routes.SetupUserRoutes(integratedProfileController)
-	routes.SetupCollectiveInsightRoutes(collectiveInsightController)
-	http.HandleFunc("/api/company-entry", companyEntryController.Submit)
+	// Echo初期化
+	e := echo.New()
+	e.HideBanner = true
 
-	go crawlService.StartScheduler()
+	// グローバルミドルウェア
+	e.Use(echo.WrapMiddleware(securityHeadersMiddleware))
+	e.Use(echo.WrapMiddleware(buildCORSMiddleware()))
 
 	// ヘルスチェックエンドポイント
 	// /healthz は ECS ターゲットグループ・ALB・Kubernetes の標準パス
@@ -293,9 +289,28 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}
-	http.HandleFunc(
-		"/health", healthHandler)
-	http.HandleFunc("/healthz", healthHandler)
+	e.Any("/health", echo.WrapHandler(http.HandlerFunc(healthHandler)))
+	e.Any("/healthz", echo.WrapHandler(http.HandlerFunc(healthHandler)))
+
+	// APIルートグループ
+	api := e.Group("/api")
+
+	// ルーティング設定
+	routes.SetupAuthRoutes(api, authController, oauthController, userRepo, cfg.UserSecret)
+	routes.SetupChatRoutes(api, chatController, questionController, userRepo, cfg.UserSecret)
+	routes.SetupCompanyRoutes(api, relationController)
+	routes.SetupAdminRoutes(api, adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, scraperSessionController, userRepo, cfg.AdminSecret)
+	routes.SetupResumeRoutes(api, resumeController, userRepo, cfg.UserSecret)
+	routes.SetupInterviewRoutes(api, interviewController, realtimeController)
+	routes.SetupGitHubRoutes(api, githubController)
+	routes.SetupESRoutes(api, esRewriteController, esReviewController)
+	routes.SetupScheduleRoutes(api, scheduleController)
+	routes.SetupApplicationRoutes(api, appController)
+	routes.SetupUserRoutes(api, integratedProfileController)
+	routes.SetupCollectiveInsightRoutes(api, collectiveInsightController)
+	api.Any("/company-entry", echo.WrapHandler(http.HandlerFunc(companyEntryController.Submit)))
+
+	go crawlService.StartScheduler()
 
 	// サーバー起動
 	port := cfg.ServerPort
@@ -304,7 +319,7 @@ func main() {
 	}
 
 	log.Printf("Starting server on port %s...", port)
-	if err := http.ListenAndServe(":"+port, securityHeadersMiddleware(corsMiddleware(http.DefaultServeMux))); err != nil {
+	if err := e.Start(":" + port); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -2,12 +2,13 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"Backend/internal/middleware"
 	"Backend/internal/repositories"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 func SetupAdminRoutes(
+	api *echo.Group,
 	adminCompanyController *controllers.AdminCompanyController,
 	adminCrawlController *controllers.AdminCrawlController,
 	adminJobController *controllers.AdminJobController,
@@ -24,54 +25,51 @@ func SetupAdminRoutes(
 	userRepo *repositories.UserRepository,
 	adminSecret string,
 ) {
-	auth := func(f http.HandlerFunc) http.HandlerFunc {
-		return middleware.AdminAuthFunc(userRepo, adminSecret, f)
-	}
+	// 認証不要（公開）エンドポイント
+	companyGraph := api.Group("/admin/company-graph")
+	companyGraph.Any("/target-year", wrap(adminCompanyGraphController.TargetYear))
 
-	http.HandleFunc("/api/admin/companies", auth(adminCompanyController.ListOrCreate))
-	// http.HandleFunc("/api/admin/companies/search-gbiz", auth(adminCompanyController.SearchGBizRoute)) // gBizINFO停止中
-	http.HandleFunc("/api/admin/companies/", auth(adminCompanyController.Detail))
-	http.HandleFunc("/api/admin/crawl-sources", auth(adminCrawlController.Sources))
-	http.HandleFunc("/api/admin/crawl-sources/", auth(adminCrawlController.SourceDetail))
-	http.HandleFunc("/api/admin/crawl-runs", auth(adminCrawlController.Runs))
-	http.HandleFunc("/api/admin/job-categories", auth(adminJobController.JobCategories))
-	http.HandleFunc("/api/admin/job-positions", auth(adminJobController.JobPositions))
-	http.HandleFunc("/api/admin/job-positions/", auth(adminJobController.JobPositionAction))
-	http.HandleFunc("/api/admin/graduate-employments", auth(adminJobController.GraduateEmployments))
-	http.HandleFunc("/api/admin/graduate-employments/", auth(adminJobController.GraduateEmploymentDetail))
-	http.HandleFunc("/api/admin/users", auth(adminUserController.List))
-	http.HandleFunc("/api/admin/users/", auth(adminUserController.Update))
-	http.HandleFunc("/api/admin/audit-logs", auth(adminAuditController.List))
+	// 管理者認証必須エンドポイント
+	admin := api.Group("/admin", EchoAdminAuth(userRepo, adminSecret))
 
-	// Company graph (scraping pipeline)
-	http.HandleFunc("/api/admin/company-graph/target-year", adminCompanyGraphController.TargetYear)
-	http.HandleFunc("/api/admin/company-graph/crawl", auth(adminCompanyGraphController.Crawl))
+	admin.Any("/companies", wrap(adminCompanyController.ListOrCreate))
+	admin.Any("/companies/*", wrap(adminCompanyController.Detail))
 
-	// Interview management
-	http.HandleFunc("/api/admin/interviews", auth(adminInterviewController.ListSessions))
-	http.HandleFunc("/api/admin/interviews/", auth(adminInterviewController.Route))
+	admin.Any("/crawl-sources", wrap(adminCrawlController.Sources))
+	admin.Any("/crawl-sources/*", wrap(adminCrawlController.SourceDetail))
+	admin.Any("/crawl-runs", wrap(adminCrawlController.Runs))
 
-	// Dashboard
-	http.HandleFunc("/api/admin/dashboard/users", auth(adminDashboardController.ListUsers))
-	http.HandleFunc("/api/admin/dashboard/users/", auth(adminDashboardController.UserSessions))
-	http.HandleFunc("/api/admin/dashboard/export/csv", auth(adminDashboardController.ExportCSV))
+	admin.Any("/job-categories", wrap(adminJobController.JobCategories))
+	admin.Any("/job-positions", wrap(adminJobController.JobPositions))
+	admin.Any("/job-positions/*", wrap(adminJobController.JobPositionAction))
+	admin.Any("/graduate-employments", wrap(adminJobController.GraduateEmployments))
+	admin.Any("/graduate-employments/*", wrap(adminJobController.GraduateEmploymentDetail))
 
-	// API Cost monitoring
-	http.HandleFunc("/api/admin/costs/summary", auth(adminCostsController.Summary))
-	http.HandleFunc("/api/admin/costs/daily", auth(adminCostsController.Daily))
-	http.HandleFunc("/api/admin/costs/monthly", auth(adminCostsController.Monthly))
+	admin.Any("/users", wrap(adminUserController.List))
+	admin.Any("/users/*", wrap(adminUserController.Update))
 
-	// Profile recalculation
-	http.HandleFunc("/api/admin/profile-recalculation", auth(profileRecalcController.Route))
-	http.HandleFunc("/api/admin/profile-recalculation/", auth(profileRecalcController.Route))
+	admin.Any("/audit-logs", wrap(adminAuditController.List))
 
-	// Score validation (correlation, calibration, A/B test)
-	http.HandleFunc("/api/admin/score-validation/", auth(scoreValidationController.Route))
+	admin.Any("/company-graph/crawl", wrap(adminCompanyGraphController.Crawl))
 
-	// Collective insight batch
-	http.HandleFunc("/api/admin/collective-insights/rebuild-summaries", auth(collectiveInsightController.RebuildSummaries))
+	admin.Any("/interviews", wrap(adminInterviewController.ListSessions))
+	admin.Any("/interviews/*", wrap(adminInterviewController.Route))
 
-	// Scraper session management
-	http.HandleFunc("/api/admin/scraper-sessions", auth(scraperSessionController.Sessions))
-	http.HandleFunc("/api/admin/scraper-sessions/", auth(scraperSessionController.SessionDetail))
+	admin.Any("/dashboard/users", wrap(adminDashboardController.ListUsers))
+	admin.Any("/dashboard/users/*", wrap(adminDashboardController.UserSessions))
+	admin.Any("/dashboard/export/csv", wrap(adminDashboardController.ExportCSV))
+
+	admin.Any("/costs/summary", wrap(adminCostsController.Summary))
+	admin.Any("/costs/daily", wrap(adminCostsController.Daily))
+	admin.Any("/costs/monthly", wrap(adminCostsController.Monthly))
+
+	admin.Any("/profile-recalculation", wrap(profileRecalcController.Route))
+	admin.Any("/profile-recalculation/*", wrap(profileRecalcController.Route))
+
+	admin.Any("/score-validation/*", wrap(scoreValidationController.Route))
+
+	admin.Any("/collective-insights/rebuild-summaries", wrap(collectiveInsightController.RebuildSummaries))
+
+	admin.Any("/scraper-sessions", wrap(scraperSessionController.Sessions))
+	admin.Any("/scraper-sessions/*", wrap(scraperSessionController.SessionDetail))
 }

--- a/Backend/internal/routes/application_routes.go
+++ b/Backend/internal/routes/application_routes.go
@@ -2,39 +2,19 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
-	"strings"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupApplicationRoutes 応募・選考ステータス管理のルーティング設定
-func SetupApplicationRoutes(appController *controllers.ApplicationController) {
+func SetupApplicationRoutes(api *echo.Group, appController *controllers.ApplicationController) {
+	applications := api.Group("/applications")
 	// POST /api/applications       → 応募登録
 	// GET  /api/applications       → 応募一覧取得
+	applications.POST("", wrap(appController.Apply))
+	applications.GET("", wrap(appController.List))
 	// GET  /api/applications/correlation → 相関分析データ
-	// PUT  /api/applications/{id}  → ステータス更新
-	http.HandleFunc("/api/applications", func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			appController.Apply(w, r)
-		case http.MethodGet:
-			appController.List(w, r)
-		default:
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		}
-	})
-
-	http.HandleFunc("/api/applications/correlation", appController.GetCorrelation)
-
-	http.HandleFunc("/api/applications/", func(w http.ResponseWriter, r *http.Request) {
-		// /api/applications/correlation は上で処理済みなのでスキップ
-		if strings.HasSuffix(r.URL.Path, "/correlation") {
-			appController.GetCorrelation(w, r)
-			return
-		}
-		if r.Method == http.MethodPut {
-			appController.UpdateStatus(w, r)
-			return
-		}
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-	})
+	applications.Any("/correlation", wrap(appController.GetCorrelation))
+	// PUT  /api/applications/:id  → ステータス更新
+	applications.PUT("/:id", wrap(appController.UpdateStatus))
 }

--- a/Backend/internal/routes/auth_routes.go
+++ b/Backend/internal/routes/auth_routes.go
@@ -4,33 +4,31 @@ import (
 	"Backend/internal/controllers"
 	"Backend/internal/middleware"
 	"Backend/internal/repositories"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupAuthRoutes 認証関連のルーティング設定
-func SetupAuthRoutes(authController *controllers.AuthController, oauthController *controllers.OAuthController, userRepo *repositories.UserRepository, userSecret string) {
-	userAuth := func(f http.HandlerFunc) http.HandlerFunc {
-		return middleware.UserAuthFunc(userRepo, userSecret, f)
-	}
+func SetupAuthRoutes(api *echo.Group, authController *controllers.AuthController, oauthController *controllers.OAuthController, userRepo *repositories.UserRepository, userSecret string) {
+	auth := api.Group("/auth")
 
-	// 認証エンドポイント（認証不要）
-	http.HandleFunc("/api/auth/request-registration", authController.RequestRegistration)
-	http.HandleFunc("/api/auth/verify-registration", authController.VerifyRegistration)
-	http.HandleFunc("/api/auth/register", authController.Register)
-	http.HandleFunc("/api/auth/login", middleware.LoginRateLimit(authController.Login))
-	http.HandleFunc("/api/auth/guest", authController.CreateGuest)
-	http.HandleFunc("/api/auth/verify-email", authController.VerifyEmail)
-	http.HandleFunc("/api/auth/forgot-password", middleware.PasswordResetRateLimit(authController.RequestPasswordReset))
-	http.HandleFunc("/api/auth/reset-password", authController.ResetPassword)
+	// 認証不要エンドポイント
+	auth.Any("/request-registration", wrap(authController.RequestRegistration))
+	auth.Any("/verify-registration", wrap(authController.VerifyRegistration))
+	auth.Any("/register", wrap(authController.Register))
+	auth.Any("/login", wrap(middleware.LoginRateLimit(authController.Login)))
+	auth.Any("/guest", wrap(authController.CreateGuest))
+	auth.Any("/verify-email", wrap(authController.VerifyEmail))
+	auth.Any("/forgot-password", wrap(middleware.PasswordResetRateLimit(authController.RequestPasswordReset)))
+	auth.Any("/reset-password", wrap(authController.ResetPassword))
+	auth.Any("/google", wrap(oauthController.GoogleLogin))
+	auth.Any("/google/callback", wrap(oauthController.GoogleCallback))
+	auth.Any("/github", wrap(oauthController.GitHubLogin))
+	auth.Any("/github/callback", wrap(oauthController.GitHubCallback))
 
 	// 認証必須エンドポイント（X-User-ID + X-User-Token ヘッダーが必要）
-	http.HandleFunc("/api/auth/user", userAuth(authController.GetUser))
-	http.HandleFunc("/api/auth/profile", userAuth(authController.UpdateProfile))
-	http.HandleFunc("/api/auth/account", userAuth(authController.DeleteAccount))
-
-	// OAuth エンドポイント
-	http.HandleFunc("/api/auth/google", oauthController.GoogleLogin)
-	http.HandleFunc("/api/auth/google/callback", oauthController.GoogleCallback)
-	http.HandleFunc("/api/auth/github", oauthController.GitHubLogin)
-	http.HandleFunc("/api/auth/github/callback", oauthController.GitHubCallback)
+	authProtected := api.Group("/auth", EchoUserAuth(userRepo, userSecret))
+	authProtected.Any("/user", wrap(authController.GetUser))
+	authProtected.Any("/profile", wrap(authController.UpdateProfile))
+	authProtected.Any("/account", wrap(authController.DeleteAccount))
 }

--- a/Backend/internal/routes/chat_routes.go
+++ b/Backend/internal/routes/chat_routes.go
@@ -2,29 +2,27 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"Backend/internal/middleware"
 	"Backend/internal/repositories"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupChatRoutes チャット関連のルーティング設定
-func SetupChatRoutes(chatController *controllers.ChatController, questionController *controllers.QuestionController, userRepo *repositories.UserRepository, userSecret string) {
-	userAuth := func(f http.HandlerFunc) http.HandlerFunc {
-		return middleware.UserAuthFunc(userRepo, userSecret, f)
-	}
-
+func SetupChatRoutes(api *echo.Group, chatController *controllers.ChatController, questionController *controllers.QuestionController, userRepo *repositories.UserRepository, userSecret string) {
 	// チャットエンドポイント（認証必須）
-	http.HandleFunc("/api/chat", userAuth(chatController.Chat))
-	http.HandleFunc("/api/chat/history", userAuth(chatController.GetHistory))
-	http.HandleFunc("/api/chat/scores", userAuth(chatController.GetScores))
-	http.HandleFunc("/api/chat/recommendations", userAuth(chatController.GetRecommendations))
-	http.HandleFunc("/api/chat/analysis", userAuth(chatController.GetAnalysisSummary))
-	http.HandleFunc("/api/chat/sessions", userAuth(chatController.GetSessions))
-	http.HandleFunc("/api/chat/send-report", userAuth(chatController.SendReport))
-	http.HandleFunc("/api/chat/favorite", userAuth(chatController.ToggleFavorite))
+	chat := api.Group("/chat", EchoUserAuth(userRepo, userSecret))
+	chat.Any("", wrap(chatController.Chat))
+	chat.Any("/history", wrap(chatController.GetHistory))
+	chat.Any("/scores", wrap(chatController.GetScores))
+	chat.Any("/recommendations", wrap(chatController.GetRecommendations))
+	chat.Any("/analysis", wrap(chatController.GetAnalysisSummary))
+	chat.Any("/sessions", wrap(chatController.GetSessions))
+	chat.Any("/send-report", wrap(chatController.SendReport))
+	chat.Any("/favorite", wrap(chatController.ToggleFavorite))
 
 	// 質問管理エンドポイント（認証必須）
-	http.HandleFunc("/api/questions/generate", userAuth(questionController.GenerateQuestions))
-	http.HandleFunc("/api/questions/create", userAuth(questionController.CreateQuestion))
-	http.HandleFunc("/api/questions/list", userAuth(questionController.GetQuestionsByCategory))
+	questions := api.Group("/questions", EchoUserAuth(userRepo, userSecret))
+	questions.Any("/generate", wrap(questionController.GenerateQuestions))
+	questions.Any("/create", wrap(questionController.CreateQuestion))
+	questions.Any("/list", wrap(questionController.GetQuestionsByCategory))
 }

--- a/Backend/internal/routes/collective_insight_routes.go
+++ b/Backend/internal/routes/collective_insight_routes.go
@@ -2,12 +2,14 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
-func SetupCollectiveInsightRoutes(controller *controllers.CollectiveInsightController) {
-	http.HandleFunc("/api/collective-insights/recommendations", controller.Route)
-	http.HandleFunc("/api/collective-insights/top-companies", controller.Route)
-	http.HandleFunc("/api/collective-insights/consent", controller.Route)
-	http.HandleFunc("/api/collective-insights/actions", controller.Route)
+func SetupCollectiveInsightRoutes(api *echo.Group, controller *controllers.CollectiveInsightController) {
+	ci := api.Group("/collective-insights")
+	ci.Any("/recommendations", wrap(controller.Route))
+	ci.Any("/top-companies", wrap(controller.Route))
+	ci.Any("/consent", wrap(controller.Route))
+	ci.Any("/actions", wrap(controller.Route))
 }

--- a/Backend/internal/routes/company_routes.go
+++ b/Backend/internal/routes/company_routes.go
@@ -2,25 +2,18 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
-	"strings"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupCompanyRoutes 企業関連のルーティング設定
-func SetupCompanyRoutes(relationController *controllers.CompanyRelationController) {
-	http.HandleFunc("/api/companies", relationController.GetCompanies)
-	http.HandleFunc("/api/companies/relations", relationController.GetAllCompanyRelations)
-	http.HandleFunc("/api/companies/market-info", relationController.GetAllMarketInfo)
-	http.HandleFunc("/api/companies/web-search", relationController.WebSearchCompanies)
-	http.HandleFunc("/api/companies/", func(w http.ResponseWriter, r *http.Request) {
-		path := strings.TrimPrefix(r.URL.Path, "/api/companies/")
-		if strings.HasSuffix(path, "/job-positions") {
-			relationController.GetCompanyJobPositions(w, r)
-		} else if !strings.Contains(path, "/") {
-			// /api/companies/{id}
-			relationController.GetCompanyByID(w, r)
-		} else {
-			http.NotFound(w, r)
-		}
-	})
+func SetupCompanyRoutes(api *echo.Group, relationController *controllers.CompanyRelationController) {
+	companies := api.Group("/companies")
+	companies.Any("", wrap(relationController.GetCompanies))
+	companies.Any("/relations", wrap(relationController.GetAllCompanyRelations))
+	companies.Any("/market-info", wrap(relationController.GetAllMarketInfo))
+	companies.Any("/web-search", wrap(relationController.WebSearchCompanies))
+	// 固定パスを :id より先に登録してEchoが優先解決する（順序は不問だがドキュメント目的で明示）
+	companies.Any("/:id", wrap(relationController.GetCompanyByID))
+	companies.Any("/:id/job-positions", wrap(relationController.GetCompanyJobPositions))
 }

--- a/Backend/internal/routes/echo_adapter.go
+++ b/Backend/internal/routes/echo_adapter.go
@@ -1,11 +1,28 @@
 package routes
 
 import (
+	"Backend/internal/middleware"
+	"Backend/internal/repositories"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
-func wrapHTTPHandler(handler http.HandlerFunc) echo.HandlerFunc {
-	return echo.WrapHandler(http.HandlerFunc(handler))
+// wrap はhttp.HandlerFuncをecho.HandlerFuncに変換する
+func wrap(h http.HandlerFunc) echo.HandlerFunc {
+	return echo.WrapHandler(h)
+}
+
+// EchoUserAuth はX-User-ID / X-User-Tokenヘッダーを検証するEchoミドルウェアを返す
+func EchoUserAuth(userRepo *repositories.UserRepository, userSecret string) echo.MiddlewareFunc {
+	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
+		return middleware.UserAuthFunc(userRepo, userSecret, http.HandlerFunc(next.ServeHTTP))
+	})
+}
+
+// EchoAdminAuth はX-Admin-Email / X-Admin-Tokenヘッダーを検証するEchoミドルウェアを返す
+func EchoAdminAuth(userRepo *repositories.UserRepository, adminSecret string) echo.MiddlewareFunc {
+	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
+		return middleware.AdminAuthFunc(userRepo, adminSecret, http.HandlerFunc(next.ServeHTTP))
+	})
 }

--- a/Backend/internal/routes/es_routes.go
+++ b/Backend/internal/routes/es_routes.go
@@ -2,10 +2,12 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
-func SetupESRoutes(esRewriteController *controllers.ESRewriteController, esReviewController *controllers.ESReviewController) {
-	http.HandleFunc("/api/es/rewrite", esRewriteController.Rewrite)
-	http.HandleFunc("/api/es/review", esReviewController.Review)
+func SetupESRoutes(api *echo.Group, esRewriteController *controllers.ESRewriteController, esReviewController *controllers.ESReviewController) {
+	es := api.Group("/es")
+	es.Any("/rewrite", wrap(esRewriteController.Rewrite))
+	es.Any("/review", wrap(esReviewController.Review))
 }

--- a/Backend/internal/routes/github_routes.go
+++ b/Backend/internal/routes/github_routes.go
@@ -2,15 +2,17 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupGitHubRoutes GitHub連携関連のルーティング設定
-func SetupGitHubRoutes(githubController *controllers.GitHubController) {
-	http.HandleFunc("/api/github/profile", githubController.GetProfile)
-	http.HandleFunc("/api/github/sync", githubController.Sync)
-	http.HandleFunc("/api/github/sync/wait", githubController.SyncAndWait)
-	http.HandleFunc("/api/github/skills", githubController.GetSkills)
-	http.HandleFunc("/api/github/repo/summaries", githubController.ListRepoSummaries)
-	http.HandleFunc("/api/github/repo/summarize", githubController.SummarizeRepo)
+func SetupGitHubRoutes(api *echo.Group, githubController *controllers.GitHubController) {
+	github := api.Group("/github")
+	github.Any("/profile", wrap(githubController.GetProfile))
+	github.Any("/sync", wrap(githubController.Sync))
+	github.Any("/sync/wait", wrap(githubController.SyncAndWait))
+	github.Any("/skills", wrap(githubController.GetSkills))
+	github.Any("/repo/summaries", wrap(githubController.ListRepoSummaries))
+	github.Any("/repo/summarize", wrap(githubController.SummarizeRepo))
 }

--- a/Backend/internal/routes/interview_routes.go
+++ b/Backend/internal/routes/interview_routes.go
@@ -2,15 +2,19 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 // SetupInterviewRoutes 面接関連のルーティング設定
-func SetupInterviewRoutes(interviewController *controllers.InterviewController, realtimeController *controllers.RealtimeController) {
-	// /api/interviews/trend はワイルドカード /api/interviews/ より先に登録する必要がある
-	http.HandleFunc("/api/interviews/trend", interviewController.GetTrend)
-	http.HandleFunc("/api/interviews", interviewController.ListOrCreate)
-	http.HandleFunc("/api/interviews/", interviewController.Route)
-	http.HandleFunc("/api/realtime/token", realtimeController.Token)
-	http.HandleFunc("/api/realtime/session-info", realtimeController.SessionInfo)
+func SetupInterviewRoutes(api *echo.Group, interviewController *controllers.InterviewController, realtimeController *controllers.RealtimeController) {
+	interviews := api.Group("/interviews")
+	// /trend は /*  より先にEchoのルーターが解決するため順序は不問
+	interviews.Any("/trend", wrap(interviewController.GetTrend))
+	interviews.Any("", wrap(interviewController.ListOrCreate))
+	interviews.Any("/*", wrap(interviewController.Route))
+
+	realtime := api.Group("/realtime")
+	realtime.Any("/token", wrap(realtimeController.Token))
+	realtime.Any("/session-info", wrap(realtimeController.SessionInfo))
 }

--- a/Backend/internal/routes/resume_routes.go
+++ b/Backend/internal/routes/resume_routes.go
@@ -2,18 +2,15 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"Backend/internal/middleware"
 	"Backend/internal/repositories"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
-func SetupResumeRoutes(resumeController *controllers.ResumeController, userRepo *repositories.UserRepository, userSecret string) {
-	userAuth := func(f http.HandlerFunc) http.HandlerFunc {
-		return middleware.UserAuthFunc(userRepo, userSecret, f)
-	}
-
-	http.HandleFunc("/api/resume/upload", userAuth(resumeController.Upload))
-	http.HandleFunc("/api/resume/review", userAuth(resumeController.Review))
-	http.HandleFunc("/api/resume/review/stream", userAuth(resumeController.ReviewStream))
-	http.HandleFunc("/api/resume/annotated", userAuth(resumeController.Annotated))
+func SetupResumeRoutes(api *echo.Group, resumeController *controllers.ResumeController, userRepo *repositories.UserRepository, userSecret string) {
+	resume := api.Group("/resume", EchoUserAuth(userRepo, userSecret))
+	resume.Any("/upload", wrap(resumeController.Upload))
+	resume.Any("/review", wrap(resumeController.Review))
+	resume.Any("/review/stream", wrap(resumeController.ReviewStream))
+	resume.Any("/annotated", wrap(resumeController.Annotated))
 }

--- a/Backend/internal/routes/schedule_routes.go
+++ b/Backend/internal/routes/schedule_routes.go
@@ -2,11 +2,13 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
-func SetupScheduleRoutes(scheduleController *controllers.ScheduleController) {
-	http.HandleFunc("/api/schedule/export/ics", scheduleController.ExportICS)
-	http.HandleFunc("/api/schedule/", scheduleController.RouteByID)
-	http.HandleFunc("/api/schedule", scheduleController.RouteList)
+func SetupScheduleRoutes(api *echo.Group, scheduleController *controllers.ScheduleController) {
+	schedule := api.Group("/schedule")
+	schedule.Any("/export/ics", wrap(scheduleController.ExportICS))
+	schedule.Any("", wrap(scheduleController.RouteList))
+	schedule.Any("/:id", wrap(scheduleController.RouteByID))
 }

--- a/Backend/internal/routes/user_routes.go
+++ b/Backend/internal/routes/user_routes.go
@@ -2,9 +2,11 @@ package routes
 
 import (
 	"Backend/internal/controllers"
-	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
-func SetupUserRoutes(profileController *controllers.IntegratedProfileController) {
-	http.HandleFunc("/api/user/profile", profileController.GetProfile)
+func SetupUserRoutes(api *echo.Group, profileController *controllers.IntegratedProfileController) {
+	user := api.Group("/user")
+	user.Any("/profile", wrap(profileController.GetProfile))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
+      NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
       APP_ENV: production
       COMPANY_GRAPH_URL: http://company-graph:9100
     depends_on:

--- a/frontend/app/api/chat/analysis/route.ts
+++ b/frontend/app/api/chat/analysis/route.ts
@@ -7,13 +7,16 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
+  const authHeaders = extractUserAuthHeaders(request)
   const params = new URLSearchParams()
   for (const key of ['session_id']) {
     const v = searchParams.get(key)
     if (v !== null) params.set(key, v)
   }
+  const userId = authHeaders['X-User-ID']
+  if (userId) params.set('user_id', userId)
   const response = await fetch(`${BACKEND_URL}/api/chat/analysis?${params}`, {
-    headers: extractUserAuthHeaders(request),
+    headers: authHeaders,
   })
   const raw = await response.text()
   let data: any = {}

--- a/frontend/app/api/chat/recommendations/route.ts
+++ b/frontend/app/api/chat/recommendations/route.ts
@@ -18,13 +18,17 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    const authHeaders = extractUserAuthHeaders(request)
+    const userId = authHeaders['X-User-ID']
+    const params = new URLSearchParams({ session_id: sessionId, limit })
+    if (userId) params.set('user_id', userId)
     const response = await fetch(
-      `${BACKEND_URL}/api/chat/recommendations?session_id=${sessionId}&limit=${limit}`,
+      `${BACKEND_URL}/api/chat/recommendations?${params}`,
       {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          ...extractUserAuthHeaders(request),
+          ...authHeaders,
         },
       }
     )

--- a/frontend/app/api/chat/scores/route.ts
+++ b/frontend/app/api/chat/scores/route.ts
@@ -17,13 +17,17 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    const authHeaders = extractUserAuthHeaders(request)
+    const userId = authHeaders['X-User-ID']
+    const params = new URLSearchParams({ session_id: sessionId })
+    if (userId) params.set('user_id', userId)
     const response = await fetch(
-      `${BACKEND_URL}/api/chat/scores?session_id=${sessionId}`,
+      `${BACKEND_URL}/api/chat/scores?${params}`,
       {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          ...extractUserAuthHeaders(request),
+          ...authHeaders,
         },
       }
     )

--- a/frontend/app/api/chat/sessions/route.ts
+++ b/frontend/app/api/chat/sessions/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server'
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse, extractUserAuthHeaders } from '@/lib/api-proxy'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/chat/sessions`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
+      },
+    })
+    return buildProxyJsonResponse(response)
+  } catch (error) {
+    console.error('API proxy error:', error)
+    return buildProxyNetworkErrorResponse(error, 'Failed to connect to backend')
+  }
+}

--- a/frontend/app/api/chat/sessions/route.ts
+++ b/frontend/app/api/chat/sessions/route.ts
@@ -7,11 +7,17 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/chat/sessions`, {
+    const authHeaders = extractUserAuthHeaders(request)
+    // 旧バックエンド（ECR）との互換性のため user_id クエリパラメータも付与する
+    const userId = authHeaders['X-User-ID']
+    const url = userId
+      ? `${BACKEND_URL}/api/chat/sessions?user_id=${userId}`
+      : `${BACKEND_URL}/api/chat/sessions`
+    const response = await fetch(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        ...extractUserAuthHeaders(request),
+        ...authHeaders,
       },
     })
     return buildProxyJsonResponse(response)

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -18,6 +18,7 @@ interface ChatSession {
 export default function ChatHistoryPage() {
   const [sessions, setSessions] = useState<ChatSession[]>([])
   const [loading, setLoading] = useState(true)
+  const [authError, setAuthError] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -26,16 +27,22 @@ export default function ChatHistoryPage() {
       router.push('/')
       return
     }
-    fetchSessions(user.user_id)
+    fetchSessions()
   }, [router])
 
-  const fetchSessions = async (userId: number) => {
+  const fetchSessions = async () => {
     try {
       const response = await fetch('/api/chat/sessions', {
         headers: authService.getUserFetchHeaders(),
       })
+      if (response.status === 401 || response.status === 403) {
+        setAuthError(true)
+        return
+      }
       if (!response.ok) {
-        throw new Error('Failed to fetch sessions')
+        console.error('Failed to fetch sessions:', response.status)
+        setSessions([])
+        return
       }
       const data = await response.json()
       setSessions(data || [])
@@ -69,6 +76,24 @@ export default function ChatHistoryPage() {
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
         <CircularProgress />
       </Box>
+    )
+  }
+
+  if (authError) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="h6" color="error" gutterBottom>
+            認証エラー
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 2 }}>
+            セッションが期限切れです。再度ログインしてください。
+          </Typography>
+          <Button variant="contained" onClick={() => { authService.logout(); router.push('/') }}>
+            ログインページへ
+          </Button>
+        </Paper>
+      </Container>
     )
   }
 

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -44,8 +44,10 @@ export default function ChatHistoryPage() {
         setSessions([])
         return
       }
-      const data = await response.json()
-      setSessions(data || [])
+      const raw = await response.json()
+      // buildProxyJsonResponse は配列を { data: [...] } にラップするため両形式に対応
+      const data: ChatSession[] = Array.isArray(raw) ? raw : Array.isArray(raw?.data) ? raw.data : []
+      setSessions(data)
     } catch (error) {
       console.error('Error fetching sessions:', error)
       setSessions([])

--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react'
 import { Box, Container, Typography, Paper, List, ListItem, ListItemButton, ListItemText, Divider, CircularProgress, Button } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { authService } from '@/lib/auth'
-import { BACKEND_URL } from '@/lib/config'
 import ChatIcon from '@mui/icons-material/Chat'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 
@@ -32,7 +31,7 @@ export default function ChatHistoryPage() {
 
   const fetchSessions = async (userId: number) => {
     try {
-      const response = await fetch(`${BACKEND_URL}/api/chat/sessions`, {
+      const response = await fetch('/api/chat/sessions', {
         headers: authService.getUserFetchHeaders(),
       })
       if (!response.ok) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,13 @@
+import { authService } from '@/lib/auth'
+
 const API_BASE = '/api'
+
+function unwrapArray<T>(raw: unknown): T[] {
+    if (Array.isArray(raw)) return raw as T[]
+    const obj = raw as Record<string, unknown>
+    if (obj && Array.isArray(obj.data)) return obj.data as T[]
+    return []
+}
 
 export interface ChatRequest {
     user_id: number
@@ -77,6 +86,7 @@ export async function sendChatMessage(request: ChatRequest): Promise<ChatRespons
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
+                ...authService.getUserFetchHeaders(),
             },
             body: JSON.stringify(request),
         })
@@ -96,14 +106,17 @@ export async function sendChatMessage(request: ChatRequest): Promise<ChatRespons
 
 export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> {
     try {
-        const response = await fetch(`${API_BASE}/chat/history?session_id=${sessionId}`)
+        const response = await fetch(`${API_BASE}/chat/history?session_id=${sessionId}`, {
+            headers: authService.getUserFetchHeaders(),
+        })
 
         if (!response.ok) {
-            console.warn(`History API error: ${response.statusText}`)
+            console.warn(`History API error: ${response.status}`)
             return []
         }
 
-        return response.json()
+        const raw = await response.json()
+        return unwrapArray<ChatHistory>(raw)
     } catch (error) {
         console.warn('Failed to fetch chat history:', error)
         return []
@@ -111,18 +124,22 @@ export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> 
 }
 
 export async function getUserScores(userId: number, sessionId: string): Promise<ChatScore[]> {
-    const response = await fetch(`${API_BASE}/chat/scores?user_id=${userId}&session_id=${sessionId}`)
+    const response = await fetch(`${API_BASE}/chat/scores?user_id=${userId}&session_id=${sessionId}`, {
+        headers: authService.getUserFetchHeaders(),
+    })
 
     if (!response.ok) {
         throw new Error(`Scores API error: ${response.statusText}`)
     }
 
-    return response.json()
+    const raw = await response.json()
+    return unwrapArray<ChatScore>(raw)
 }
 
 export async function getRecommendations(userId: number, sessionId: string, limit = 5) {
     const response = await fetch(
         `${API_BASE}/chat/recommendations?user_id=${userId}&session_id=${sessionId}&limit=${limit}`,
+        { headers: authService.getUserFetchHeaders() },
     )
 
     if (!response.ok) {
@@ -157,8 +174,9 @@ export async function sendAnalysisReport(userId: number, sessionId: string): Pro
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
+            ...authService.getUserFetchHeaders(),
         },
-        body: JSON.stringify({ user_id: userId, session_id: sessionId }),
+        body: JSON.stringify({ session_id: sessionId }),
     })
 
     if (!response.ok) {


### PR DESCRIPTION
Closes #409

## 変更内容

- **`echo_adapter.go`**: `wrap()` / `EchoUserAuth()` / `EchoAdminAuth()` ヘルパー関数を追加。既存の`wrapHTTPHandler`を置き換え
- **全13ルートファイル**: 関数シグネチャを `http.HandleFunc` から `*echo.Group` を受け取る形式に変更し、`e.Group()` パターンでルーティングを設定
- **`main.go`**: Echo インスタンスを初期化し、CORSミドルウェアを `buildCORSMiddleware()` にリファクタ（allowedOriginsを一度だけ構築するように改善）

## 設計方針

- コントローラーは一切変更なし（`r.URL.Path` ベースのパラメータ解析をそのまま維持）
- `echo.WrapHandler` でコントローラーの `http.HandlerFunc` をラップし、Echo ルーターから呼び出せるようにした
- 認証ミドルウェア（`UserAuthFunc` / `AdminAuthFunc`）を `echo.WrapMiddleware` で Echo ミドルウェアに変換し、`e.Group()` のミドルウェアとして適用
- 管理者認証不要の `/admin/company-graph/target-year` は別グループで登録しAuth除外を明示