### PR TITLE
Resolve #406: ToggleFavorite IDOR脆弱性の修正（所有者検証を追加）

### DIFF
--- a/Backend/internal/controllers/chat_controller.go
+++ b/Backend/internal/controllers/chat_controller.go
@@ -412,6 +412,12 @@ func (c *ChatController) ToggleFavorite(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	userID, err := authenticatedUserID(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	var req struct {
 		MatchID uint `json:"match_id"`
 	}
@@ -420,7 +426,11 @@ func (c *ChatController) ToggleFavorite(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := c.matchingService.ToggleFavorite(req.MatchID); err != nil {
+	if err := c.matchingService.ToggleFavorite(req.MatchID, userID); err != nil {
+		if err == services.ErrForbidden {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
 		writeInternalServerError(w, err)
 		return
 	}

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -157,7 +157,15 @@ func (s *MatchingService) GetTopMatches(ctx context.Context, userID uint, sessio
 }
 
 // ToggleFavorite お気に入りをトグル
-func (s *MatchingService) ToggleFavorite(matchID uint) error {
+// userID を検証し、マッチングレコードの所有者のみが操作できることを保証する
+func (s *MatchingService) ToggleFavorite(matchID uint, userID uint) error {
+	match, err := s.matchRepo.FindByID(matchID)
+	if err != nil {
+		return err
+	}
+	if match.UserID != userID {
+		return ErrForbidden
+	}
 	return s.matchRepo.ToggleFavorite(matchID)
 }
 


### PR DESCRIPTION
Closes #406

## 変更内容

Issue #406 で報告されたチャットエンドポイントの認証バイパス脆弱性のうち、残存していた `ToggleFavorite` の IDOR 脆弱性を修正。

### 修正前の状態

```go
// コントローラー — 認証・所有者チェックなし
if err := c.matchingService.ToggleFavorite(req.MatchID); err != nil {
```

認証済みユーザーが他ユーザーの `match_id` を指定することで、任意のマッチングレコードのお気に入り状態を変更できる IDOR (Insecure Direct Object Reference) 脆弱性が存在していた。

### 修正内容

**`matching_service.go`**
- `ToggleFavorite(matchID uint)` → `ToggleFavorite(matchID uint, userID uint)` にシグネチャ変更
- `FindByID` でマッチングレコードを取得し `match.UserID == userID` を検証
- 所有者不一致の場合は `ErrForbidden` を返す

**`chat_controller.go`**
- `authenticatedUserID(r)` で認証ユーザーIDを取得
- サービス層に `userID` を渡すよう変更
- `ErrForbidden` の場合は HTTP 403 を返す

### 既実装済みの修正（前回コミット）
- 全チャットエンドポイントへの `UserAuthFunc` ミドルウェア適用（Echo 移行 #409 で完了）
- `authenticatedUserID(r)` による X-User-ID ヘッダーからのユーザーID取得（Chat, GetHistory, GetScores, GetRecommendations, GetAnalysisSummary, SendReport, GetSessions すべて対応済み）