### PR TITLE
Fix missing arguments in StartTurn call and update dependencies

### DIFF
--- a/Backend/go.mod
+++ b/Backend/go.mod
@@ -52,6 +52,6 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/Backend/test/services/interview_service_test.go
+++ b/Backend/test/services/interview_service_test.go
@@ -176,7 +176,7 @@ func TestInterviewService_TTSVoiceSelection(t *testing.T) {
 		}
 		sRepo.On("FindByID", uint(100)).Return(session, nil)
 
-		_, err := svc.StartTurn(context.Background(), 1, 100, "", "", "", "", "")
+		_, err := svc.StartTurn(context.Background(), 1, 100, "", "", "", "", "", 0, 0, 0, 0)
 		assert.NoError(t, err)
 	})
 
@@ -209,7 +209,7 @@ func TestInterviewService_TTSVoiceSelection(t *testing.T) {
 		}
 		sRepo.On("FindByID", uint(101)).Return(session, nil)
 
-		_, err := svc.StartTurn(context.Background(), 1, 101, "", "", "", "", "")
+		_, err := svc.StartTurn(context.Background(), 1, 101, "", "", "", "", "", 0, 0, 0, 0)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This pull request makes a minor update to dependency management and test coverage. The most important changes are:

Dependency management:

* The `golang.org/x/text` dependency in `go.mod` is no longer marked as indirect, indicating it is now a direct dependency.

Test updates:

* The `TestInterviewService_TTSVoiceSelection` test in `interview_service_test.go` has been updated to call `StartTurn` with four additional integer arguments, reflecting a change in the method signature. [[1]](diffhunk://#diff-c43fb837d0ce4418d37f6b66144ac4193367ad40a8172f8ebf1d5972e6beeaa9L179-R179) [[2]](diffhunk://#diff-c43fb837d0ce4418d37f6b66144ac4193367ad40a8172f8ebf1d5972e6beeaa9L212-R212)