### PR TITLE
Resolve #412: 全画面のレスポンシブデザイン対応

### DIFF
--- a/frontend/app/applications/page.tsx
+++ b/frontend/app/applications/page.tsx
@@ -132,7 +132,7 @@ function ApplicationsContent() {
   }
 
   return (
-    <Box sx={{ maxWidth: 800, mx: 'auto', p: 3 }}>
+    <Box sx={{ maxWidth: 800, mx: 'auto', p: { xs: 2, sm: 3 } }}>
       <Stack direction="row" alignItems="center" spacing={1} mb={3}>
         <IconButton onClick={() => router.back()}>
           <ArrowBack />

--- a/frontend/app/company-entry/page.tsx
+++ b/frontend/app/company-entry/page.tsx
@@ -187,7 +187,7 @@ export default function CompanyEntryPage() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 800, mx: 'auto' }}>
+    <Box sx={{ p: { xs: 2, sm: 4 }, maxWidth: 800, mx: 'auto' }}>
       <Typography variant="h4" fontWeight="bold" gutterBottom>
         企業情報登録フォーム
       </Typography>
@@ -306,7 +306,7 @@ export default function CompanyEntryPage() {
                     <MenuItem value="no">不可</MenuItem>
                     <MenuItem value="yes">可</MenuItem>
                   </TextField>
-                  <Stack direction="row" spacing={2}>
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
                     <TextField label="最低年収（万円）" value={job.min_salary} onChange={(e) => updateJob(idx, 'min_salary', e.target.value)} type="number" fullWidth />
                     <TextField label="最高年収（万円）" value={job.max_salary} onChange={(e) => updateJob(idx, 'max_salary', e.target.value)} type="number" fullWidth />
                   </Stack>

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordPage() {
       }}
     >
       <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Typography variant="h5" align="center" gutterBottom fontWeight="bold">
             パスワードをお忘れですか？
           </Typography>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -84,7 +84,7 @@ export default function OnboardingPage() {
       <Box sx={{ maxWidth: 720, width: '100%' }}>
         {/* ウェルカムメッセージ */}
         <Box sx={{ textAlign: 'center', mb: 5 }}>
-          <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+          <Typography variant="h4" sx={{ fontWeight: 700, mb: 1, fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>
             ようこそ！まずはここから始めましょう
           </Typography>
           <Typography sx={{ color: 'text.secondary', fontSize: 16 }}>
@@ -115,7 +115,7 @@ export default function OnboardingPage() {
                   bgcolor: isDone ? '#f1f8f1' : isActive ? '#fff8f5' : '#fff',
                 }}
               >
-                <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 2.5 }}>
+                <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 2.5, flexWrap: { xs: 'wrap', sm: 'nowrap' } }}>
                   <Box sx={{ mt: 0.5, flexShrink: 0 }}>
                     {isDone ? <CheckCircleIcon sx={{ fontSize: 32, color: '#388e3c' }} /> : step.icon}
                   </Box>
@@ -136,6 +136,7 @@ export default function OnboardingPage() {
                     onClick={() => handleStart(step.path)}
                     sx={{
                       flexShrink: 0,
+                      width: { xs: '100%', sm: 'auto' },
                       ...(isActive && !isDone
                         ? { bgcolor: '#ec5b13', '&:hover': { bgcolor: '#c44d0e' }, color: '#fff' }
                         : {}),

--- a/frontend/app/register/confirm/page.tsx
+++ b/frontend/app/register/confirm/page.tsx
@@ -81,7 +81,7 @@ function RegisterConfirmForm() {
       }}
     >
       <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Typography variant="h5" align="center" gutterBottom fontWeight="bold">
             会員登録の完了
           </Typography>

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -70,7 +70,7 @@ function ResetPasswordForm() {
       }}
     >
       <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Typography variant="h5" align="center" gutterBottom fontWeight="bold">
             新しいパスワードを設定
           </Typography>

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -824,7 +824,7 @@ function ResultsContent() {
 
                 {/* タブ1: 資本関連図 */}
                 {detailTab === 1 && (
-                  <Box sx={{ height: 600 }}>
+                  <Box sx={{ height: { xs: 320, sm: 450, md: 600 } }}>
                     {diagramLoading ? (
                       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
                         <CircularProgress />
@@ -892,7 +892,7 @@ function ResultsContent() {
 
                 {/* タブ2: ビジネス関連図 */}
                 {detailTab === 2 && (
-                  <Box sx={{ height: 600 }}>
+                  <Box sx={{ height: { xs: 320, sm: 450, md: 600 } }}>
                     {diagramLoading ? (
                       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
                         <CircularProgress />

--- a/frontend/app/schedule/page.tsx
+++ b/frontend/app/schedule/page.tsx
@@ -269,7 +269,7 @@ export default function SchedulePage() {
           {/* Month navigation */}
           <Stack direction="row" alignItems="center" justifyContent="center" sx={{ p: 2, bgcolor: '#fff' }}>
             <IconButton onClick={handlePrevMonth}><ArrowBackIosIcon fontSize="small" /></IconButton>
-            <Typography variant="h6" fontWeight={600} sx={{ minWidth: 160, textAlign: 'center' }}>
+            <Typography variant="h6" fontWeight={600} sx={{ minWidth: { xs: 120, sm: 160 }, textAlign: 'center' }}>
               {viewYear}年 {viewMonth + 1}月
             </Typography>
             <IconButton onClick={handleNextMonth}><ArrowForwardIosIcon fontSize="small" /></IconButton>

--- a/frontend/app/verify-email/page.tsx
+++ b/frontend/app/verify-email/page.tsx
@@ -41,7 +41,7 @@ function VerifyEmailContent() {
 
   return (
     <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: '#f5f5f5' }}>
-      <Paper sx={{ p: 4, maxWidth: 440, width: '100%', textAlign: 'center', borderRadius: 2 }}>
+      <Paper sx={{ p: { xs: 2, sm: 4 }, maxWidth: 440, width: '100%', textAlign: 'center', borderRadius: 2 }}>
         {status === 'loading' && (
           <>
             <CircularProgress sx={{ mb: 2 }} />
@@ -82,7 +82,7 @@ export default function VerifyEmailPage() {
     <Suspense
       fallback={
         <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: '#f5f5f5' }}>
-          <Paper sx={{ p: 4, maxWidth: 440, width: '100%', textAlign: 'center', borderRadius: 2 }}>
+          <Paper sx={{ p: { xs: 2, sm: 4 }, maxWidth: 440, width: '100%', textAlign: 'center', borderRadius: 2 }}>
             <CircularProgress sx={{ mb: 2 }} />
             <Typography>認証中...</Typography>
           </Paper>

--- a/frontend/app/verify-registration/page.tsx
+++ b/frontend/app/verify-registration/page.tsx
@@ -95,7 +95,7 @@ function VerifyRegistrationContent() {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', p: 2 }}>
         <Card sx={{ maxWidth: 450, width: '100%' }}>
-          <CardContent sx={{ p: 4 }}>
+          <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
             <Alert severity="error">{tokenError}</Alert>
             <Button sx={{ mt: 2 }} onClick={() => router.push('/login')}>
               ログインページへ
@@ -109,7 +109,7 @@ function VerifyRegistrationContent() {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', p: 2 }}>
       <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Typography variant="h5" fontWeight="bold" gutterBottom>
             アカウント情報の入力
           </Typography>

--- a/frontend/components/login-page.tsx
+++ b/frontend/components/login-page.tsx
@@ -107,7 +107,7 @@ export function LoginPage({ onAuthSuccess }: LoginPageProps) {
       }}
     >
       <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Typography variant="h4" align="center" gutterBottom fontWeight="bold">
             IT業界キャリアエージェント
           </Typography>


### PR DESCRIPTION
Closes #412

## 変更内容

### 固定高さの解消
- `results/page.tsx`: ReactFlow（資本関連図・ビジネス関連図）のコンテナ `height: 600` を `{ xs: 320, sm: 450, md: 600 }` に変更し、モバイルでも図が適切に表示されるようにした

### レスポンシブパディングの適用
- `company-entry/page.tsx`: 外部パディング `p: 4` を `p: { xs: 2, sm: 4 }` に変更し、スマートフォンでの余白不足を解消
- `applications/page.tsx`: 外部パディング `p: 3` を `p: { xs: 2, sm: 3 }` に変更

### フォームレイアウトの改善
- `company-entry/page.tsx`: 年収入力欄（最低年収・最高年収）の `Stack direction="row"` を `{ xs: 'column', sm: 'row' }` に変更し、モバイルでの横並び溢れを防止

### オンボーディング画面の最適化
- `onboarding/page.tsx`: h4見出しに `fontSize: { xs: '1.4rem', sm: '2.125rem' }` を追加してモバイルでの文字サイズを最適化
- `onboarding/page.tsx`: カードのボタンに `width: { xs: '100%', sm: 'auto' }` と `flexWrap` を追加し、小画面でボタンがテキストに重なる問題を解消

### 認証ページのパディング改善
- `login-page.tsx` / `forgot-password/page.tsx` / `reset-password/page.tsx` / `register/confirm/page.tsx` / `verify-email/page.tsx` / `verify-registration/page.tsx`: `CardContent/Paper` の固定パディング `p: 4` を `p: { xs: 2, sm: 4 }` に変更し、小画面での余白過多を解消

### カレンダーナビゲーションの調整
- `schedule/page.tsx`: 月名表示の `minWidth: 160` を `{ xs: 120, sm: 160 }` に変更し、小画面での表示崩れを防止