### PR TITLE
Resolve #412: スマホ・タブレット・FULLHD以下PC対応の追加修正

### DIFF
--- a/frontend/app/applications/page.tsx
+++ b/frontend/app/applications/page.tsx
@@ -154,8 +154,8 @@ function ApplicationsContent() {
           {applications.map(app => (
             <Card key={app.id} variant="outlined">
               <CardContent>
-                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-                  <Box>
+                <Stack direction="row" justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap={1}>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography variant="h6" fontWeight="bold">
                       {app.company_name}
                     </Typography>
@@ -172,6 +172,7 @@ function ApplicationsContent() {
                     label={STATUS_LABELS[app.status] || app.status}
                     color={STATUS_COLORS[app.status] || 'default'}
                     size="small"
+                    sx={{ flexShrink: 0 }}
                   />
                 </Stack>
 

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -142,14 +142,14 @@ export default function ESRewritePage() {
         component="header"
         sx={{
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          px: { xs: 3, lg: 8 }, py: 2,
+          px: { xs: 2, sm: 3, lg: 8 }, py: 2,
           bgcolor: '#fff', borderBottom: '1px solid #e2e8f0',
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           <Box sx={{ color: PRIMARY }}><EditNoteIcon sx={{ fontSize: 32 }} /></Box>
           <Box>
-            <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>ES添削・リライト</Typography>
+            <Typography sx={{ fontWeight: 700, fontSize: { xs: 16, sm: 20 }, color: '#0f172a' }}>ES添削・リライト</Typography>
             <Typography sx={{ fontSize: 12, color: '#64748b' }}>AIがあなたのES文章を添削・リライトします</Typography>
           </Box>
         </Box>
@@ -160,7 +160,7 @@ export default function ESRewritePage() {
 
       {/* Mode toggle */}
       <Box sx={{ maxWidth: 1200, mx: 'auto', px: { xs: 2, md: 4 }, pt: 3 }}>
-        <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 3 }}>
           <Button
             startIcon={<RateReviewIcon />}
             onClick={() => { setMode('review'); setRewriteResult(null); setError(null) }}

--- a/frontend/app/interview/history/page.tsx
+++ b/frontend/app/interview/history/page.tsx
@@ -96,10 +96,10 @@ export default function InterviewHistoryPage() {
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: '#f8f6f6' }}>
       {/* Header */}
-      <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 3, lg: 8 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
+      <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, sm: 3, lg: 8 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           <Box sx={{ color: PRIMARY }}><PsychologyIcon sx={{ fontSize: 32 }} /></Box>
-          <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>面接履歴</Typography>
+          <Typography sx={{ fontWeight: 700, fontSize: { xs: 16, sm: 20 }, color: '#0f172a' }}>面接履歴</Typography>
           {user?.role === 'teacher' && (
             <Chip label="教員モード" size="small" sx={{ bgcolor: '#3b82f6', color: '#fff', fontWeight: 700, ml: 1 }} />
           )}
@@ -134,7 +134,8 @@ export default function InterviewHistoryPage() {
               完了した面接がないためトレンドを表示できません。
             </Typography>
           ) : (
-            <ResponsiveContainer width="100%" height={240}>
+            <Box sx={{ height: { xs: 180, md: 240 } }}>
+            <ResponsiveContainer width="100%" height="100%">
               <LineChart data={trendPoints.map((p, i) => ({
                 ...p,
                 label: `#${p.session_id}`,
@@ -152,6 +153,7 @@ export default function InterviewHistoryPage() {
                 <Line type="monotone" dataKey="enthusiasm" name="熱意" stroke="#f59e0b" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
               </LineChart>
             </ResponsiveContainer>
+            </Box>
           )}
         </Paper>
       </Box>

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -710,12 +710,12 @@ function InterviewContent() {
     return (
       <Box sx={{ minHeight: '100vh', bgcolor: BG_LIGHT }}>
         {/* Header */}
-        <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 3, lg: 10 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
+        <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, sm: 3, lg: 10 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
             <Box sx={{ color: PRIMARY, display: 'flex', alignItems: 'center' }}>
               <PsychologyIcon sx={{ fontSize: 32 }} />
             </Box>
-            <Typography sx={{ fontWeight: 700, fontSize: 20, color: '#0f172a' }}>InterviewAI</Typography>
+            <Typography sx={{ fontWeight: 700, fontSize: { xs: 16, sm: 20 }, color: '#0f172a' }}>InterviewAI</Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
             <IconButton sx={{ bgcolor: '#f1f5f9', color: '#475569' }} size="small" onClick={() => router.push('/')}>
@@ -730,7 +730,7 @@ function InterviewContent() {
         </Box>
 
         {/* Main */}
-        <Box component="main" sx={{ display: 'flex', justifyContent: 'center', py: 5, px: { xs: 3, lg: 10 } }}>
+        <Box component="main" sx={{ display: 'flex', justifyContent: 'center', py: { xs: 3, sm: 5 }, px: { xs: 2, sm: 3, lg: 10 } }}>
           <Box sx={{ maxWidth: 896, width: '100%', display: 'flex', flexDirection: 'column', gap: 4 }}>
 
             {/* Step indicator + Title */}
@@ -743,7 +743,7 @@ function InterviewContent() {
                   <Box sx={{ height: '100%', width: '33%', bgcolor: PRIMARY }} />
                 </Box>
               </Box>
-              <Typography variant="h4" sx={{ fontWeight: 700, color: '#0f172a' }}>練習する企業・職種を選ぶ</Typography>
+              <Typography variant="h4" sx={{ fontWeight: 700, color: '#0f172a', fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>練習する企業・職種を選ぶ</Typography>
               <Typography sx={{ color: '#64748b', fontSize: 15 }}>
                 志望企業と職種を選択して、AIが面接内容をカスタマイズします。
               </Typography>

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -137,7 +137,7 @@ export default function ProfilePage() {
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: '#f5f7fa' }}>
       {/* ページヘッダー */}
-      <Box sx={{ bgcolor: 'white', borderBottom: '1px solid #e0e0e0', px: 3, py: 1.5 }}>
+      <Box sx={{ bgcolor: 'white', borderBottom: '1px solid #e0e0e0', px: { xs: 2, sm: 3 }, py: 1.5 }}>
         <Container maxWidth="lg">
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <Typography variant="h6" fontWeight="bold" color="primary">

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -601,16 +601,16 @@ function ResultsContent() {
         <Typography variant="h6" color="text.secondary" sx={{ textAlign: 'center' }}>
           データがありません。診断を完了してから数秒待ち、ページを更新してください。
         </Typography>
-        <Stack direction="row" spacing={2}>
-          <Button 
-            variant="contained" 
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: { xs: '100%', sm: 'auto' } }}>
+          <Button
+            variant="contained"
             startIcon={<Refresh />}
             onClick={() => window.location.reload()}
           >
             ページを更新
           </Button>
-          <Button 
-            variant="outlined" 
+          <Button
+            variant="outlined"
             onClick={() => router.push('/')}
           >
             チャットに戻る
@@ -622,7 +622,7 @@ function ResultsContent() {
 
   if (error) {
     return (
-      <Box sx={{ 
+      <Box sx={{
         height: '100vh',
         display: 'flex',
         alignItems: 'center',
@@ -634,22 +634,22 @@ function ResultsContent() {
         <Typography variant="h6" color="error" sx={{ whiteSpace: 'pre-line', textAlign: 'center' }}>
           {error}
         </Typography>
-        <Stack direction="row" spacing={2}>
-          <Button 
-            variant="contained" 
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ width: { xs: '100%', sm: 'auto' } }}>
+          <Button
+            variant="contained"
             startIcon={<Refresh />}
             onClick={() => window.location.reload()}
           >
             ページを更新
           </Button>
-          <Button 
-            variant="outlined" 
+          <Button
+            variant="outlined"
             onClick={() => router.push('/chat')}
           >
             チャットに戻る
           </Button>
-          <Button 
-            variant="outlined" 
+          <Button
+            variant="outlined"
             color="error"
             onClick={handleReset}
           >
@@ -1015,7 +1015,7 @@ function ResultsContent() {
                   📊 4分析スコア
                 </Typography>
                 {analysisScores && (
-                  <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 2, mb: 2 }}>
+                  <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' }, gap: 2, mb: 2 }}>
                     {[
                       { label: '職種分析', value: analysisScores.job },
                       { label: '興味分析', value: analysisScores.interest },

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -691,8 +691,8 @@ function ResultsContent() {
         backgroundColor: '#fff',
       }}>
         {/* ヘッダー */}
-        <Box sx={{ 
-          p: 3, 
+        <Box sx={{
+          p: { xs: 2, sm: 3 },
           borderBottom: '1px solid #e0e0e0',
           backgroundColor: '#fff',
           flexShrink: 0,
@@ -706,27 +706,27 @@ function ResultsContent() {
         </Box>
 
         {/* 企業詳細コンテンツ */}
-        <Box sx={{ 
+        <Box sx={{
           flexGrow: 1,
           overflowY: 'auto',
-          p: 3,
+          p: { xs: 2, sm: 3 },
           backgroundColor: '#fafafa',
         }}>
           <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
             <Card elevation={3}>
-              <CardContent sx={{ p: 4 }}>
+              <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
                 {/* 企業名とマッチスコア */}
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}>
+                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'flex-start' }, mb: 3, gap: 1 }}>
                   <Box>
-                    <Typography variant="h4" fontWeight="bold" gutterBottom>
+                    <Typography variant="h4" fontWeight="bold" gutterBottom sx={{ fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>
                       {selectedCompany.name}
                     </Typography>
-                    <Typography variant="h6" color="text.secondary">
+                    <Typography variant="h6" color="text.secondary" sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }}>
                       {selectedCompany.industry}
                     </Typography>
                   </Box>
-                  <Box sx={{ textAlign: 'right' }}>
-                    <Typography variant="h2" color="primary.main" fontWeight="bold">
+                  <Box sx={{ textAlign: { xs: 'left', sm: 'right' }, display: 'flex', alignItems: 'center', gap: 1, flexDirection: { xs: 'row', sm: 'column' } }}>
+                    <Typography variant="h2" color="primary.main" fontWeight="bold" sx={{ fontSize: { xs: '2rem', sm: '3.75rem' } }}>
                       {selectedCompany.matchScore}
                     </Typography>
                     <Typography variant="body1" color="text.secondary">
@@ -966,13 +966,13 @@ function ResultsContent() {
       backgroundColor: '#fff',
     }}>
       {/* ヘッダー部分 */}
-      <Box sx={{ 
-        p: 3, 
+      <Box sx={{
+        p: { xs: 2, sm: 3 },
         borderBottom: '1px solid #e0e0e0',
         backgroundColor: '#fff',
         flexShrink: 0,
       }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1, mb: 2 }}>
           <Button variant="outlined" startIcon={<ArrowBack />} onClick={handleBack}>
             チャットに戻る
           </Button>
@@ -981,12 +981,13 @@ function ResultsContent() {
             startIcon={<Email />}
             onClick={handleSendEmail}
             disabled={emailSending}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
           >
             {emailSending ? '送信中...' : '結果をメールで受け取る'}
           </Button>
         </Box>
         <Box sx={{ textAlign: 'center' }}>
-          <Typography variant="h4" fontWeight="bold" gutterBottom>
+          <Typography variant="h4" fontWeight="bold" gutterBottom sx={{ fontSize: { xs: '1.2rem', sm: '2.125rem' } }}>
             🎉 AI分析完了！適合企業を{companies.length}社に絞り込みました
           </Typography>
           {isProvisional && (
@@ -999,10 +1000,10 @@ function ResultsContent() {
       </Box>
 
       {/* スクロール可能なコンテンツエリア */}
-      <Box sx={{ 
+      <Box sx={{
         flexGrow: 1,
         overflowY: 'auto',
-        p: 3,
+        p: { xs: 2, sm: 3 },
         backgroundColor: '#fafafa',
       }}>
         <Box sx={{ maxWidth: 1200, mx: 'auto' }}>

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -246,8 +246,8 @@ function ResumeContent() {
   }
 
   return (
-    <Box sx={{ p: 4, maxWidth: 900, mx: 'auto' }}>
-      <Typography variant="h4" fontWeight="bold" gutterBottom>
+    <Box sx={{ p: { xs: 2, sm: 4 }, maxWidth: 900, mx: 'auto' }}>
+      <Typography variant="h4" fontWeight="bold" gutterBottom sx={{ fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>
         履歴書・エントリシート レビュー
       </Typography>
       <Typography variant="body1" color="text.secondary" sx={{ mb: prefilledCompany ? 1.5 : 3 }}>

--- a/frontend/app/schedule/page.tsx
+++ b/frontend/app/schedule/page.tsx
@@ -231,14 +231,14 @@ export default function SchedulePage() {
   const today = new Date()
 
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: '#f5f5f5', p: 3 }}>
+    <Box sx={{ minHeight: '100vh', bgcolor: '#f5f5f5', p: { xs: 1.5, sm: 3 } }}>
       <Box sx={{ maxWidth: 900, mx: 'auto' }}>
         {/* Header */}
-        <Stack direction="row" alignItems="center" spacing={2} mb={3}>
-          <IconButton onClick={() => router.back()}>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1, mb: 3 }}>
+          <IconButton onClick={() => router.back()} size="small">
             <ArrowBackIcon />
           </IconButton>
-          <Typography variant="h5" fontWeight={700} flex={1}>
+          <Typography variant="h5" fontWeight={700} sx={{ flex: 1, minWidth: 0, fontSize: { xs: '1.1rem', sm: '1.5rem' } }}>
             選考スケジュール
           </Typography>
           <Button
@@ -247,16 +247,17 @@ export default function SchedulePage() {
             onClick={handleExport}
             size="small"
           >
-            .ics エクスポート
+            .ics
           </Button>
           <Button
             variant="contained"
             startIcon={<AddIcon />}
             onClick={() => openCreateDialog()}
+            size="small"
           >
-            イベント追加
+            追加
           </Button>
-        </Stack>
+        </Box>
 
         {error && (
           <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
@@ -281,9 +282,9 @@ export default function SchedulePage() {
           <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', bgcolor: '#f9f9f9' }}>
             {WEEKDAYS.map((d, i) => (
               <Box key={d} sx={{
-                p: 1, textAlign: 'center',
+                p: { xs: 0.5, sm: 1 }, textAlign: 'center',
                 color: i === 0 ? '#d32f2f' : i === 6 ? '#1565c0' : 'text.secondary',
-                fontWeight: 600, fontSize: '0.85rem',
+                fontWeight: 600, fontSize: { xs: '0.65rem', sm: '0.85rem' },
               }}>
                 {d}
               </Box>
@@ -307,7 +308,7 @@ export default function SchedulePage() {
                       key={di}
                       onClick={() => day && openCreateDialog(day)}
                       sx={{
-                        minHeight: 80,
+                        minHeight: { xs: 52, sm: 80 },
                         p: 0.5,
                         borderRight: di < 6 ? '1px solid #eee' : 'none',
                         bgcolor: day ? '#fff' : '#f9f9f9',
@@ -320,11 +321,11 @@ export default function SchedulePage() {
                         <>
                           <Box
                             sx={{
-                              width: 26, height: 26, borderRadius: '50%', display: 'flex',
+                              width: { xs: 20, sm: 26 }, height: { xs: 20, sm: 26 }, borderRadius: '50%', display: 'flex',
                               alignItems: 'center', justifyContent: 'center',
                               bgcolor: isToday ? '#1976d2' : 'transparent',
                               color: isToday ? '#fff' : di === 0 ? '#d32f2f' : di === 6 ? '#1565c0' : 'text.primary',
-                              fontSize: '0.85rem', fontWeight: isToday ? 700 : 400,
+                              fontSize: { xs: '0.65rem', sm: '0.85rem' }, fontWeight: isToday ? 700 : 400,
                               mb: 0.5,
                             }}
                           >
@@ -340,7 +341,7 @@ export default function SchedulePage() {
                                     color: '#fff',
                                     borderRadius: 0.5,
                                     px: 0.5,
-                                    fontSize: '0.7rem',
+                                    fontSize: { xs: '0.55rem', sm: '0.7rem' },
                                     whiteSpace: 'nowrap',
                                     overflow: 'hidden',
                                     textOverflow: 'ellipsis',


### PR DESCRIPTION
Closes #412

## 変更内容

### `results/page.tsx`
- データなし・エラー画面のボタン行を `direction: { xs: 'column', sm: 'row' }` に変更し、スマートフォンでの横溢れを解消
- 4分析スコアグリッドを `gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' }` に変更し、xs時に1列化

### `schedule/page.tsx`
- 外部パディングを `p: { xs: 1.5, sm: 3 }` に変更
- ヘッダーの4ボタン行を `flexWrap: wrap` 構成に変更し、モバイルでのボタン溢れを防止
- カレンダーヘッダーフォントを `{ xs: '0.65rem', sm: '0.85rem' }` にレスポンシブ化
- カレンダーセルの `minHeight` を `{ xs: 52, sm: 80 }` に変更
- 日付円サイズ・日付フォント・イベントラベルフォントをレスポンシブ化

### `resume/page.tsx`
- 外部パディングを `p: { xs: 2, sm: 4 }` に変更
- h4見出しに `fontSize: { xs: '1.4rem', sm: '2.125rem' }` を追加

### `es-rewrite/page.tsx`
- ヘッダーパディングを `px: { xs: 2, sm: 3, lg: 8 }` に変更
- タイトルフォントを `{ xs: 16, sm: 20 }` にレスポンシブ化
- モード切替ボタン行に `flexWrap: 'wrap'` を追加し、長いボタンテキストの折り返しに対応

### `interview/history/page.tsx`
- ヘッダーパディングを `px: { xs: 2, sm: 3, lg: 8 }` に変更、タイトルフォントをレスポンシブ化
- パフォーマンストレンドグラフ（recharts）を `Box` でラップし `height: { xs: 180, md: 240 }` のレスポンシブ高さを実現

### `interview/page.tsx`（面接セットアップ画面）
- ヘッダーパディング・メインエリアパディングを `{ xs: 2, sm: 3, lg: 10 }` に変更
- h4見出しにレスポンシブフォントサイズを追加

### `applications/page.tsx`
- 会社名＋ステータスChip行に `flexWrap: 'wrap'` と `gap: 1` を追加し、長い会社名でのChip押し出しを防止
- 会社名ボックスに `minWidth: 0, flex: 1` を追加してテキスト折り返しを保証

### `profile/page.tsx`
- ヘッダーパディングを `px: { xs: 2, sm: 3 }` に変更