### PR TITLE
Resolve #403: 構造化ログ・モニタリング基盤の整備

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"Backend/internal/config"
 	"Backend/internal/controllers"
+	"Backend/internal/logger"
+	"Backend/internal/middleware"
 	"Backend/internal/models"
 	"Backend/internal/openai"
 	"Backend/internal/repositories"
@@ -10,6 +12,7 @@ import (
 	"Backend/internal/scraper"
 	"Backend/internal/services"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -32,7 +35,8 @@ func buildAllowedOrigins() map[string]struct{} {
 	// フェイルセーフ: ALLOWED_ORIGINS 未設定時は全オリジン拒否（#327）
 	// ローカル開発時は .env に ALLOWED_ORIGINS=http://localhost:3000 を明示設定してください。
 	if len(allowedOrigins) == 0 {
-		log.Println("WARNING: ALLOWED_ORIGINS が未設定のため、全クロスオリジンリクエストを拒否します。")
+		slog.Warn("ALLOWED_ORIGINS が未設定のため、全クロスオリジンリクエストを拒否します",
+			"hint", "ローカル開発時は .env に ALLOWED_ORIGINS=http://localhost:3000 を設定してください")
 	}
 
 	return allowedOrigins
@@ -87,21 +91,23 @@ func buildCORSMiddleware() func(http.Handler) http.Handler {
 func checkAnnotationFont() {
 	fontPath := os.Getenv("ANNOTATION_FONT_PATH")
 	if fontPath == "" {
-		log.Println("WARNING: ANNOTATION_FONT_PATH が設定されていません。" +
-			"フォールバックフォントを使用します（日本語注釈が正常に表示されない可能性があります）。" +
-			"環境変数 ANNOTATION_FONT_PATH にフォントパスを設定してください。")
+		slog.Warn("ANNOTATION_FONT_PATH が設定されていません。フォールバックフォントを使用します",
+			"hint", "環境変数 ANNOTATION_FONT_PATH にフォントパスを設定してください")
 		return
 	}
 	if _, err := os.Stat(fontPath); os.IsNotExist(err) {
-		log.Printf("WARNING: ANNOTATION_FONT_PATH のフォントが見つかりません: %q\n"+
-			"PDF注釈の日本語レビューページが生成されない場合があります。\n"+
-			"Dockerfileで fonts-noto-cjk がインストールされているか確認してください。", fontPath)
+		slog.Warn("ANNOTATION_FONT_PATH のフォントが見つかりません",
+			"path", fontPath,
+			"hint", "Dockerfileで fonts-noto-cjk がインストールされているか確認してください")
 		return
 	}
-	log.Printf("INFO: PDF アノテーションフォント確認済み: %q", fontPath)
+	slog.Info("PDF アノテーションフォント確認済み", "path", fontPath)
 }
 
 func main() {
+	// 構造化ログの初期化（LOG_LEVEL / LOG_FORMAT 環境変数で制御）
+	logger.Setup()
+
 	// PDF アノテーションフォントの存在チェック（起動時警告）
 	checkAnnotationFont()
 
@@ -121,13 +127,13 @@ func main() {
 	if err := models.AutoMigrate(db); err != nil {
 		log.Fatalf("Failed to migrate database: %v", err)
 	}
-	log.Println("Database migration completed")
+	slog.Info("Database migration completed")
 
 	// 初期データ投入
 	if err := models.SeedData(db); err != nil {
 		log.Fatalf("Failed to seed data: %v", err)
 	}
-	log.Println("Database seeding completed")
+	slog.Info("Database seeding completed")
 
 	// OpenAI クライアント初期化
 	aiClient, err := openai.NewFromEnv("")
@@ -244,7 +250,7 @@ func main() {
 	// S3 upload service for interview videos (optional — skipped if env vars are not set)
 	s3UploadService, s3Err := services.NewS3UploadService()
 	if s3Err != nil {
-		log.Printf("S3 upload service not available: %v", s3Err)
+		slog.Warn("S3 upload service not available", "error", s3Err)
 		s3UploadService = nil
 	}
 	interviewController := controllers.NewInterviewController(interviewService, videoRepo, s3UploadService)
@@ -278,6 +284,8 @@ func main() {
 	e.HideBanner = true
 
 	// グローバルミドルウェア
+	e.Use(echo.WrapMiddleware(middleware.RequestIDMiddleware))
+	e.Use(echo.WrapMiddleware(middleware.RequestLoggerMiddleware))
 	e.Use(echo.WrapMiddleware(securityHeadersMiddleware))
 	e.Use(echo.WrapMiddleware(buildCORSMiddleware()))
 
@@ -318,7 +326,7 @@ func main() {
 		port = "80"
 	}
 
-	log.Printf("Starting server on port %s...", port)
+	slog.Info("Starting server", "port", port)
 	if err := e.Start(":" + port); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}

--- a/Backend/internal/logger/logger.go
+++ b/Backend/internal/logger/logger.go
@@ -1,0 +1,39 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Setup は環境変数に基づいて slog をデフォルトロガーとして初期化する。
+// LOG_LEVEL: DEBUG / INFO / WARN / ERROR (デフォルト: INFO)
+// LOG_FORMAT: json / text (デフォルト: json)
+//
+// slog.SetDefault により既存の log.Println 等も slog 経由で出力される。
+func Setup() {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+	opts := &slog.HandlerOptions{Level: level}
+
+	var handler slog.Handler
+	if strings.ToLower(os.Getenv("LOG_FORMAT")) == "text" {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	}
+
+	slog.SetDefault(slog.New(handler))
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToUpper(s) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN", "WARNING":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/Backend/internal/logger/logger_test.go
+++ b/Backend/internal/logger/logger_test.go
@@ -1,0 +1,56 @@
+package logger_test
+
+// 実行: cd Backend && go test ./internal/logger/... -v
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"Backend/internal/logger"
+)
+
+// TestSetup_DefaultIsInfo はLOG_LEVEL未設定時にInfoレベルになることを検証する
+func TestSetup_DefaultIsInfo(t *testing.T) {
+	os.Unsetenv("LOG_LEVEL")
+	os.Unsetenv("LOG_FORMAT")
+	logger.Setup()
+	if !slog.Default().Enabled(nil, slog.LevelInfo) {
+		t.Error("INFO レベルが有効になっていない")
+	}
+	if slog.Default().Enabled(nil, slog.LevelDebug) {
+		t.Error("デフォルト設定では DEBUG レベルは無効であるべき")
+	}
+}
+
+// TestSetup_DebugLevel はLOG_LEVEL=DEBUGでDebugレベルが有効になることを検証する
+func TestSetup_DebugLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "DEBUG")
+	os.Unsetenv("LOG_FORMAT")
+	logger.Setup()
+	if !slog.Default().Enabled(nil, slog.LevelDebug) {
+		t.Error("DEBUG レベルが有効になっていない")
+	}
+}
+
+// TestSetup_WarnLevel はLOG_LEVEL=WARNでInfoレベルが無効になることを検証する
+func TestSetup_WarnLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "WARN")
+	logger.Setup()
+	if slog.Default().Enabled(nil, slog.LevelInfo) {
+		t.Error("WARN 設定では INFO レベルは無効であるべき")
+	}
+	if !slog.Default().Enabled(nil, slog.LevelWarn) {
+		t.Error("WARN レベルが有効になっていない")
+	}
+}
+
+// TestSetup_DoesNotPanic はSetupがパニックしないことを検証する
+func TestSetup_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Setup() がパニックした: %v", r)
+		}
+	}()
+	logger.Setup()
+}

--- a/Backend/internal/middleware/request_id.go
+++ b/Backend/internal/middleware/request_id.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+const RequestIDHeader = "X-Request-ID"
+const requestIDContextKey contextKey = "requestID"
+
+func generateRequestID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// RequestIDMiddleware はリクエストごとに一意の ID を付与し、
+// レスポンスヘッダー X-Request-ID とコンテキストにセットする。
+// クライアントが X-Request-ID を送信した場合はその値を優先する。
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rid := r.Header.Get(RequestIDHeader)
+		if rid == "" {
+			rid = generateRequestID()
+		}
+		w.Header().Set(RequestIDHeader, rid)
+		ctx := context.WithValue(r.Context(), requestIDContextKey, rid)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetRequestID はコンテキストからリクエスト ID を取得する。
+func GetRequestID(ctx context.Context) string {
+	v, _ := ctx.Value(requestIDContextKey).(string)
+	return v
+}

--- a/Backend/internal/middleware/request_logger.go
+++ b/Backend/internal/middleware/request_logger.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// RequestLoggerMiddleware はリクエストの method / path / status / duration を
+// 構造化ログで記録する。X-Request-ID が存在する場合はフィールドに含める。
+func RequestLoggerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(rw, r)
+
+		attrs := []any{
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", rw.status),
+			slog.Duration("duration", time.Since(start)),
+		}
+		if rid := GetRequestID(r.Context()); rid != "" {
+			attrs = append(attrs, slog.String("request_id", rid))
+		}
+
+		level := slog.LevelInfo
+		if rw.status >= 500 {
+			level = slog.LevelError
+		} else if rw.status >= 400 {
+			level = slog.LevelWarn
+		}
+		slog.Log(r.Context(), level, "http request", attrs...)
+	})
+}

--- a/Backend/test/middleware/request_id_test.go
+++ b/Backend/test/middleware/request_id_test.go
@@ -1,0 +1,81 @@
+package middleware_test
+
+// リクエストIDミドルウェアのテスト（Issue #403）
+// 実行: cd Backend && go test ./test/middleware/... -run TestRequestID -v
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/middleware"
+)
+
+// TestRequestIDMiddleware_GeneratesIDWhenAbsent はヘッダーがない場合にIDが生成されることを検証する
+func TestRequestIDMiddleware_GeneratesIDWhenAbsent(t *testing.T) {
+	var capturedID string
+	handler := middleware.RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedID = middleware.GetRequestID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if capturedID == "" {
+		t.Error("リクエストIDがコンテキストに設定されていない")
+	}
+	if w.Header().Get(middleware.RequestIDHeader) == "" {
+		t.Error("レスポンスヘッダーにリクエストIDが設定されていない")
+	}
+}
+
+// TestRequestIDMiddleware_UsesClientProvidedID はクライアントから送信されたIDが優先されることを検証する
+func TestRequestIDMiddleware_UsesClientProvidedID(t *testing.T) {
+	const clientID = "test-request-id-abc123"
+	var capturedID string
+	handler := middleware.RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedID = middleware.GetRequestID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(middleware.RequestIDHeader, clientID)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if capturedID != clientID {
+		t.Errorf("got %q, want %q", capturedID, clientID)
+	}
+	if w.Header().Get(middleware.RequestIDHeader) != clientID {
+		t.Errorf("レスポンスヘッダーが %q でない", clientID)
+	}
+}
+
+// TestRequestIDMiddleware_UniquePerRequest は2リクエストで異なるIDが生成されることを検証する
+func TestRequestIDMiddleware_UniquePerRequest(t *testing.T) {
+	ids := make([]string, 2)
+	handler := middleware.RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		ids[i] = w.Header().Get(middleware.RequestIDHeader)
+	}
+
+	if ids[0] == ids[1] {
+		t.Errorf("2リクエストのIDが同一: %q", ids[0])
+	}
+}
+
+// TestGetRequestID_EmptyWhenNotSet はコンテキストにIDがない場合は空文字が返ることを検証する
+func TestGetRequestID_EmptyWhenNotSet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if id := middleware.GetRequestID(req.Context()); id != "" {
+		t.Errorf("got %q, want empty", id)
+	}
+}

--- a/Backend/test/middleware/request_logger_test.go
+++ b/Backend/test/middleware/request_logger_test.go
@@ -1,0 +1,94 @@
+package middleware_test
+
+// リクエストロガーミドルウェアのテスト（Issue #403）
+// 実行: cd Backend && go test ./test/middleware/... -run TestRequestLogger -v
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"Backend/internal/middleware"
+)
+
+// TestRequestLoggerMiddleware_LogsRequest はリクエスト情報がログに記録されることを検証する
+func TestRequestLoggerMiddleware_LogsRequest(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	handler := middleware.RequestLoggerMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	logged := buf.String()
+	for _, want := range []string{"GET", "/api/health", "200"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("ログに %q が含まれていない: %s", want, logged)
+		}
+	}
+}
+
+// TestRequestLoggerMiddleware_IncludesRequestID はX-Request-IDがある場合にログに含まれることを検証する
+func TestRequestLoggerMiddleware_IncludesRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	const testID = "trace-xyz-999"
+	handler := middleware.RequestIDMiddleware(
+		middleware.RequestLoggerMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+	req.Header.Set(middleware.RequestIDHeader, testID)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(buf.String(), testID) {
+		t.Errorf("ログにrequest_id %q が含まれていない: %s", testID, buf.String())
+	}
+}
+
+// TestRequestLoggerMiddleware_WarnOnClientError は4xxステータスでWARNレベルで記録されることを検証する
+func TestRequestLoggerMiddleware_WarnOnClientError(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	handler := middleware.RequestLoggerMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/not-found", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(buf.String(), "WARN") {
+		t.Errorf("4xx は WARN レベルで記録されるべき: %s", buf.String())
+	}
+}
+
+// TestRequestLoggerMiddleware_ErrorOnServerError は5xxステータスでERRORレベルで記録されることを検証する
+func TestRequestLoggerMiddleware_ErrorOnServerError(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	handler := middleware.RequestLoggerMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/crash", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(buf.String(), "ERROR") {
+		t.Errorf("5xx は ERROR レベルで記録されるべき: %s", buf.String())
+	}
+}

--- a/rag/main.py
+++ b/rag/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import datetime
 import json
 import logging
@@ -7,23 +8,88 @@ import os
 import re
 import threading
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Awaitable, Callable, Generator, List, Optional, Tuple, TypeVar
 
 import chromadb
 import tiktoken
 from crewai import Agent, Task, Crew, Process
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 import openai as openai_module
 from openai import OpenAI
 from pydantic import BaseModel, Field, field_validator
 
+# ── 構造化ログ設定 ────────────────────────────────────────────────────────────
+_trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("trace_id", default="")
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+_LOG_LEVEL_MAP = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+}
+_log_level = _LOG_LEVEL_MAP.get(os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        trace_id = _trace_id_var.get("")
+        if trace_id:
+            payload["trace_id"] = trace_id
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _setup_logging() -> logging.Logger:
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(_log_level)
+    root.handlers = [handler]
+    return logging.getLogger(__name__)
+
+
+logger = _setup_logging()
 
 app = FastAPI()
+
+
+@app.middleware("http")
+async def _trace_id_middleware(request: Request, call_next: Callable) -> Any:
+    trace_id = request.headers.get("X-Trace-ID") or str(uuid.uuid4())
+    token = _trace_id_var.set(trace_id)
+    start = time.time()
+    try:
+        response = await call_next(request)
+        duration_ms = int((time.time() - start) * 1000)
+        level = "INFO" if response.status_code < 400 else ("WARN" if response.status_code < 500 else "ERROR")
+        payload = {
+            "time": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "level": level,
+            "logger": __name__,
+            "message": "http request",
+            "trace_id": trace_id,
+            "method": request.method,
+            "path": request.url.path,
+            "status": response.status_code,
+            "duration_ms": duration_ms,
+        }
+        print(json.dumps(payload, ensure_ascii=False), flush=True)
+        response.headers["X-Trace-ID"] = trace_id
+        return response
+    finally:
+        _trace_id_var.reset(token)
+
 
 # ── 環境変数 ────────────────────────────────────────────────────────────────
 DEFAULT_CACHE_TTL_SECONDS = 86400


### PR DESCRIPTION
Closes #403

## 変更内容

### バックエンド（Go）
- `Backend/internal/logger/logger.go` を新規追加
  - `log/slog` による構造化ログのセットアップ
  - `LOG_FORMAT=json`（本番）/ `text`（開発）の切替対応
  - `LOG_LEVEL=DEBUG/INFO/WARN/ERROR` 環境変数によるレベル制御
  - `slog.SetDefault` により既存の `log.Println` 等も slog 経由で出力される
- `Backend/internal/middleware/request_id.go` を新規追加
  - リクエストごとに一意の `X-Request-ID` を付与するミドルウェア
  - クライアントから送信された ID を優先し、なければランダム生成
  - コンテキストへの保存と `GetRequestID()` ヘルパー関数を提供
- `Backend/internal/middleware/request_logger.go` を新規追加
  - method / path / status / duration / request_id を構造化ログで記録
  - ステータスコードに応じてログレベルを自動切替（2xx→INFO、4xx→WARN、5xx→ERROR）
- `Backend/cmd/server/main.go` を更新
  - 起動時に `logger.Setup()` を実行して slog を初期化
  - 起動ログ・警告ログを `slog` へ移行（`log.Println` → `slog.Info/Warn`）
  - `RequestIDMiddleware` と `RequestLoggerMiddleware` を Echo に追加

### RAG（Python）
- `rag/main.py` を更新
  - `logging.basicConfig()` から `_JsonFormatter` による JSON 構造化ログへ移行
  - `LOG_LEVEL` 環境変数によるログレベル制御
  - `contextvars` によるリクエスト単位のトレースID管理
  - FastAPI ミドルウェアで `X-Trace-ID` ヘッダーをリクエスト・レスポンスに付与
  - method / path / status / duration_ms を JSON 形式でログ出力

### テスト
- `Backend/internal/logger/logger_test.go`: ログレベル制御の検証（4ケース）
- `Backend/test/middleware/request_id_test.go`: ID生成・クライアント提供ID優先・一意性・未設定時の挙動（4ケース）
- `Backend/test/middleware/request_logger_test.go`: リクエスト情報の記録・request_id含有・4xx/5xx のログレベル（4ケース）