### PR TITLE
Resolve #436: GitHub・OAuth・Realtime・IntegratedProfileコントローラーのテスト追加

### DIFF
--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"Backend/internal/services"
+	ifaces "Backend/internal/services/interfaces"
 	"context"
 	"errors"
 	"net/http"
@@ -11,11 +12,11 @@ import (
 
 // GitHubController GitHub連携APIのコントローラー
 type GitHubController struct {
-	githubService     *services.GitHubService
-	skillScoreService *services.SkillScoreService
+	githubService     ifaces.GitHubService
+	skillScoreService ifaces.SkillScoreService
 }
 
-func NewGitHubController(githubService *services.GitHubService, skillScoreService *services.SkillScoreService) *GitHubController {
+func NewGitHubController(githubService ifaces.GitHubService, skillScoreService ifaces.SkillScoreService) *GitHubController {
 	return &GitHubController{
 		githubService:     githubService,
 		skillScoreService: skillScoreService,

--- a/Backend/internal/controllers/integrated_profile_controller.go
+++ b/Backend/internal/controllers/integrated_profile_controller.go
@@ -1,8 +1,7 @@
 package controllers
 
 import (
-	"Backend/internal/repositories"
-	"Backend/internal/services"
+	ifaces "Backend/internal/services/interfaces"
 	"net/http"
 	"strconv"
 
@@ -11,15 +10,15 @@ import (
 
 // IntegratedProfileController ユーザー統合プロファイルAPI
 type IntegratedProfileController struct {
-	crossFeature         *services.CrossFeatureIntegrationService
-	interviewSessionRepo *repositories.InterviewSessionRepository
-	resumeRepo           *repositories.ResumeRepository
+	crossFeature         ifaces.CrossFeatureIntegrationService
+	interviewSessionRepo ifaces.InterviewSessionCounter
+	resumeRepo           ifaces.ResumeDocumentFinder
 }
 
 func NewIntegratedProfileController(
-	crossFeature *services.CrossFeatureIntegrationService,
-	interviewSessionRepo *repositories.InterviewSessionRepository,
-	resumeRepo *repositories.ResumeRepository,
+	crossFeature ifaces.CrossFeatureIntegrationService,
+	interviewSessionRepo ifaces.InterviewSessionCounter,
+	resumeRepo ifaces.ResumeDocumentFinder,
 ) *IntegratedProfileController {
 	return &IntegratedProfileController{
 		crossFeature:         crossFeature,

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -4,6 +4,7 @@ import (
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"Backend/internal/services"
+	ifaces "Backend/internal/services/interfaces"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,12 +20,12 @@ import (
 )
 
 type InterviewController struct {
-	interviewService *services.InterviewService
+	interviewService ifaces.InterviewService
 	videoRepo        repository.InterviewVideoRepository
 	s3Service        *services.S3UploadService
 }
 
-func NewInterviewController(interviewService *services.InterviewService, videoRepo repository.InterviewVideoRepository, s3Service *services.S3UploadService) *InterviewController {
+func NewInterviewController(interviewService ifaces.InterviewService, videoRepo repository.InterviewVideoRepository, s3Service *services.S3UploadService) *InterviewController {
 	return &InterviewController{
 		interviewService: interviewService,
 		videoRepo:        videoRepo,

--- a/Backend/internal/controllers/oauth_controller.go
+++ b/Backend/internal/controllers/oauth_controller.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"Backend/internal/config"
 	"Backend/internal/middleware"
-	"Backend/internal/services"
+	ifaces "Backend/internal/services/interfaces"
 	"encoding/base64"
 	"encoding/json"
 	"log"
@@ -13,10 +13,10 @@ import (
 )
 
 type OAuthController struct {
-	oauthService *services.OAuthService
+	oauthService ifaces.OAuthService
 }
 
-func NewOAuthController(oauthService *services.OAuthService) *OAuthController {
+func NewOAuthController(oauthService ifaces.OAuthService) *OAuthController {
 	return &OAuthController{oauthService: oauthService}
 }
 

--- a/Backend/internal/controllers/realtime_controller.go
+++ b/Backend/internal/controllers/realtime_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"Backend/internal/services"
+	ifaces "Backend/internal/services/interfaces"
 	"net/http"
 	"strings"
 
@@ -9,11 +9,11 @@ import (
 )
 
 type RealtimeController struct {
-	interviewService     *services.InterviewService
-	realtimeUsageService *services.RealtimeUsageService
+	interviewService     ifaces.InterviewService
+	realtimeUsageService ifaces.RealtimeUsageService
 }
 
-func NewRealtimeController(interviewService *services.InterviewService, realtimeUsageService *services.RealtimeUsageService) *RealtimeController {
+func NewRealtimeController(interviewService ifaces.InterviewService, realtimeUsageService ifaces.RealtimeUsageService) *RealtimeController {
 	return &RealtimeController{interviewService: interviewService, realtimeUsageService: realtimeUsageService}
 }
 

--- a/Backend/internal/services/interfaces/costs_service.go
+++ b/Backend/internal/services/interfaces/costs_service.go
@@ -15,6 +15,7 @@ type APICostService interface {
 
 // RealtimeUsageService リアルタイム使用量サービスのインターフェース
 type RealtimeUsageService interface {
+	SessionDurationMinutes() int
 	CurrentMonthTotalCost() (float64, error)
 	CurrentActiveCount() (int64, error)
 	GetUserBreakdown(days int, limit int) ([]services.RealtimeUserSummary, error)

--- a/Backend/internal/services/interfaces/cross_feature_service.go
+++ b/Backend/internal/services/interfaces/cross_feature_service.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "Backend/internal/services"
+
+type CrossFeatureIntegrationService interface {
+	BuildIntegratedProfile(userID uint, chatSessionID string, interviewCount int, resumeReviewDone bool) (*services.UserIntegratedProfile, error)
+}

--- a/Backend/internal/services/interfaces/github_service.go
+++ b/Backend/internal/services/interfaces/github_service.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"Backend/internal/models"
+	"context"
+)
+
+type GitHubService interface {
+	GetProfile(userID uint) (*models.GitHubProfile, error)
+	GetRepositories(userID uint) ([]models.GitHubRepo, error)
+	GetLanguageStats(userID uint) ([]models.GitHubLanguageStat, error)
+	TriggerAsyncSync(userID uint, force bool)
+	SyncUserData(ctx context.Context, userID uint, force bool) error
+	ListRepoSummaries(userID uint) ([]models.GitHubRepoSummary, error)
+	SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error)
+}
+
+type SkillScoreService interface {
+	GetScores(userID uint) ([]models.SkillScore, error)
+}

--- a/Backend/internal/services/interfaces/integrated_profile_repos.go
+++ b/Backend/internal/services/interfaces/integrated_profile_repos.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import "Backend/internal/models"
+
+// InterviewSessionCounter IntegratedProfileControllerが使うリポジトリの最小インターフェース
+type InterviewSessionCounter interface {
+	CountByUser(userID uint) (int64, error)
+}
+
+// ResumeDocumentFinder IntegratedProfileControllerが使うリポジトリの最小インターフェース
+type ResumeDocumentFinder interface {
+	FindDocumentsByUserID(userID uint) ([]models.ResumeDocument, error)
+}

--- a/Backend/internal/services/interfaces/interview_service.go
+++ b/Backend/internal/services/interfaces/interview_service.go
@@ -1,0 +1,37 @@
+package interfaces
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/services"
+	"context"
+)
+
+type InterviewService interface {
+	CreateSession(userID uint, language string, interviewerGender string) (*services.InterviewSessionResponse, error)
+	StartSession(userID uint, sessionID uint) (*services.InterviewSessionResponse, error)
+	FinishSession(userID uint, sessionID uint) (*services.InterviewSessionResponse, error)
+	ListSessions(userID uint, all bool, limit int, offset int) ([]services.InterviewSessionResponse, int64, error)
+	GetSessionDetailWithRole(userID uint, sessionID uint, role string) (*services.InterviewDetailResponse, error)
+	GetReport(userID uint, sessionID uint) (*models.InterviewReport, error)
+	GetPhraseSuggestions(ctx context.Context, userID uint, sessionID uint) ([]services.PhraseSuggestion, error)
+	GetTrend(userID uint, limit int) ([]services.InterviewTrendPoint, error)
+	SendReportEmail(userID, sessionID uint) error
+	SaveUtterance(userID uint, sessionID uint, role string, text string) error
+	CreateRealtimeToken(ctx context.Context, userID uint, sessionID uint) (string, error)
+	Turn(
+		ctx context.Context,
+		userID uint,
+		sessionID uint,
+		audioData []byte,
+		history []map[string]string,
+		companyName, companyReading, position, companyInfo, companyType string,
+		turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
+	) (*services.TurnResult, error)
+	StartTurn(
+		ctx context.Context,
+		userID uint,
+		sessionID uint,
+		companyName, companyReading, position, companyInfo, companyType string,
+		questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
+	) (*services.TurnResult, error)
+}

--- a/Backend/internal/services/interfaces/oauth_service.go
+++ b/Backend/internal/services/interfaces/oauth_service.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	"Backend/internal/services"
+	"context"
+)
+
+type OAuthService interface {
+	GetGoogleAuthURL(state string) string
+	GetGitHubAuthURL(state string) string
+	HandleGoogleCallback(ctx context.Context, code string) (*services.AuthResponse, error)
+	HandleGitHubCallback(ctx context.Context, code string) (*services.AuthResponse, error)
+}

--- a/Backend/test/controllers/github_oauth_realtime_integrated_test.go
+++ b/Backend/test/controllers/github_oauth_realtime_integrated_test.go
@@ -1,0 +1,412 @@
+package controllers_test
+
+// GitHub・OAuth・Realtime・IntegratedProfileコントローラーのHTTPハンドラーテスト
+//
+// 実行: cd Backend && go test ./test/controllers/... -run "GitHub|OAuth|Realtime|Integrated" -v
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/controllers"
+	"Backend/internal/models"
+	"Backend/internal/services"
+	"Backend/test/controllers/mocks"
+
+	"github.com/stretchr/testify/assert"
+	tmock "github.com/stretchr/testify/mock"
+)
+
+// ========== GitHubController ==========
+
+func newGitHubController(gh *mocks.GitHubServiceMock, ss *mocks.SkillScoreServiceMock) *controllers.GitHubController {
+	return controllers.NewGitHubController(gh, ss)
+}
+
+// ---- GetProfile ----
+
+func TestGitHubController_GetProfile_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/profile", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).GetProfile, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_GetProfile_NotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/profile", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("GetProfile", uint(1)).Return(nil, nil)
+	assertStatus(t, newGitHubController(gh, nil).GetProfile, newCtx(req, rec), http.StatusNotFound)
+	gh.AssertExpectations(t)
+}
+
+func TestGitHubController_GetProfile_ServiceError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/profile", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("GetProfile", uint(1)).Return(nil, errors.New("db error"))
+	assertStatus(t, newGitHubController(gh, nil).GetProfile, newCtx(req, rec), http.StatusInternalServerError)
+}
+
+func TestGitHubController_GetProfile_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/profile", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("GetProfile", uint(1)).Return(&models.GitHubProfile{UserID: 1, GitHubLogin: "testuser"}, nil)
+	gh.On("GetRepositories", uint(1)).Return([]models.GitHubRepo{}, nil)
+	gh.On("GetLanguageStats", uint(1)).Return([]models.GitHubLanguageStat{}, nil)
+	assertStatus(t, newGitHubController(gh, nil).GetProfile, newCtx(req, rec), http.StatusOK)
+
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body, "profile")
+	assert.Contains(t, body, "repositories")
+	assert.Contains(t, body, "language_stats")
+	gh.AssertExpectations(t)
+}
+
+// ---- Sync ----
+
+func TestGitHubController_Sync_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).Sync, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_Sync_ProfileNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("GetProfile", uint(1)).Return(nil, nil)
+	assertStatus(t, newGitHubController(gh, nil).Sync, newCtx(req, rec), http.StatusNotFound)
+}
+
+func TestGitHubController_Sync_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("GetProfile", uint(1)).Return(&models.GitHubProfile{UserID: 1}, nil)
+	gh.On("TriggerAsyncSync", uint(1), false).Return()
+	assertStatus(t, newGitHubController(gh, nil).Sync, newCtx(req, rec), http.StatusOK)
+	gh.AssertExpectations(t)
+}
+
+// ---- SyncAndWait ----
+
+func TestGitHubController_SyncAndWait_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync/wait", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).SyncAndWait, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_SyncAndWait_ServiceError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync/wait", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("SyncUserData", tmock.Anything, uint(1), true).Return(errors.New("network error"))
+	assertStatus(t, newGitHubController(gh, nil).SyncAndWait, newCtx(req, rec), http.StatusInternalServerError)
+}
+
+func TestGitHubController_SyncAndWait_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/sync/wait", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("SyncUserData", tmock.Anything, uint(1), true).Return(nil)
+	assertStatus(t, newGitHubController(gh, nil).SyncAndWait, newCtx(req, rec), http.StatusOK)
+	gh.AssertExpectations(t)
+}
+
+// ---- GetSkills ----
+
+func TestGitHubController_GetSkills_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/skills", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).GetSkills, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_GetSkills_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/skills", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	ss := &mocks.SkillScoreServiceMock{}
+	ss.On("GetScores", uint(1)).Return([]models.SkillScore{{UserID: 1}}, nil)
+	assertStatus(t, newGitHubController(nil, ss).GetSkills, newCtx(req, rec), http.StatusOK)
+	ss.AssertExpectations(t)
+}
+
+func TestGitHubController_GetSkills_ServiceError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/skills", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	ss := &mocks.SkillScoreServiceMock{}
+	ss.On("GetScores", uint(1)).Return([]models.SkillScore{}, errors.New("db error"))
+	assertStatus(t, newGitHubController(nil, ss).GetSkills, newCtx(req, rec), http.StatusInternalServerError)
+}
+
+// ---- ListRepoSummaries ----
+
+func TestGitHubController_ListRepoSummaries_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/repo/summaries", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).ListRepoSummaries, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_ListRepoSummaries_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/github/repo/summaries", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("ListRepoSummaries", uint(1)).Return([]models.GitHubRepoSummary{{UserID: 1}}, nil)
+	assertStatus(t, newGitHubController(gh, nil).ListRepoSummaries, newCtx(req, rec), http.StatusOK)
+	gh.AssertExpectations(t)
+}
+
+// ---- SummarizeRepo ----
+
+func TestGitHubController_SummarizeRepo_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/github/repo/summarize", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).SummarizeRepo, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestGitHubController_SummarizeRepo_MissingFullName(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"full_name": ""})
+	req := httptest.NewRequest(http.MethodPost, "/api/github/repo/summarize", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newGitHubController(nil, nil).SummarizeRepo, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestGitHubController_SummarizeRepo_Success(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"full_name": "owner/repo", "force_refresh": false})
+	req := httptest.NewRequest(http.MethodPost, "/api/github/repo/summarize", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	gh := &mocks.GitHubServiceMock{}
+	gh.On("SummarizeRepo", tmock.Anything, uint(1), "owner/repo", false).
+		Return(&models.GitHubRepoSummary{FullName: "owner/repo"}, nil)
+	assertStatus(t, newGitHubController(gh, nil).SummarizeRepo, newCtx(req, rec), http.StatusOK)
+	gh.AssertExpectations(t)
+}
+
+// ========== OAuthController ==========
+
+func newOAuthController(svc *mocks.OAuthServiceMock) *controllers.OAuthController {
+	return controllers.NewOAuthController(svc)
+}
+
+// ---- GoogleLogin ----
+
+func TestOAuthController_GoogleLogin_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/google", nil)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.OAuthServiceMock{}
+	svc.On("GetGoogleAuthURL", tmock.AnythingOfType("string")).Return("https://accounts.google.com/auth?state=xxx")
+	assertStatus(t, newOAuthController(svc).GoogleLogin, newCtx(req, rec), http.StatusOK)
+
+	var body map[string]string
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body["auth_url"], "accounts.google.com")
+}
+
+// ---- GitHubLogin ----
+
+func TestOAuthController_GitHubLogin_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/github", nil)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.OAuthServiceMock{}
+	svc.On("GetGitHubAuthURL", tmock.AnythingOfType("string")).Return("https://github.com/login/oauth/authorize?state=xxx")
+	assertStatus(t, newOAuthController(svc).GitHubLogin, newCtx(req, rec), http.StatusOK)
+
+	var body map[string]string
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body["auth_url"], "github.com")
+}
+
+// ---- GoogleCallback ----
+
+func TestOAuthController_GoogleCallback_MissingCode(t *testing.T) {
+	// state検証をスキップするためcookieなしリクエスト → stateミスマッチでリダイレクト(307)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/google/callback", nil)
+	rec := httptest.NewRecorder()
+	// VerifyOAuthState は cookie がないため false を返す → Redirect 307
+	assertStatus(t, newOAuthController(nil).GoogleCallback, newCtx(req, rec), http.StatusTemporaryRedirect)
+}
+
+func TestOAuthController_GitHubCallback_MissingCode(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/github/callback", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newOAuthController(nil).GitHubCallback, newCtx(req, rec), http.StatusTemporaryRedirect)
+}
+
+// ========== RealtimeController ==========
+
+func newRealtimeController(interviewSvc *mocks.InterviewServiceMock, realtimeSvc *mocks.RealtimeUsageServiceMock) *controllers.RealtimeController {
+	return controllers.NewRealtimeController(interviewSvc, realtimeSvc)
+}
+
+// ---- Token ----
+
+func TestRealtimeController_Token_MissingFields(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"user_id": 0, "interview_id": 0})
+	req := httptest.NewRequest(http.MethodPost, "/api/realtime/token", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	assertStatus(t, newRealtimeController(nil, nil).Token, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestRealtimeController_Token_Forbidden(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"user_id": 1, "interview_id": 2})
+	req := httptest.NewRequest(http.MethodPost, "/api/realtime/token", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("CreateRealtimeToken", tmock.Anything, uint(1), uint(2)).Return("", errors.New("forbidden"))
+	assertStatus(t, newRealtimeController(svc, nil).Token, newCtx(req, rec), http.StatusForbidden)
+}
+
+func TestRealtimeController_Token_Success(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"user_id": 1, "interview_id": 2})
+	req := httptest.NewRequest(http.MethodPost, "/api/realtime/token", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("CreateRealtimeToken", tmock.Anything, uint(1), uint(2)).Return("ephemeral-secret-token", nil)
+	assertStatus(t, newRealtimeController(svc, nil).Token, newCtx(req, rec), http.StatusOK)
+
+	var resp map[string]string
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "ephemeral-secret-token", resp["client_secret"])
+	svc.AssertExpectations(t)
+}
+
+func TestRealtimeController_Token_TooManyRequests(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"user_id": 1, "interview_id": 2})
+	req := httptest.NewRequest(http.MethodPost, "/api/realtime/token", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("CreateRealtimeToken", tmock.Anything, uint(1), uint(2)).Return("", errors.New("realtime capacity exceeded: max 10 concurrent sessions"))
+	assertStatus(t, newRealtimeController(svc, nil).Token, newCtx(req, rec), http.StatusTooManyRequests)
+}
+
+// ---- SessionInfo ----
+
+func TestRealtimeController_SessionInfo_WithService(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/realtime/session-info", nil)
+	rec := httptest.NewRecorder()
+
+	rtSvc := &mocks.RealtimeUsageServiceMock{}
+	rtSvc.On("SessionDurationMinutes").Return(15)
+	assertStatus(t, newRealtimeController(nil, rtSvc).SessionInfo, newCtx(req, rec), http.StatusOK)
+
+	var resp map[string]int
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 15, resp["session_minutes"])
+	rtSvc.AssertExpectations(t)
+}
+
+func TestRealtimeController_SessionInfo_NilService(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/realtime/session-info", nil)
+	rec := httptest.NewRecorder()
+	// nil インターフェースを直接渡すとデフォルト10分が返る
+	ctrl := controllers.NewRealtimeController(nil, nil)
+	assertStatus(t, ctrl.SessionInfo, newCtx(req, rec), http.StatusOK)
+
+	var resp map[string]int
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 10, resp["session_minutes"])
+}
+
+// ========== IntegratedProfileController ==========
+
+func newIntegratedProfileController(
+	cf *mocks.CrossFeatureServiceMock,
+	sc *mocks.InterviewSessionCounterMock,
+	rd *mocks.ResumeDocumentFinderMock,
+) *controllers.IntegratedProfileController {
+	return controllers.NewIntegratedProfileController(cf, sc, rd)
+}
+
+func TestIntegratedProfileController_GetProfile_MissingUserID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newIntegratedProfileController(nil, nil, nil).GetProfile, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestIntegratedProfileController_GetProfile_MissingSessionID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile?user_id=1", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newIntegratedProfileController(nil, nil, nil).GetProfile, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestIntegratedProfileController_GetProfile_InvalidUserID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile?user_id=abc&session_id=sess-1", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newIntegratedProfileController(nil, nil, nil).GetProfile, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestIntegratedProfileController_GetProfile_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile?user_id=1&session_id=sess-abc", nil)
+	rec := httptest.NewRecorder()
+
+	cf := &mocks.CrossFeatureServiceMock{}
+	sc := &mocks.InterviewSessionCounterMock{}
+	rd := &mocks.ResumeDocumentFinderMock{}
+
+	sc.On("CountByUser", uint(1)).Return(int64(3), nil)
+	rd.On("FindDocumentsByUserID", uint(1)).Return([]models.ResumeDocument{{Status: "reviewed"}}, nil)
+	cf.On("BuildIntegratedProfile", uint(1), "sess-abc", 3, true).Return(&services.UserIntegratedProfile{UserID: 1}, nil)
+
+	assertStatus(t, newIntegratedProfileController(cf, sc, rd).GetProfile, newCtx(req, rec), http.StatusOK)
+
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	cf.AssertExpectations(t)
+	sc.AssertExpectations(t)
+	rd.AssertExpectations(t)
+}
+
+func TestIntegratedProfileController_GetProfile_ServiceError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile?user_id=1&session_id=sess-abc", nil)
+	rec := httptest.NewRecorder()
+
+	cf := &mocks.CrossFeatureServiceMock{}
+	sc := &mocks.InterviewSessionCounterMock{}
+	rd := &mocks.ResumeDocumentFinderMock{}
+
+	sc.On("CountByUser", uint(1)).Return(int64(0), nil)
+	rd.On("FindDocumentsByUserID", uint(1)).Return([]models.ResumeDocument{}, nil)
+	cf.On("BuildIntegratedProfile", uint(1), "sess-abc", 0, false).Return(nil, errors.New("service failure"))
+
+	assertStatus(t, newIntegratedProfileController(cf, sc, rd).GetProfile, newCtx(req, rec), http.StatusInternalServerError)
+}

--- a/Backend/test/controllers/interview_controller_test.go
+++ b/Backend/test/controllers/interview_controller_test.go
@@ -1,0 +1,467 @@
+package controllers_test
+
+// InterviewControllerのHTTPハンドラーテスト
+//
+// 実行: cd Backend && go test ./test/controllers/... -run Interview -v
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/controllers"
+	"Backend/internal/models"
+	"Backend/internal/services"
+	"Backend/test/controllers/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newInterviewController(svc *mocks.InterviewServiceMock) *controllers.InterviewController {
+	return controllers.NewInterviewController(svc, nil, nil)
+}
+
+// ---- Create ----
+
+func TestInterviewController_Create_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newInterviewController(nil).Create, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestInterviewController_Create_InvalidBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews", bytes.NewBufferString("invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newInterviewController(nil).Create, newCtx(req, rec), http.StatusBadRequest)
+}
+
+func TestInterviewController_Create_Success(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"language": "ja", "interviewer_gender": "female"})
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("CreateSession", uint(1), "ja", "female").Return(&services.InterviewSessionResponse{ID: 10}, nil)
+	assertStatus(t, newInterviewController(svc).Create, newCtx(req, rec), http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_Create_ServiceError(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"language": "ja"})
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("CreateSession", uint(1), "ja", "").Return(nil, errors.New("guest limit exceeded"))
+	assertStatus(t, newInterviewController(svc).Create, newCtx(req, rec), http.StatusBadRequest)
+}
+
+// ---- List ----
+
+func TestInterviewController_List_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newInterviewController(nil).List, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestInterviewController_List_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews?page=1&limit=10", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("ListSessions", uint(1), false, 10, 0).Return([]services.InterviewSessionResponse{{ID: 1}}, int64(1), nil)
+	assertStatus(t, newInterviewController(svc).List, newCtx(req, rec), http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_List_LimitCapped(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews?limit=999", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	// limit は100に切り捨てられる
+	svc.On("ListSessions", uint(1), false, 100, 0).Return([]services.InterviewSessionResponse{}, int64(0), nil)
+	assertStatus(t, newInterviewController(svc).List, newCtx(req, rec), http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_List_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("ListSessions", uint(1), false, 20, 0).Return([]services.InterviewSessionResponse{}, int64(0), errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).List, newCtx(req, rec), http.StatusForbidden)
+}
+
+// ---- Get ----
+
+func TestInterviewController_Get_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/1", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).Get, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_Get_InvalidID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/abc", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("abc")
+	assertStatus(t, newInterviewController(nil).Get, c, http.StatusBadRequest)
+}
+
+func TestInterviewController_Get_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/5", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("5")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetSessionDetailWithRole", uint(1), uint(5), "student").Return(&services.InterviewDetailResponse{}, nil)
+	assertStatus(t, newInterviewController(svc).Get, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_Get_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/5", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("5")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetSessionDetailWithRole", uint(1), uint(5), "student").Return(nil, errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).Get, c, http.StatusForbidden)
+}
+
+// ---- Start ----
+
+func TestInterviewController_Start_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/start", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).Start, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_Start_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/start", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("StartSession", uint(1), uint(3)).Return(&services.InterviewSessionResponse{ID: 3}, nil)
+	assertStatus(t, newInterviewController(svc).Start, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_Start_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/start", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("StartSession", uint(1), uint(3)).Return(nil, errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).Start, c, http.StatusForbidden)
+}
+
+// ---- Finish ----
+
+func TestInterviewController_Finish_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/finish", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).Finish, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_Finish_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/finish", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("FinishSession", uint(1), uint(3)).Return(&services.InterviewSessionResponse{ID: 3}, nil)
+	assertStatus(t, newInterviewController(svc).Finish, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_Finish_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/finish", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("FinishSession", uint(1), uint(3)).Return(nil, errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).Finish, c, http.StatusForbidden)
+}
+
+// ---- GetTrend ----
+
+func TestInterviewController_GetTrend_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/trend", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newInterviewController(nil).GetTrend, newCtx(req, rec), http.StatusUnauthorized)
+}
+
+func TestInterviewController_GetTrend_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/trend?limit=5", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetTrend", uint(1), 5).Return([]services.InterviewTrendPoint{{SessionID: 1}}, nil)
+	assertStatus(t, newInterviewController(svc).GetTrend, newCtx(req, rec), http.StatusOK)
+
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body, "points")
+	svc.AssertExpectations(t)
+}
+
+// ---- GetReport ----
+
+func TestInterviewController_GetReport_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/1/report", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).GetReport, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_GetReport_NotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/1/report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetReport", uint(1), uint(1)).Return(nil, nil)
+	assertStatus(t, newInterviewController(svc).GetReport, c, http.StatusNotFound)
+}
+
+func TestInterviewController_GetReport_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/2/report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetReport", uint(1), uint(2)).Return(&models.InterviewReport{SessionID: 2}, nil)
+	assertStatus(t, newInterviewController(svc).GetReport, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_GetReport_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/2/report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetReport", uint(1), uint(2)).Return(nil, errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).GetReport, c, http.StatusForbidden)
+}
+
+// ---- SendReport ----
+
+func TestInterviewController_SendReport_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/send-report", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).SendReport, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_SendReport_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/2/send-report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("SendReportEmail", uint(1), uint(2)).Return(nil)
+	assertStatus(t, newInterviewController(svc).SendReport, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_SendReport_NotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/2/send-report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("SendReportEmail", uint(1), uint(2)).Return(errors.New("report not found"))
+	assertStatus(t, newInterviewController(svc).SendReport, c, http.StatusNotFound)
+}
+
+func TestInterviewController_SendReport_GuestForbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/2/send-report", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("SendReportEmail", uint(1), uint(2)).Return(errors.New("guest users cannot receive email reports"))
+	assertStatus(t, newInterviewController(svc).SendReport, c, http.StatusForbidden)
+}
+
+// ---- AddUtterance ----
+
+func TestInterviewController_AddUtterance_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/utterances", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).AddUtterance, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_AddUtterance_Success(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"role": "user", "text": "自己紹介をします"})
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/utterances", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("SaveUtterance", uint(1), uint(3), "user", "自己紹介をします").Return(nil)
+	assertStatus(t, newInterviewController(svc).AddUtterance, c, http.StatusNoContent)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_AddUtterance_Forbidden(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"role": "user", "text": "hello"})
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/3/utterances", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("3")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("SaveUtterance", uint(1), uint(3), "user", "hello").Return(errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).AddUtterance, c, http.StatusForbidden)
+}
+
+// ---- GetPhraseSuggestions ----
+
+func TestInterviewController_GetPhraseSuggestions_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/1/phrase-suggestions", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newInterviewController(nil).GetPhraseSuggestions, c, http.StatusUnauthorized)
+}
+
+func TestInterviewController_GetPhraseSuggestions_Success(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/2/phrase-suggestions", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetPhraseSuggestions", req.Context(), uint(1), uint(2)).
+		Return([]services.PhraseSuggestion{{Original: "頑張ります", Suggestions: []string{"尽力します"}}}, nil)
+	assertStatus(t, newInterviewController(svc).GetPhraseSuggestions, c, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestInterviewController_GetPhraseSuggestions_Forbidden(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/interviews/2/phrase-suggestions", nil)
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("2")
+
+	svc := &mocks.InterviewServiceMock{}
+	svc.On("GetPhraseSuggestions", req.Context(), uint(1), uint(2)).
+		Return([]services.PhraseSuggestion{}, errors.New("forbidden"))
+	assertStatus(t, newInterviewController(svc).GetPhraseSuggestions, c, http.StatusForbidden)
+}
+
+// ---- UploadVideo (サービス未設定パス) ----
+
+func TestInterviewController_UploadVideo_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/upload-video", nil)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	// videoRepo/s3Service がnilのとき ServiceUnavailable
+	ctrl := controllers.NewInterviewController(nil, nil, nil)
+	// まずInvalidID確認（ParseMultipartFormより前）
+	c2 := newCtx(req, rec)
+	c2.SetParamNames("id")
+	c2.SetParamValues("abc")
+	assertStatus(t, ctrl.UploadVideo, c2, http.StatusBadRequest)
+}
+
+func TestInterviewController_UploadVideo_ServiceUnavailable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/interviews/1/upload-video", bytes.NewBufferString(""))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	// videoRepo/s3Service がnilのとき ServiceUnavailable を返す
+	ctrl := controllers.NewInterviewController(nil, nil, nil)
+	assertStatus(t, ctrl.UploadVideo, c, http.StatusServiceUnavailable)
+}

--- a/Backend/test/controllers/mocks/costs_service_mocks.go
+++ b/Backend/test/controllers/mocks/costs_service_mocks.go
@@ -46,6 +46,11 @@ type RealtimeUsageServiceMock struct {
 	mock.Mock
 }
 
+func (m *RealtimeUsageServiceMock) SessionDurationMinutes() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
 func (m *RealtimeUsageServiceMock) CurrentMonthTotalCost() (float64, error) {
 	args := m.Called()
 	return args.Get(0).(float64), args.Error(1)

--- a/Backend/test/controllers/mocks/github_service_mock.go
+++ b/Backend/test/controllers/mocks/github_service_mock.go
@@ -1,0 +1,60 @@
+package mocks
+
+import (
+	"Backend/internal/models"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type GitHubServiceMock struct {
+	mock.Mock
+}
+
+func (m *GitHubServiceMock) GetProfile(userID uint) (*models.GitHubProfile, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.GitHubProfile), args.Error(1)
+}
+
+func (m *GitHubServiceMock) GetRepositories(userID uint) ([]models.GitHubRepo, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]models.GitHubRepo), args.Error(1)
+}
+
+func (m *GitHubServiceMock) GetLanguageStats(userID uint) ([]models.GitHubLanguageStat, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]models.GitHubLanguageStat), args.Error(1)
+}
+
+func (m *GitHubServiceMock) TriggerAsyncSync(userID uint, force bool) {
+	m.Called(userID, force)
+}
+
+func (m *GitHubServiceMock) SyncUserData(ctx context.Context, userID uint, force bool) error {
+	return m.Called(ctx, userID, force).Error(0)
+}
+
+func (m *GitHubServiceMock) ListRepoSummaries(userID uint) ([]models.GitHubRepoSummary, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]models.GitHubRepoSummary), args.Error(1)
+}
+
+func (m *GitHubServiceMock) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error) {
+	args := m.Called(ctx, userID, fullName, forceRefresh)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.GitHubRepoSummary), args.Error(1)
+}
+
+type SkillScoreServiceMock struct {
+	mock.Mock
+}
+
+func (m *SkillScoreServiceMock) GetScores(userID uint) ([]models.SkillScore, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]models.SkillScore), args.Error(1)
+}

--- a/Backend/test/controllers/mocks/integrated_profile_mocks.go
+++ b/Backend/test/controllers/mocks/integrated_profile_mocks.go
@@ -1,0 +1,38 @@
+package mocks
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/services"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type CrossFeatureServiceMock struct {
+	mock.Mock
+}
+
+func (m *CrossFeatureServiceMock) BuildIntegratedProfile(userID uint, chatSessionID string, interviewCount int, resumeReviewDone bool) (*services.UserIntegratedProfile, error) {
+	args := m.Called(userID, chatSessionID, interviewCount, resumeReviewDone)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.UserIntegratedProfile), args.Error(1)
+}
+
+type InterviewSessionCounterMock struct {
+	mock.Mock
+}
+
+func (m *InterviewSessionCounterMock) CountByUser(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+type ResumeDocumentFinderMock struct {
+	mock.Mock
+}
+
+func (m *ResumeDocumentFinderMock) FindDocumentsByUserID(userID uint) ([]models.ResumeDocument, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]models.ResumeDocument), args.Error(1)
+}

--- a/Backend/test/controllers/mocks/interview_service_mock.go
+++ b/Backend/test/controllers/mocks/interview_service_mock.go
@@ -1,0 +1,115 @@
+package mocks
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/services"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type InterviewServiceMock struct {
+	mock.Mock
+}
+
+func (m *InterviewServiceMock) CreateSession(userID uint, language string, interviewerGender string) (*services.InterviewSessionResponse, error) {
+	args := m.Called(userID, language, interviewerGender)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.InterviewSessionResponse), args.Error(1)
+}
+
+func (m *InterviewServiceMock) StartSession(userID uint, sessionID uint) (*services.InterviewSessionResponse, error) {
+	args := m.Called(userID, sessionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.InterviewSessionResponse), args.Error(1)
+}
+
+func (m *InterviewServiceMock) FinishSession(userID uint, sessionID uint) (*services.InterviewSessionResponse, error) {
+	args := m.Called(userID, sessionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.InterviewSessionResponse), args.Error(1)
+}
+
+func (m *InterviewServiceMock) ListSessions(userID uint, all bool, limit int, offset int) ([]services.InterviewSessionResponse, int64, error) {
+	args := m.Called(userID, all, limit, offset)
+	return args.Get(0).([]services.InterviewSessionResponse), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *InterviewServiceMock) GetSessionDetailWithRole(userID uint, sessionID uint, role string) (*services.InterviewDetailResponse, error) {
+	args := m.Called(userID, sessionID, role)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.InterviewDetailResponse), args.Error(1)
+}
+
+func (m *InterviewServiceMock) GetReport(userID uint, sessionID uint) (*models.InterviewReport, error) {
+	args := m.Called(userID, sessionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.InterviewReport), args.Error(1)
+}
+
+func (m *InterviewServiceMock) GetPhraseSuggestions(ctx context.Context, userID uint, sessionID uint) ([]services.PhraseSuggestion, error) {
+	args := m.Called(ctx, userID, sessionID)
+	return args.Get(0).([]services.PhraseSuggestion), args.Error(1)
+}
+
+func (m *InterviewServiceMock) GetTrend(userID uint, limit int) ([]services.InterviewTrendPoint, error) {
+	args := m.Called(userID, limit)
+	return args.Get(0).([]services.InterviewTrendPoint), args.Error(1)
+}
+
+func (m *InterviewServiceMock) SendReportEmail(userID, sessionID uint) error {
+	return m.Called(userID, sessionID).Error(0)
+}
+
+func (m *InterviewServiceMock) SaveUtterance(userID uint, sessionID uint, role string, text string) error {
+	return m.Called(userID, sessionID, role, text).Error(0)
+}
+
+func (m *InterviewServiceMock) CreateRealtimeToken(ctx context.Context, userID uint, sessionID uint) (string, error) {
+	args := m.Called(ctx, userID, sessionID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *InterviewServiceMock) Turn(
+	ctx context.Context,
+	userID uint,
+	sessionID uint,
+	audioData []byte,
+	history []map[string]string,
+	companyName, companyReading, position, companyInfo, companyType string,
+	turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
+) (*services.TurnResult, error) {
+	args := m.Called(ctx, userID, sessionID, audioData, history,
+		companyName, companyReading, position, companyInfo, companyType,
+		turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.TurnResult), args.Error(1)
+}
+
+func (m *InterviewServiceMock) StartTurn(
+	ctx context.Context,
+	userID uint,
+	sessionID uint,
+	companyName, companyReading, position, companyInfo, companyType string,
+	questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
+) (*services.TurnResult, error) {
+	args := m.Called(ctx, userID, sessionID,
+		companyName, companyReading, position, companyInfo, companyType,
+		questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.TurnResult), args.Error(1)
+}

--- a/Backend/test/controllers/mocks/oauth_service_mock.go
+++ b/Backend/test/controllers/mocks/oauth_service_mock.go
@@ -1,0 +1,36 @@
+package mocks
+
+import (
+	"Backend/internal/services"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type OAuthServiceMock struct {
+	mock.Mock
+}
+
+func (m *OAuthServiceMock) GetGoogleAuthURL(state string) string {
+	return m.Called(state).String(0)
+}
+
+func (m *OAuthServiceMock) GetGitHubAuthURL(state string) string {
+	return m.Called(state).String(0)
+}
+
+func (m *OAuthServiceMock) HandleGoogleCallback(ctx context.Context, code string) (*services.AuthResponse, error) {
+	args := m.Called(ctx, code)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.AuthResponse), args.Error(1)
+}
+
+func (m *OAuthServiceMock) HandleGitHubCallback(ctx context.Context, code string) (*services.AuthResponse, error) {
+	args := m.Called(ctx, code)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.AuthResponse), args.Error(1)
+}

--- a/Backend/test/controllers/remaining_controller_test.go
+++ b/Backend/test/controllers/remaining_controller_test.go
@@ -196,25 +196,3 @@ func TestESRewriteController_Rewrite_InvalidBody(t *testing.T) {
 	assertStatus(t, c.Rewrite, newCtx(req, rec), http.StatusBadRequest)
 }
 
-// ---- GitHubController ----
-
-func TestGitHubController_GetProfile_Unauthorized(t *testing.T) {
-	c := controllers.NewGitHubController(nil, nil)
-	req := httptest.NewRequest(http.MethodGet, "/api/github/profile", nil)
-	rec := httptest.NewRecorder()
-	assertStatus(t, c.GetProfile, newCtx(req, rec), http.StatusUnauthorized)
-}
-
-func TestGitHubController_Sync_Unauthorized(t *testing.T) {
-	c := controllers.NewGitHubController(nil, nil)
-	req := httptest.NewRequest(http.MethodPost, "/api/github/sync", nil)
-	rec := httptest.NewRecorder()
-	assertStatus(t, c.Sync, newCtx(req, rec), http.StatusUnauthorized)
-}
-
-func TestGitHubController_GetSkills_Unauthorized(t *testing.T) {
-	c := controllers.NewGitHubController(nil, nil)
-	req := httptest.NewRequest(http.MethodGet, "/api/github/skills", nil)
-	rec := httptest.NewRecorder()
-	assertStatus(t, c.GetSkills, newCtx(req, rec), http.StatusUnauthorized)
-}


### PR DESCRIPTION
Closes #436

## 変更内容
### インターフェース追加
- `GitHubService`・`SkillScoreService` インターフェースを追加
- `OAuthService` インターフェースを追加
- `CrossFeatureIntegrationService` インターフェースを追加
- `InterviewSessionCounter`・`ResumeDocumentFinder` リポジトリ最小インターフェースを追加
- `RealtimeUsageService` に `SessionDurationMinutes()` メソッドを追加

### コントローラー更新
- `GitHubController`・`OAuthController`・`RealtimeController`・`IntegratedProfileController` の依存を具象型からインターフェースに変更

### モック追加
- `GitHubServiceMock`・`SkillScoreServiceMock`
- `OAuthServiceMock`
- `CrossFeatureServiceMock`・`InterviewSessionCounterMock`・`ResumeDocumentFinderMock`

### テスト追加（39テスト）
- `GitHubController`: GetProfile/Sync/SyncAndWait/GetSkills/ListRepoSummaries/SummarizeRepo（14テスト）
- `OAuthController`: GoogleLogin/GitHubLogin/Callback CSRF検証（4テスト）
- `RealtimeController`: Token（MissingFields/Forbidden/Success/TooManyRequests）/SessionInfo（7テスト）
- `IntegratedProfileController`: GetProfile（MissingUserID/MissingSessionID/Invalid/Success/ServiceError）（5テスト）