### PR TITLE
Resolve #396: APIエラーレスポンスの標準化

### DIFF
--- a/Backend/internal/controllers/auth_controller.go
+++ b/Backend/internal/controllers/auth_controller.go
@@ -25,24 +25,23 @@ func NewAuthController(authService interfaces.AuthService) *AuthController {
 func (c *AuthController) Register(ctx echo.Context) error {
 	var req services.RegisterRequest
 	if err := ctx.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
 
 	resp, err := c.authService.Register(req)
 	if err != nil {
 		if err.Error() == "email already exists" {
 			if isProduction() {
-				// ユーザー列挙対策: 本番では汎用メッセージを返す
 				log.Printf("[Register] email already exists: %s", req.Email)
-				return echo.NewHTTPError(http.StatusConflict, "Registration failed")
+				return newAPIError(http.StatusConflict, ErrCodeDuplicateEmail, "Registration failed")
 			}
-			return echo.NewHTTPError(http.StatusConflict, err.Error())
+			return newAPIError(http.StatusConflict, ErrCodeDuplicateEmail, err.Error())
 		}
 		if isProduction() {
 			log.Printf("[Register] error: %v", err)
-			return echo.NewHTTPError(http.StatusBadRequest, "Registration failed")
+			return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Registration failed")
 		}
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 
 	return ctx.JSON(http.StatusCreated, resp)
@@ -52,19 +51,19 @@ func (c *AuthController) Register(ctx echo.Context) error {
 func (c *AuthController) Login(ctx echo.Context) error {
 	var req services.LoginRequest
 	if err := ctx.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
 
 	resp, err := c.authService.Login(req)
 	if err != nil {
 		msg := err.Error()
 		if msg == "invalid email or password" || msg == "guest users cannot login" {
-			return echo.NewHTTPError(http.StatusUnauthorized, msg)
+			return newAPIError(http.StatusUnauthorized, ErrCodeUnauthorized, msg)
 		}
 		if msg == "email_not_verified" || msg == "re_verification_required" {
-			return ctx.JSON(http.StatusForbidden, map[string]string{"error": msg})
+			return newAPIError(http.StatusForbidden, ErrCodeForbidden, msg)
 		}
-		return echo.NewHTTPError(http.StatusInternalServerError, msg)
+		return echoInternalError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, resp)
@@ -84,13 +83,13 @@ func (c *AuthController) CreateGuest(ctx echo.Context) error {
 func (c *AuthController) GetUser(ctx echo.Context) error {
 	userID, ok := echoUserID(ctx)
 	if !ok {
-		return echo.NewHTTPError(http.StatusUnauthorized, "Unauthorized")
+		return newAPIError(http.StatusUnauthorized, ErrCodeUnauthorized, "Unauthorized")
 	}
 
 	resp, err := c.authService.GetUser(userID)
 	if err != nil {
 		if err.Error() == "user not found" {
-			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+			return newAPIError(http.StatusNotFound, ErrCodeNotFound, err.Error())
 		}
 		return echoInternalError(err)
 	}
@@ -104,19 +103,18 @@ func (c *AuthController) RequestRegistration(ctx echo.Context) error {
 		Email string `json:"email"`
 	}
 	if err := ctx.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
 
 	if err := c.authService.RequestRegistration(body.Email); err != nil {
 		if isProduction() {
-			// ユーザー列挙対策: 本番では成功と同じレスポンスを返す
 			log.Printf("[RequestRegistration] error for %s: %v", body.Email, err)
 			return ctx.JSON(http.StatusOK, map[string]string{"message": "confirmation email sent"})
 		}
 		if err.Error() == "email already exists" {
-			return echo.NewHTTPError(http.StatusConflict, err.Error())
+			return newAPIError(http.StatusConflict, ErrCodeDuplicateEmail, err.Error())
 		}
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "confirmation email sent"})
@@ -126,12 +124,12 @@ func (c *AuthController) RequestRegistration(ctx echo.Context) error {
 func (c *AuthController) VerifyRegistration(ctx echo.Context) error {
 	token := ctx.QueryParam("token")
 	if token == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "token is required")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "token is required")
 	}
 
 	email, err := c.authService.ValidateRegistrationToken(token)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]string{"email": email, "token": token})
@@ -141,22 +139,21 @@ func (c *AuthController) VerifyRegistration(ctx echo.Context) error {
 func (c *AuthController) UpdateProfile(ctx echo.Context) error {
 	userID, ok := echoUserID(ctx)
 	if !ok {
-		return echo.NewHTTPError(http.StatusUnauthorized, "Unauthorized")
+		return newAPIError(http.StatusUnauthorized, ErrCodeUnauthorized, "Unauthorized")
 	}
 
 	var req services.UpdateProfileRequest
 	if err := ctx.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
-	// リクエストボディの user_id を無視し、JWTから取得した値で上書き
 	req.UserID = userID
 
 	resp, err := c.authService.UpdateProfile(req)
 	if err != nil {
 		if err.Error() == "user not found" {
-			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+			return newAPIError(http.StatusNotFound, ErrCodeNotFound, err.Error())
 		}
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, resp)
@@ -168,7 +165,7 @@ func (c *AuthController) RequestPasswordReset(ctx echo.Context) error {
 		Email string `json:"email"`
 	}
 	if err := ctx.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
 
 	// エラーがあっても常に200を返す（情報漏洩防止）
@@ -184,11 +181,11 @@ func (c *AuthController) ResetPassword(ctx echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := ctx.Bind(&body); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "Invalid request body")
 	}
 
 	if err := c.authService.ResetPassword(body.Token, body.Password); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "パスワードをリセットしました"})
@@ -205,7 +202,7 @@ func (c *AuthController) VerifyEmail(ctx echo.Context) error {
 		token = req.Token
 	}
 	if err := c.authService.VerifyEmail(token); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, err.Error())
 	}
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "メールアドレスを確認しました。ログインしてください。"})
 }
@@ -215,7 +212,7 @@ func (c *AuthController) VerifyEmail(ctx echo.Context) error {
 func (c *AuthController) DeleteAccount(ctx echo.Context) error {
 	userID, ok := echoUserID(ctx)
 	if !ok {
-		return echo.NewHTTPError(http.StatusUnauthorized, "Unauthorized")
+		return newAPIError(http.StatusUnauthorized, ErrCodeUnauthorized, "Unauthorized")
 	}
 
 	if err := c.authService.DeleteAccount(userID); err != nil {

--- a/Backend/internal/controllers/auth_controller_test.go
+++ b/Backend/internal/controllers/auth_controller_test.go
@@ -1,0 +1,333 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"Backend/internal/middleware"
+	"Backend/internal/services"
+	"Backend/internal/services/interfaces"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ── モック ────────────────────────────────────────────────────────────────────
+
+type mockAuthService struct {
+	interfaces.AuthService
+	registerFn            func(req services.RegisterRequest) (*services.AuthResponse, error)
+	loginFn               func(req services.LoginRequest) (*services.AuthResponse, error)
+	getUserFn             func(userID uint) (*services.AuthResponse, error)
+	requestRegistrationFn func(email string) error
+	validateRegTokenFn    func(token string) (string, error)
+	updateProfileFn       func(req services.UpdateProfileRequest) (*services.AuthResponse, error)
+	resetPasswordFn       func(token, pw string) error
+	verifyEmailFn         func(token string) error
+	createGuestFn         func() (*services.AuthResponse, error)
+	deleteAccountFn       func(userID uint) error
+}
+
+func (m *mockAuthService) Register(req services.RegisterRequest) (*services.AuthResponse, error) {
+	return m.registerFn(req)
+}
+func (m *mockAuthService) Login(req services.LoginRequest) (*services.AuthResponse, error) {
+	return m.loginFn(req)
+}
+func (m *mockAuthService) GetUser(userID uint) (*services.AuthResponse, error) {
+	return m.getUserFn(userID)
+}
+func (m *mockAuthService) RequestRegistration(email string) error {
+	return m.requestRegistrationFn(email)
+}
+func (m *mockAuthService) ValidateRegistrationToken(token string) (string, error) {
+	return m.validateRegTokenFn(token)
+}
+func (m *mockAuthService) UpdateProfile(req services.UpdateProfileRequest) (*services.AuthResponse, error) {
+	return m.updateProfileFn(req)
+}
+func (m *mockAuthService) ResetPassword(token, pw string) error {
+	return m.resetPasswordFn(token, pw)
+}
+func (m *mockAuthService) VerifyEmail(token string) error {
+	return m.verifyEmailFn(token)
+}
+func (m *mockAuthService) CreateGuestUser() (*services.AuthResponse, error) {
+	return m.createGuestFn()
+}
+func (m *mockAuthService) DeleteAccount(userID uint) error {
+	return m.deleteAccountFn(userID)
+}
+func (m *mockAuthService) RequestPasswordReset(_ string) error { return nil }
+
+// ── テスト共通セットアップ ─────────────────────────────────────────────────────
+
+// newAuthTestServer はルート登録済みのEchoと記録済みレスポンスを返すヘルパー。
+// e.ServeHTTP 経由で呼ぶことでカスタムエラーハンドラーが必ず通る。
+func newAuthTestServer(svc interfaces.AuthService) (*echo.Echo, *AuthController) {
+	e := echo.New()
+	e.HTTPErrorHandler = middleware.CustomHTTPErrorHandler
+	ctrl := NewAuthController(svc)
+	return e, ctrl
+}
+
+func servePost(e *echo.Echo, path, body string, handler echo.HandlerFunc) *httptest.ResponseRecorder {
+	e.POST(path, handler)
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func serveGet(e *echo.Echo, path string, handler echo.HandlerFunc) *httptest.ResponseRecorder {
+	e.GET(path, handler)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func serveDelete(e *echo.Echo, path string, handler echo.HandlerFunc) *httptest.ResponseRecorder {
+	e.DELETE(path, handler)
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeAuthErrResp(t *testing.T, rec *httptest.ResponseRecorder) middleware.ErrorResponse {
+	t.Helper()
+	var resp middleware.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("JSONデコード失敗: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+// ── Register ──────────────────────────────────────────────────────────────────
+
+func TestRegister_DuplicateEmail_ReturnsDuplicateEmailCode(t *testing.T) {
+	svc := &mockAuthService{
+		registerFn: func(_ services.RegisterRequest) (*services.AuthResponse, error) {
+			return nil, errors.New("email already exists")
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/register", `{"email":"a@example.com","password":"pass"}`, ctrl.Register)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeDuplicateEmail {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeDuplicateEmail)
+	}
+}
+
+func TestRegister_InvalidBody_ReturnsValidationError(t *testing.T) {
+	svc := &mockAuthService{}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/register", `{invalid json`, ctrl.Register)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeValidationError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeValidationError)
+	}
+}
+
+func TestRegister_OtherError_ReturnsValidationError(t *testing.T) {
+	svc := &mockAuthService{
+		registerFn: func(_ services.RegisterRequest) (*services.AuthResponse, error) {
+			return nil, errors.New("weak password")
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/register", `{"email":"a@example.com","password":"pw"}`, ctrl.Register)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeValidationError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeValidationError)
+	}
+}
+
+func TestRegister_Success(t *testing.T) {
+	svc := &mockAuthService{
+		registerFn: func(_ services.RegisterRequest) (*services.AuthResponse, error) {
+			return &services.AuthResponse{}, nil
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/register", `{"email":"a@example.com","password":"pass"}`, ctrl.Register)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+}
+
+// ── Login ─────────────────────────────────────────────────────────────────────
+
+func TestLogin_InvalidCredentials_ReturnsUnauthorized(t *testing.T) {
+	svc := &mockAuthService{
+		loginFn: func(_ services.LoginRequest) (*services.AuthResponse, error) {
+			return nil, errors.New("invalid email or password")
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/login", `{"email":"a@example.com","password":"wrong"}`, ctrl.Login)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeUnauthorized {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeUnauthorized)
+	}
+}
+
+func TestLogin_EmailNotVerified_ReturnsForbidden(t *testing.T) {
+	for _, msg := range []string{"email_not_verified", "re_verification_required"} {
+		t.Run(msg, func(t *testing.T) {
+			svc := &mockAuthService{
+				loginFn: func(_ services.LoginRequest) (*services.AuthResponse, error) {
+					return nil, errors.New(msg)
+				},
+			}
+			e, ctrl := newAuthTestServer(svc)
+			rec := servePost(e, "/login", `{"email":"a@example.com","password":"pass"}`, ctrl.Login)
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("msg=%q: status = %d, want %d", msg, rec.Code, http.StatusForbidden)
+			}
+			resp := decodeAuthErrResp(t, rec)
+			if resp.Code != ErrCodeForbidden {
+				t.Errorf("msg=%q: code = %q, want %q", msg, resp.Code, ErrCodeForbidden)
+			}
+		})
+	}
+}
+
+func TestLogin_Success(t *testing.T) {
+	svc := &mockAuthService{
+		loginFn: func(_ services.LoginRequest) (*services.AuthResponse, error) {
+			return &services.AuthResponse{}, nil
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/login", `{"email":"a@example.com","password":"pass"}`, ctrl.Login)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// ── GetUser ───────────────────────────────────────────────────────────────────
+
+func TestGetUser_Unauthorized_WhenNoUserIDInContext(t *testing.T) {
+	svc := &mockAuthService{}
+	e, ctrl := newAuthTestServer(svc)
+	rec := serveGet(e, "/user", ctrl.GetUser)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeUnauthorized {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeUnauthorized)
+	}
+}
+
+// ── RequestRegistration ───────────────────────────────────────────────────────
+
+func TestRequestRegistration_DuplicateEmail(t *testing.T) {
+	svc := &mockAuthService{
+		requestRegistrationFn: func(_ string) error {
+			return errors.New("email already exists")
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/registration", `{"email":"a@example.com"}`, ctrl.RequestRegistration)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeDuplicateEmail {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeDuplicateEmail)
+	}
+}
+
+func TestRequestRegistration_InvalidBody(t *testing.T) {
+	svc := &mockAuthService{}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/registration", `{bad`, ctrl.RequestRegistration)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeValidationError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeValidationError)
+	}
+}
+
+// ── VerifyRegistration ────────────────────────────────────────────────────────
+
+func TestVerifyRegistration_MissingToken(t *testing.T) {
+	svc := &mockAuthService{}
+	e, ctrl := newAuthTestServer(svc)
+	rec := serveGet(e, "/verify", ctrl.VerifyRegistration)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeValidationError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeValidationError)
+	}
+}
+
+// ── ResetPassword ─────────────────────────────────────────────────────────────
+
+func TestResetPassword_InvalidToken_ReturnsValidationError(t *testing.T) {
+	svc := &mockAuthService{
+		resetPasswordFn: func(_, _ string) error {
+			return errors.New("invalid or expired token")
+		},
+	}
+	e, ctrl := newAuthTestServer(svc)
+	rec := servePost(e, "/reset", `{"token":"bad","password":"newpass"}`, ctrl.ResetPassword)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeValidationError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeValidationError)
+	}
+}
+
+// ── DeleteAccount ─────────────────────────────────────────────────────────────
+
+func TestDeleteAccount_Unauthorized_WhenNoUserID(t *testing.T) {
+	svc := &mockAuthService{}
+	e, ctrl := newAuthTestServer(svc)
+	rec := serveDelete(e, "/account", ctrl.DeleteAccount)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	resp := decodeAuthErrResp(t, rec)
+	if resp.Code != ErrCodeUnauthorized {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeUnauthorized)
+	}
+}

--- a/Backend/internal/controllers/error_response.go
+++ b/Backend/internal/controllers/error_response.go
@@ -12,12 +12,43 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// ── エラーコード定数 ──────────────────────────────────────────────────────────
+
+const (
+	ErrCodeDuplicateEmail   = "DUPLICATE_EMAIL"
+	ErrCodeNotFound         = "NOT_FOUND"
+	ErrCodeValidationError  = "VALIDATION_ERROR"
+	ErrCodeUnauthorized     = "UNAUTHORIZED"
+	ErrCodeForbidden        = "FORBIDDEN"
+	ErrCodeInvalidStatus    = "INVALID_STATUS"
+	ErrCodeInternalError    = "INTERNAL_ERROR"
+	ErrCodeServiceUnavail   = "SERVICE_UNAVAILABLE"
+	ErrCodeConflict         = "CONFLICT"
+	ErrCodeTooManyRequests  = "TOO_MANY_REQUESTS"
+)
+
+// ── ヘルパー関数 ──────────────────────────────────────────────────────────────
+
+// newAPIError はエラーコード付きの echo エラーを生成する。
+// detail は省略可能（省略時はレスポンスに含まれない）。
+func newAPIError(status int, code, message string, detail ...string) error {
+	d := ""
+	if len(detail) > 0 {
+		d = detail[0]
+	}
+	return echo.NewHTTPError(status, middleware.APIError{
+		Code:   code,
+		Msg:    message,
+		Detail: d,
+	})
+}
+
 // echoUintParam はパスパラメータを uint として取得する。
 func echoUintParam(c echo.Context, key string) (uint, error) {
 	s := c.Param(key)
 	id, err := strconv.ParseUint(s, 10, 64)
 	if err != nil || id == 0 {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "invalid "+key)
+		return 0, newAPIError(http.StatusBadRequest, ErrCodeValidationError, "invalid "+key)
 	}
 	return uint(id), nil
 }
@@ -27,7 +58,7 @@ const internalServerErrorMessage = "内部エラーが発生しました"
 // echoInternalError はエラーをログ出力しつつ echo.HTTPError を返す。
 func echoInternalError(err error) error {
 	logError(err)
-	return echo.NewHTTPError(http.StatusInternalServerError, internalServerErrorMessage)
+	return newAPIError(http.StatusInternalServerError, ErrCodeInternalError, internalServerErrorMessage)
 }
 
 // echoUserID は echo.Context のリクエストコンテキストからユーザーIDを取得する。

--- a/Backend/internal/controllers/error_response_test.go
+++ b/Backend/internal/controllers/error_response_test.go
@@ -1,0 +1,193 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/middleware"
+
+	"github.com/labstack/echo/v4"
+)
+
+// setupEcho はテスト用のEchoインスタンスを生成する
+func setupEcho() *echo.Echo {
+	e := echo.New()
+	e.HTTPErrorHandler = middleware.CustomHTTPErrorHandler
+	return e
+}
+
+func decodeErrResp(t *testing.T, rec *httptest.ResponseRecorder) middleware.ErrorResponse {
+	t.Helper()
+	var resp middleware.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("レスポンスのJSONデコード失敗: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+// ── newAPIError ────────────────────────────────────────────────────────────────
+
+func TestNewAPIError_WithCode(t *testing.T) {
+	e := setupEcho()
+	e.GET("/", func(c echo.Context) error {
+		return newAPIError(http.StatusConflict, ErrCodeDuplicateEmail, "email already exists")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+	resp := decodeErrResp(t, rec)
+	if resp.Code != ErrCodeDuplicateEmail {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeDuplicateEmail)
+	}
+	if resp.Error != "email already exists" {
+		t.Errorf("error = %q, want %q", resp.Error, "email already exists")
+	}
+}
+
+func TestNewAPIError_WithDetail(t *testing.T) {
+	e := setupEcho()
+	e.GET("/", func(c echo.Context) error {
+		return newAPIError(http.StatusBadRequest, ErrCodeValidationError, "invalid input", "nameフィールドは必須です")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	resp := decodeErrResp(t, rec)
+	if resp.Detail != "nameフィールドは必須です" {
+		t.Errorf("detail = %q, want %q", resp.Detail, "nameフィールドは必須です")
+	}
+}
+
+func TestNewAPIError_WithoutDetail(t *testing.T) {
+	e := setupEcho()
+	e.GET("/", func(c echo.Context) error {
+		return newAPIError(http.StatusNotFound, ErrCodeNotFound, "not found")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("JSONデコード失敗: %v", err)
+	}
+	if _, exists := raw["detail"]; exists {
+		t.Error("detail を省略したとき JSON に含まれるべきでない")
+	}
+}
+
+// ── echoInternalError ─────────────────────────────────────────────────────────
+
+func TestEchoInternalError(t *testing.T) {
+	e := setupEcho()
+	e.GET("/", func(c echo.Context) error {
+		return echoInternalError(errors.New("db connection failed"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	resp := decodeErrResp(t, rec)
+	if resp.Code != ErrCodeInternalError {
+		t.Errorf("code = %q, want %q", resp.Code, ErrCodeInternalError)
+	}
+	if resp.Error != internalServerErrorMessage {
+		t.Errorf("error = %q, want %q", resp.Error, internalServerErrorMessage)
+	}
+}
+
+// ── echoUintParam ─────────────────────────────────────────────────────────────
+
+func TestEchoUintParam_Valid(t *testing.T) {
+	e := setupEcho()
+	e.GET("/items/:id", func(c echo.Context) error {
+		id, err := echoUintParam(c, "id")
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, map[string]uint{"id": id})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/items/42", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestEchoUintParam_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		param string
+	}{
+		{"文字列", "abc"},
+		{"ゼロ", "0"},
+		{"負の値", "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := setupEcho()
+			e.GET("/items/:id", func(c echo.Context) error {
+				_, err := echoUintParam(c, "id")
+				return err
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/items/"+tt.param, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("param=%q: status = %d, want %d", tt.param, rec.Code, http.StatusBadRequest)
+			}
+			resp := decodeErrResp(t, rec)
+			if resp.Code != ErrCodeValidationError {
+				t.Errorf("param=%q: code = %q, want %q", tt.param, resp.Code, ErrCodeValidationError)
+			}
+		})
+	}
+}
+
+// ── エラーコード定数 ──────────────────────────────────────────────────────────
+
+func TestErrorCodeConstants(t *testing.T) {
+	codes := []string{
+		ErrCodeDuplicateEmail,
+		ErrCodeNotFound,
+		ErrCodeValidationError,
+		ErrCodeUnauthorized,
+		ErrCodeForbidden,
+		ErrCodeInvalidStatus,
+		ErrCodeInternalError,
+		ErrCodeServiceUnavail,
+		ErrCodeConflict,
+		ErrCodeTooManyRequests,
+	}
+	seen := make(map[string]bool)
+	for _, c := range codes {
+		if c == "" {
+			t.Error("空のエラーコード定数が存在する")
+		}
+		if seen[c] {
+			t.Errorf("重複したエラーコード定数: %q", c)
+		}
+		seen[c] = true
+	}
+}

--- a/Backend/internal/middleware/error_handler.go
+++ b/Backend/internal/middleware/error_handler.go
@@ -9,8 +9,43 @@ import (
 
 // ErrorResponse はAPIエラーレスポンスの統一形式
 type ErrorResponse struct {
-	Error string `json:"error"`
-	Code  int    `json:"code"`
+	Error  string `json:"error"`
+	Code   string `json:"code"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// APIError はエラーコードと詳細を持つ構造体。
+// echo.NewHTTPError の Message として渡すことで構造化エラーを返せる。
+type APIError struct {
+	Code   string
+	Msg    string
+	Detail string
+}
+
+// defaultCodeByStatus は HTTPステータスコードからデフォルトのエラーコードを返す。
+func defaultCodeByStatus(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "VALIDATION_ERROR"
+	case http.StatusUnauthorized:
+		return "UNAUTHORIZED"
+	case http.StatusForbidden:
+		return "FORBIDDEN"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	case http.StatusConflict:
+		return "CONFLICT"
+	case http.StatusUnprocessableEntity:
+		return "VALIDATION_ERROR"
+	case http.StatusTooManyRequests:
+		return "TOO_MANY_REQUESTS"
+	case http.StatusBadGateway:
+		return "BAD_GATEWAY"
+	case http.StatusServiceUnavailable:
+		return "SERVICE_UNAVAILABLE"
+	default:
+		return "INTERNAL_ERROR"
+	}
 }
 
 // CustomHTTPErrorHandler はEchoのグローバルエラーハンドラー。
@@ -20,16 +55,34 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 		return
 	}
 
-	code := http.StatusInternalServerError
-	message := http.StatusText(code)
+	status := http.StatusInternalServerError
+	resp := ErrorResponse{
+		Error: http.StatusText(status),
+		Code:  defaultCodeByStatus(status),
+	}
 
 	var he *echo.HTTPError
 	if errors.As(err, &he) {
-		code = he.Code
-		if m, ok := he.Message.(string); ok {
-			message = m
+		status = he.Code
+		switch msg := he.Message.(type) {
+		case APIError:
+			resp = ErrorResponse{
+				Error:  msg.Msg,
+				Code:   msg.Code,
+				Detail: msg.Detail,
+			}
+		case string:
+			resp = ErrorResponse{
+				Error: msg,
+				Code:  defaultCodeByStatus(status),
+			}
+		default:
+			resp = ErrorResponse{
+				Error: http.StatusText(status),
+				Code:  defaultCodeByStatus(status),
+			}
 		}
 	}
 
-	_ = c.JSON(code, ErrorResponse{Error: message, Code: code})
+	_ = c.JSON(status, resp)
 }

--- a/Backend/internal/middleware/error_handler_test.go
+++ b/Backend/internal/middleware/error_handler_test.go
@@ -1,0 +1,217 @@
+package middleware
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func newTestEcho() *echo.Echo {
+	e := echo.New()
+	e.HTTPErrorHandler = CustomHTTPErrorHandler
+	return e
+}
+
+func decodeErrorResponse(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var resp ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("レスポンスのJSONデコード失敗: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+// TestDefaultCodeByStatus はHTTPステータスコードからエラーコードへの変換を検証する
+func TestDefaultCodeByStatus(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{http.StatusBadRequest, "VALIDATION_ERROR"},
+		{http.StatusUnauthorized, "UNAUTHORIZED"},
+		{http.StatusForbidden, "FORBIDDEN"},
+		{http.StatusNotFound, "NOT_FOUND"},
+		{http.StatusConflict, "CONFLICT"},
+		{http.StatusUnprocessableEntity, "VALIDATION_ERROR"},
+		{http.StatusTooManyRequests, "TOO_MANY_REQUESTS"},
+		{http.StatusBadGateway, "BAD_GATEWAY"},
+		{http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE"},
+		{http.StatusInternalServerError, "INTERNAL_ERROR"},
+		{http.StatusTeapot, "INTERNAL_ERROR"}, // 未定義ステータスはINTERNAL_ERRORにフォールバック
+	}
+
+	for _, tt := range tests {
+		got := defaultCodeByStatus(tt.status)
+		if got != tt.want {
+			t.Errorf("defaultCodeByStatus(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+// TestCustomHTTPErrorHandler_PlainStringMessage は文字列メッセージのecho.HTTPErrorを検証する
+func TestCustomHTTPErrorHandler_PlainStringMessage(t *testing.T) {
+	e := newTestEcho()
+	e.GET("/test", func(c echo.Context) error {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid input")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	resp := decodeErrorResponse(t, rec)
+	if resp.Error != "invalid input" {
+		t.Errorf("error = %q, want %q", resp.Error, "invalid input")
+	}
+	if resp.Code != "VALIDATION_ERROR" {
+		t.Errorf("code = %q, want %q", resp.Code, "VALIDATION_ERROR")
+	}
+	if resp.Detail != "" {
+		t.Errorf("detail は空であるべき, got %q", resp.Detail)
+	}
+}
+
+// TestCustomHTTPErrorHandler_APIErrorMessage はAPIError構造体を使ったエラーを検証する
+func TestCustomHTTPErrorHandler_APIErrorMessage(t *testing.T) {
+	e := newTestEcho()
+	e.GET("/test", func(c echo.Context) error {
+		return echo.NewHTTPError(http.StatusConflict, APIError{
+			Code:   "DUPLICATE_EMAIL",
+			Msg:    "email already exists",
+			Detail: "このメールアドレスは既に登録されています",
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusConflict)
+	}
+	resp := decodeErrorResponse(t, rec)
+	if resp.Error != "email already exists" {
+		t.Errorf("error = %q, want %q", resp.Error, "email already exists")
+	}
+	if resp.Code != "DUPLICATE_EMAIL" {
+		t.Errorf("code = %q, want %q", resp.Code, "DUPLICATE_EMAIL")
+	}
+	if resp.Detail != "このメールアドレスは既に登録されています" {
+		t.Errorf("detail = %q, want %q", resp.Detail, "このメールアドレスは既に登録されています")
+	}
+}
+
+// TestCustomHTTPErrorHandler_APIErrorWithoutDetail はDetailが空のAPIErrorを検証する
+func TestCustomHTTPErrorHandler_APIErrorWithoutDetail(t *testing.T) {
+	e := newTestEcho()
+	e.GET("/test", func(c echo.Context) error {
+		return echo.NewHTTPError(http.StatusNotFound, APIError{
+			Code: "NOT_FOUND",
+			Msg:  "user not found",
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	resp := decodeErrorResponse(t, rec)
+	if resp.Code != "NOT_FOUND" {
+		t.Errorf("code = %q, want %q", resp.Code, "NOT_FOUND")
+	}
+
+	// detail フィールドがJSONに含まれないことを確認
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("JSONデコード失敗: %v", err)
+	}
+	if _, exists := raw["detail"]; exists {
+		t.Error("detail が空のとき JSON に含まれるべきでない")
+	}
+}
+
+// TestCustomHTTPErrorHandler_InternalServerError は500エラーを検証する
+func TestCustomHTTPErrorHandler_InternalServerError(t *testing.T) {
+	e := newTestEcho()
+	e.GET("/test", func(c echo.Context) error {
+		return errors.New("unexpected db error")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	resp := decodeErrorResponse(t, rec)
+	if resp.Code != "INTERNAL_ERROR" {
+		t.Errorf("code = %q, want %q", resp.Code, "INTERNAL_ERROR")
+	}
+}
+
+// TestCustomHTTPErrorHandler_ResponseAlreadyCommitted はレスポンス送信済みの場合に二重送信しないことを検証する
+func TestCustomHTTPErrorHandler_ResponseAlreadyCommitted(t *testing.T) {
+	e := newTestEcho()
+	e.GET("/test", func(c echo.Context) error {
+		// 先に200レスポンスを送信してCommittedをtrueにする
+		_ = c.String(http.StatusOK, "ok")
+		return echo.NewHTTPError(http.StatusBadRequest, "too late")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// 最初のレスポンス（200）が返り、エラーで上書きされないこと
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestErrorResponse_JSONSerialization はErrorResponseのJSONシリアライズを検証する
+func TestErrorResponse_JSONSerialization(t *testing.T) {
+	tests := []struct {
+		name       string
+		resp       ErrorResponse
+		wantDetail bool
+	}{
+		{
+			name:       "detail あり",
+			resp:       ErrorResponse{Error: "msg", Code: "CODE", Detail: "detail"},
+			wantDetail: true,
+		},
+		{
+			name:       "detail なし（omitempty）",
+			resp:       ErrorResponse{Error: "msg", Code: "CODE"},
+			wantDetail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.resp)
+			if err != nil {
+				t.Fatalf("JSONマーシャル失敗: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(b, &raw); err != nil {
+				t.Fatalf("JSONアンマーシャル失敗: %v", err)
+			}
+			_, hasDetail := raw["detail"]
+			if hasDetail != tt.wantDetail {
+				t.Errorf("detail 存在 = %v, want %v", hasDetail, tt.wantDetail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #396

## 変更内容

### `Backend/internal/middleware/error_handler.go`
- `ErrorResponse` 構造体に `Code string`（エラーコード）と `Detail string`（詳細、omitempty）フィールドを追加
- `APIError` 構造体を新設。`echo.NewHTTPError` の `Message` として渡すことで、コントローラーから構造化エラーコードを渡せるように
- `defaultCodeByStatus()` を追加し、HTTPステータスコードからデフォルトのエラーコードを自動マッピング（400→`VALIDATION_ERROR`、401→`UNAUTHORIZED`、404→`NOT_FOUND`、409→`CONFLICT` 等）
- `CustomHTTPErrorHandler` を拡張し、`APIError` / 文字列メッセージ / その他の3パターンを統一的に処理

### `Backend/internal/controllers/error_response.go`
- エラーコード定数を定義（`DUPLICATE_EMAIL`, `NOT_FOUND`, `VALIDATION_ERROR`, `UNAUTHORIZED`, `FORBIDDEN`, `INVALID_STATUS`, `INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`, `CONFLICT`, `TOO_MANY_REQUESTS`）
- `newAPIError(status, code, message, detail...)` ヘルパーを追加し、型安全な構造化エラー生成を統一
- 既存の `echoInternalError` / `echoUintParam` を `newAPIError` ベースにリファクタ

### `Backend/internal/controllers/auth_controller.go`
- 全 `echo.NewHTTPError` 呼び出しを `newAPIError` に置き換え
- メールアドレス重複 → `DUPLICATE_EMAIL`、ユーザー未存在 → `NOT_FOUND`、認証失敗 → `UNAUTHORIZED`、バリデーション → `VALIDATION_ERROR` のコードを付与
- `email_not_verified` / `re_verification_required` のレスポンスを `map[string]string` から `newAPIError` の統一形式に変更

## レスポンス形式の変化

```json
// Before
{"error": "email already exists", "code": 409}

// After
{"error": "email already exists", "code": "DUPLICATE_EMAIL"}
```

## 後方互換性

既存の `echo.NewHTTPError(status, "文字列")` はカスタムエラーハンドラーがステータスから自動でコードを割り当てるため、変更していないコントローラーも即座に新形式に対応済み。