### PR TITLE
Resolve #399 機能間連携スコア更新結果の可視化

### DIFF
--- a/frontend/app/api/user/weight-scores/route.ts
+++ b/frontend/app/api/user/weight-scores/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const userId = searchParams.get('user_id')
+  const sessionId = searchParams.get('session_id')
+
+  if (!userId || !sessionId) {
+    return NextResponse.json({ error: 'user_id and session_id are required' }, { status: 400 })
+  }
+
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/user/profile?user_id=${encodeURIComponent(userId)}&session_id=${encodeURIComponent(sessionId)}`,
+    )
+    if (!res.ok) {
+      return NextResponse.json({ weight_scores: [] }, { status: 200 })
+    }
+    const data = await res.json()
+    return NextResponse.json({ weight_scores: data.weight_scores ?? [] })
+  } catch {
+    return NextResponse.json({ weight_scores: [] }, { status: 200 })
+  }
+}

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -45,6 +45,7 @@ import { interviewApi, interviewLimits, InterviewReport, InterviewSession } from
 import { formatSeconds, parseJsonSafe, parseMediaError, parseMultipartResponse } from '@/lib/interview-utils'
 import ThreeAvatar from './components/ThreeAvatar'
 import InterviewSummary from './components/InterviewSummary'
+import ScoreUpdateBanner, { WeightScore } from '@/components/ScoreUpdateBanner'
 
 const PRIMARY = '#ec5b13'
 const BG_LIGHT = '#f8f6f6'
@@ -140,6 +141,9 @@ function InterviewContent() {
   const [videoUploadStatus, setVideoUploadStatus] = useState<'idle' | 'uploading' | 'done' | 'error'>('idle')
   const [videoUploadProgress, setVideoUploadProgress] = useState(0)
   const [videoSizeWarning, setVideoSizeWarning] = useState<string | null>(null)
+
+  const [scoresBefore, setScoresBefore] = useState<WeightScore[] | null>(null)
+  const [scoresAfter, setScoresAfter] = useState<WeightScore[] | null>(null)
 
   const streamRef = useRef<MediaStream | null>(null)
   const lobbyVideoRef = useRef<HTMLVideoElement | null>(null)
@@ -550,6 +554,12 @@ function InterviewContent() {
     const currentSession = session
     const currentUser = user
     if (currentUser && currentSession) {
+      const scoreSessionId = `interview-${currentUser.user_id}`
+      try {
+        const res = await fetch(`/api/user/weight-scores?user_id=${currentUser.user_id}&session_id=${encodeURIComponent(scoreSessionId)}`)
+        const data = await res.json()
+        setScoresBefore(data.weight_scores ?? null)
+      } catch { /* ignore */ }
       try { await interviewApi.finishSession(currentSession.id, currentUser.user_id) } catch { /* ignore */ }
     }
     setStatus('finished')
@@ -587,6 +597,12 @@ function InterviewContent() {
         if (detail.report) {
           setReport(detail.report); setReportStatus('ready')
           clearInterval(pollRef.current!); pollRef.current = null
+          const scoreSessionId = `interview-${userId}`
+          try {
+            const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(scoreSessionId)}`)
+            const data = await res.json()
+            setScoresAfter(data.weight_scores ?? null)
+          } catch { /* ignore */ }
         }
       } catch { setReportStatus('error') }
     }, 3000)
@@ -1320,6 +1336,11 @@ function InterviewContent() {
 
           {reportStatus === 'ready' && report && (
             <Stack spacing={2}>
+              <ScoreUpdateBanner
+                beforeScores={scoresBefore}
+                afterScores={scoresAfter}
+                title="面接結果がプロフィールスコアに反映されました"
+              />
               <InterviewSummary report={report} userId={user?.user_id} theme="dark" />
               <Button
                 variant="outlined"

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -18,6 +18,7 @@ import {
   Chip,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import ScoreUpdateBanner, { WeightScore } from '@/components/ScoreUpdateBanner'
 
 type ReviewItem = {
   id: number
@@ -61,6 +62,8 @@ function ResumeContent() {
   const [annotateError, setAnnotateError] = useState('')
   const [review, setReview] = useState<ReviewResult | null>(null)
   const [ragReport, setRagReport] = useState('')
+  const [scoresBefore, setScoresBefore] = useState<WeightScore[] | null>(null)
+  const [scoresAfter, setScoresAfter] = useState<WeightScore[] | null>(null)
 
   const checkAnnotatedPdfAvailable = async (id: number) => {
     try {
@@ -161,7 +164,16 @@ function ResumeContent() {
     setAnnotateError('')
     setReview(null)
     setRagReport('')
+    setScoresAfter(null)
     setReviewLoading(true)
+
+    if (userId && sessionId) {
+      try {
+        const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
+        const data = await res.json()
+        setScoresBefore(data.weight_scores ?? null)
+      } catch { /* ignore */ }
+    }
 
     try {
       const response = await fetch(`/api/resume/review/stream?document_id=${documentId}`, {
@@ -201,6 +213,13 @@ function ResumeContent() {
               const backendAnnotated = data.annotated_available === true
               const annotatedAvailable = backendAnnotated || (documentId ? await checkAnnotatedPdfAvailable(documentId) : false)
               setReview({ review: data.review, items: data.items, annotated_available: annotatedAvailable })
+              if (userId && sessionId) {
+                try {
+                  const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
+                  const scoreData = await res.json()
+                  setScoresAfter(scoreData.weight_scores ?? null)
+                } catch { /* ignore */ }
+              }
             } else if (data.type === 'annotate_error') {
               setAnnotateError(data.message)
             } else if (data.type === 'error') {
@@ -390,6 +409,16 @@ function ResumeContent() {
             {ragReport}
           </Box>
         </Paper>
+      )}
+
+      {review && scoresAfter && (
+        <Box mt={4}>
+          <ScoreUpdateBanner
+            beforeScores={scoresBefore}
+            afterScores={scoresAfter}
+            title="職務経歴書レビュー結果がプロフィールスコアに反映されました"
+          />
+        </Box>
       )}
 
       {review && (

--- a/frontend/components/ScoreUpdateBanner.tsx
+++ b/frontend/components/ScoreUpdateBanner.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { Box, Chip, Collapse, IconButton, Paper, Stack, Typography } from '@mui/material'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+import TrendingDownIcon from '@mui/icons-material/TrendingDown'
+import RemoveIcon from '@mui/icons-material/Remove'
+import CloseIcon from '@mui/icons-material/Close'
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import { useState } from 'react'
+
+export type WeightScore = {
+  weight_category: string
+  score: number
+}
+
+export type ScoreDelta = {
+  category: string
+  before: number
+  after: number
+  delta: number
+}
+
+export function computeScoreDeltas(before: WeightScore[], after: WeightScore[]): ScoreDelta[] {
+  const beforeMap = new Map(before.map(s => [s.weight_category, s.score]))
+  return after
+    .map(s => {
+      const prev = beforeMap.get(s.weight_category) ?? 0
+      return {
+        category: s.weight_category,
+        before: prev,
+        after: s.score,
+        delta: s.score - prev,
+      }
+    })
+    .filter(d => d.delta !== 0)
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+}
+
+type Props = {
+  beforeScores: WeightScore[] | null
+  afterScores: WeightScore[] | null
+  title?: string
+}
+
+export default function ScoreUpdateBanner({ beforeScores, afterScores, title = 'プロフィールスコアが更新されました' }: Props) {
+  const [open, setOpen] = useState(true)
+
+  if (!afterScores || afterScores.length === 0) return null
+
+  const deltas = beforeScores ? computeScoreDeltas(beforeScores, afterScores) : []
+  const hasChanges = deltas.length > 0
+
+  return (
+    <Collapse in={open}>
+      <Paper
+        elevation={0}
+        sx={{
+          border: '1px solid',
+          borderColor: 'primary.light',
+          borderRadius: 2,
+          bgcolor: 'primary.50',
+          p: 2,
+          mb: 2,
+        }}
+      >
+        <Stack direction="row" alignItems="flex-start" spacing={1}>
+          <AutoAwesomeIcon color="primary" sx={{ mt: 0.25 }} />
+          <Box flex={1}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between">
+              <Typography fontWeight={700} color="primary.main" fontSize="0.95rem">
+                {title}
+              </Typography>
+              <IconButton size="small" onClick={() => setOpen(false)}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+
+            {hasChanges ? (
+              <Stack direction="row" flexWrap="wrap" gap={1} mt={1}>
+                {deltas.map(d => (
+                  <DeltaChip key={d.category} delta={d} />
+                ))}
+              </Stack>
+            ) : (
+              <Typography variant="body2" color="text.secondary" mt={0.5}>
+                今回のセッション結果がプロフィールに反映されました。
+              </Typography>
+            )}
+          </Box>
+        </Stack>
+      </Paper>
+    </Collapse>
+  )
+}
+
+function DeltaChip({ delta }: { delta: ScoreDelta }) {
+  if (delta.delta > 0) {
+    return (
+      <Chip
+        icon={<TrendingUpIcon />}
+        label={`${delta.category} +${delta.delta}`}
+        size="small"
+        color="success"
+        variant="outlined"
+      />
+    )
+  }
+  if (delta.delta < 0) {
+    return (
+      <Chip
+        icon={<TrendingDownIcon />}
+        label={`${delta.category} ${delta.delta}`}
+        size="small"
+        color="error"
+        variant="outlined"
+      />
+    )
+  }
+  return (
+    <Chip
+      icon={<RemoveIcon />}
+      label={delta.category}
+      size="small"
+      variant="outlined"
+    />
+  )
+}

--- a/frontend/tests/components/score-update-banner.test.ts
+++ b/frontend/tests/components/score-update-banner.test.ts
@@ -1,0 +1,68 @@
+import { computeScoreDeltas } from '@/components/ScoreUpdateBanner'
+import type { WeightScore } from '@/components/ScoreUpdateBanner'
+
+describe('computeScoreDeltas', () => {
+  const before: WeightScore[] = [
+    { weight_category: '論理性', score: 60 },
+    { weight_category: '伝達力', score: 50 },
+    { weight_category: '熱意', score: 70 },
+    { weight_category: 'リーダーシップ', score: 40 },
+  ]
+
+  it('スコアが増加したカテゴリを検出する', () => {
+    const after: WeightScore[] = [
+      { weight_category: '論理性', score: 75 },
+      { weight_category: '伝達力', score: 50 },
+      { weight_category: '熱意', score: 70 },
+      { weight_category: 'リーダーシップ', score: 40 },
+    ]
+    const deltas = computeScoreDeltas(before, after)
+    expect(deltas).toHaveLength(1)
+    expect(deltas[0]).toMatchObject({ category: '論理性', before: 60, after: 75, delta: 15 })
+  })
+
+  it('スコアが減少したカテゴリを検出する', () => {
+    const after: WeightScore[] = [
+      { weight_category: '論理性', score: 60 },
+      { weight_category: '伝達力', score: 40 },
+      { weight_category: '熱意', score: 70 },
+      { weight_category: 'リーダーシップ', score: 40 },
+    ]
+    const deltas = computeScoreDeltas(before, after)
+    expect(deltas).toHaveLength(1)
+    expect(deltas[0]).toMatchObject({ category: '伝達力', before: 50, after: 40, delta: -10 })
+  })
+
+  it('変化がない場合は空配列を返す', () => {
+    const after: WeightScore[] = [...before]
+    const deltas = computeScoreDeltas(before, after)
+    expect(deltas).toHaveLength(0)
+  })
+
+  it('複数カテゴリの変化を絶対値の大きい順で返す', () => {
+    const after: WeightScore[] = [
+      { weight_category: '論理性', score: 65 },    // +5
+      { weight_category: '伝達力', score: 70 },    // +20
+      { weight_category: '熱意', score: 60 },      // -10
+      { weight_category: 'リーダーシップ', score: 40 },
+    ]
+    const deltas = computeScoreDeltas(before, after)
+    expect(deltas).toHaveLength(3)
+    expect(Math.abs(deltas[0].delta)).toBeGreaterThanOrEqual(Math.abs(deltas[1].delta))
+    expect(Math.abs(deltas[1].delta)).toBeGreaterThanOrEqual(Math.abs(deltas[2].delta))
+  })
+
+  it('before に存在しないカテゴリは0からのデルタとして計算する', () => {
+    const after: WeightScore[] = [
+      { weight_category: '新カテゴリ', score: 50 },
+    ]
+    const deltas = computeScoreDeltas([], after)
+    expect(deltas).toHaveLength(1)
+    expect(deltas[0]).toMatchObject({ category: '新カテゴリ', before: 0, after: 50, delta: 50 })
+  })
+
+  it('after が空の場合は空配列を返す', () => {
+    const deltas = computeScoreDeltas(before, [])
+    expect(deltas).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #399

## 変更内容

### 新規ファイル

**`components/ScoreUpdateBanner.tsx`**
- 面接・職務経歴書完了後に表示するスコア更新通知バナー
- `computeScoreDeltas(before, after)` — before/after の WeightScore を比較し差分リストを生成（純粋関数）
- TrendingUp/Down アイコン付きチップでカテゴリ別増減値を視覚化
- 変化なしの場合は「セッション結果が反映されました」メッセージを表示

**`app/api/user/weight-scores/route.ts`**
- バックエンドの `GET /api/user/profile` にプロキシする Next.js API ルート
- `?user_id=&session_id=` パラメータで現在の weight_scores を取得

### 修正ファイル

**`app/interview/page.tsx`**
- `finishSession` 呼び出し前にスコアを取得（セッションID: `interview-{userId}`）
- レポートポーリング完了時に新スコアを取得
- レポート画面に `ScoreUpdateBanner` を表示

**`app/resume/page.tsx`**
- `handleReview` 開始前にスコアを取得
- SSE ストリームの `complete` イベント時に新スコアを取得
- レビュー結果表示の直前に `ScoreUpdateBanner` を表示

### テスト
- `computeScoreDeltas` の6ケース（増加・減少・変化なし・複数同時・新規カテゴリ・空配列）、全件パス