### PR TITLE
Resolve #457: GitHub分析プロンプトを職種別・ユーザー文脈に最適化する

### DIFF
--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -142,12 +142,13 @@ func (c *GitHubController) SummarizeRepo(ctx echo.Context) error {
 	var body struct {
 		FullName     string `json:"full_name"`
 		ForceRefresh bool   `json:"force_refresh"`
+		TargetRole   string `json:"target_role"`
 	}
 	if err := ctx.Bind(&body); err != nil || body.FullName == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "full_name is required")
 	}
 
-	summary, err := c.githubService.SummarizeRepo(ctx.Request().Context(), userID, body.FullName, body.ForceRefresh)
+	summary, err := c.githubService.SummarizeRepo(ctx.Request().Context(), userID, body.FullName, body.ForceRefresh, body.TargetRole)
 	if err != nil {
 		return echoInternalError(err)
 	}

--- a/Backend/internal/services/github_service.go
+++ b/Backend/internal/services/github_service.go
@@ -31,6 +31,8 @@ const (
 	// レート制限リトライ: 最大2回
 	maxRetries                  = 2
 	githubTokenEncryptionKeyEnv = "GITHUB_TOKEN_ENCRYPTION_KEY"
+	// プロンプトバージョン（#457）
+	repoSummaryPromptVersion = "v2"
 )
 
 // GitHubService GitHub API連携サービス
@@ -274,7 +276,8 @@ func (s *GitHubService) ListRepoSummaries(userID uint) ([]models.GitHubRepoSumma
 
 // SummarizeRepo リポジトリのREADMEをAIが解析し、技術的強みを要約する。
 // キャッシュがあれば再生成しない。forceRefresh=trueで強制再生成。
-func (s *GitHubService) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error) {
+// targetRole は志望職種（例: "エンジニア", "マーケ", "営業"）で、分析観点をカスタマイズする（#457）。
+func (s *GitHubService) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool, targetRole string) (*models.GitHubRepoSummary, error) {
 	// キャッシュ確認
 	if !forceRefresh {
 		cached, err := s.githubRepo.GetRepoSummary(userID, fullName)
@@ -305,7 +308,7 @@ func (s *GitHubService) SummarizeRepo(ctx context.Context, userID uint, fullName
 	}
 
 	// AI要約生成
-	summary, err := s.generateRepoSummary(ctx, fullName, readme)
+	summary, err := s.generateRepoSummary(ctx, fullName, readme, targetRole)
 	if err != nil {
 		return nil, fmt.Errorf("AI summary generation failed: %w", err)
 	}
@@ -347,8 +350,51 @@ func (s *GitHubService) fetchREADME(ctx context.Context, client *http.Client, to
 	return resp.Content, nil
 }
 
-// generateRepoSummary OpenAIを使ってリポジトリの技術的強みを要約する
-func (s *GitHubService) generateRepoSummary(ctx context.Context, fullName, readme string) (*models.GitHubRepoSummary, error) {
+// roleBasedPromptConfig 職種別プロンプト設定（#457）
+type roleBasedPromptConfig struct {
+	systemRole   string
+	analysisFocus string
+	summaryHint   string
+}
+
+// getRolePromptConfig 志望職種に応じたプロンプト設定を返す（#457）
+func getRolePromptConfig(targetRole string) roleBasedPromptConfig {
+	switch {
+	case strings.Contains(targetRole, "エンジニア") || strings.Contains(targetRole, "engineer") || strings.Contains(targetRole, "開発"):
+		return roleBasedPromptConfig{
+			systemRole:    "エンジニア採用のキャリアアドバイザー",
+			analysisFocus: "技術スキル・アーキテクチャ設計力・コード品質",
+			summaryHint:   "使用技術・設計パターン・実装上の工夫を重点的に評価してください",
+		}
+	case strings.Contains(targetRole, "マーケ") || strings.Contains(targetRole, "marketing"):
+		return roleBasedPromptConfig{
+			systemRole:    "マーケティング職採用のキャリアアドバイザー",
+			analysisFocus: "技術への理解度・データ活用能力・ツール活用力",
+			summaryHint:   "技術を使って何を実現したか、データ分析・自動化・ツール活用の観点で評価してください",
+		}
+	case strings.Contains(targetRole, "営業") || strings.Contains(targetRole, "sales"):
+		return roleBasedPromptConfig{
+			systemRole:    "営業職採用のキャリアアドバイザー",
+			analysisFocus: "プロジェクト管理能力・課題解決力・コミュニケーション能力の証拠",
+			summaryHint:   "プロジェクトをどう推進したか、課題発見〜解決のプロセスを重点的に評価してください",
+		}
+	case strings.Contains(targetRole, "デザイン") || strings.Contains(targetRole, "design"):
+		return roleBasedPromptConfig{
+			systemRole:    "デザイン職採用のキャリアアドバイザー",
+			analysisFocus: "UIへの配慮・UX思考・フロントエンド技術への理解",
+			summaryHint:   "ユーザー体験や見た目への配慮、フロントエンド実装の質を重点的に評価してください",
+		}
+	default:
+		return roleBasedPromptConfig{
+			systemRole:    "IT業界採用のキャリアアドバイザー",
+			analysisFocus: "技術的強み・実装力・問題解決能力",
+			summaryHint:   "このリポジトリで発揮された技術力と問題解決の観点で評価してください",
+		}
+	}
+}
+
+// generateRepoSummary OpenAIを使ってリポジトリの技術的強みを要約する（#457: 職種別プロンプト対応）
+func (s *GitHubService) generateRepoSummary(ctx context.Context, fullName, readme, targetRole string) (*models.GitHubRepoSummary, error) {
 	if s.openaiClient == nil {
 		return nil, fmt.Errorf("openai client not configured")
 	}
@@ -358,23 +404,27 @@ func (s *GitHubService) generateRepoSummary(ctx context.Context, fullName, readm
 		readmeSection = readme
 	}
 
-	systemPrompt := `あなたはエンジニア採用のキャリアアドバイザーです。
-GitHubリポジトリのREADMEを読み、技術的な強みを簡潔にまとめてください。JSONのみで返してください。`
+	cfg := getRolePromptConfig(targetRole)
+	log.Printf("[SummarizeRepo] prompt_version=%s repo=%s target_role=%q focus=%s", repoSummaryPromptVersion, fullName, targetRole, cfg.analysisFocus)
 
-	userPrompt := fmt.Sprintf(`以下のGitHubリポジトリ「%s」のREADMEを読み、エンジニア採用担当者に伝わる技術的強みを3点でまとめてください。
+	systemPrompt := fmt.Sprintf(`あなたは%sです。
+GitHubリポジトリのREADMEを読み、%sの観点から強みを簡潔にまとめてください。JSONのみで返してください。`, cfg.systemRole, cfg.analysisFocus)
+
+	userPrompt := fmt.Sprintf(`以下のGitHubリポジトリ「%s」のREADMEを読み、%sの観点でまとめてください。
+%s
 
 ## README
 %s
 
 ## 出力フォーマット（このキーと型を厳守）
 {
-  "summary_text": "技術的な強みの3行要約（全体を1段落で簡潔に）",
+  "summary_text": "リポジトリの強みの要約（全体を1段落で簡潔に）",
   "tech_reason": "技術選定の理由（なぜその技術・言語・フレームワークを選んだか）",
   "challenge": "解決した課題（どんな問題に取り組み、どう解決したか）",
   "achievement": "成果（数値・具体的な改善・学んだこと）"
 }
 
-※ 情報が不足している場合はREADMEから推測して記述してください。各フィールドは1〜2文で簡潔に。`, fullName, readmeSection)
+※ 情報が不足している場合はREADMEから推測して記述してください。各フィールドは1〜2文で簡潔に。`, fullName, cfg.analysisFocus, cfg.summaryHint, readmeSection)
 
 	raw, err := s.openaiClient.ChatCompletionJSON(ctx, systemPrompt, userPrompt, 0.5, 800)
 	if err != nil {

--- a/Backend/internal/services/interfaces/github_service.go
+++ b/Backend/internal/services/interfaces/github_service.go
@@ -12,7 +12,7 @@ type GitHubService interface {
 	TriggerAsyncSync(userID uint, force bool)
 	SyncUserData(ctx context.Context, userID uint, force bool) error
 	ListRepoSummaries(userID uint) ([]models.GitHubRepoSummary, error)
-	SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error)
+	SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool, targetRole string) (*models.GitHubRepoSummary, error)
 }
 
 type SkillScoreService interface {

--- a/Backend/test/controllers/github_oauth_realtime_integrated_test.go
+++ b/Backend/test/controllers/github_oauth_realtime_integrated_test.go
@@ -207,7 +207,7 @@ func TestGitHubController_SummarizeRepo_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	gh := &mocks.GitHubServiceMock{}
-	gh.On("SummarizeRepo", tmock.Anything, uint(1), "owner/repo", false).
+	gh.On("SummarizeRepo", tmock.Anything, uint(1), "owner/repo", false, "").
 		Return(&models.GitHubRepoSummary{FullName: "owner/repo"}, nil)
 	assertStatus(t, newGitHubController(gh, nil).SummarizeRepo, newCtx(req, rec), http.StatusOK)
 	gh.AssertExpectations(t)
@@ -227,11 +227,8 @@ func TestOAuthController_GoogleLogin_Success(t *testing.T) {
 
 	svc := &mocks.OAuthServiceMock{}
 	svc.On("GetGoogleAuthURL", tmock.AnythingOfType("string")).Return("https://accounts.google.com/auth?state=xxx")
-	assertStatus(t, newOAuthController(svc).GoogleLogin, newCtx(req, rec), http.StatusOK)
-
-	var body map[string]string
-	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.Contains(t, body["auth_url"], "accounts.google.com")
+	assertStatus(t, newOAuthController(svc).GoogleLogin, newCtx(req, rec), http.StatusTemporaryRedirect)
+	assert.Contains(t, rec.Header().Get("Location"), "accounts.google.com")
 }
 
 // ---- GitHubLogin ----
@@ -242,11 +239,8 @@ func TestOAuthController_GitHubLogin_Success(t *testing.T) {
 
 	svc := &mocks.OAuthServiceMock{}
 	svc.On("GetGitHubAuthURL", tmock.AnythingOfType("string")).Return("https://github.com/login/oauth/authorize?state=xxx")
-	assertStatus(t, newOAuthController(svc).GitHubLogin, newCtx(req, rec), http.StatusOK)
-
-	var body map[string]string
-	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.Contains(t, body["auth_url"], "github.com")
+	assertStatus(t, newOAuthController(svc).GitHubLogin, newCtx(req, rec), http.StatusTemporaryRedirect)
+	assert.Contains(t, rec.Header().Get("Location"), "github.com")
 }
 
 // ---- GoogleCallback ----

--- a/Backend/test/controllers/mocks/github_service_mock.go
+++ b/Backend/test/controllers/mocks/github_service_mock.go
@@ -42,8 +42,8 @@ func (m *GitHubServiceMock) ListRepoSummaries(userID uint) ([]models.GitHubRepoS
 	return args.Get(0).([]models.GitHubRepoSummary), args.Error(1)
 }
 
-func (m *GitHubServiceMock) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool) (*models.GitHubRepoSummary, error) {
-	args := m.Called(ctx, userID, fullName, forceRefresh)
+func (m *GitHubServiceMock) SummarizeRepo(ctx context.Context, userID uint, fullName string, forceRefresh bool, targetRole string) (*models.GitHubRepoSummary, error) {
+	args := m.Called(ctx, userID, fullName, forceRefresh, targetRole)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -353,7 +353,7 @@ export default function ProfilePage() {
           {/* 右カラム: GitHub スキル分析（ゲストアカウントは非表示） */}
           {!isGuest && (
             <Box sx={{ flex: 1, minWidth: 0 }}>
-              <GitHubSkills userId={user.user_id} />
+              <GitHubSkills userId={user.user_id} targetRole={user.target_level} />
             </Box>
           )}
         </Box>

--- a/frontend/components/github-skills.tsx
+++ b/frontend/components/github-skills.tsx
@@ -186,7 +186,7 @@ function RadarChart({ scores, size = 240 }: RadarChartProps) {
 
 // --- メインコンポーネント ---
 
-export default function GitHubSkills({ userId }: { userId: number }) {
+export default function GitHubSkills({ userId, targetRole = '' }: { userId: number; targetRole?: string }) {
   const [scores, setScores] = useState<SkillScore[]>([])
   const [profile, setProfile] = useState<GitHubProfile | null>(null)
   const [langStats, setLangStats] = useState<LanguageStat[]>([])
@@ -253,7 +253,7 @@ export default function GitHubSkills({ userId }: { userId: number }) {
       const res = await fetch(`${BACKEND_URL}/api/github/repo/summarize?user_id=${userId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
-        body: JSON.stringify({ full_name: fullName }),
+        body: JSON.stringify({ full_name: fullName, target_role: targetRole }),
       })
       if (!res.ok) {
         const msg = await res.text()


### PR DESCRIPTION
Closes #457

## 変更内容

### バックエンド

- **職種別プロンプト設定の追加** (`github_service.go`): `getRolePromptConfig()` 関数を新設し、志望職種に応じた分析観点・システムロール・ヒントを返す
  - `エンジニア` → 技術スキル・アーキテクチャ設計力・コード品質
  - `マーケ` → 技術への理解度・データ活用能力・ツール活用力
  - `営業` → プロジェクト管理能力・課題解決力
  - `デザイン` → UI/UX思考・フロントエンド実装品質
  - 未設定 / その他 → 汎用プロンプト（後方互換）

- **`SummarizeRepo` / `generateRepoSummary` のシグネチャ変更**: `targetRole string` パラメータを追加し、プロンプトを職種に応じて動的に構築

- **プロンプトバージョンのログ記録**: 定数 `repoSummaryPromptVersion = "v2"` を定義し、要約生成時に `prompt_version`・`target_role`・`focus` をログ出力（受け入れ条件）

- **インターフェース・コントローラー更新**: `interfaces/github_service.go` と `github_controller.go` の `SummarizeRepo` シグネチャに `targetRole` を追加。リクエストボディに `target_role` フィールドを追加

### テスト修正

- **モック更新** (`mocks/github_service_mock.go`): `SummarizeRepo` モックに `targetRole` 引数を追加
- **OAuthログインテストの修正** (`github_oauth_realtime_integrated_test.go`): 以前のOAuth修正（常にリダイレクト）に合わせて、200 JSON → 307 リダイレクト + `Location` ヘッダー検証に変更

### フロントエンド

- **`GitHubSkills` コンポーネント**: `targetRole?: string` prop を追加し、AI要約生成リクエストの body に `target_role` を含めて送信
- **プロフィールページ**: `user.target_level` を `targetRole` として `GitHubSkills` に渡すよう変更