### PR TITLE
Resolve #470: OpenAI APIコストモニタリングの記録漏れ修正

### DIFF
--- a/Backend/internal/openai/client.go
+++ b/Backend/internal/openai/client.go
@@ -325,6 +325,9 @@ func (cli *Client) Embedding(ctx context.Context, input string, modelOverride ..
 	if len(resp.Data) == 0 {
 		return nil, errors.New("empty embedding response")
 	}
+	if cli.OnUsage != nil && resp.Usage.PromptTokens > 0 {
+		cli.OnUsage(model, resp.Usage.PromptTokens, 0)
+	}
 	return resp.Data[0].Embedding, nil
 }
 
@@ -539,14 +542,22 @@ func (cli *Client) WebSearchQuery(ctx context.Context, query string) (string, er
 		Type    string          `json:"type"`
 		Content []outputContent `json:"content"`
 	}
+	type webSearchUsage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	}
 	type webSearchResponse struct {
-		Output     []outputItem `json:"output"`
-		OutputText string       `json:"output_text"`
+		Output     []outputItem   `json:"output"`
+		OutputText string         `json:"output_text"`
+		Usage      webSearchUsage `json:"usage"`
 	}
 
 	var parsed webSearchResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return "", err
+	}
+	if cli.OnUsage != nil && (parsed.Usage.InputTokens > 0 || parsed.Usage.OutputTokens > 0) {
+		cli.OnUsage(model, parsed.Usage.InputTokens, parsed.Usage.OutputTokens)
 	}
 	if strings.TrimSpace(parsed.OutputText) != "" {
 		return strings.TrimSpace(parsed.OutputText), nil


### PR DESCRIPTION
Closes #470

## 変更内容

### 問題の概要
OpenAI APIコストモニタリングが正常に動作していなかった。具体的には `Embedding()` と `WebSearchQuery()` の2つの関数でトークン使用量が記録されていなかった。

### 修正内容

#### 1. `Embedding()` への `OnUsage` コールバック追加 (`internal/openai/client.go`)
- `CreateEmbeddings` のレスポンスから `resp.Usage.PromptTokens` を取得し、`OnUsage` コールバックを呼び出すよう修正
- Embedding APIは出力トークンがないため `completionTokens = 0` として記録
- 影響範囲: `chat_embeddings.go`（ユーザー/職種の埋め込み生成）、`chat_answer_validator.go`（回答妥当性判定）

#### 2. `WebSearchQuery()` のトークン記録追加 (`internal/openai/client.go`)
- レスポンス構造体に `webSearchUsage` フィールド（`input_tokens`, `output_tokens`）を追加
- Responses API から返却される使用量を解析し、`OnUsage` コールバックを呼び出すよう修正
- 影響範囲: 企業グラフ構築、企業関連検索、ES対策、面接情報検索など5箇所

### 修正されなかった点（既存コードで正常）
- `Responses()`, `ResponsesWithTemperature()`, `ResponsesWithMaxTokens()` は `callResponsesAPI()` 経由で `OnUsage` が正しく呼ばれていたため変更不要