### PR TITLE
fix: CIの重複実行をconcurrencyグループで防止

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-backend:
     name: Go Unit Tests


### PR DESCRIPTION
## 問題

`test.yml` に `push`（feature ブランチへの push 時）と `pull_request`（main への PR 時）の両方のトリガーが設定されていたため、**PR が開いているブランチに push するたびに全4ジョブが2回実行されていた**。

PR #469 のチェック結果でも「Go Unit Tests」が2つの異なる run ID で表示されており、重複が確認できる。

## 修正内容

`concurrency` グループを追加：

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

- `github.head_ref`：PR イベント時のソースブランチ名
- `github.ref`：push イベント時の ref

同じブランチに対して `push` と `pull_request` の両イベントが発火した場合、同一の concurrency グループキーになり、古い実行が自動的にキャンセルされる。