### PR TITLE
fix: Backend変更時にフロントCIが動かないようパスフィルタを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'Backend/**'
+            frontend:
+              - 'frontend/**'
+
   test-backend:
     name: Go Unit Tests
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
     defaults:
@@ -47,6 +66,8 @@ jobs:
 
   audit-frontend:
     name: Frontend Security Audit
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     defaults:
@@ -71,6 +92,8 @@ jobs:
 
   test-frontend-unit:
     name: Frontend Unit Tests
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     defaults:
@@ -95,6 +118,8 @@ jobs:
 
   e2e-frontend:
     name: Frontend E2E Tests (Playwright)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     defaults:


### PR DESCRIPTION
## 問題

`test.yml` の全ジョブにパス条件がなく、Backend だけの変更でも Frontend E2E / Unit / Security Audit の3ジョブが実行されていた。逆にフロント変更でも Go Unit Tests が動いていた。

## 修正内容

`dorny/paths-filter@v3` を使った `changes` ジョブを追加し、変更されたパスを検出する。
各ジョブに `needs: changes` と `if:` 条件を追加し、関係ないファイルの変更では実行されないようにした。

| ジョブ | 実行条件 |
|--------|---------|
| Go Unit Tests | `Backend/**` に変更あり |
| Frontend Security Audit | `frontend/**` に変更あり |
| Frontend Unit Tests | `frontend/**` に変更あり |
| Frontend E2E Tests (Playwright) | `frontend/**` に変更あり |

## ベースブランチ

PR #473（concurrency グループによる重複実行防止）の変更を含む。