### PR TITLE
fix: 興味分析0%表示バグ修正・チャット進捗を回答品質ベースに改善

### DIFF
--- a/Backend/internal/services/analysis_scoring_service.go
+++ b/Backend/internal/services/analysis_scoring_service.go
@@ -252,12 +252,20 @@ func (s *AnalysisScoringService) calculateInterestScore(userID uint, sessionID s
 	favoritedCount, _ := stats["favorited_count"].(int64)
 	appliedCount, _ := stats["applied_count"].(int64)
 
+	phaseScore := s.phaseCompletionScore("interest_analysis", userID, sessionID)
+
+	// マッチ企業との操作実績がなければチャット回答の達成度をそのまま返す
+	if viewedCount+appliedCount+favoritedCount == 0 {
+		return phaseScore
+	}
+
 	raw := (float64(viewedCount) * 0.7) + (float64(appliedCount) * 1.0) + (float64(favoritedCount) * 1.2)
 	max := float64(totalMatches) * (0.7 + 1.0 + 1.2)
 	if max <= 0 {
-		return s.phaseCompletionScore("interest_analysis", userID, sessionID)
+		return phaseScore
 	}
-	return clamp01(raw / max)
+	// チャット達成度60% + マッチ操作40% でブレンド
+	return clamp01(phaseScore*0.6 + clamp01(raw/max)*0.4)
 }
 
 func (s *AnalysisScoringService) calculateAptitudeScore(userID uint, sessionID string) (float64, []AxisScore) {

--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -131,8 +131,8 @@ func (s *ChatService) validateAnswerRelevance(ctx context.Context, question, ans
 			cos := dot / (math.Sqrt(qNorm) * math.Sqrt(aNorm))
 			log.Printf("[Validation] Embedding cosine similarity=%f\n", cos)
 
-			// 閾値は運用で調整。まずは 0.45 を採用（高めの類似度がある場合は有効とする）
-			if cos >= 0.45 {
+			// 閾値は運用で調整。0.30 を採用（緩めに設定して誤検知を抑える）
+			if cos >= 0.30 {
 				return true, nil
 			}
 			return false, nil

--- a/Backend/internal/services/chat_score_updater.go
+++ b/Backend/internal/services/chat_score_updater.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 )
 
-// analyzeAndUpdateWeights ユーザーの回答を分析し重み係数を更新
-func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, sessionID, message string, jobCategoryID uint) error {
+// analyzeAndUpdateWeights ユーザーの回答を分析し重み係数を更新する。
+// 戻り値の bool は「有効な品質回答かどうか」を示す（進捗カウントに使用）。
+func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, sessionID, message string, jobCategoryID uint) (bool, error) {
 	// 会話履歴から直近の質問を取得
 	history, err := s.chatMessageRepo.FindRecentBySessionID(sessionID, 5)
 	if err != nil {
@@ -28,31 +29,42 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 
 	if strings.TrimSpace(lastQuestion) == "" {
 		log.Printf("Warning: no previous question found for scoring\n")
-		return nil
+		// 質問が見つからない場合は進捗を進める（チャット開始直後など）
+		return true, nil
 	}
 	if s.isJobSelectionQuestion(lastQuestion) {
 		log.Printf("Skipping analysis for job selection question\n")
-		return nil
+		return true, nil
 	}
 
 	targetCategory := s.inferCategoryFromQuestion(lastQuestion)
 	isChoice := !isTextBasedQuestion(lastQuestion)
 
 	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, message, isChoice, jobCategoryID != 0, nil)
-	if result.Action != PrecheckScore {
-		log.Printf("Skipping scoring due to precheck: %s\n", result.Reason)
-		return nil
+	if result.Action == PrecheckSkip {
+		// 「わかりません」などのスキップフレーズは進捗カウントしない
+		log.Printf("Skipping progress: skip phrase detected (%s)\n", result.Reason)
+		return false, nil
+	}
+	if result.Action == PrecheckIgnore {
+		// 空・極短回答も進捗カウントしない
+		log.Printf("Skipping progress: answer ignored (%s)\n", result.Reason)
+		return false, nil
 	}
 	if result.Score <= 0 {
-		log.Printf("No human score applied (score=%d)\n", result.Score)
-		return nil
+		log.Printf("No human score applied (score=%d), not counting for progress\n", result.Score)
+		return false, nil
 	}
 
-	return s.updateCategoryScore(userID, sessionID, targetCategory, result.Score)
+	if err := s.updateCategoryScore(userID, sessionID, targetCategory, result.Score); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-// processChoiceAnswer 選択肢回答を処理してスコアを更新
-func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sessionID, answer string, history []models.ChatMessage, jobCategoryID uint) error {
+// processChoiceAnswer 選択肢回答を処理してスコアを更新する。
+// 戻り値の bool は「有効な品質回答かどうか」を示す（進捗カウントに使用）。
+func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sessionID, answer string, history []models.ChatMessage, jobCategoryID uint) (bool, error) {
 	// 最後のAIの質問を取得
 	var lastQuestion string
 	var targetCategory string
@@ -65,17 +77,18 @@ func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sess
 	}
 
 	if lastQuestion == "" {
-		return fmt.Errorf("no previous question found")
+		return false, fmt.Errorf("no previous question found")
 	}
 	if s.isJobSelectionQuestion(lastQuestion) {
 		log.Printf("[Choice Answer] Skipping score update for job selection question\n")
-		return nil
+		// 職種選択は進捗カウントする（ユーザーが意思表示した）
+		return true, nil
 	}
 
 	// AIが生成した質問から対象カテゴリを特定
 	aiQuestions, err := s.aiGeneratedQuestionRepo.FindByUserAndSession(userID, sessionID)
 	if err != nil {
-		return fmt.Errorf("failed to get AI questions: %w", err)
+		return false, fmt.Errorf("failed to get AI questions: %w", err)
 	}
 
 	for i := len(aiQuestions) - 1; i >= 0; i-- {
@@ -89,7 +102,6 @@ func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sess
 	}
 
 	if targetCategory == "" {
-		// カテゴリが特定できない場合は、質問文から推測
 		targetCategory = s.inferCategoryFromQuestion(lastQuestion)
 	}
 
@@ -98,12 +110,14 @@ func (s *ChatService) processChoiceAnswer(ctx context.Context, userID uint, sess
 	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, answer, true, jobCategoryID != 0, nil)
 	if result.Action != PrecheckScore {
 		log.Printf("Skipping choice scoring due to precheck: %s\n", result.Reason)
-		return nil
+		return false, nil
 	}
-	score := result.Score
 
-	// スコアを保存または更新
-	return s.updateCategoryScore(userID, sessionID, targetCategory, score)
+	if err := s.updateCategoryScore(userID, sessionID, targetCategory, result.Score); err != nil {
+		return false, err
+	}
+	// 選択肢回答は選択した内容に関わらず有効（スコア0でも意思表示）
+	return true, nil
 }
 
 // convertChoiceToScore 選択肢をスコアに変換

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -357,33 +357,29 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 		}, nil
 	}
 
-	// 3. ユーザーの回答から重み係数を判定・更新
-	// 3. ユーザーの回答から重み係数を判定・更新し、結果に応じてフェーズ進捗を更新
-	// スコア更新に成功した場合のみ有効回答としてカウントする
+	// 3. ユーザーの回答から重み係数を判定・更新し、回答品質に応じてフェーズ進捗を更新
+	// isQualityAnswer: スキップフレーズ・極短回答・スコア0でなければ true（進捗カウント対象）
 	trimmedAnswer := strings.TrimSpace(req.Message)
 	log.Printf("[ProcessChat] Checking if choice answer: '%s' (len=%d)\n", trimmedAnswer, len(trimmedAnswer))
-	scoreUpdated := false
+	isQualityAnswer := false
 	if len(trimmedAnswer) <= 3 && s.isChoiceAnswer(trimmedAnswer) {
 		log.Printf("[ProcessChat] Processing as choice answer\n")
-		// 選択肢回答の場合は直接スコアを計算
-		if err := s.processChoiceAnswer(ctx, req.UserID, req.SessionID, trimmedAnswer, history, jobCategoryID); err != nil {
+		var err error
+		isQualityAnswer, err = s.processChoiceAnswer(ctx, req.UserID, req.SessionID, trimmedAnswer, history, jobCategoryID)
+		if err != nil {
 			log.Printf("Warning: failed to process choice answer: %v\n", err)
-		} else {
-			scoreUpdated = true
 		}
 	} else {
 		log.Printf("[ProcessChat] Processing as text answer\n")
-		// 通常の回答分析
-		if err := s.analyzeAndUpdateWeights(ctx, req.UserID, req.SessionID, req.Message, jobCategoryID); err != nil {
-			// ログに記録するが、処理は継続
+		var err error
+		isQualityAnswer, err = s.analyzeAndUpdateWeights(ctx, req.UserID, req.SessionID, req.Message, jobCategoryID)
+		if err != nil {
 			log.Printf("Warning: failed to update weights: %v\n", err)
-		} else {
-			scoreUpdated = true
 		}
 	}
 
-	// フェーズ進捗を更新（スコア更新成功時のみ有効カウント）
-	if err := s.updatePhaseProgress(currentPhase, scoreUpdated); err != nil {
+	// 品質回答のみ valid_answers をインクリメントして進捗を進める
+	if err := s.updatePhaseProgress(currentPhase, isQualityAnswer); err != nil {
 		log.Printf("Warning: failed to update phase progress: %v\n", err)
 	}
 

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -117,11 +117,12 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
     const getPhasePercent = (phaseName: string, fallback: number) => {
         const phase = phaseProgressFor(phaseName)
         if (!phase) return fallback
+        // まだ質問が始まっていないフェーズは「待機中」として fallback を返さない
+        if (phase.questions_asked === 0) return 0
         const required = phase.max_questions > 0 ? phase.max_questions : phase.min_questions
         if (required > 0) {
             return Math.min(100, Math.max(0, Math.floor((phase.valid_answers / required) * 100)))
         }
-        if (phase.questions_asked <= 0) return 0
         return Math.min(100, Math.floor((phase.valid_answers / phase.questions_asked) * 100))
     }
     const getPhaseStatus = (phaseName: string, defaultLabel: string) => {


### PR DESCRIPTION
## 変更内容

### バグ修正
- **興味分析0%表示バグ**: `calculateInterestScore` がマッチ企業の閲覧・応募・お気に入り操作がゼロのとき常に0を返していた。チャット回答の達成度（`phaseCompletionScore`）を基準にし、マッチ操作がある場合のみブレンド（60% チャット + 40% マッチ）するよう変更。
- **バリデーション誤検知削減**: テキスト回答の埋め込みコサイン類似度閾値を 0.45 → 0.30 に緩和。

### 機能改善（回答品質ベース進捗）
- `analyzeAndUpdateWeights` / `processChoiceAnswer` の戻り値を `(bool, error)` に変更し、回答品質を呼び出し元に返す。
  - スキップフレーズ（「わかりません」等）: `false` → 進捗カウントしない
  - 極短回答（空・1文字等）: `false` → 進捗カウントしない
  - スコア0（具体性・アクション・理由がない回答）: `false` → 進捗カウントしない
  - スコア > 0 の品質回答: `true` → `valid_answers++`
- `chat_service.go` で `isQualityAnswer` フラグを使い、品質回答のみフェーズ進捗を進める。
- `analysis-sidebar.tsx`: `questions_asked === 0` のフェーズは「待機中」として扱い、0%計算をスキップ。

## テスト
- `go test ./internal/... ./test/...` 全テストPASS