### PR TITLE
Resolve #451: プロンプト管理を動的化・職種別/フェーズ別に最適化

### DIFF
--- a/Backend/internal/services/prompts/builder.go
+++ b/Backend/internal/services/prompts/builder.go
@@ -1,0 +1,118 @@
+package prompts
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// PromptVersion はプロンプトバージョンを管理する。
+// 環境変数 PROMPT_VERSION で上書き可能（デフォルト: "v1"）。
+var PromptVersion = func() string {
+	if v := os.Getenv("PROMPT_VERSION"); v != "" {
+		return v
+	}
+	return "v1"
+}()
+
+// JobType は職種タイプを表す。
+type JobType string
+
+const (
+	JobTypeEngineer  JobType = "エンジニア"
+	JobTypeSales     JobType = "営業"
+	JobTypeMarketing JobType = "マーケ"
+	JobTypeDesign    JobType = "デザイン"
+	JobTypeGeneral   JobType = "一般"
+)
+
+// JobTypeConfig は職種ごとのプロンプト設定を保持する。
+type JobTypeConfig struct {
+	Type          JobType
+	ToneGuideline string // 質問トーンの方向性
+	TechFocusNote string // 技術フォーカスの注記
+}
+
+var jobTypeConfigs = map[JobType]JobTypeConfig{
+	JobTypeEngineer: {
+		Type:          JobTypeEngineer,
+		ToneGuideline: "技術的な話題に深く踏み込んでよい。コードやツールの具体的な話を歓迎する。",
+		TechFocusNote: "プログラミング・システム設計・ツール活用について具体的に聞く。",
+	},
+	JobTypeSales: {
+		Type:          JobTypeSales,
+		ToneGuideline: "対人スキル・交渉力・コミュニケーションを重視した文脈で質問する。",
+		TechFocusNote: "ITツール活用や業務効率化への関心を聞く。プログラミング経験は前提としない。",
+	},
+	JobTypeMarketing: {
+		Type:          JobTypeMarketing,
+		ToneGuideline: "創造性・データ活用・マーケット感覚を重視した文脈で質問する。",
+		TechFocusNote: "デジタルマーケティングツールやSNS活用への関心を聞く。",
+	},
+	JobTypeDesign: {
+		Type:          JobTypeDesign,
+		ToneGuideline: "ビジュアル表現・ユーザー体験・創造的思考を重視した文脈で質問する。",
+		TechFocusNote: "デザインツールやUI/UXへの感度を聞く。",
+	},
+	JobTypeGeneral: {
+		Type:          JobTypeGeneral,
+		ToneGuideline: "業種に依存しない汎用的な文脈で質問する。",
+		TechFocusNote: "ITツールへの親しみやすさや効率化への意識を聞く。",
+	},
+}
+
+// InferJobType は職種名文字列から JobType を推定する。
+func InferJobType(jobCategoryName string) JobType {
+	switch {
+	case strings.Contains(jobCategoryName, "エンジニア") ||
+		strings.Contains(jobCategoryName, "開発") ||
+		strings.Contains(jobCategoryName, "プログラマ") ||
+		strings.Contains(jobCategoryName, "SE") ||
+		strings.Contains(jobCategoryName, "IT"):
+		return JobTypeEngineer
+	case strings.Contains(jobCategoryName, "営業") ||
+		strings.Contains(jobCategoryName, "セールス"):
+		return JobTypeSales
+	case strings.Contains(jobCategoryName, "マーケ") ||
+		strings.Contains(jobCategoryName, "広告") ||
+		strings.Contains(jobCategoryName, "PR"):
+		return JobTypeMarketing
+	case strings.Contains(jobCategoryName, "デザイン") ||
+		strings.Contains(jobCategoryName, "デザイナー") ||
+		strings.Contains(jobCategoryName, "UI") ||
+		strings.Contains(jobCategoryName, "UX"):
+		return JobTypeDesign
+	default:
+		return JobTypeGeneral
+	}
+}
+
+// GetJobTypeConfig は職種名から設定を返し、使用バージョンをログに記録する。
+func GetJobTypeConfig(jobCategoryName string) JobTypeConfig {
+	jt := InferJobType(jobCategoryName)
+	cfg, ok := jobTypeConfigs[jt]
+	if !ok {
+		cfg = jobTypeConfigs[JobTypeGeneral]
+	}
+	slog.Info("プロンプト設定取得",
+		"job_type", string(jt),
+		"prompt_version", PromptVersion,
+	)
+	return cfg
+}
+
+// BuildJobTypeToneGuidance は職種別トーンガイダンスセクションを返す。
+func BuildJobTypeToneGuidance(jobCategoryName string) string {
+	cfg := GetJobTypeConfig(jobCategoryName)
+	return fmt.Sprintf("## 職種別トーンガイドライン（%s）\n- %s\n- %s",
+		string(cfg.Type), cfg.ToneGuideline, cfg.TechFocusNote)
+}
+
+// LogPromptVersion は使用するプロンプトバージョンをログに記録する。
+func LogPromptVersion(context string) {
+	slog.Info("プロンプトバージョン使用",
+		"context", context,
+		"version", PromptVersion,
+	)
+}

--- a/Backend/internal/services/prompts/matching_reason.go
+++ b/Backend/internal/services/prompts/matching_reason.go
@@ -1,6 +1,16 @@
 package prompts
 
+import "fmt"
+
+// MatchingReasonPromptVersion は後方互換のための固定バージョン定数です。
+// 新規コードでは GetMatchingReasonPromptVersion() を使用してください。
 const MatchingReasonPromptVersion = "matching_reason_v1"
+
+// GetMatchingReasonPromptVersion は環境変数 PROMPT_VERSION に基づいた
+// マッチング理由プロンプトのバージョン文字列を返します。
+func GetMatchingReasonPromptVersion() string {
+	return fmt.Sprintf("matching_reason_%s", PromptVersion)
+}
 
 const MatchingReasonSystemPrompt = `あなたは新卒向け採用マッチングのキャリアアドバイザーです。
 与えられたユーザー適性と企業情報を使って、マッチング理由を日本語で作成してください。

--- a/Backend/internal/services/prompts/prompts_test.go
+++ b/Backend/internal/services/prompts/prompts_test.go
@@ -198,3 +198,132 @@ func TestBuildAnswerValidationUserPrompt(t *testing.T) {
 		t.Error("判定フォーマットが含まれていない")
 	}
 }
+
+// ──────────────────────────────────────────────
+// builder.go のテスト
+// ──────────────────────────────────────────────
+
+func TestInferJobType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  JobType
+	}{
+		{"エンジニア", JobTypeEngineer},
+		{"Webエンジニア", JobTypeEngineer},
+		{"開発職", JobTypeEngineer},
+		{"SE", JobTypeEngineer},
+		{"ITコンサル", JobTypeEngineer},
+		{"営業", JobTypeSales},
+		{"インサイドセールス", JobTypeSales},
+		{"マーケティング", JobTypeMarketing},
+		{"広告プランナー", JobTypeMarketing},
+		{"デザイナー", JobTypeDesign},
+		{"UIデザイン", JobTypeDesign},
+		{"総合職", JobTypeGeneral},
+		{"人事", JobTypeGeneral},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := InferJobType(tt.input)
+			if got != tt.want {
+				t.Errorf("InferJobType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetJobTypeConfig(t *testing.T) {
+	cfg := GetJobTypeConfig("エンジニア")
+	if cfg.Type != JobTypeEngineer {
+		t.Errorf("GetJobTypeConfig(エンジニア) type = %q, want エンジニア", cfg.Type)
+	}
+	if cfg.ToneGuideline == "" {
+		t.Error("ToneGuideline が空")
+	}
+	if cfg.TechFocusNote == "" {
+		t.Error("TechFocusNote が空")
+	}
+}
+
+func TestBuildJobTypeToneGuidance(t *testing.T) {
+	tests := []struct {
+		jobName  string
+		contains string
+	}{
+		{"エンジニア", "エンジニア"},
+		{"営業", "営業"},
+		{"マーケティング", "マーケ"},
+		{"不明な職種", "一般"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.jobName, func(t *testing.T) {
+			result := BuildJobTypeToneGuidance(tt.jobName)
+			if !strings.Contains(result, tt.contains) {
+				t.Errorf("BuildJobTypeToneGuidance(%q) に %q が含まれていない: %s", tt.jobName, tt.contains, result)
+			}
+		})
+	}
+}
+
+func TestBuildSimplifyQuestionPromptWithJobType(t *testing.T) {
+	q := "あなたのリーダーシップ経験について教えてください"
+
+	t.Run("エンジニア向けは100文字まで許容", func(t *testing.T) {
+		result := BuildSimplifyQuestionPromptWithJobType(q, "エンジニア")
+		if !strings.Contains(result, "100文字") {
+			t.Error("エンジニア向け文字数制約（100文字）が含まれていない")
+		}
+		if !strings.Contains(result, q) {
+			t.Error("元の質問が含まれていない")
+		}
+	})
+
+	t.Run("営業向けは80文字まで", func(t *testing.T) {
+		result := BuildSimplifyQuestionPromptWithJobType(q, "営業")
+		if !strings.Contains(result, "80文字") {
+			t.Error("営業向け文字数制約（80文字）が含まれていない")
+		}
+	})
+}
+
+func TestPromptVersion(t *testing.T) {
+	if PromptVersion == "" {
+		t.Error("PromptVersion が空文字")
+	}
+}
+
+func TestGetMatchingReasonPromptVersion(t *testing.T) {
+	v := GetMatchingReasonPromptVersion()
+	if !strings.HasPrefix(v, "matching_reason_") {
+		t.Errorf("GetMatchingReasonPromptVersion() = %q, プレフィックス matching_reason_ がない", v)
+	}
+}
+
+func TestBuildAnswerQualitySystemPromptWithContext(t *testing.T) {
+	t.Run("属性なし→基本プロンプトと同一", func(t *testing.T) {
+		result := BuildAnswerQualitySystemPromptWithContext("", "")
+		if result != AnswerQualitySystemPrompt {
+			t.Error("属性なしの場合、基本プロンプトと一致すべき")
+		}
+	})
+
+	t.Run("学年あり→背景セクション追加", func(t *testing.T) {
+		result := BuildAnswerQualitySystemPromptWithContext("新卒", "")
+		if !strings.Contains(result, "新卒") {
+			t.Error("学年情報が含まれていない")
+		}
+		if !strings.Contains(result, "背景") {
+			t.Error("背景セクションが含まれていない")
+		}
+	})
+
+	t.Run("学年・職種両方あり", func(t *testing.T) {
+		result := BuildAnswerQualitySystemPromptWithContext("中途", "エンジニア")
+		if !strings.Contains(result, "中途") {
+			t.Error("学年情報が含まれていない")
+		}
+		if !strings.Contains(result, "エンジニア") {
+			t.Error("志望職種が含まれていない")
+		}
+	})
+}

--- a/Backend/internal/services/prompts/question_generation.go
+++ b/Backend/internal/services/prompts/question_generation.go
@@ -185,3 +185,31 @@ func BuildSimplifyQuestionPrompt(question string) string {
 質問:
 %s`, question)
 }
+
+// BuildSimplifyQuestionPromptWithJobType は職種別のトーンと文字数ガイドラインを考慮した
+// 質問簡略化プロンプトを構築します。
+func BuildSimplifyQuestionPromptWithJobType(question, jobCategoryName string) string {
+	cfg := GetJobTypeConfig(jobCategoryName)
+	charRange := "40〜80文字"
+	// エンジニア向けは技術的な文脈を保つため若干長めも許容
+	if cfg.Type == JobTypeEngineer {
+		charRange = "40〜100文字"
+	}
+	return fmt.Sprintf(`次の質問を、%s向けに短く言い換えてください。
+
+## 制約
+- 1文で、%s程度
+- 例示やカッコ補足は入れない
+- 元の質問の意図・キーワードを必ず保持する
+- 質問文のみを返す
+- %s
+
+## 自己検証
+言い換えた質問が以下を満たすか確認してから出力してください：
+1. 元の質問が問いたい「評価対象（技術志向・リーダーシップ等）」が伝わるか
+2. 対象者が経験をもとに答えられる内容か
+3. 文字数の範囲に収まっているか
+
+質問:
+%s`, jobCategoryName, charRange, cfg.TechFocusNote, question)
+}

--- a/Backend/internal/services/prompts/score_evaluation.go
+++ b/Backend/internal/services/prompts/score_evaluation.go
@@ -46,3 +46,21 @@ const AnswerQualitySystemPrompt = `あなたは就職面接の回答品質を評
 func BuildAnswerQualityUserPrompt(question, answer string) string {
 	return fmt.Sprintf("【質問】\n%s\n\n【回答】\n%s", question, answer)
 }
+
+// BuildAnswerQualitySystemPromptWithContext はユーザーの学年・志望職種を考慮した
+// 回答品質評価システムプロンプトを返します。
+// gradeLevel: "新卒" / "既卒" / "中途" など、targetJob: 志望職種名
+func BuildAnswerQualitySystemPromptWithContext(gradeLevel, targetJob string) string {
+	if gradeLevel == "" && targetJob == "" {
+		return AnswerQualitySystemPrompt
+	}
+	ctx := "\n\n## 評価対象者の背景"
+	if gradeLevel != "" {
+		ctx += fmt.Sprintf("\n- 学年・経験レベル: %s", gradeLevel)
+	}
+	if targetJob != "" {
+		ctx += fmt.Sprintf("\n- 志望職種: %s", targetJob)
+	}
+	ctx += "\n\n上記の背景を踏まえ、経験レベルに応じた評価軸（新卒なら学生経験ベース、中途なら実務経験ベース）で判定してください。"
+	return AnswerQualitySystemPrompt + ctx
+}


### PR DESCRIPTION
Closes #451

## 変更内容

### 新規: `prompts/builder.go` — PromptBuilder 基盤
- `JobType` 型とコンスタント（`JobTypeEngineer` / `JobTypeSales` / `JobTypeMarketing` / `JobTypeDesign` / `JobTypeGeneral`）を定義
- `JobTypeConfig` 構造体（`ToneGuideline` / `TechFocusNote`）で職種別設定を保持
- `InferJobType(name string) JobType` — 職種名文字列から JobType を自動推定
- `GetJobTypeConfig(name string) JobTypeConfig` — 設定取得時に使用バージョンをログ記録
- `BuildJobTypeToneGuidance(name string) string` — 職種別トーンセクションを生成
- `LogPromptVersion(context string)` — 任意のコンテキストでバージョンをログ出力
- `PromptVersion` 変数 — 環境変数 `PROMPT_VERSION` で上書き可能（デフォルト: `v1`）

### Phase 1: 職種別プロンプト切り替え
- `BuildSimplifyQuestionPromptWithJobType(question, jobCategoryName string) string` を追加
  - エンジニア向けは文字数上限を 80 → 100 文字に拡張
  - 職種別の `TechFocusNote` を制約に組み込む

### Phase 2: バージョン切り替え機構
- `GetMatchingReasonPromptVersion()` — `PROMPT_VERSION` 環境変数に基づいた動的バージョン文字列を返す
- 既存定数 `MatchingReasonPromptVersion` は後方互換のため残置

### Phase 3: ユーザー属性の反映
- `BuildAnswerQualitySystemPromptWithContext(gradeLevel, targetJob string) string` を追加
  - 学年（新卒/中途など）・志望職種を評価プロンプトに挿入
  - 属性なしの場合は既存プロンプトと同一を返す（後方互換）

## テスト
- `TestInferJobType` — 13ケースで職種推定の正確性を検証
- `TestGetJobTypeConfig` / `TestBuildJobTypeToneGuidance` — 設定・ガイダンス生成を検証
- `TestBuildSimplifyQuestionPromptWithJobType` — エンジニア/営業の文字数制約を検証
- `TestPromptVersion` / `TestGetMatchingReasonPromptVersion` — バージョン管理を検証
- `TestBuildAnswerQualitySystemPromptWithContext` — ユーザー属性注入を検証
- `go test ./internal/... ./test/...` 全テストPASS