### PR TITLE
feat: GitHub ↔ Backlog 双方向Issue連携ワークフローを追加

### DIFF
--- a/.github/workflows/backlog-notify.yml
+++ b/.github/workflows/backlog-notify.yml
@@ -1,0 +1,24 @@
+name: Backlog 通知 (commit / PR)
+
+# commit メッセージや PR に Backlog 課題キー（例: PROJ-123）が含まれている場合、
+# 対応する Backlog 課題へ自動コメント・ステータス更新を行います。
+# コミットメッセージに #fixed / #closed を付けると課題をクローズできます。
+#
+# 必要な GitHub Secrets:
+#   BACKLOG_SPACE_ID  : スペースID（例: myspace ← myspace.backlog.jp の場合）
+#   BACKLOG_API_KEY   : Backlog のアカウント設定で発行した APIキー
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bicstone/backlog-notify@v4
+        with:
+          space_id: ${{ secrets.BACKLOG_SPACE_ID }}
+          api_key: ${{ secrets.BACKLOG_API_KEY }}

--- a/.github/workflows/backlog-to-github-issue.yml
+++ b/.github/workflows/backlog-to-github-issue.yml
@@ -1,0 +1,149 @@
+name: Backlog 課題 → GitHub Issue
+
+# 15分ごとに Backlog の更新課題をポーリングし、
+# 対応する GitHub Issue を自動作成・更新・クローズします。
+# GitHub Issue タイトル形式: [PROJ-N] 課題タイトル
+#
+# ループ防止: 説明に "GitHub Issue:" を含む課題（GitHub起源）はスキップします。
+#
+# 必要な GitHub Secrets:
+#   BACKLOG_SPACE_ID    : スペースID（例: myspace）
+#   BACKLOG_API_KEY     : Backlog APIキー
+#   BACKLOG_PROJECT_KEY : プロジェクトキー（例: PROJ）
+#   GH_TOKEN            : GitHub PAT（issues 読み書き権限）
+#                         ※省略時は github.token を使用
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      minutes_back:
+        description: '何分前からの更新を取得するか（デフォルト: 20）'
+        required: false
+        default: '20'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Backlog 課題を GitHub Issue へ同期
+        env:
+          BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+          BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+          BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+          MINUTES_BACK: ${{ inputs.minutes_back || '20' }}
+        run: |
+          python3 - << 'PYEOF'
+          import os, sys, json, urllib.parse, urllib.request, urllib.error
+          from datetime import datetime, timezone, timedelta
+
+          API_KEY    = os.environ['BACKLOG_API_KEY']
+          SPACE_ID   = os.environ['BACKLOG_SPACE_ID']
+          PROJ_KEY   = os.environ['BACKLOG_PROJECT_KEY']
+          GH_TOKEN   = os.environ['GH_TOKEN']
+          GH_REPO    = os.environ['GH_REPO']
+          MINUTES    = int(os.environ.get('MINUTES_BACK', '20'))
+
+          BL_BASE = f"https://{SPACE_ID}.backlog.jp/api/v2"
+          GH_BASE = "https://api.github.com"
+
+          def bl_request(method, path, data=None):
+              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
+              body = urllib.parse.urlencode(data).encode() if data else None
+              req = urllib.request.Request(url, data=body, method=method)
+              if body:
+                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
+                  sys.exit(1)
+
+          def gh_request(method, path, data=None):
+              url = f"{GH_BASE}{path}"
+              body = json.dumps(data).encode() if data else None
+              req = urllib.request.Request(url, data=body, method=method)
+              req.add_header('Authorization', f'Bearer {GH_TOKEN}')
+              req.add_header('Accept', 'application/vnd.github+json')
+              req.add_header('X-GitHub-Api-Version', '2022-11-28')
+              if body:
+                  req.add_header('Content-Type', 'application/json')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  print(f"GitHub API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
+                  return None
+
+          def gh_search_issue(bl_key):
+              """GitHub Issue を Backlog キーで検索する（タイトルの [PROJ-N] プレフィックスで照合）"""
+              q = urllib.parse.quote(f"[{bl_key}] repo:{GH_REPO} in:title is:issue")
+              result = gh_request('GET', f"/search/issues?q={q}&per_page=5")
+              if not result:
+                  return None
+              for item in result.get('items', []):
+                  if item['title'].startswith(f"[{bl_key}]"):
+                      return item
+              return None
+
+          project    = bl_request('GET', f"/projects/{PROJ_KEY}")
+          project_id = project['id']
+
+          since  = (datetime.now(timezone.utc) - timedelta(minutes=MINUTES)).strftime('%Y-%m-%dT%H:%M:%SZ')
+          issues = bl_request('GET', f"/issues?projectId[]={project_id}&updatedSince={since}&count=100&sort=updated&order=desc")
+
+          print(f"{len(issues)} 件の Backlog 課題を取得しました（直近 {MINUTES} 分）。")
+
+          CLOSED_STATUS_IDS = {3, 4}  # 処理済み / 完了
+
+          for issue in issues:
+              bl_key       = issue['issueKey']
+              bl_summary   = issue['summary']
+              bl_desc      = issue.get('description') or ''
+              bl_url       = f"https://{SPACE_ID}.backlog.jp/view/{bl_key}"
+              bl_status_id = issue['status']['id']
+
+              # GitHub 側から作成された課題はスキップ（説明に "GitHub Issue:" を含む）
+              if 'GitHub Issue:' in bl_desc:
+                  print(f"  スキップ（GitHub 起源）: {bl_key}")
+                  continue
+
+              # GitHub Issue のタイトル・本文
+              gh_title = f"[{bl_key}] {bl_summary}"
+              gh_body  = (
+                  f"<!-- backlog-synced -->\n"
+                  f"<!-- backlog-key:{bl_key} -->\n\n"
+                  f"**Backlog 課題:** [{bl_key}]({bl_url})\n\n"
+                  f"---\n\n{bl_desc}"
+              )
+
+              existing_gh = gh_search_issue(bl_key)
+
+              if existing_gh is None:
+                  result = gh_request('POST', f"/repos/{GH_REPO}/issues", {
+                      'title': gh_title,
+                      'body':  gh_body,
+                  })
+                  if result:
+                      print(f"  GitHub Issue を作成しました: #{result['number']} ← {bl_key}")
+                      if bl_status_id in CLOSED_STATUS_IDS:
+                          gh_request('PATCH', f"/repos/{GH_REPO}/issues/{result['number']}", {'state': 'closed'})
+              else:
+                  gh_num         = existing_gh['number']
+                  gh_curr_state  = existing_gh['state']
+                  new_state      = 'closed' if bl_status_id in CLOSED_STATUS_IDS else 'open'
+                  update_data    = {'title': gh_title, 'body': gh_body}
+                  if gh_curr_state != new_state:
+                      update_data['state'] = new_state
+                  gh_request('PATCH', f"/repos/{GH_REPO}/issues/{gh_num}", update_data)
+                  print(f"  GitHub Issue を更新しました: #{gh_num} ← {bl_key} (state: {new_state})")
+
+          print("同期完了。")
+          PYEOF

--- a/.github/workflows/github-issue-to-backlog.yml
+++ b/.github/workflows/github-issue-to-backlog.yml
@@ -1,0 +1,148 @@
+name: GitHub Issue → Backlog 課題
+
+# GitHub Issue の作成・編集・クローズ・再オープン時に
+# 対応する Backlog 課題を自動作成・更新します。
+#
+# 課題作成後、GitHub Issue タイトルを [PROJ-N] 形式に自動更新します。
+# ループ防止: 本文に <!-- backlog-synced --> を含む Issue（Backlog起源）はスキップします。
+#
+# 必要な GitHub Secrets:
+#   BACKLOG_SPACE_ID    : スペースID（例: myspace）
+#   BACKLOG_API_KEY     : Backlog APIキー
+#   BACKLOG_PROJECT_KEY : プロジェクトキー（例: PROJ）
+
+on:
+  issues:
+    types: [opened, edited, closed, reopened]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub Issue を Backlog 課題へ同期
+        env:
+          BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+          BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+          BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+          GH_NUMBER: ${{ github.event.issue.number }}
+          GH_TITLE: ${{ github.event.issue.title }}
+          GH_BODY: ${{ github.event.issue.body }}
+          GH_URL: ${{ github.event.issue.html_url }}
+          ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          python3 - << 'PYEOF'
+          import os, sys, json, re, urllib.parse, urllib.request, urllib.error
+
+          API_KEY   = os.environ['BACKLOG_API_KEY']
+          SPACE_ID  = os.environ['BACKLOG_SPACE_ID']
+          PROJ_KEY  = os.environ['BACKLOG_PROJECT_KEY']
+          GH_NUMBER = os.environ['GH_NUMBER']
+          GH_TITLE  = os.environ.get('GH_TITLE', '')
+          GH_BODY   = os.environ.get('GH_BODY') or ''
+          GH_URL    = os.environ['GH_URL']
+          ACTION    = os.environ['ACTION']
+          GH_TOKEN  = os.environ['GH_TOKEN']
+          GH_REPO   = os.environ['GH_REPO']
+
+          BL_BASE = f"https://{SPACE_ID}.backlog.jp/api/v2"
+          GH_BASE = "https://api.github.com"
+
+          # Backlog 側から同期された Issue はスキップ（ループ防止）
+          if '<!-- backlog-synced -->' in GH_BODY:
+              print("Backlog 側から同期された Issue のためスキップします。")
+              sys.exit(0)
+
+          def bl_request(method, path, data=None):
+              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
+              body = urllib.parse.urlencode(data).encode() if data else None
+              req = urllib.request.Request(url, data=body, method=method)
+              if body:
+                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
+                  sys.exit(1)
+
+          def gh_update_issue(number, data):
+              """github.token を使用するため、この更新は issues/edited イベントを再トリガーしない"""
+              url = f"{GH_BASE}/repos/{GH_REPO}/issues/{number}"
+              req = urllib.request.Request(url, data=json.dumps(data).encode(), method='PATCH')
+              req.add_header('Authorization', f'Bearer {GH_TOKEN}')
+              req.add_header('Accept', 'application/vnd.github+json')
+              req.add_header('X-GitHub-Api-Version', '2022-11-28')
+              req.add_header('Content-Type', 'application/json')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  print(f"GitHub API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
+
+          def extract_bl_key(body, title):
+              """本文のマーカーまたはタイトルのプレフィックスから Backlog キーを抽出"""
+              m = re.search(r'<!--\s*backlog-key:(\S+?)\s*-->', body)
+              if m:
+                  return m.group(1)
+              m = re.match(rf'\[({re.escape(PROJ_KEY)}-\d+)\]\s', title)
+              return m.group(1) if m else None
+
+          def strip_prefix(title):
+              """タイトルから [PROJ-N] プレフィックスを除去"""
+              return re.sub(rf'^\[{re.escape(PROJ_KEY)}-\d+\]\s*', '', title).strip()
+
+          # ---- opened: Backlog 課題を新規作成 ----
+          if ACTION == 'opened':
+              project    = bl_request('GET', f"/projects/{PROJ_KEY}")
+              project_id = project['id']
+              types      = bl_request('GET', f"/projects/{PROJ_KEY}/issueTypes")
+              type_id    = types[0]['id']
+
+              result = bl_request('POST', '/issues', {
+                  'projectId':   project_id,
+                  'summary':     GH_TITLE,
+                  'issueTypeId': type_id,
+                  'description': f"GitHub Issue: {GH_URL}\n\n{GH_BODY}",
+              })
+              bl_key = result['issueKey']
+              print(f"Backlog 課題を作成しました: {bl_key}")
+
+              # GitHub Issue タイトルを [PROJ-N] 形式に更新し、マーカーを本文に追加
+              new_title = f"[{bl_key}] {GH_TITLE}"
+              new_body  = f"<!-- backlog-key:{bl_key} -->\n\n{GH_BODY}" if GH_BODY else f"<!-- backlog-key:{bl_key} -->"
+              gh_update_issue(GH_NUMBER, {'title': new_title, 'body': new_body})
+              print(f"GitHub Issue #{GH_NUMBER} を '{new_title}' に更新しました。")
+
+          # ---- edited: Backlog 課題のタイトル・説明を更新 ----
+          elif ACTION == 'edited':
+              bl_key = extract_bl_key(GH_BODY, GH_TITLE)
+              if not bl_key:
+                  print("Backlog 課題キーが見つかりません。スキップします。")
+                  sys.exit(0)
+              clean_title = strip_prefix(GH_TITLE)
+              bl_request('PATCH', f"/issues/{bl_key}", {
+                  'summary':     clean_title,
+                  'description': f"GitHub Issue: {GH_URL}\n\n{GH_BODY}",
+              })
+              print(f"Backlog 課題を更新しました: {bl_key}")
+
+          # ---- closed: Backlog 課題を完了（ステータス 4）にする ----
+          elif ACTION == 'closed':
+              bl_key = extract_bl_key(GH_BODY, GH_TITLE)
+              if not bl_key:
+                  print("Backlog 課題キーが見つかりません。スキップします。")
+                  sys.exit(0)
+              bl_request('PATCH', f"/issues/{bl_key}", {'statusId': 4})
+              print(f"Backlog 課題をクローズしました: {bl_key}")
+
+          # ---- reopened: Backlog 課題を未対応（ステータス 1）に戻す ----
+          elif ACTION == 'reopened':
+              bl_key = extract_bl_key(GH_BODY, GH_TITLE)
+              if not bl_key:
+                  print("Backlog 課題キーが見つかりません。スキップします。")
+                  sys.exit(0)
+              bl_request('PATCH', f"/issues/{bl_key}", {'statusId': 1})
+              print(f"Backlog 課題を再オープンしました: {bl_key}")
+          PYEOF


### PR DESCRIPTION
## 概要

GitHub Issues と Backlog 課題の双方向自動同期を GitHub Actions で実装します。

## 変更内容

### 追加ファイル

| ファイル | トリガー | 機能 |
|---|---|---|
| `.github/workflows/backlog-notify.yml` | push / PR | commit・PRメッセージ → Backlog課題へコメント・ステータス更新（bicstone/backlog-notify） |
| `.github/workflows/github-issue-to-backlog.yml` | issues (opened/edited/closed/reopened) | GitHub Issue → Backlog課題の自動作成・更新・クローズ |
| `.github/workflows/backlog-to-github-issue.yml` | schedule (15分) / workflow_dispatch | Backlog課題 → GitHub Issue への自動同期（ポーリング方式） |

### 実装の詳細

- **タイトル命名規則**: 両プラットフォームで `[PROJ-N] タイトル` 形式に統一
  - GitHub Issue作成後、Backlog課題キー取得 → GitHubタイトルを自動リネーム
- **ループ防止**:
  - GitHub起源の課題: Backlog説明に `GitHub Issue:` を付与 → Backlogポーリング時スキップ
  - Backlog起源の課題: GitHub Issue本文に `<!-- backlog-synced -->` を埋め込み → issuesイベント時スキップ
- **キー追跡**: GitHub Issue本文の `<!-- backlog-key:PROJ-N -->` マーカーで対応Backlog課題を管理
- **ステータス同期**: closed → Backlog完了(4) / reopened → Backlog未対応(1)

### 必要な GitHub Secrets

| Secret名 | 説明 |
|---|---|
| `BACKLOG_SPACE_ID` | BacklogスペースID（例: myspace） |
| `BACKLOG_API_KEY` | Backlog APIキー |
| `BACKLOG_PROJECT_KEY` | BacklogプロジェクトキーID（例: PROJ） |
| `GH_TOKEN` | GitHub PAT（issues write権限）※省略時はgithub.token使用 |