### PR TITLE
feat: #498 管理者機能に企業名一覧取得エンドポイントを追加

### DIFF
--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -17,6 +17,7 @@ type CompanyRelationQueryRepository interface {
 // CompanyRepository は企業情報の永続化インターフェース。
 type CompanyRepository interface {
 	FindAllActive(limit, offset int) ([]models.Company, error)
+	FindAllActiveNames(q string) ([]models.CompanyName, error)
 	CountActive() (int64, error)
 	FindAllPublished(limit, offset int) ([]models.Company, error)
 	CountPublished() (int64, error)

--- a/Backend/internal/controllers/admin_company_names.go
+++ b/Backend/internal/controllers/admin_company_names.go
@@ -1,0 +1,19 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Names GET /api/admin/companies/names
+// アクティブな企業の {id, name} 一覧を返す。q による部分一致検索をサポート。
+func (c *AdminCompanyController) Names(ctx echo.Context) error {
+	q := strings.TrimSpace(ctx.QueryParam("q"))
+	names, err := c.repo.FindAllActiveNames(q)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch company names")
+	}
+	return ctx.JSON(http.StatusOK, names)
+}

--- a/Backend/internal/models/company_name.go
+++ b/Backend/internal/models/company_name.go
@@ -1,0 +1,8 @@
+package models
+
+// CompanyName は軽量な企業ID/名前構造体（セレクト用）
+// JSON出力は {"id":..., "name":...} となる
+type CompanyName struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+}

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"Backend/internal/models"
+	"strings"
 
 	"gorm.io/gorm"
 )
@@ -35,6 +36,17 @@ func (r *CompanyRepository) CountActive() (int64, error) {
 		Where("is_active = ?", true).
 		Count(&count).Error
 	return count, err
+}
+
+// FindAllActiveNames アクティブ企業のIDと名前を取得（フィルタ q で部分一致）
+func (r *CompanyRepository) FindAllActiveNames(q string) ([]models.CompanyName, error) {
+	var names []models.CompanyName
+	query := r.db.Model(&models.Company{}).Select("id, name").Where("is_active = ?", true)
+	if q = strings.TrimSpace(q); q != "" {
+		query = query.Where("name LIKE ?", "%"+q+"%")
+	}
+	err := query.Order("name asc").Find(&names).Error
+	return names, err
 }
 
 // FindAllPublished 公開済み企業をページネーション付きで取得（マッチング用）

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -35,6 +35,8 @@ func SetupAdminRoutes(
 	// 企業管理
 	admin.GET("/companies", adminCompanyController.List)
 	admin.POST("/companies", adminCompanyController.Create)
+	// 軽量な企業名一覧（セレクト用）
+	admin.GET("/companies/names", adminCompanyController.Names)
 	admin.GET("/companies/:id", adminCompanyController.Get)
 	admin.PUT("/companies/:id", adminCompanyController.Update)
 	admin.POST("/companies/:id/publish", adminCompanyController.Publish)

--- a/Backend/test/controllers/admin_company_names_test.go
+++ b/Backend/test/controllers/admin_company_names_test.go
@@ -1,0 +1,34 @@
+package controllers_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/models"
+	"Backend/test/controllers/mocks"
+
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAdminCompanyController_Names_ServiceError(t *testing.T) {
+	repo := &mocks.CompanyRepositoryMock{}
+	repo.On("FindAllActiveNames", "").Return(nil, errors.New("db error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/companies/names", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newAdminCompanyController(repo, nil).Names, newCtx(req, rec), http.StatusInternalServerError)
+	repo.AssertExpectations(t)
+}
+
+func TestAdminCompanyController_Names_Success(t *testing.T) {
+	repo := &mocks.CompanyRepositoryMock{}
+	list := []models.CompanyName{{ID: 1, Name: "Test Corp"}}
+	repo.On("FindAllActiveNames", "Test").Return(list, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/companies/names?q=Test", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, newAdminCompanyController(repo, nil).Names, newCtx(req, rec), http.StatusOK)
+	repo.AssertExpectations(t)
+}

--- a/Backend/test/controllers/mocks/company_repository_mock.go
+++ b/Backend/test/controllers/mocks/company_repository_mock.go
@@ -19,6 +19,14 @@ func (m *CompanyRepositoryMock) FindAllActive(limit, offset int) ([]models.Compa
 	return nil, args.Error(1)
 }
 
+func (m *CompanyRepositoryMock) FindAllActiveNames(q string) ([]models.CompanyName, error) {
+	args := m.Called(q)
+	if v := args.Get(0); v != nil {
+		return v.([]models.CompanyName), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *CompanyRepositoryMock) CountActive() (int64, error) {
 	args := m.Called()
 	return args.Get(0).(int64), args.Error(1)

--- a/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
+++ b/frontend/app/admin/graduate-employments/[id]/edit/page.tsx
@@ -46,11 +46,11 @@ export default function AdminGraduateEmploymentEditPage() {
     if (!id) return
     const headers = authService.getAdminFetchHeaders()
     Promise.all([
-      fetch('/api/admin/companies', { headers }).then((r) => r.json()),
+      fetch('/api/admin/companies/names', { headers }).then((r) => r.json()),
       fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()),
       fetch(`/api/admin/graduate-employments/${id}`, { headers }).then((r) => r.json()),
     ]).then(([companiesData, positionsData, entry]) => {
-      setCompanies(companiesData?.companies || [])
+      setCompanies(companiesData || [])
       setJobPositions(positionsData?.positions || [])
       if (entry?.id) {
         setCompanyId(String(entry.company_id || ''))

--- a/frontend/app/admin/graduate-employments/new/page.tsx
+++ b/frontend/app/admin/graduate-employments/new/page.tsx
@@ -38,7 +38,7 @@ export default function AdminGraduateEmploymentNewPage() {
 
   useEffect(() => {
     const headers = authService.getAdminFetchHeaders()
-    fetch('/api/admin/companies', { headers }).then((r) => r.json()).then((d) => setCompanies(d?.companies || []))
+    fetch('/api/admin/companies/names', { headers }).then((r) => r.json()).then((d) => setCompanies(d || []))
     fetch('/api/admin/job-positions?limit=100', { headers }).then((r) => r.json()).then((d) => setJobPositions(d?.positions || []))
   }, [])
 

--- a/frontend/app/api/admin/companies/names/route.ts
+++ b/frontend/app/api/admin/companies/names/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams.toString()
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/names${query ? `?${query}` : ''}`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  // backend returns JSON array; try parse, otherwise wrap
+  if (!raw) return NextResponse.json([], { status: response.status })
+  try {
+    const data = JSON.parse(raw)
+    return NextResponse.json(data, { status: response.status })
+  } catch {
+    return NextResponse.json(response.ok ? { message: raw } : { error: raw }, { status: response.status })
+  }
+}


### PR DESCRIPTION
### 変更点
- Backend: GET /api/admin/companies/names を追加（アクティブ企業の {id,name} 一覧を返す、q による部分一致対応）
- Frontend: 管理画面の企業選択で軽量エンドポイントを使用するよう切替
- テスト: Backend のコントローラー用ユニットテストを追加

### 目的
ドロップダウン/オートコンプリート用途で余分なデータを排除し、効率化します。

### 動作確認
- Backend: Backend/test/controllers/admin_company_names_test.go を追加（go test で実行）
- CI: .github/workflows/test.yml により backend のユニットテストが実行されます

レビューをお願いします。