### PR TITLE
Resolve #501: 管理者企業登録画面にAI(OpenWebSearch)による企業情報自動取得機能を追加

### DIFF
--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -196,6 +196,76 @@ func (c *AdminCompanyController) SyncGBiz(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, result)
 }
 
+// WebSearchCompanyInfo POST /api/admin/companies/web-search
+// 企業名をもとにOpenAI WebSearchで一般的な企業情報を取得してプレビュー用に返す
+func (c *AdminCompanyController) WebSearchCompanyInfo(ctx echo.Context) error {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+	}
+	if c.openaiClient == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "openai client not configured")
+	}
+
+	prompt := fmt.Sprintf(
+		`「%s」という企業の情報を調査してください。以下のJSON形式のみで回答してください（余分な説明は不要）。
+{
+  "description": "企業概要（100〜200文字程度）",
+  "industry": "業種（例: IT・ソフトウェア, 金融, 製造業）",
+  "location": "本社所在地（例: 東京都渋谷区）",
+  "website_url": "公式サイトURL（https://から始まる）",
+  "founded_year": 設立年（整数、不明なら0）,
+  "employee_count": 従業員数（整数、不明なら0）,
+  "main_business": "主要事業内容（50〜100文字程度）",
+  "culture": "企業文化・働き方の特徴（50〜100文字程度）",
+  "work_style": "勤務スタイル（リモート / ハイブリッド / オフィス のいずれか、不明なら空文字）"
+}`,
+		req.Name,
+	)
+
+	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), 30*time.Second)
+	defer cancel()
+
+	text, err := c.openaiClient.WebSearchQuery(reqCtx, prompt)
+	if err != nil {
+		return echoInternalError(err)
+	}
+
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end == -1 || end <= start {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to parse web search response")
+	}
+
+	type companyInfoResult struct {
+		Description   string `json:"description"`
+		Industry      string `json:"industry"`
+		Location      string `json:"location"`
+		WebsiteURL    string `json:"website_url"`
+		FoundedYear   int    `json:"founded_year"`
+		EmployeeCount int    `json:"employee_count"`
+		MainBusiness  string `json:"main_business"`
+		Culture       string `json:"culture"`
+		WorkStyle     string `json:"work_style"`
+	}
+	var result companyInfoResult
+	if err := json.Unmarshal([]byte(text[start:end+1]), &result); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to parse company info json")
+	}
+
+	actor := ctx.Request().Header.Get("X-Admin-Email")
+	c.audit.Record(actor, "company.web_search", "company", 0, map[string]any{
+		"name": req.Name,
+	})
+
+	return ctx.JSON(http.StatusOK, result)
+}
+
 // FetchTechStack POST /api/admin/companies/:id/tech-stack-search
 // OpenAI WebSearchで企業の技術スタックを取得してDBを更新する
 func (c *AdminCompanyController) FetchTechStack(ctx echo.Context) error {

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -39,6 +39,7 @@ func SetupAdminRoutes(
 	admin.PUT("/companies/:id", adminCompanyController.Update)
 	admin.POST("/companies/:id/publish", adminCompanyController.Publish)
 	admin.POST("/companies/:id/reject", adminCompanyController.Reject)
+	admin.POST("/companies/web-search", adminCompanyController.WebSearchCompanyInfo)
 	admin.GET("/companies/:id/gbiz-search", adminCompanyController.SearchGBiz)
 	admin.POST("/companies/:id/gbiz-sync", adminCompanyController.SyncGBiz)
 	admin.POST("/companies/:id/fetch-tech-stack", adminCompanyController.FetchTechStack)

--- a/frontend/app/admin/companies/new/page.tsx
+++ b/frontend/app/admin/companies/new/page.tsx
@@ -3,10 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
+  Alert,
   Button,
+  CircularProgress,
+  Divider,
   MenuItem,
-  TextField,
   Stack,
+  TextField,
+  Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
@@ -23,18 +27,60 @@ export default function AdminCompanyNewPage() {
   }, [])
 
   const [error, setError] = useState('')
+  const [aiSuccess, setAiSuccess] = useState('')
+  const [aiLoading, setAiLoading] = useState(false)
+
   const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
   const [industry, setIndustry] = useState('')
   const [location, setLocation] = useState('')
   const [websiteUrl, setWebsiteUrl] = useState('')
+  const [foundedYear, setFoundedYear] = useState('')
+  const [employeeCount, setEmployeeCount] = useState('')
+  const [mainBusiness, setMainBusiness] = useState('')
+  const [culture, setCulture] = useState('')
+  const [workStyle, setWorkStyle] = useState('')
   const [sourceType, setSourceType] = useState('manual')
   const [sourceUrl, setSourceUrl] = useState('')
   const [dataStatus, setDataStatus] = useState('draft')
   const [isProvisional, setIsProvisional] = useState(true)
 
+  const handleAiFetch = async () => {
+    setAiLoading(true)
+    setError('')
+    setAiSuccess('')
+    try {
+      const res = await fetch('/api/admin/companies/web-search', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authService.getAdminFetchHeaders(),
+        },
+        body: JSON.stringify({ name }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || 'AI企業情報取得に失敗しました')
+        return
+      }
+      if (data.description) setDescription(data.description)
+      if (data.industry) setIndustry(data.industry)
+      if (data.location) setLocation(data.location)
+      if (data.website_url) setWebsiteUrl(data.website_url)
+      if (data.founded_year) setFoundedYear(String(data.founded_year))
+      if (data.employee_count) setEmployeeCount(String(data.employee_count))
+      if (data.main_business) setMainBusiness(data.main_business)
+      if (data.culture) setCulture(data.culture)
+      if (data.work_style) setWorkStyle(data.work_style)
+      setAiSuccess('AI情報取得が完了しました。内容を確認・修正してから追加してください。')
+    } finally {
+      setAiLoading(false)
+    }
+  }
+
   const handleCreate = async () => {
     setError('')
-    const admin = authService.getStoredUser()
+    setAiSuccess('')
     const res = await fetch('/api/admin/companies', {
       method: 'POST',
       headers: {
@@ -43,9 +89,15 @@ export default function AdminCompanyNewPage() {
       },
       body: JSON.stringify({
         name,
+        description,
         industry,
         location,
         website_url: websiteUrl,
+        founded_year: foundedYear ? parseInt(foundedYear, 10) : undefined,
+        employee_count: employeeCount ? parseInt(employeeCount, 10) : undefined,
+        main_business: mainBusiness,
+        culture,
+        work_style: workStyle,
         source_type: sourceType,
         source_url: sourceUrl,
         is_provisional: isProvisional,
@@ -63,11 +115,81 @@ export default function AdminCompanyNewPage() {
   return (
     <AdminFormContainer title="企業の追加" maxWidth={700} backHref="/admin/companies" backLabel="一覧に戻る">
       <ErrorAlert error={error} />
+      {aiSuccess && <Alert severity="success" sx={{ mb: 2 }}>{aiSuccess}</Alert>}
       <Stack spacing={2}>
         <TextField label="企業名" value={name} onChange={(e) => setName(e.target.value)} required />
+
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={handleAiFetch}
+            disabled={!name.trim() || aiLoading}
+            startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {aiLoading ? 'AI検索中...' : '🤖 AIで企業情報を自動取得'}
+          </Button>
+          <Typography variant="caption" color="text.secondary">
+            企業名を入力後にクリックしてください
+          </Typography>
+        </Stack>
+
+        <Divider />
+
+        <TextField
+          label="企業概要"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          multiline
+          minRows={2}
+        />
         <TextField label="業種" value={industry} onChange={(e) => setIndustry(e.target.value)} />
         <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
         <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="設立年"
+            value={foundedYear}
+            onChange={(e) => setFoundedYear(e.target.value)}
+            type="number"
+            sx={{ flex: 1 }}
+          />
+          <TextField
+            label="従業員数"
+            value={employeeCount}
+            onChange={(e) => setEmployeeCount(e.target.value)}
+            type="number"
+            sx={{ flex: 1 }}
+          />
+        </Stack>
+        <TextField
+          label="主要事業内容"
+          value={mainBusiness}
+          onChange={(e) => setMainBusiness(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        <TextField
+          label="企業文化"
+          value={culture}
+          onChange={(e) => setCulture(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        <TextField
+          select
+          label="勤務スタイル"
+          value={workStyle}
+          onChange={(e) => setWorkStyle(e.target.value)}
+        >
+          <MenuItem value="">未設定</MenuItem>
+          <MenuItem value="リモート">リモート</MenuItem>
+          <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
+          <MenuItem value="オフィス">オフィス</MenuItem>
+        </TextField>
+
+        <Divider />
+
         <TextField select label="出典タイプ" value={sourceType} onChange={(e) => setSourceType(e.target.value)}>
           <MenuItem value="official">公式サイト</MenuItem>
           <MenuItem value="job_site">就活/転職サイト</MenuItem>
@@ -87,6 +209,7 @@ export default function AdminCompanyNewPage() {
           <MenuItem value="yes">暫定</MenuItem>
           <MenuItem value="no">確定</MenuItem>
         </TextField>
+
         <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>
           追加する
         </Button>

--- a/frontend/app/api/admin/companies/web-search/route.ts
+++ b/frontend/app/api/admin/companies/web-search/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/web-search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+    body,
+  })
+  const raw = await response.text()
+  let data: Record<string, unknown> = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}


### PR DESCRIPTION
Closes #501

## 変更内容

### Backend

**`Backend/internal/controllers/admin_company_controller.go`**
- `WebSearchCompanyInfo` メソッドを新規追加
  - `POST /api/admin/companies/web-search` エンドポイントを実装
  - リクエストボディ `{"name": "企業名"}` を受け取り、既存の `WebSearchQuery`（OpenAI `web_search_preview`）でWeb検索を実行
  - 取得テキストからJSON部分を抽出・パースし、以下フィールドを構造化して返す
    - `description`（企業概要）, `industry`（業種）, `location`（所在地）
    - `website_url`（公式URL）, `founded_year`（設立年）, `employee_count`（従業員数）
    - `main_business`（主要事業）, `culture`（企業文化）, `work_style`（勤務スタイル）
  - 監査ログに `company.web_search` イベントを記録
  - OpenAIクライアント未設定時は `503 Service Unavailable` を返す

**`Backend/internal/routes/admin_routes.go`**
- `admin.POST("/companies/web-search", adminCompanyController.WebSearchCompanyInfo)` を追加
  - `:id` を含まない固定パスのため既存ルートとの競合なし

### Frontend

**`frontend/app/api/admin/companies/web-search/route.ts`** (新規)
- バックエンドの `POST /api/admin/companies/web-search` へのNext.jsプロキシルートを新規作成
- `X-Admin-Email` / `X-Admin-Token` ヘッダーを透過

**`frontend/app/admin/companies/new/page.tsx`**
- 「🤖 AIで企業情報を自動取得」ボタンを追加
  - 企業名入力後に有効化、ローディング中はスピナー表示
  - 取得成功時はフォームに自動補完し、Success Alertを表示
  - 取得失敗時はエラーメッセージを表示
- フォームに以下フィールドを追加（AI取得 or 手動入力）
  - 企業概要（textarea）
  - 主要事業内容（textarea）
  - 企業文化（textarea）
  - 勤務スタイル（select: リモート / ハイブリッド / オフィス）
  - 設立年・従業員数（数値入力、横並び）
- 新フィールドを `Create` APIの送信ペイロードに含めるよう修正

## テスト観点

- 企業名入力 → AIボタン押下 → フォーム自動補完されること
- 補完後に各フィールドを手動修正 → 追加ボタンで保存できること
- OpenAIクライアント未設定環境でも既存の手動入力フローは正常動作すること
- 監査ログに `company.web_search` が記録されること