### PR TITLE
[SOCAIAGENT-8] feat: AI面接のUI改善と企業特化の質問対応強化

### DIFF
--- a/.github/backlog-user-map.json
+++ b/.github/backlog-user-map.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "GitHub ログイン名 → Backlog ユーザーID のマッピング。ユーザーIDは Backlog の「個人設定」または GET /api/v2/users/myself で確認できます。",
+  "oohasikazuyuki": 0
+}

--- a/.github/workflows/pr-to-backlog.yml
+++ b/.github/workflows/pr-to-backlog.yml
@@ -1,0 +1,141 @@
+name: PR → Backlog 同期
+
+# PR に Backlog 課題キー（例: SOCAIAGENT-8）が含まれる場合に Backlog 課題を自動更新します。
+#
+# 動作:
+#   - PR オープン/更新時 : ステータスを「処理中」に変更し、説明に PR URL を追記
+#   - PR マージ時        : ステータスを「完了」に変更
+#   - PR クローズ（非マージ）: ステータスを「未対応」に戻す
+#
+# 課題キーの検出場所（優先順）:
+#   1. PR タイトルの [PROJ-N] プレフィックス
+#   2. PR 本文の <!-- backlog-key:PROJ-N --> マーカー
+#   3. PR 本文の「Backlog: PROJ-N」記述
+#
+# 必要な GitHub Secrets:
+#   BACKLOG_SPACE_ID    : スペースID（例: myspace ← myspace.backlog.jp の場合）
+#   BACKLOG_API_KEY     : Backlog APIキー
+#   BACKLOG_PROJECT_KEY : プロジェクトキー（例: SOCAIAGENT）
+#   BACKLOG_DOMAIN      : ドメイン（省略時は backlog.jp → backlog.com の順に自動判定）
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: PR を Backlog 課題へ反映
+        env:
+          BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+          BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+          BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+          BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          python3 - << 'PYEOF'
+          import os, sys, json, re, urllib.parse, urllib.request, urllib.error
+
+          API_KEY   = os.environ['BACKLOG_API_KEY']
+          SPACE_ID  = os.environ['BACKLOG_SPACE_ID']
+          PROJ_KEY  = os.environ['BACKLOG_PROJECT_KEY']
+          PR_TITLE  = os.environ.get('PR_TITLE', '')
+          PR_BODY   = os.environ.get('PR_BODY') or ''
+          PR_URL    = os.environ['PR_URL']
+          PR_MERGED = os.environ.get('PR_MERGED', 'false').lower() == 'true'
+          ACTION    = os.environ['ACTION']
+          DOMAIN    = os.environ.get('BACKLOG_DOMAIN', '').strip()
+
+          def resolve_bl_base(space_id, api_key, domain):
+              candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
+              for d in candidates:
+                  url = f"https://{space_id}.{d}/api/v2/space?apiKey={api_key}"
+                  try:
+                      with urllib.request.urlopen(urllib.request.Request(url)) as r:
+                          r.read()
+                          return f"https://{space_id}.{d}/api/v2", d
+                  except urllib.error.HTTPError as e:
+                      body = e.read().decode()
+                      if e.code == 404 and '"code":6' in body:
+                          continue
+                      print(f"Backlog API エラー {e.code}: {body}", file=sys.stderr)
+                      sys.exit(1)
+              print(f"エラー: スペース '{space_id}' が見つかりませんでした。", file=sys.stderr)
+              sys.exit(1)
+
+          BL_BASE, BL_DOMAIN = resolve_bl_base(SPACE_ID, API_KEY, DOMAIN)
+          print(f"Backlog ドメイン: {BL_DOMAIN}")
+
+          def bl_request(method, path, data=None):
+              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
+              body = urllib.parse.urlencode(data).encode() if data else None
+              req = urllib.request.Request(url, data=body, method=method)
+              if body:
+                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
+                  return None
+
+          def extract_bl_key(title, body):
+              # 1. タイトルの [PROJ-N] プレフィックス
+              m = re.search(rf'\[({re.escape(PROJ_KEY)}-\d+)\]', title)
+              if m:
+                  return m.group(1)
+              # 2. 本文の <!-- backlog-key:PROJ-N --> マーカー
+              m = re.search(r'<!--\s*backlog-key:(\S+?)\s*-->', body)
+              if m:
+                  return m.group(1)
+              # 3. 本文の「Backlog: PROJ-N」記述
+              m = re.search(rf'[Bb]acklog[：:]\s*({re.escape(PROJ_KEY)}-\d+)', body)
+              if m:
+                  return m.group(1)
+              return None
+
+          bl_key = extract_bl_key(PR_TITLE, PR_BODY)
+          if not bl_key:
+              print("Backlog 課題キーが見つかりません。スキップします。")
+              sys.exit(0)
+
+          print(f"検出した Backlog 課題キー: {bl_key}")
+
+          # 現在の課題情報を取得
+          issue = bl_request('GET', f"/issues/{bl_key}")
+          if not issue:
+              print(f"Backlog 課題 {bl_key} が見つかりません。")
+              sys.exit(0)
+
+          # 説明に PR URL セクションを追記（すでにあれば上書き）
+          current_desc = issue.get('description') or ''
+          pr_section = f'\n\n## GitHub PR\n{PR_URL}'
+          pr_pattern  = r'\n*## GitHub PR\n[^\n]*'
+          if re.search(pr_pattern, current_desc):
+              new_desc = re.sub(pr_pattern, pr_section, current_desc)
+          else:
+              new_desc = current_desc.rstrip() + pr_section
+
+          # ステータスID の決定
+          # 1=未対応 / 2=処理中 / 3=処理済み / 4=完了
+          if ACTION == 'closed':
+              status_id    = 4 if PR_MERGED else 1
+              status_label = '完了' if PR_MERGED else '未対応'
+          else:
+              status_id    = 2
+              status_label = '処理中'
+
+          result = bl_request('PATCH', f"/issues/{bl_key}", {
+              'description': new_desc,
+              'statusId':    status_id,
+          })
+          if result:
+              print(f"Backlog 課題を更新しました: {bl_key} (ステータス: {status_label}、PR URL を追記)")
+          PYEOF

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -27,7 +27,7 @@ OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-4o-mini
 
 # Realtime interview cost controls
-OPENAI_REALTIME_MODEL=gpt-realtime
+OPENAI_REALTIME_MODEL=gpt-4o-realtime-preview
 OPENAI_REALTIME_TRANSCRIBE_MODEL=gpt-4o-mini-transcribe
 OPENAI_REALTIME_MAX_OUTPUT_TOKENS=120
 INTERVIEW_COST_PER_MIN_USD=0.18

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -310,7 +310,7 @@ func main() {
 	routes.SetupCompanyRoutes(api, relationController)
 	routes.SetupAdminRoutes(api, adminCompanyController, adminCrawlController, adminJobController, adminUserController, adminAuditController, adminCompanyGraphController, adminInterviewController, adminDashboardController, adminCostsController, profileRecalcController, scoreValidationController, collectiveInsightController, scraperSessionController, userRepo, cfg.AdminSecret)
 	routes.SetupResumeRoutes(api, resumeController, cfg.UserSecret)
-	routes.SetupInterviewRoutes(api, interviewController, realtimeController)
+	routes.SetupInterviewRoutes(api, interviewController, realtimeController, cfg.UserSecret)
 	routes.SetupGitHubRoutes(api, githubController, cfg.UserSecret)
 	routes.SetupESRoutes(api, esRewriteController, esReviewController)
 	routes.SetupScheduleRoutes(api, scheduleController)

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -196,6 +196,76 @@ func (c *AdminCompanyController) SyncGBiz(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, result)
 }
 
+// WebSearchCompanyInfo POST /api/admin/companies/web-search
+// 企業名をもとにOpenAI WebSearchで一般的な企業情報を取得してプレビュー用に返す
+func (c *AdminCompanyController) WebSearchCompanyInfo(ctx echo.Context) error {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+	}
+	if c.openaiClient == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "openai client not configured")
+	}
+
+	prompt := fmt.Sprintf(
+		`「%s」という企業の情報を調査してください。以下のJSON形式のみで回答してください（余分な説明は不要）。
+{
+  "description": "企業概要（100〜200文字程度）",
+  "industry": "業種（例: IT・ソフトウェア, 金融, 製造業）",
+  "location": "本社所在地（例: 東京都渋谷区）",
+  "website_url": "公式サイトURL（https://から始まる）",
+  "founded_year": 設立年（整数、不明なら0）,
+  "employee_count": 従業員数（整数、不明なら0）,
+  "main_business": "主要事業内容（50〜100文字程度）",
+  "culture": "企業文化・働き方の特徴（50〜100文字程度）",
+  "work_style": "勤務スタイル（リモート / ハイブリッド / オフィス のいずれか、不明なら空文字）"
+}`,
+		req.Name,
+	)
+
+	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), 30*time.Second)
+	defer cancel()
+
+	text, err := c.openaiClient.WebSearchQuery(reqCtx, prompt)
+	if err != nil {
+		return echoInternalError(err)
+	}
+
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end == -1 || end <= start {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to parse web search response")
+	}
+
+	type companyInfoResult struct {
+		Description   string `json:"description"`
+		Industry      string `json:"industry"`
+		Location      string `json:"location"`
+		WebsiteURL    string `json:"website_url"`
+		FoundedYear   int    `json:"founded_year"`
+		EmployeeCount int    `json:"employee_count"`
+		MainBusiness  string `json:"main_business"`
+		Culture       string `json:"culture"`
+		WorkStyle     string `json:"work_style"`
+	}
+	var result companyInfoResult
+	if err := json.Unmarshal([]byte(text[start:end+1]), &result); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to parse company info json")
+	}
+
+	actor := ctx.Request().Header.Get("X-Admin-Email")
+	c.audit.Record(actor, "company.web_search", "company", 0, map[string]any{
+		"name": req.Name,
+	})
+
+	return ctx.JSON(http.StatusOK, result)
+}
+
 // FetchTechStack POST /api/admin/companies/:id/tech-stack-search
 // OpenAI WebSearchで企業の技術スタックを取得してDBを更新する
 func (c *AdminCompanyController) FetchTechStack(ctx echo.Context) error {

--- a/Backend/internal/controllers/error_response.go
+++ b/Backend/internal/controllers/error_response.go
@@ -80,6 +80,16 @@ func echoIntQuery(c echo.Context, key string, def int) int {
 	return n
 }
 
+// Exported wrappers for testing from external packages.
+
+const InternalServerErrorMessage = internalServerErrorMessage
+
+func NewAPIError(status int, code, message string, detail ...string) error {
+	return newAPIError(status, code, message, detail...)
+}
+func EchoUintParam(c echo.Context, key string) (uint, error) { return echoUintParam(c, key) }
+func EchoInternalError(err error) error                       { return echoInternalError(err) }
+
 func logError(err error) {
 	if err == nil {
 		return

--- a/Backend/internal/middleware/error_handler.go
+++ b/Backend/internal/middleware/error_handler.go
@@ -86,3 +86,6 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 
 	_ = c.JSON(status, resp)
 }
+
+// DefaultCodeByStatus is an exported wrapper for defaultCodeByStatus for use in external tests.
+func DefaultCodeByStatus(status int) string { return defaultCodeByStatus(status) }

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -39,6 +39,7 @@ func SetupAdminRoutes(
 	admin.PUT("/companies/:id", adminCompanyController.Update)
 	admin.POST("/companies/:id/publish", adminCompanyController.Publish)
 	admin.POST("/companies/:id/reject", adminCompanyController.Reject)
+	admin.POST("/companies/web-search", adminCompanyController.WebSearchCompanyInfo)
 	admin.GET("/companies/:id/gbiz-search", adminCompanyController.SearchGBiz)
 	admin.POST("/companies/:id/gbiz-sync", adminCompanyController.SyncGBiz)
 	admin.POST("/companies/:id/fetch-tech-stack", adminCompanyController.FetchTechStack)

--- a/Backend/internal/routes/interview_routes.go
+++ b/Backend/internal/routes/interview_routes.go
@@ -7,8 +7,8 @@ import (
 )
 
 // SetupInterviewRoutes 面接関連のルーティング設定
-func SetupInterviewRoutes(api *echo.Group, interviewController *controllers.InterviewController, realtimeController *controllers.RealtimeController) {
-	interviews := api.Group("/interviews")
+func SetupInterviewRoutes(api *echo.Group, interviewController *controllers.InterviewController, realtimeController *controllers.RealtimeController, userSecret string) {
+	interviews := api.Group("/interviews", EchoUserAuth(userSecret))
 	// /trend は /:id より先にEchoのルーターが解決するため先に登録する
 	interviews.GET("/trend", interviewController.GetTrend)
 	interviews.GET("", interviewController.List)
@@ -24,7 +24,7 @@ func SetupInterviewRoutes(api *echo.Group, interviewController *controllers.Inte
 	interviews.POST("/:id/turn", interviewController.Turn)
 	interviews.POST("/:id/start-turn", interviewController.StartTurn)
 
-	realtime := api.Group("/realtime")
+	realtime := api.Group("/realtime", EchoUserAuth(userSecret))
 	realtime.POST("/token", realtimeController.Token)
 	realtime.GET("/session-info", realtimeController.SessionInfo)
 }

--- a/Backend/internal/services/analysis_scoring_service.go
+++ b/Backend/internal/services/analysis_scoring_service.go
@@ -625,3 +625,16 @@ func averageCategoryScore(scoreMap map[string]float64, categories []string) floa
 	}
 	return clamp01(sum / count)
 }
+
+// Exported wrappers for testing from external packages.
+
+func BuildScoreComment(scores AnalysisScores) string { return buildScoreComment(scores) }
+func BuildJobSuitabilityComment(scores []entity.UserWeightScore) (string, []JobSuitabilityRole) {
+	return buildJobSuitabilityComment(scores)
+}
+func ParseEmbedding(raw string) ([]float64, error)     { return parseEmbedding(raw) }
+func CosineSimilarity(a, b []float64) float64          { return cosineSimilarity(a, b) }
+func Clamp01(value float64) float64                    { return clamp01(value) }
+func AverageCategoryScore(scoreMap map[string]float64, categories []string) float64 {
+	return averageCategoryScore(scoreMap, categories)
+}

--- a/Backend/internal/services/crawl_service.go
+++ b/Backend/internal/services/crawl_service.go
@@ -1082,3 +1082,16 @@ func computeNextRun(now time.Time, source *models.CrawlSource) *time.Time {
 func lastDayOfMonth(year int, month time.Month, loc *time.Location) int {
 	return time.Date(year, month+1, 0, 0, 0, 0, 0, loc).Day()
 }
+
+// Exported type alias and wrappers for testing from external packages.
+
+type MynaviCompanyData = mynaviCompanyData
+
+func ParseMynaviCompanyPage(htmlBytes []byte) (*MynaviCompanyData, error) {
+	return parseMynaviCompanyPage(htmlBytes)
+}
+func ExtractYear(s string) int                                          { return extractYear(s) }
+func ExtractInt(s string) int                                           { return extractInt(s) }
+func ExtractFloat(s string) float64                                     { return extractFloat(s) }
+func ExtractCharset(contentType string) string                          { return extractCharset(contentType) }
+func ValidateCrawlSource(source *models.CrawlSource) error             { return validateCrawlSource(source) }

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -796,13 +796,9 @@ func buildInterviewSystemPrompt(
 			base += "\n応募職種: " + position
 		}
 		if companyInfo != "" {
-			if companyType == "general" {
-				base += "\n\n【企業研究情報（公式サイトより）】\n" + companyInfo
-			} else {
-				base += "\n企業概要: " + companyInfo
-			}
+			base += "\n\n【企業情報】\n" + companyInfo
 		}
-		base += "\n\n上記の企業・職種に合わせた質問を行ってください。"
+		base += "\n\n上記の企業・職種に合わせた質問を行ってください。企業文化・働き方・福利厚生の情報がある場合は、それらを踏まえた「この企業ならでは」の深掘り質問を取り入れてください。"
 	}
 
 	if companyType == "sier" {
@@ -813,7 +809,8 @@ func buildInterviewSystemPrompt(
 - 上流工程（要件定義・基本設計）への関与実績を確認する
 - ウォーターフォール・アジャイルどちらの経験があるか確認する
 - IPA資格や技術資格の取得状況・今後の学習意欲を聞く
-- 多様な現場・技術スタックへの適応力を問う`
+- 多様な現場・技術スタックへの適応力を問う
+- 技術フェーズ（詳細設計・実装・テスト）と要件定義フェーズの両方を経験しているか確認する`
 	}
 
 	return strings.TrimSpace(base)
@@ -1134,6 +1131,14 @@ func ttsVoiceForGenderAndLang(gender, lang string) string {
 	default: // female
 		return "shimmer"
 	}
+}
+
+// TTSVoiceForGenderAndLang is an exported wrapper for ttsVoiceForGenderAndLang for external tests.
+func TTSVoiceForGenderAndLang(gender, lang string) string { return ttsVoiceForGenderAndLang(gender, lang) }
+
+// RealtimeVoiceForLangAndGender is an exported wrapper for realtimeVoiceForLangAndGender for external tests.
+func RealtimeVoiceForLangAndGender(lang, gender string) string {
+	return realtimeVoiceForLangAndGender(lang, gender)
 }
 
 // realtimeVoiceForLangAndGender 言語・性別コードに応じた推奨ボイスを返す。

--- a/Backend/internal/services/job_category_validator.go
+++ b/Backend/internal/services/job_category_validator.go
@@ -203,6 +203,11 @@ func (v *JobCategoryValidator) normalizeNumericAnswer(userAnswer string) (string
 	return userAnswer, nil
 }
 
+// NormalizeNumericAnswer is an exported wrapper for normalizeNumericAnswer for use in external tests.
+func (v *JobCategoryValidator) NormalizeNumericAnswer(userAnswer string) (string, error) {
+	return v.normalizeNumericAnswer(userAnswer)
+}
+
 // GenerateJobSelectionQuestion 職種選択の質問を生成
 func (v *JobCategoryValidator) GenerateJobSelectionQuestion(ctx context.Context) (string, error) {
 	// 主要な職種カテゴリを取得

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -308,3 +308,12 @@ func fallbackValue(value, fallback string) string {
 	}
 	return trimmed
 }
+
+// Exported wrappers for testing from external packages.
+
+func FormatTopUserScores(scores []entity.UserWeightScore) string { return formatTopUserScores(scores) }
+
+// NewMatchingServiceForTest returns a MatchingService with no AI client, suitable for unit tests.
+func NewMatchingServiceForTest() *MatchingService {
+	return &MatchingService{}
+}

--- a/Backend/internal/services/openwork_scraper.go
+++ b/Backend/internal/services/openwork_scraper.go
@@ -341,3 +341,19 @@ func decodeOpenworkToUTF8(b []byte, charset string) ([]byte, error) {
 		return b, nil
 	}
 }
+
+// Exported type aliases and wrappers for testing from external packages.
+
+type OpenworkScores = openworkScores
+type OpenworkCompanyData = openworkCompanyData
+
+func ParseOpenworkCompanyPage(htmlBytes []byte) (*OpenworkCompanyData, error) {
+	return parseOpenworkCompanyPage(htmlBytes)
+}
+func ParseOpenworkScore(s string) float64                    { return parseOpenworkScore(s) }
+func ParseOpenworkSalary(s string) int                       { return parseOpenworkSalary(s) }
+func ParseOpenworkReviewCount(s string) int                  { return parseOpenworkReviewCount(s) }
+func BuildOpenworkCultureJSON(scores OpenworkScores) string  { return buildOpenworkCultureJSON(scores) }
+func BuildOpenworkWelfareText(welfareScore float64) string   { return buildOpenworkWelfareText(welfareScore) }
+func BuildOpenworkSalaryText(salary int) string              { return buildOpenworkSalaryText(salary) }
+func ExtractOpenworkCharset(contentType string) string       { return extractOpenworkCharset(contentType) }

--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -663,6 +663,14 @@ func (s *seekableReader) Close() error {
 	return nil
 }
 
+// MaxResumeBytes is the exported constant for use in external tests.
+const MaxResumeBytes = maxResumeBytes
+
+// NewSeekableReader is an exported wrapper for newSeekableReader for use in external tests.
+func NewSeekableReader(src io.ReadCloser) (io.ReadSeekCloser, error) {
+	return newSeekableReader(src)
+}
+
 func derefInt64(value *int64) int64 {
 	if value == nil {
 		return 0

--- a/Backend/internal/services/schedule_service.go
+++ b/Backend/internal/services/schedule_service.go
@@ -157,3 +157,6 @@ func escapeICS(s string) string {
 	s = strings.ReplaceAll(s, "\n", "\\n")
 	return s
 }
+
+// FoldICSLine is an exported wrapper for foldICSLine for use in external tests.
+func FoldICSLine(line string) string { return foldICSLine(line) }

--- a/Backend/test/logger/logger_test.go
+++ b/Backend/test/logger/logger_test.go
@@ -1,0 +1,56 @@
+package logger_test
+
+// 実行: cd Backend && go test ./test/logger/... -v
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"Backend/internal/logger"
+)
+
+// TestSetup_DefaultIsInfo はLOG_LEVEL未設定時にInfoレベルになることを検証する
+func TestSetup_DefaultIsInfo(t *testing.T) {
+	os.Unsetenv("LOG_LEVEL")
+	os.Unsetenv("LOG_FORMAT")
+	logger.Setup()
+	if !slog.Default().Enabled(nil, slog.LevelInfo) {
+		t.Error("INFO レベルが有効になっていない")
+	}
+	if slog.Default().Enabled(nil, slog.LevelDebug) {
+		t.Error("デフォルト設定では DEBUG レベルは無効であるべき")
+	}
+}
+
+// TestSetup_DebugLevel はLOG_LEVEL=DEBUGでDebugレベルが有効になることを検証する
+func TestSetup_DebugLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "DEBUG")
+	os.Unsetenv("LOG_FORMAT")
+	logger.Setup()
+	if !slog.Default().Enabled(nil, slog.LevelDebug) {
+		t.Error("DEBUG レベルが有効になっていない")
+	}
+}
+
+// TestSetup_WarnLevel はLOG_LEVEL=WARNでInfoレベルが無効になることを検証する
+func TestSetup_WarnLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "WARN")
+	logger.Setup()
+	if slog.Default().Enabled(nil, slog.LevelInfo) {
+		t.Error("WARN 設定では INFO レベルは無効であるべき")
+	}
+	if !slog.Default().Enabled(nil, slog.LevelWarn) {
+		t.Error("WARN レベルが有効になっていない")
+	}
+}
+
+// TestSetup_DoesNotPanic はSetupがパニックしないことを検証する
+func TestSetup_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Setup() がパニックした: %v", r)
+		}
+	}()
+	logger.Setup()
+}

--- a/Backend/test/openai/client_cache_test.go
+++ b/Backend/test/openai/client_cache_test.go
@@ -1,0 +1,86 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"Backend/internal/openai"
+)
+
+func TestResponses_CachedTokensLogging(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/responses" {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]any{
+				"output_text": "hello",
+				"usage": map[string]any{
+					"input_tokens":  100,
+					"output_tokens": 10,
+					"prompt_tokens_details": map[string]int{"cached_tokens": 40},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := openai.NewWithBaseURL(server.URL, "gpt-4o-mini")
+	called := false
+	client.OnUsage = func(model string, promptTokens, completionTokens int) {
+		called = true
+		assert.Equal(t, "gpt-4o-mini", model)
+		assert.Equal(t, 100, promptTokens)
+		assert.Equal(t, 10, completionTokens)
+	}
+
+	ctx := context.Background()
+	out, err := client.Responses(ctx, "input", "gpt-4o-mini")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", out)
+	assert.True(t, called, "OnUsage should be called")
+}
+
+func TestChatCompletion_CachedTokensLogging(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/chat/completions") {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]string{"content": "hello"},
+				}},
+				"usage": map[string]any{
+					"prompt_tokens":     100,
+					"completion_tokens": 10,
+					"prompt_tokens_details": map[string]int{"cached_tokens": 40},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := openai.NewWithBaseURL(server.URL, "gpt-4o-mini")
+	called := false
+	client.OnUsage = func(model string, promptTokens, completionTokens int) {
+		called = true
+		assert.Equal(t, "gpt-4o-mini", model)
+		assert.Equal(t, 100, promptTokens)
+		assert.Equal(t, 10, completionTokens)
+	}
+
+	ctx := context.Background()
+	out, err := client.ChatCompletionJSON(ctx, "system", "user", 0.0, 100, "gpt-4o-mini")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", out)
+	assert.True(t, called, "OnUsage should be called for ChatCompletion")
+}

--- a/Backend/test/services/analysis_scoring_service_test.go
+++ b/Backend/test/services/analysis_scoring_service_test.go
@@ -1,0 +1,320 @@
+package services_test
+
+// 分析スコアリングサービスのユニットテスト
+// 実行: cd Backend && go test ./test/services/... -run TestRuleBased -v
+
+import (
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	"Backend/domain/entity"
+	"Backend/internal/models"
+	"Backend/internal/services"
+)
+
+func TestRuleBasedFutureAnalyzerScore(t *testing.T) {
+	analyzer := services.NewRuleBasedFutureAnalyzer()
+
+	tests := []struct {
+		name         string
+		messages     []models.ChatMessage
+		wantScore    float64
+		wantKeywords []string
+	}{
+		{
+			name:      "空メッセージは0点",
+			messages:  nil,
+			wantScore: 0,
+		},
+		{
+			name: "user以外は無視",
+			messages: []models.ChatMessage{
+				{Role: "assistant", Content: "成長したいですか"},
+			},
+			wantScore: 0,
+		},
+		{
+			name: "キーワードを重複なく検出してスコア化",
+			messages: []models.ChatMessage{
+				{Role: "user", Content: "将来は成長して、海外にも挑戦したいです"},
+				{Role: "user", Content: "さらに成長したい"},
+			},
+			wantScore:    0.8, // 4 / threshold(5)
+			wantKeywords: []string{"将来", "成長", "海外", "挑戦"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotScore, gotKeywords := analyzer.Score(tt.messages)
+			if math.Abs(gotScore-tt.wantScore) > 1e-9 {
+				t.Fatalf("score mismatch: got=%v want=%v", gotScore, tt.wantScore)
+			}
+			for _, keyword := range tt.wantKeywords {
+				if !slices.Contains(gotKeywords, keyword) {
+					t.Fatalf("expected keyword %q in %v", keyword, gotKeywords)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildScoreComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		scores   services.AnalysisScores
+		contains []string
+	}{
+		{
+			name:   "未評価コメント",
+			scores: services.AnalysisScores{},
+			contains: []string{
+				"チャット診断を完了させることで",
+			},
+		},
+		{
+			name: "高評価コメント",
+			scores: services.AnalysisScores{
+				JobScore:      0.85,
+				InterestScore: 0.82,
+				AptitudeScore: 0.81,
+				FutureScore:   0.80,
+				FinalScore:    0.83,
+			},
+			contains: []string{
+				"志望職種への適性が高い",
+				"企業への関心・意欲が非常に高い",
+				"総合的に非常に優れたプロフィールです",
+			},
+		},
+		{
+			name: "中位評価コメント",
+			scores: services.AnalysisScores{
+				JobScore:      0.55,
+				InterestScore: 0.52,
+				AptitudeScore: 0.51,
+				FutureScore:   0.50,
+				FinalScore:    0.61,
+			},
+			contains: []string{
+				"一定水準ある",
+				"示されている",
+				"総合的にバランスの取れたプロフィールです",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := services.BuildScoreComment(tt.scores)
+			for _, part := range tt.contains {
+				if !strings.Contains(got, part) {
+					t.Fatalf("expected %q in %q", part, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildJobSuitabilityComment(t *testing.T) {
+	tests := []struct {
+		name               string
+		scores             []entity.UserWeightScore
+		wantCommentContain string
+		wantMinRoles       int
+		wantRoleContain    string
+	}{
+		{
+			name:         "空スコア",
+			scores:       nil,
+			wantMinRoles: 0,
+		},
+		{
+			name: "主要スコアがある場合にコメントとロールを返す",
+			scores: []entity.UserWeightScore{
+				{WeightCategory: "リーダーシップ志向", Score: 90},
+				{WeightCategory: "成長志向", Score: 85},
+				{WeightCategory: "チャレンジ志向", Score: 80},
+				{WeightCategory: "技術志向", Score: 78},
+			},
+			wantCommentContain: "強みがあります",
+			wantMinRoles:       1,
+			wantRoleContain:    "プロジェクトマネージャー",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comment, roles := services.BuildJobSuitabilityComment(tt.scores)
+			if tt.wantCommentContain != "" && !strings.Contains(comment, tt.wantCommentContain) {
+				t.Fatalf("expected comment to contain %q, got %q", tt.wantCommentContain, comment)
+			}
+			if len(roles) < tt.wantMinRoles {
+				t.Fatalf("roles length mismatch: got=%d want>=%d", len(roles), tt.wantMinRoles)
+			}
+			if tt.wantRoleContain != "" {
+				found := false
+				for _, role := range roles {
+					if strings.Contains(role.Title, tt.wantRoleContain) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected a role title containing %q, got=%v", tt.wantRoleContain, roles)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEmbedding(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		want      []float64
+		wantError bool
+	}{
+		{
+			name: "空文字はnil",
+			raw:  "   ",
+			want: nil,
+		},
+		{
+			name: "有効なJSON配列",
+			raw:  "[0.1, 0.2, 0.3]",
+			want: []float64{0.1, 0.2, 0.3},
+		},
+		{
+			name:      "不正なJSON",
+			raw:       "{bad json}",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := services.ParseEmbedding(tt.raw)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("embedding mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCosineSimilarityService(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []float64
+		b    []float64
+		want float64
+	}{
+		{
+			name: "同一ベクトルは1",
+			a:    []float64{1, 2, 3},
+			b:    []float64{1, 2, 3},
+			want: 1,
+		},
+		{
+			name: "長さ不一致は0",
+			a:    []float64{1, 2},
+			b:    []float64{1, 2, 3},
+			want: 0,
+		},
+		{
+			name: "ゼロノルムは0",
+			a:    []float64{0, 0},
+			b:    []float64{1, 2},
+			want: 0,
+		},
+		{
+			name: "負値方向はclampされ0",
+			a:    []float64{1, 0},
+			b:    []float64{-1, 0},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := services.CosineSimilarity(tt.a, tt.b)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("cosine mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClamp01(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float64
+		want  float64
+	}{
+		{name: "下限以下", value: -0.1, want: 0},
+		{name: "範囲内", value: 0.25, want: 0.25},
+		{name: "上限以上", value: 1.2, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := services.Clamp01(tt.value)
+			if got != tt.want {
+				t.Fatalf("clamp mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAverageCategoryScore(t *testing.T) {
+	tests := []struct {
+		name       string
+		scoreMap   map[string]float64
+		categories []string
+		want       float64
+	}{
+		{
+			name:       "カテゴリ空",
+			scoreMap:   map[string]float64{"技術志向": 80},
+			categories: nil,
+			want:       0,
+		},
+		{
+			name: "一部カテゴリのみ存在",
+			scoreMap: map[string]float64{
+				"技術志向": 80,
+			},
+			categories: []string{"技術志向", "成長志向"},
+			want:       0.8,
+		},
+		{
+			name: "100超えスコアはclamp",
+			scoreMap: map[string]float64{
+				"技術志向": 120,
+				"成長志向": 100,
+			},
+			categories: []string{"技術志向", "成長志向"},
+			want:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := services.AverageCategoryScore(tt.scoreMap, tt.categories)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("average mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/Backend/test/services/github_service_security_test.go
+++ b/Backend/test/services/github_service_security_test.go
@@ -1,0 +1,113 @@
+package services_test
+
+// GitHub GraphQL インジェクション対策のテスト（Issue #311）
+// 実行: cd Backend && go test ./test/services/... -run TestGitHub -v
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestFetchTotalContributions_LoginIsSafelyEncoded は login 値が JSON として安全にエンコードされることを検証する（#311修正の担保）
+func TestFetchTotalContributions_LoginIsSafelyEncoded(t *testing.T) {
+	tests := []struct {
+		name  string
+		login string
+	}{
+		{"通常のログイン名", "alice"},
+		{"ハイフン含む", "alice-bob"},
+		{"ダブルクオート含む（インジェクション試行）", `alice"evil`},
+		{"バックスラッシュ含む", `alice\evil`},
+		{"改行含む", "alice\nevil"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := struct {
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
+			}{
+				Query:     `query($login: String!) { user(login: $login) { contributionsCollection { contributionCalendar { totalContributions } } } }`,
+				Variables: map[string]any{"login": tc.login},
+			}
+			b, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("json.Marshal failed: %v", err)
+			}
+
+			var decoded map[string]any
+			if err := json.Unmarshal(b, &decoded); err != nil {
+				t.Fatalf("login=%q を含むJSONが不正: %v", tc.login, err)
+			}
+
+			raw := string(b)
+			vars, ok := decoded["variables"].(map[string]any)
+			if !ok {
+				t.Fatal("variables フィールドが不正")
+			}
+			decodedLogin, ok := vars["login"].(string)
+			if !ok {
+				t.Fatal("variables.login フィールドが不正")
+			}
+			if decodedLogin != tc.login {
+				t.Errorf("ラウンドトリップ後の login 値が不一致: got %q, want %q", decodedLogin, tc.login)
+			}
+
+			if strings.Contains(raw, tc.login) && tc.login != "alice" && tc.login != "alice-bob" {
+				if strings.Contains(tc.login, `"`) {
+					escapedQ := `\"`
+					if !strings.Contains(raw, escapedQ) {
+						t.Errorf("ダブルクオートがエスケープされていない: %s", raw)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestContributedReposQuery_CursorIsSafelyEncoded はカーソル値が JSON として安全にエンコードされることを検証する（#311修正の担保）
+func TestContributedReposQuery_CursorIsSafelyEncoded(t *testing.T) {
+	type contributedReposVars struct {
+		After *string `json:"after,omitempty"`
+	}
+
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{"通常のbase64カーソル", "Y3Vyc29yOnYyOpK5"},
+		{"ダブルクオート含む（インジェクション試行）", `cursor"evil`},
+		{"バックスラッシュ含む", `cursor\evil`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			after := tc.cursor
+			vars := contributedReposVars{After: &after}
+			payload := struct {
+				Query     string               `json:"query"`
+				Variables contributedReposVars `json:"variables"`
+			}{
+				Query:     `query($after: String) { viewer { repositoriesContributedTo(first: 100, after: $after) { pageInfo { hasNextPage endCursor } } } }`,
+				Variables: vars,
+			}
+
+			b, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("json.Marshal failed: %v", err)
+			}
+
+			var decoded map[string]any
+			if err := json.Unmarshal(b, &decoded); err != nil {
+				t.Fatalf("カーソル=%q を含むJSONが不正: %v", tc.cursor, err)
+			}
+
+			varsDecoded, _ := decoded["variables"].(map[string]any)
+			decodedAfter, _ := varsDecoded["after"].(string)
+			if decodedAfter != tc.cursor {
+				t.Errorf("ラウンドトリップ後のカーソル値が不一致: got %q, want %q", decodedAfter, tc.cursor)
+			}
+		})
+	}
+}

--- a/Backend/test/services/matching_service_unit_test.go
+++ b/Backend/test/services/matching_service_unit_test.go
@@ -1,0 +1,62 @@
+package services_test
+
+// マッチングサービス内部ロジックのユニットテスト
+// 実行: cd Backend && go test ./test/services/... -run TestFormatTopUserScores -v
+
+import (
+	"strings"
+	"testing"
+
+	"Backend/domain/entity"
+	"Backend/internal/services"
+)
+
+func TestFormatTopUserScores(t *testing.T) {
+	scores := []entity.UserWeightScore{
+		{WeightCategory: "成長志向", Score: 72},
+		{WeightCategory: "技術志向", Score: 90},
+		{WeightCategory: "チームワーク志向", Score: 81},
+		{WeightCategory: "安定志向", Score: 40},
+	}
+
+	got := services.FormatTopUserScores(scores)
+	wantParts := []string{"技術志向:90", "チームワーク志向:81", "成長志向:72"}
+	for _, part := range wantParts {
+		if !strings.Contains(got, part) {
+			t.Fatalf("expected %q in %q", part, got)
+		}
+	}
+}
+
+func TestGenerateMatchReasonFallbackWhenAIClientNil(t *testing.T) {
+	svc := services.NewMatchingServiceForTest()
+	match := &entity.UserCompanyMatch{
+		MatchScore: 88.5,
+		Company: &entity.Company{
+			ID:           1,
+			Name:         "テスト株式会社",
+			Industry:     "IT",
+			MainBusiness: "Webサービス開発",
+			Culture:      "挑戦を歓迎する",
+			WorkStyle:    "ハイブリッド",
+		},
+		TechnicalMatch: 95.0,
+		TeamworkMatch:  90.0,
+		GrowthMatch:    92.0,
+	}
+	userScores := []entity.UserWeightScore{
+		{WeightCategory: "技術志向", Score: 88},
+		{WeightCategory: "成長志向", Score: 84},
+	}
+
+	got, err := svc.GenerateMatchReason(t.Context(), match, userScores)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("reason should not be empty")
+	}
+	if !strings.Contains(got, "テスト株式会社") {
+		t.Fatalf("expected company name in reason, got: %q", got)
+	}
+}

--- a/Backend/test/services/prompts/prompts_test.go
+++ b/Backend/test/services/prompts/prompts_test.go
@@ -1,0 +1,189 @@
+package prompts_test
+
+import (
+	"strings"
+	"testing"
+
+	"Backend/internal/services/prompts"
+)
+
+func TestSystemRoleConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant string
+		contains string
+	}{
+		{"SystemRoleExpert", prompts.SystemRoleExpert, "専門家"},
+		{"SystemRoleValidator", prompts.SystemRoleValidator, "審査AI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(tt.constant, tt.contains) {
+				t.Errorf("%s に %q が含まれていない: %q", tt.name, tt.contains, tt.constant)
+			}
+		})
+	}
+}
+
+func TestCommonConstraintPrompt(t *testing.T) {
+	if !strings.Contains(prompts.CommonConstraintPrompt, "重複厳禁") {
+		t.Error("CommonConstraintPrompt に「重複厳禁」が含まれていない")
+	}
+	if !strings.Contains(prompts.CommonConstraintPrompt, "進捗表示禁止") {
+		t.Error("CommonConstraintPrompt に「進捗表示禁止」が含まれていない")
+	}
+}
+
+func TestJobContextGuidance(t *testing.T) {
+	if !strings.Contains(prompts.JobContextGuidance, "%s") {
+		t.Error("JobContextGuidance に職種名のプレースホルダーがない")
+	}
+	if !strings.Contains(prompts.JobContextGuidance, "%d") {
+		t.Error("JobContextGuidance に業界/職種IDのプレースホルダーがない")
+	}
+}
+
+func TestPhaseEvaluationPoints(t *testing.T) {
+	requiredPhases := []string{"job_analysis", "interest_analysis", "aptitude_analysis", "future_analysis"}
+	for _, phase := range requiredPhases {
+		t.Run(phase, func(t *testing.T) {
+			val, ok := prompts.PhaseEvaluationPoints[phase]
+			if !ok {
+				t.Errorf("PhaseEvaluationPoints に %q が存在しない", phase)
+			}
+			if val == "" {
+				t.Errorf("PhaseEvaluationPoints[%q] が空文字", phase)
+			}
+		})
+	}
+}
+
+func TestRealityCheckGuidelines(t *testing.T) {
+	if !strings.Contains(prompts.RealityCheckGuidelines, "本音") {
+		t.Error("RealityCheckGuidelines に「本音」が含まれていない")
+	}
+}
+
+func TestBuildStrategicQuestionPrompt(t *testing.T) {
+	result := prompts.BuildStrategicQuestionPrompt(
+		"新卒", "就活フェーズ", "選択肢A/B",
+		"過去の会話履歴", "スコア分析", "既出質問リスト",
+		"カテゴリ評価", "リーダーシップ", "説明文",
+		"エンジニア", 1, 2,
+	)
+
+	cases := []struct {
+		label string
+		text  string
+	}{
+		{"SystemRoleExpert", prompts.SystemRoleExpert},
+		{"NewGradGuidelines の一部", "新卒"},
+		{"CommonConstraintPrompt の一部", "重複厳禁"},
+		{"JobContextGuidance の展開", "エンジニア"},
+		{"historyText", "過去の会話履歴"},
+		{"scoreAnalysis", "スコア分析"},
+		{"targetCategory", "リーダーシップ"},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(result, c.text) {
+				t.Errorf("BuildStrategicQuestionPrompt の出力に %q が含まれていない", c.text)
+			}
+		})
+	}
+}
+
+func TestBuildStrategicQuestionPromptWithPhase(t *testing.T) {
+	t.Run("フェーズあり", func(t *testing.T) {
+		result := prompts.BuildStrategicQuestionPromptWithPhase(
+			"新卒", "job_analysis", "就活フェーズ", "選択肢A/B",
+			"会話履歴", "スコア分析", "既出質問",
+			"目的", "職種分析", "説明",
+			"営業", 3, 4,
+		)
+		if !strings.Contains(result, "職種分析") {
+			t.Error("フェーズの評価観点が含まれていない")
+		}
+	})
+
+	t.Run("存在しないフェーズ", func(t *testing.T) {
+		result := prompts.BuildStrategicQuestionPromptWithPhase(
+			"中途", "unknown_phase", "フェーズ", "選択肢",
+			"履歴", "スコア", "既出",
+			"目的", "カテゴリ", "説明",
+			"デザイナー", 5, 6,
+		)
+		if !strings.Contains(result, "実務経験") {
+			t.Error("中途ガイドラインが含まれていない")
+		}
+	})
+}
+
+func TestBuildLowConfidenceQuestionPrompt(t *testing.T) {
+	result := prompts.BuildLowConfidenceQuestionPrompt("会話履歴", "前の質問", 1, 2)
+	if !strings.Contains(result, prompts.SystemRoleExpert) {
+		t.Error("SystemRoleExpert が含まれていない")
+	}
+	if !strings.Contains(result, "前の質問") {
+		t.Error("lastQuestion が含まれていない")
+	}
+	if !strings.Contains(result, "答えやすい") {
+		t.Error("「答えやすい」が含まれていない")
+	}
+}
+
+func TestBuildUnevaluatedCategoryQuestionPrompt(t *testing.T) {
+	result := prompts.BuildUnevaluatedCategoryQuestionPrompt("履歴", "協調性", "チームで働く力", 1, 2)
+	if !strings.Contains(result, "協調性") {
+		t.Error("targetCategory が含まれていない")
+	}
+	if !strings.Contains(result, "チームで働く力") {
+		t.Error("description が含まれていない")
+	}
+}
+
+func TestBuildDeepeningQuestionPrompt(t *testing.T) {
+	result := prompts.BuildDeepeningQuestionPrompt("履歴", "リーダーシップ", 85, 1, 2)
+	if !strings.Contains(result, "リーダーシップ") {
+		t.Error("highestCategory が含まれていない")
+	}
+	if !strings.Contains(result, "85") {
+		t.Error("highestScore が含まれていない")
+	}
+}
+
+func TestBuildSimplifyQuestionPrompt(t *testing.T) {
+	q := "あなたのリーダーシップ経験について教えてください"
+	result := prompts.BuildSimplifyQuestionPrompt(q)
+	if !strings.Contains(result, q) {
+		t.Error("元の質問が含まれていない")
+	}
+	if !strings.Contains(result, "40〜80文字") {
+		t.Error("文字数制約が含まれていない")
+	}
+}
+
+func TestAnswerValidationSystemPrompt(t *testing.T) {
+	if !strings.Contains(prompts.AnswerValidationSystemPrompt, prompts.SystemRoleValidator) {
+		t.Error("AnswerValidationSystemPrompt に SystemRoleValidator が含まれていない")
+	}
+	if !strings.Contains(prompts.AnswerValidationSystemPrompt, "JSON") {
+		t.Error("AnswerValidationSystemPrompt に JSON 制約が含まれていない")
+	}
+}
+
+func TestBuildAnswerValidationUserPrompt(t *testing.T) {
+	question := "あなたの強みを教えてください"
+	answer := "コミュニケーション能力です"
+	result := prompts.BuildAnswerValidationUserPrompt(question, answer)
+
+	if !strings.Contains(result, question) {
+		t.Error("質問が含まれていない")
+	}
+	if !strings.Contains(result, answer) {
+		t.Error("回答が含まれていない")
+	}
+	if !strings.Contains(result, `{"valid": true}`) {
+		t.Error("判定フォーマットが含まれていない")
+	}
+}

--- a/Backend/test/services/score_validation_security_test.go
+++ b/Backend/test/services/score_validation_security_test.go
@@ -1,0 +1,69 @@
+package services_test
+
+// スコアバリデーション相関係数のテスト（Issue #313）
+// 実行: cd Backend && go test ./test/services/... -run TestCorrelation -v
+
+import (
+	"math"
+	"testing"
+)
+
+// correlationApprox は本番コードと同一の相関係数近似ロジック
+func correlationApprox(weight float64) float64 {
+	return math.Max(-1.0, math.Min(weight-1.0, 1.0))
+}
+
+// TestCorrelation_AlwaysInRange は計算結果が常に [-1, 1] に収まることを検証する（#313修正の担保）
+func TestCorrelation_AlwaysInRange(t *testing.T) {
+	tests := []struct {
+		weight float64
+	}{
+		{0.0},
+		{0.1},
+		{0.5},
+		{1.0},
+		{1.5},
+		{2.0},
+		{3.0},
+		{10.0},
+	}
+
+	for _, tc := range tests {
+		c := correlationApprox(tc.weight)
+		if c < -1.0 || c > 1.0 {
+			t.Errorf("weight=%.1f: 相関係数 %f は [-1, 1] 範囲外", tc.weight, c)
+		}
+	}
+}
+
+// TestCorrelation_AverageWeightIsZero は weight=1.0 のとき相関係数が 0 になることを検証する
+func TestCorrelation_AverageWeightIsZero(t *testing.T) {
+	c := correlationApprox(1.0)
+	if math.Abs(c) > 1e-9 {
+		t.Errorf("weight=1.0 は相関係数 0 になるべき: got %f", c)
+	}
+}
+
+// TestCorrelation_HighWeightClampedToOne は weight=2.0 以上のとき相関係数が 1.0 になることを検証する
+func TestCorrelation_HighWeightClampedToOne(t *testing.T) {
+	c := correlationApprox(2.0)
+	if math.Abs(c-1.0) > 1e-9 {
+		t.Errorf("weight=2.0 は相関係数 1.0 になるべき: got %f", c)
+	}
+}
+
+// TestCorrelation_LowWeightClampedToMinusOne は weight=0.0 のとき相関係数が -1.0 になることを検証する（旧実装では下限なし）
+func TestCorrelation_LowWeightClampedToMinusOne(t *testing.T) {
+	c := correlationApprox(0.0)
+	if math.Abs(c-(-1.0)) > 1e-9 {
+		t.Errorf("weight=0.0 は相関係数 -1.0 になるべき: got %f", c)
+	}
+}
+
+// TestCorrelation_OldBugRegression は修正前のバグ（下限がなかった）が再発しないことを検証する
+func TestCorrelation_OldBugRegression(t *testing.T) {
+	c := correlationApprox(-0.5)
+	if c < -1.0 {
+		t.Errorf("相関係数は -1.0 を下回ってはならない（旧バグ回帰テスト）: got %f", c)
+	}
+}

--- a/frontend/app/admin/companies/new/page.tsx
+++ b/frontend/app/admin/companies/new/page.tsx
@@ -3,10 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
+  Alert,
   Button,
+  CircularProgress,
+  Divider,
   MenuItem,
-  TextField,
   Stack,
+  TextField,
+  Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
@@ -23,18 +27,60 @@ export default function AdminCompanyNewPage() {
   }, [])
 
   const [error, setError] = useState('')
+  const [aiSuccess, setAiSuccess] = useState('')
+  const [aiLoading, setAiLoading] = useState(false)
+
   const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
   const [industry, setIndustry] = useState('')
   const [location, setLocation] = useState('')
   const [websiteUrl, setWebsiteUrl] = useState('')
+  const [foundedYear, setFoundedYear] = useState('')
+  const [employeeCount, setEmployeeCount] = useState('')
+  const [mainBusiness, setMainBusiness] = useState('')
+  const [culture, setCulture] = useState('')
+  const [workStyle, setWorkStyle] = useState('')
   const [sourceType, setSourceType] = useState('manual')
   const [sourceUrl, setSourceUrl] = useState('')
   const [dataStatus, setDataStatus] = useState('draft')
   const [isProvisional, setIsProvisional] = useState(true)
 
+  const handleAiFetch = async () => {
+    setAiLoading(true)
+    setError('')
+    setAiSuccess('')
+    try {
+      const res = await fetch('/api/admin/companies/web-search', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authService.getAdminFetchHeaders(),
+        },
+        body: JSON.stringify({ name }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || 'AI企業情報取得に失敗しました')
+        return
+      }
+      if (data.description) setDescription(data.description)
+      if (data.industry) setIndustry(data.industry)
+      if (data.location) setLocation(data.location)
+      if (data.website_url) setWebsiteUrl(data.website_url)
+      if (data.founded_year) setFoundedYear(String(data.founded_year))
+      if (data.employee_count) setEmployeeCount(String(data.employee_count))
+      if (data.main_business) setMainBusiness(data.main_business)
+      if (data.culture) setCulture(data.culture)
+      if (data.work_style) setWorkStyle(data.work_style)
+      setAiSuccess('AI情報取得が完了しました。内容を確認・修正してから追加してください。')
+    } finally {
+      setAiLoading(false)
+    }
+  }
+
   const handleCreate = async () => {
     setError('')
-    const admin = authService.getStoredUser()
+    setAiSuccess('')
     const res = await fetch('/api/admin/companies', {
       method: 'POST',
       headers: {
@@ -43,9 +89,15 @@ export default function AdminCompanyNewPage() {
       },
       body: JSON.stringify({
         name,
+        description,
         industry,
         location,
         website_url: websiteUrl,
+        founded_year: foundedYear ? parseInt(foundedYear, 10) : undefined,
+        employee_count: employeeCount ? parseInt(employeeCount, 10) : undefined,
+        main_business: mainBusiness,
+        culture,
+        work_style: workStyle,
         source_type: sourceType,
         source_url: sourceUrl,
         is_provisional: isProvisional,
@@ -63,11 +115,81 @@ export default function AdminCompanyNewPage() {
   return (
     <AdminFormContainer title="企業の追加" maxWidth={700} backHref="/admin/companies" backLabel="一覧に戻る">
       <ErrorAlert error={error} />
+      {aiSuccess && <Alert severity="success" sx={{ mb: 2 }}>{aiSuccess}</Alert>}
       <Stack spacing={2}>
         <TextField label="企業名" value={name} onChange={(e) => setName(e.target.value)} required />
+
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={handleAiFetch}
+            disabled={!name.trim() || aiLoading}
+            startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {aiLoading ? 'AI検索中...' : '🤖 AIで企業情報を自動取得'}
+          </Button>
+          <Typography variant="caption" color="text.secondary">
+            企業名を入力後にクリックしてください
+          </Typography>
+        </Stack>
+
+        <Divider />
+
+        <TextField
+          label="企業概要"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          multiline
+          minRows={2}
+        />
         <TextField label="業種" value={industry} onChange={(e) => setIndustry(e.target.value)} />
         <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
         <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="設立年"
+            value={foundedYear}
+            onChange={(e) => setFoundedYear(e.target.value)}
+            type="number"
+            sx={{ flex: 1 }}
+          />
+          <TextField
+            label="従業員数"
+            value={employeeCount}
+            onChange={(e) => setEmployeeCount(e.target.value)}
+            type="number"
+            sx={{ flex: 1 }}
+          />
+        </Stack>
+        <TextField
+          label="主要事業内容"
+          value={mainBusiness}
+          onChange={(e) => setMainBusiness(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        <TextField
+          label="企業文化"
+          value={culture}
+          onChange={(e) => setCulture(e.target.value)}
+          multiline
+          minRows={2}
+        />
+        <TextField
+          select
+          label="勤務スタイル"
+          value={workStyle}
+          onChange={(e) => setWorkStyle(e.target.value)}
+        >
+          <MenuItem value="">未設定</MenuItem>
+          <MenuItem value="リモート">リモート</MenuItem>
+          <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
+          <MenuItem value="オフィス">オフィス</MenuItem>
+        </TextField>
+
+        <Divider />
+
         <TextField select label="出典タイプ" value={sourceType} onChange={(e) => setSourceType(e.target.value)}>
           <MenuItem value="official">公式サイト</MenuItem>
           <MenuItem value="job_site">就活/転職サイト</MenuItem>
@@ -87,6 +209,7 @@ export default function AdminCompanyNewPage() {
           <MenuItem value="yes">暫定</MenuItem>
           <MenuItem value="no">確定</MenuItem>
         </TextField>
+
         <Button variant="contained" onClick={handleCreate} disabled={!name.trim()}>
           追加する
         </Button>

--- a/frontend/app/api/admin/companies/web-search/route.ts
+++ b/frontend/app/api/admin/companies/web-search/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/web-search`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+    body,
+  })
+  const raw = await response.text()
+  let data: Record<string, unknown> = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/companies/interview-hints/route.ts
+++ b/frontend/app/api/companies/interview-hints/route.ts
@@ -19,13 +19,17 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      return NextResponse.json({ style_tags: [], top_questions: [] }, { status: response.status })
+      // RAG サービス側のエラーは UI に伝えず空レスポンスで正常扱い
+      return NextResponse.json({ style_tags: [], top_questions: [] })
     }
 
     const data = await response.json()
     return NextResponse.json(data)
-  } catch (error) {
-    console.error('[API] Interview hints error:', error)
-    return NextResponse.json({ style_tags: [], top_questions: [] }, { status: 500 })
+  } catch (error: any) {
+    // RAG 未起動（ECONNREFUSED 等）はログのみで空レスポンスを返す
+    if (error?.cause?.code !== 'ECONNREFUSED') {
+      console.error('[API] Interview hints error:', error)
+    }
+    return NextResponse.json({ style_tags: [], top_questions: [] })
   }
 }

--- a/frontend/app/interview/components/ThreeAvatar.tsx
+++ b/frontend/app/interview/components/ThreeAvatar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js'
 import { Box } from '@mui/material'
 import { loadAvatar, type AvatarGender } from '@/lib/avatar-loader'
 import { LipsyncManager } from '@/lib/lipsync-manager'
@@ -238,7 +239,21 @@ export default function ThreeAvatar({ gender, audioStream, level, speaking }: Th
         const gltf  = await loadAvatar(gender)
         if (disposed) return
 
-        const model = gltf.scene
+        // キャッシュされた gltf.scene を直接使うとクリーンアップ時の dispose が
+        // キャッシュ上のテクスチャを破棄し、次回マウント時に blob URL エラーが発生する。
+        // SkeletonUtils.clone でスケルトンを含むディープクローンを作り、
+        // マテリアルも個別にクローンして各インスタンスが独立した状態を持つようにする。
+        const model = cloneSkeleton(gltf.scene) as THREE.Group
+        model.traverse((child) => {
+          if ((child as THREE.Mesh).isMesh) {
+            const mesh = child as THREE.Mesh
+            if (Array.isArray(mesh.material)) {
+              mesh.material = mesh.material.map((m) => m.clone())
+            } else {
+              mesh.material = (mesh.material as THREE.Material).clone()
+            }
+          }
+        })
 
         // ── Auto-normalize model size and position ────────────────────────
         // RPM / standard glTF: front faces +Z (no rotation needed)

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -745,6 +745,13 @@ function InterviewContent() {
   const totalQuestionCount = Math.max(1, selectedPosition.questions)
   const questionProgress = Math.min(100, Math.round((questionElapsedSeconds / questionDurationSeconds) * 100))
   const questionRemainingSeconds = Math.max(0, questionDurationSeconds - questionElapsedSeconds)
+  const questionRemainingLabel = (() => {
+    if (questionRemainingSeconds <= 0) return '次の質問へ移行中...'
+    if (questionRemainingSeconds < 60) return `あと${questionRemainingSeconds}秒で次の質問へ`
+    const m = Math.floor(questionRemainingSeconds / 60)
+    const s = questionRemainingSeconds % 60
+    return s > 0 ? `あと${m}分${s}秒で次の質問へ` : `あと${m}分で次の質問へ`
+  })()
   const progress = Math.min(100, Math.round(((interviewLimits.maxMinutes * 60 - remainingSeconds) / (interviewLimits.maxMinutes * 60)) * 100))
   const isFemale = avatarGender === 'female'
   const companyName = interviewCompany?.name || 'AI面接練習'
@@ -1065,7 +1072,9 @@ function InterviewContent() {
                       </Box>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography sx={{ fontSize: 14 }}>❓</Typography>
-                        <Typography sx={{ fontSize: 13, color: '#475569' }}>{selectedPosition.questions}問 技術・行動面接</Typography>
+                        <Typography sx={{ fontSize: 13, color: '#475569' }}>
+                          {selectedPosition.questions}問（1問あたり約{Math.round(questionDurationSeconds / 60)}分）
+                        </Typography>
                       </Box>
                     </Box>
                   </Stack>
@@ -1506,6 +1515,54 @@ function InterviewContent() {
           <Box sx={{ bgcolor: remainingSeconds <= 0 ? 'rgba(234,67,53,0.25)' : 'rgba(251,188,4,0.2)', borderRadius: 1.5, px: 2, py: 0.7 }}>
             <Typography sx={{ fontSize: 13, color: remainingSeconds <= 0 ? '#ffb3ae' : '#ffe082', fontWeight: 600 }}>
               {remainingSeconds <= 0 ? 'セッションが終了しました。' : `⚠️ 残り約${Math.ceil(remainingSeconds / 60)}分です。`}
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      {/* ── 質問タイマー ── */}
+      {isConnected && (
+        <Box sx={{ px: 2, pb: 1.5, flexShrink: 0 }}>
+          <Box sx={{
+            bgcolor: 'rgba(0,0,0,0.35)', backdropFilter: 'blur(8px)',
+            borderRadius: 2, px: 2, py: 1,
+            display: 'flex', alignItems: 'center', gap: 2,
+          }}>
+            {/* 質問番号バッジ */}
+            <Box sx={{
+              flexShrink: 0, display: 'flex', alignItems: 'center', gap: 0.5,
+              bgcolor: 'rgba(255,255,255,0.12)', borderRadius: 1, px: 1, py: 0.3,
+            }}>
+              <Typography sx={{ color: 'rgba(255,255,255,0.5)', fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>Q</Typography>
+              <Typography sx={{ color: '#fff', fontSize: 13, fontWeight: 700, lineHeight: 1 }}>
+                {currentQuestionIndex}
+              </Typography>
+              <Typography sx={{ color: 'rgba(255,255,255,0.4)', fontSize: 10 }}>
+                /{totalQuestionCount}
+              </Typography>
+            </Box>
+
+            {/* プログレスバー */}
+            <Box sx={{ flex: 1, height: 5, bgcolor: 'rgba(255,255,255,0.12)', borderRadius: 9999, overflow: 'hidden' }}>
+              <Box sx={{
+                height: '100%',
+                width: `${questionProgress}%`,
+                bgcolor: questionRemainingSeconds <= 30 ? '#f28b82'
+                       : questionRemainingSeconds <= 60 ? '#fdd663'
+                       : '#34a853',
+                borderRadius: 9999,
+                transition: 'width 1s linear, background-color 0.5s',
+              }} />
+            </Box>
+
+            {/* カウントダウンテキスト */}
+            <Typography sx={{
+              flexShrink: 0, fontSize: 12, fontWeight: 600,
+              color: questionRemainingSeconds <= 30 ? '#f28b82'
+                   : questionRemainingSeconds <= 60 ? '#fdd663'
+                   : 'rgba(255,255,255,0.75)',
+            }}>
+              {questionRemainingLabel}
             </Typography>
           </Box>
         </Box>

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState, Suspense } from 'react'
+import { useEffect, useRef, useState, Suspense, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
   Box,
@@ -148,6 +148,15 @@ function InterviewContent() {
   const streamRef = useRef<MediaStream | null>(null)
   const lobbyVideoRef = useRef<HTMLVideoElement | null>(null)
   const sessionVideoRef = useRef<HTMLVideoElement | null>(null)
+  // video 要素がマウントした瞬間にストリームをアタッチするための callback ref。
+  // useEffect([status]) では DOM コミット前に status が更新されるため srcObject が設定されないことがある。
+  const sessionVideoCallbackRef = useCallback((node: HTMLVideoElement | null) => {
+    sessionVideoRef.current = node
+    if (node && streamRef.current) {
+      node.srcObject = streamRef.current
+      node.play().catch(() => undefined)
+    }
+  }, [])
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const audioChunksRef = useRef<Blob[]>([])
   const videoRecorderRef = useRef<MediaRecorder | null>(null)
@@ -264,7 +273,12 @@ function InterviewContent() {
         }
       } catch (err: any) {
         if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
-          setLobbyPermissionError('マイクとカメラへのアクセスが拒否されました。ブラウザの設定から許可してください。')
+          // カメラとマイクを個別に試してどちらがブロックされているか特定する
+          const blocked: string[] = []
+          await navigator.mediaDevices.getUserMedia({ video: true }).then(s => s.getTracks().forEach(t => t.stop())).catch(() => { blocked.push('カメラ') })
+          await navigator.mediaDevices.getUserMedia({ audio: true }).then(s => s.getTracks().forEach(t => t.stop())).catch(() => { blocked.push('マイク') })
+          const target = blocked.length > 0 ? blocked.join('と') : 'マイクとカメラ'
+          setLobbyPermissionError(`${target}へのアクセスが拒否されました。`)
         } else if (err.name === 'NotFoundError') {
           setLobbyPermissionError('マイクまたはカメラが見つかりません。デバイスを確認してください。')
         } else {
@@ -383,51 +397,58 @@ function InterviewContent() {
     }, 1000)
   }
 
-  const playAudioBlob = (blob: Blob): Promise<void> => {
-    return new Promise((resolve) => {
-      const url = URL.createObjectURL(blob)
-      // Always create a fresh Audio element so createMediaElementSource can be called each time
-      const el = new Audio()
-      aiAudioRef.current = el
-      el.src = url
-      setAiSpeaking(true)
+  const playAudioBlob = async (blob: Blob): Promise<void> => {
+    const url = URL.createObjectURL(blob)
+    const el = new Audio()
+    aiAudioRef.current = el
+    el.src = url
+    setAiSpeaking(true)
 
-      // Set up AudioContext for real-time amplitude analysis (drives aiLevel / lipsync)
-      let rafId: number | null = null
-      try {
-        if (!aiAudioCtxRef.current || aiAudioCtxRef.current.state === 'closed') {
-          aiAudioCtxRef.current = new AudioContext()
-        }
-        const ctx = aiAudioCtxRef.current
-        if (ctx.state === 'suspended') ctx.resume().catch(() => {})
+    let rafId: number | null = null
+    let routedThroughCtx = false
 
-        const source   = ctx.createMediaElementSource(el)
-        const analyser = ctx.createAnalyser()
-        analyser.fftSize = 512
-        analyser.smoothingTimeConstant = 0.6
-        source.connect(analyser)
-        analyser.connect(ctx.destination)
-
-        const timeData = new Uint8Array(analyser.fftSize)
-        const trackLevel = () => {
-          analyser.getByteTimeDomainData(timeData)
-          let sum = 0
-          for (const v of timeData) { const n = (v - 128) / 128; sum += n * n }
-          const rms = Math.sqrt(sum / timeData.length)
-          setAiLevel(Math.min(1, rms * 6))
-          rafId = requestAnimationFrame(trackLevel)
-        }
-        rafId = requestAnimationFrame(trackLevel)
-        aiLevelRafRef.current = rafId
-      } catch { /* AudioContext not supported – lipsync disabled */ }
-
-      const cleanup = () => {
-        if (rafId !== null) cancelAnimationFrame(rafId)
-        if (aiLevelRafRef.current !== null) cancelAnimationFrame(aiLevelRafRef.current)
-        aiLevelRafRef.current = null
-        setAiLevel(0)
+    try {
+      if (!aiAudioCtxRef.current || aiAudioCtxRef.current.state === 'closed') {
+        aiAudioCtxRef.current = new AudioContext()
       }
+      const ctx = aiAudioCtxRef.current
+      // resume を await して running 状態を確実に待つ（suspended のまま再生すると無音になる）
+      await ctx.resume()
 
+      const source   = ctx.createMediaElementSource(el)
+      routedThroughCtx = true
+      const analyser = ctx.createAnalyser()
+      analyser.fftSize = 512
+      analyser.smoothingTimeConstant = 0.6
+      source.connect(analyser)
+      analyser.connect(ctx.destination)
+
+      const timeData = new Uint8Array(analyser.fftSize)
+      const trackLevel = () => {
+        analyser.getByteTimeDomainData(timeData)
+        let sum = 0
+        for (const v of timeData) { const n = (v - 128) / 128; sum += n * n }
+        const rms = Math.sqrt(sum / timeData.length)
+        setAiLevel(Math.min(1, rms * 6))
+        rafId = requestAnimationFrame(trackLevel)
+      }
+      rafId = requestAnimationFrame(trackLevel)
+      aiLevelRafRef.current = rafId
+    } catch {
+      // AudioContext 未対応またはセキュリティポリシーで拒否された場合はリップシンク無効で続行
+      if (!routedThroughCtx) {
+        // AudioContext を経由していないので Audio 要素がデフォルト出力に直接流れる
+      }
+    }
+
+    const cleanup = () => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      if (aiLevelRafRef.current !== null) cancelAnimationFrame(aiLevelRafRef.current)
+      aiLevelRafRef.current = null
+      setAiLevel(0)
+    }
+
+    return new Promise<void>((resolve) => {
       el.onended = () => { cleanup(); setAiSpeaking(false); URL.revokeObjectURL(url); resolve() }
       el.onerror = () => { cleanup(); setAiSpeaking(false); URL.revokeObjectURL(url); resolve() }
       el.play().catch(() => { cleanup(); setAiSpeaking(false); resolve() })
@@ -437,13 +458,19 @@ function InterviewContent() {
   const doStartTurn = async (sessionId: number, userId: number) => {
     const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/start-turn`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({
         user_id: userId,
         company_name: interviewCompany?.name || '',
         company_reading: interviewCompany?.name_reading || '',
         position: selectedPosition?.title || '',
-        company_info: [interviewCompany?.description, interviewCompany?.main_business].filter(Boolean).join(' / '),
+        company_info: [
+          interviewCompany?.description,
+          interviewCompany?.main_business,
+          interviewCompany?.culture && `企業文化: ${interviewCompany.culture}`,
+          interviewCompany?.work_style && `働き方: ${interviewCompany.work_style}`,
+          interviewCompany?.welfare_details && `福利厚生: ${interviewCompany.welfare_details}`,
+        ].filter(Boolean).join(' / '),
         company_type: selectedPosition?.category || 'general',
         question_index: 1,
         total_questions: Math.max(1, selectedPosition?.questions || 1),
@@ -488,6 +515,14 @@ function InterviewContent() {
       setStatus('connecting')
       const nextGender = getNextAvatarGender()
       setAvatarGender(nextGender)
+
+      // ユーザー操作中に AudioContext を事前作成・resume（autoplay policy 対策）
+      try {
+        if (!aiAudioCtxRef.current || aiAudioCtxRef.current.state === 'closed') {
+          aiAudioCtxRef.current = new AudioContext()
+        }
+        await aiAudioCtxRef.current.resume()
+      } catch { /* 非対応環境は無視 */ }
 
       // Acquire camera/mic stream
       let stream = streamRef.current
@@ -652,11 +687,18 @@ function InterviewContent() {
     formData.append('company_name', interviewCompany?.name || '')
     formData.append('company_reading', interviewCompany?.name_reading || '')
     formData.append('position', selectedPosition?.title || '')
-    formData.append('company_info', [interviewCompany?.description, interviewCompany?.main_business].filter(Boolean).join(' / '))
+    formData.append('company_info', [
+      interviewCompany?.description,
+      interviewCompany?.main_business,
+      interviewCompany?.culture && `企業文化: ${interviewCompany.culture}`,
+      interviewCompany?.work_style && `働き方: ${interviewCompany.work_style}`,
+      interviewCompany?.welfare_details && `福利厚生: ${interviewCompany.welfare_details}`,
+    ].filter(Boolean).join(' / '))
     formData.append('company_type', selectedPosition?.category || 'general')
     try {
       const res = await fetch(`${BACKEND_URL}/api/interviews/${session.id}/turn`, {
         method: 'POST',
+        headers: { ...authService.getUserFetchHeaders() },
         body: formData,
       })
       if (!res.ok) throw new Error(await res.text())
@@ -1178,7 +1220,18 @@ function InterviewContent() {
               <Box sx={{ position: 'relative', width: '100%', aspectRatio: '16/9', bgcolor: '#202124', borderRadius: 2, overflow: 'hidden', boxShadow: '0 4px 20px rgba(0,0,0,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 {lobbyPermissionError ? (
                   <Box sx={{ textAlign: 'center', p: 3 }}>
-                    <Typography sx={{ color: '#f28b82', mb: 2, fontSize: 14 }}>{lobbyPermissionError}</Typography>
+                    <Typography sx={{ color: '#f28b82', mb: 1.5, fontSize: 14 }}>{lobbyPermissionError}</Typography>
+                    <Box sx={{ mb: 2, textAlign: 'left', bgcolor: 'rgba(0,0,0,0.4)', borderRadius: 1, p: 1.5 }}>
+                      <Typography sx={{ color: '#e8eaed', fontSize: 12, mb: 0.5 }}>【ブラウザの許可】</Typography>
+                      <Typography sx={{ color: '#9aa0a6', fontSize: 12, lineHeight: 1.8, mb: 1 }}>
+                        アドレスバー左端の 🔒 → カメラ・マイクを「許可」
+                      </Typography>
+                      <Typography sx={{ color: '#e8eaed', fontSize: 12, mb: 0.5 }}>【Mac のシステム設定】</Typography>
+                      <Typography sx={{ color: '#9aa0a6', fontSize: 12, lineHeight: 1.8 }}>
+                        システム設定 → プライバシーとセキュリティ<br />
+                        → カメラ / マイク → 使用中のブラウザをオン
+                      </Typography>
+                    </Box>
                     <Button size="small" startIcon={<RefreshIcon />} onClick={() => { setLobbyPermissionError(null); window.location.reload() }} sx={{ color: '#8ab4f8' }}>
                       再試行
                     </Button>
@@ -1279,16 +1332,32 @@ function InterviewContent() {
                 </Button>
               </Stack>
 
-              <Box sx={{ mt: 5 }}>
-                <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1.5 }}>募集要項を確認する</Typography>
-                <Button
-                  size="small"
-                  onClick={() => {/* scroll to info */ }}
-                  sx={{ color: '#1a73e8', textTransform: 'none', fontWeight: 500, p: 0, '&:hover': { textDecoration: 'underline', bgcolor: 'transparent' } }}
-                >
-                  求人詳細を見る →
-                </Button>
-              </Box>
+              {/* 企業特徴プレビュー */}
+              {interviewCompany && (interviewCompany.culture || interviewCompany.work_style || interviewCompany.welfare_details) && (
+                <Box sx={{ mt: 3, width: '100%', maxWidth: 340 }}>
+                  <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1, fontWeight: 600 }}>企業情報</Typography>
+                  <Stack spacing={1}>
+                    {interviewCompany.culture && (
+                      <Box sx={{ p: 1.5, bgcolor: '#f0f4ff', borderRadius: 2, border: '1px solid #c7d7f0' }}>
+                        <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#3b5bdb', mb: 0.3, textTransform: 'uppercase', letterSpacing: 0.5 }}>企業文化</Typography>
+                        <Typography sx={{ fontSize: 13, color: '#1e3a8a', lineHeight: 1.5 }}>{interviewCompany.culture}</Typography>
+                      </Box>
+                    )}
+                    {interviewCompany.work_style && (
+                      <Box sx={{ p: 1.5, bgcolor: '#f0fff4', borderRadius: 2, border: '1px solid #b2dfdb' }}>
+                        <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#2e7d32', mb: 0.3, textTransform: 'uppercase', letterSpacing: 0.5 }}>働き方</Typography>
+                        <Typography sx={{ fontSize: 13, color: '#1b5e20', lineHeight: 1.5 }}>{interviewCompany.work_style}</Typography>
+                      </Box>
+                    )}
+                    {interviewCompany.welfare_details && (
+                      <Box sx={{ p: 1.5, bgcolor: '#fff8f0', borderRadius: 2, border: '1px solid #ffcc80' }}>
+                        <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#e65100', mb: 0.3, textTransform: 'uppercase', letterSpacing: 0.5 }}>福利厚生</Typography>
+                        <Typography sx={{ fontSize: 13, color: '#bf360c', lineHeight: 1.5 }}>{interviewCompany.welfare_details}</Typography>
+                      </Box>
+                    )}
+                  </Stack>
+                </Box>
+              )}
             </Box>
           </Box>
         </Box>
@@ -1401,237 +1470,180 @@ function InterviewContent() {
   // ─────────────────────────────────────────────
   // SESSION SCREEN (connecting / connected / error)
   // ─────────────────────────────────────────────
+  const waveHeights = [5, 8, 13, 18, 25, 34, 42, 48, 44, 36, 28, 20, 14, 9, 6, 7, 11, 18, 27, 36, 44, 48, 42, 34, 26, 18, 12, 8, 5, 7, 10, 14]
+
   return (
-    <Box sx={{ height: '100vh', width: '100vw', bgcolor: BG_DARK, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <Box sx={{ height: '100vh', width: '100vw', bgcolor: '#606553', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
 
       {/* ── Header ── */}
-      <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 3, py: 1.5, flexShrink: 0, borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-          <Box sx={{ width: 36, height: 36, borderRadius: 2, bgcolor: PRIMARY, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <PsychologyIcon sx={{ color: '#fff', fontSize: 20 }} />
-          </Box>
-          <Box>
-            <Typography sx={{ fontWeight: 700, fontSize: 15, color: '#e8eaed', lineHeight: 1.2 }}>AI面接練習</Typography>
-            <Typography sx={{ fontSize: 12, color: '#9aa0a6' }}>セッション: {companyName}</Typography>
-          </Box>
+      <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 3, py: 1.5, flexShrink: 0 }}>
+        {/* 企業名 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, bgcolor: 'rgba(255,255,255,0.18)', borderRadius: 2, px: 2, py: 0.8, backdropFilter: 'blur(8px)' }}>
+          <Typography sx={{ color: '#fff', fontWeight: 600, fontSize: 14 }}>
+            {companyName || 'AI面接練習'}
+          </Typography>
+          <Typography sx={{ color: 'rgba(255,255,255,0.65)', fontSize: 12, lineHeight: 1 }}>▾</Typography>
         </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+
+        {/* タイマー + ユーザーアバター */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           {isActive && (
-            <Box sx={{ display: 'flex', alignItems: 'center', px: 1.5, py: 0.6, borderRadius: 9999, bgcolor: 'rgba(255,255,255,0.08)', gap: 1 }}>
-              <Box component="span" sx={{ fontSize: 16 }}>⏱</Box>
-              <Typography sx={{ fontSize: 13, color: '#e8eaed', fontWeight: 500 }}>{formatSeconds(remainingSeconds)}</Typography>
-            </Box>
+            <Typography sx={{ color: 'rgba(255,255,255,0.75)', fontSize: 13, fontWeight: 500 }}>
+              {formatSeconds(remainingSeconds)}
+            </Typography>
           )}
-          {isActive && (
-            <Box sx={{ display: 'flex', alignItems: 'center', px: 1.5, py: 0.6, borderRadius: 9999, bgcolor: 'rgba(236,91,19,0.2)', border: `1px solid ${PRIMARY}66` }}>
-              <Typography sx={{ fontSize: 12, color: '#ffd8c2', fontWeight: 700 }}>
-                質問 {currentQuestionIndex}/{totalQuestionCount}
-              </Typography>
-            </Box>
-          )}
-          {isConnected && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: '#34a853', animation: 'pulse 2s infinite', '@keyframes pulse': { '0%,100%': { opacity: 1 }, '50%': { opacity: 0.4 } } }} />
-              <Typography sx={{ fontSize: 12, color: '#34a853', fontWeight: 600 }}>接続中</Typography>
-            </Box>
-          )}
+          <Box sx={{ width: 34, height: 34, borderRadius: '50%', bgcolor: 'rgba(255,255,255,0.22)', border: '1.5px solid rgba(255,255,255,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography sx={{ fontSize: 13, fontWeight: 700, color: '#fff' }}>
+              {(user.name || 'U').charAt(0).toUpperCase()}
+            </Typography>
+          </Box>
         </Box>
       </Box>
 
-      {/* ── Time warning ── */}
+      {/* ── 残り時間警告 ── */}
       {isConnected && sessionWarningShown && (
-        <Box sx={{ px: 2, pt: 1, flexShrink: 0 }}>
-          <Box sx={{ bgcolor: remainingSeconds <= 0 ? 'rgba(234,67,53,0.2)' : 'rgba(251,188,4,0.15)', border: `1px solid ${remainingSeconds <= 0 ? '#ea4335' : '#fbbc04'}`, borderRadius: 1, px: 2, py: 0.8, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography sx={{ fontSize: 13, color: remainingSeconds <= 0 ? '#f28b82' : '#fdd663', fontWeight: 600 }}>
-              {remainingSeconds <= 0
-                ? 'セッションが終了しました。'
-                : `⚠️ 残り約${Math.ceil(remainingSeconds / 60)}分です。セッションがまもなく終了します。`}
+        <Box sx={{ px: 2, pb: 1, flexShrink: 0 }}>
+          <Box sx={{ bgcolor: remainingSeconds <= 0 ? 'rgba(234,67,53,0.25)' : 'rgba(251,188,4,0.2)', borderRadius: 1.5, px: 2, py: 0.7 }}>
+            <Typography sx={{ fontSize: 13, color: remainingSeconds <= 0 ? '#ffb3ae' : '#ffe082', fontWeight: 600 }}>
+              {remainingSeconds <= 0 ? 'セッションが終了しました。' : `⚠️ 残り約${Math.ceil(remainingSeconds / 60)}分です。`}
             </Typography>
           </Box>
         </Box>
       )}
 
-      {/* ── Question progress ── */}
-      {isConnected && (
-        <Box sx={{ px: 2, pt: 1, flexShrink: 0 }}>
-          <Paper sx={{ bgcolor: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 2, p: 1.5 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-              <Typography sx={{ fontSize: 13, color: '#e8eaed', fontWeight: 700 }}>
-                質問 {currentQuestionIndex}/{totalQuestionCount}
-              </Typography>
-              <Typography sx={{ fontSize: 12, color: '#cdd1d5' }}>
-                全体経過 {formatSeconds(elapsedSeconds)} • 質問内 {formatSeconds(questionElapsedSeconds)} / 残り目安 {formatSeconds(questionRemainingSeconds)}
-              </Typography>
-            </Box>
-            <LinearProgress
-              variant="determinate"
-              value={questionProgress}
-              sx={{ height: 7, borderRadius: 9999, bgcolor: 'rgba(255,255,255,0.12)', '& .MuiLinearProgress-bar': { bgcolor: PRIMARY } }}
-            />
-          </Paper>
-        </Box>
-      )}
-
       {/* ── Main ── */}
-      <Box sx={{ flex: 1, display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2, px: 2, pb: '88px', pt: 2, overflow: 'hidden', minHeight: 0 }}>
+      <Box sx={{ flex: 1, display: 'flex', gap: 2, px: 2, pb: 2, overflow: 'hidden', minHeight: 0 }}>
 
-        {/* Video grid */}
-        <Box sx={{ flex: 1, display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2, alignContent: 'center', minHeight: 0 }}>
+        {/* ── 左: アバターパネル ── */}
+        <Box sx={{ flex: '0 0 62%', position: 'relative', borderRadius: 3, overflow: 'hidden' }}>
 
-          {/* AI interviewer tile */}
-          <Box sx={{ position: 'relative', aspectRatio: '16/9', borderRadius: 2, overflow: 'hidden', bgcolor: '#303134', boxShadow: '0 8px 32px rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Box sx={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              background: 'radial-gradient(circle at 50% 40%, #3c4043 0%, #202124 100%)',
-            }}>
-              <Box sx={{
-                width: { xs: 120, md: 180 },
-                height: { xs: 120, md: 180 },
-                borderRadius: '50%',
-                boxShadow: aiSpeaking ? `0 0 0 16px rgba(236,91,19,0.15), 0 0 40px rgba(236,91,19,0.1)` : 'none',
-                transition: 'box-shadow 0.3s',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-              }}>
-                <ThreeAvatar gender={avatarGender} audioStream={null} level={aiLevel} speaking={aiSpeaking} />
-              </Box>
-            </Box>
-
-            {/* Speaking indicator */}
-            {aiSpeaking && (
-              <Box sx={{ position: 'absolute', top: 12, right: 12, width: 10, height: 10, borderRadius: '50%', bgcolor: PRIMARY, animation: 'pulse 1s infinite' }} />
-            )}
-
-            {/* Label */}
-            <Box sx={{ position: 'absolute', bottom: 12, left: 12, display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(8px)', px: 1.5, py: 0.6, borderRadius: 1.5 }}>
-              <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: PRIMARY }} />
-              <Typography sx={{ color: '#fff', fontSize: 13, fontWeight: 500 }}>
-                面接官AI（{isFemale ? '女性' : '男性'}）
-              </Typography>
-            </Box>
-
-
-            {/* Error overlay */}
-            {status === 'error' && (
-              <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(0,0,0,0.8)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', p: 3, gap: 2 }}>
-                <Typography sx={{ color: '#f28b82', textAlign: 'center', fontSize: 14, lineHeight: 1.6 }}>{errorMessage}</Typography>
-                <Button variant="contained" startIcon={<RefreshIcon />} onClick={handleJoin}
-                  sx={{ bgcolor: '#4285f4', '&:hover': { bgcolor: '#3367d6' }, textTransform: 'none' }}>
-                  再接続する
-                </Button>
-              </Box>
-            )}
-
-            {/* Connecting overlay */}
-            {status === 'connecting' && (
-              <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(0,0,0,0.6)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
-                <Typography sx={{ color: '#e8eaed' }}>接続中...</Typography>
-                <LinearProgress sx={{ width: 160, bgcolor: '#3c4043', '& .MuiLinearProgress-bar': { bgcolor: PRIMARY } }} />
-              </Box>
-            )}
+          {/* アバター（全面） */}
+          <Box sx={{ width: '100%', height: '100%' }}>
+            <ThreeAvatar gender={avatarGender} audioStream={null} level={aiLevel} speaking={aiSpeaking} />
           </Box>
 
-          {/* Subtitle below avatar frame */}
-          {captionsVisible && latestAiText && (
-            <Box sx={{ mx: 1, mt: -0.5, mb: 0.5, bgcolor: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', borderRadius: 1.5, px: 2, py: 0.8, textAlign: 'center' }}>
-              <Typography sx={{ color: '#fff', fontSize: 13, lineHeight: 1.5 }}>{latestAiText}</Typography>
+          {/* 面接官ロールラベル */}
+          <Box sx={{
+            position: 'absolute', top: 12, left: 0, right: 0,
+            display: 'flex', justifyContent: 'center',
+          }}>
+            <Box sx={{
+              bgcolor: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(6px)',
+              borderRadius: 9999, px: 2, py: 0.6,
+              display: 'flex', alignItems: 'center', gap: 0.75,
+            }}>
+              <Box sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: '#34a853' }} />
+              <Typography sx={{ color: '#fff', fontSize: 12, fontWeight: 600 }}>
+                {companyName} 面接官
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* 音声波形 */}
+          <Box sx={{
+            position: 'absolute', bottom: 88, left: 0, right: 0,
+            display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+            gap: '3px', height: 52, px: 6,
+          }}>
+            {waveHeights.map((h, i) => (
+              <Box key={i} sx={{
+                width: 3,
+                height: `${Math.max(4, h * Math.max(0.12, aiSpeaking ? aiLevel * 1.2 : 0.12))}px`,
+                bgcolor: 'rgba(255,255,255,0.75)',
+                borderRadius: '2px 2px 1px 1px',
+                transition: 'height 0.09s ease',
+              }} />
+            ))}
+          </Box>
+
+          {/* ユーザーカメラ（小）- 左下オーバーレイ */}
+          <Box sx={{
+            position: 'absolute', bottom: 16, left: 16,
+            width: 128, borderRadius: 2, overflow: 'hidden',
+            border: '2px solid rgba(255,255,255,0.3)',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.5)',
+            bgcolor: '#1a1a1a',
+          }}>
+            <Box sx={{ paddingTop: '75%', position: 'relative' }}>
+              <video
+                ref={sessionVideoCallbackRef}
+                muted
+                playsInline
+                style={{
+                  position: 'absolute', inset: 0,
+                  width: '100%', height: '100%',
+                  objectFit: 'cover', transform: 'scaleX(-1)',
+                  display: cameraEnabled ? 'block' : 'none',
+                }}
+              />
+              {!cameraEnabled && (
+                <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <VideocamOffIcon sx={{ color: '#666', fontSize: 28 }} />
+                </Box>
+              )}
+            </Box>
+          </Box>
+
+          {/* 接続中オーバーレイ */}
+          {status === 'connecting' && (
+            <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(0,0,0,0.55)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+              <Typography sx={{ color: '#e8eaed', fontSize: 15 }}>接続中...</Typography>
+              <LinearProgress sx={{ width: 160, bgcolor: 'rgba(255,255,255,0.1)', '& .MuiLinearProgress-bar': { bgcolor: PRIMARY } }} />
             </Box>
           )}
 
-          {/* User camera tile */}
-          <Box sx={{ position: 'relative', aspectRatio: '16/9', borderRadius: 2, overflow: 'hidden', bgcolor: '#3c4043', boxShadow: `0 0 0 2px rgba(236,91,19,0.3), 0 8px 32px rgba(0,0,0,0.4)`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <video
-              ref={sessionVideoRef}
-              muted
-              playsInline
-              style={{ width: '100%', height: '100%', objectFit: 'cover', transform: 'scaleX(-1)', display: cameraEnabled ? 'block' : 'none' }}
-            />
-            {!cameraEnabled && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
-                <VideocamOffIcon sx={{ color: '#9aa0a6', fontSize: 40 }} />
-                <Typography sx={{ color: '#9aa0a6', fontSize: 13 }}>カメラオフ</Typography>
-              </Box>
-            )}
-            <Box sx={{ position: 'absolute', bottom: 12, left: 12, display: 'flex', alignItems: 'center', gap: 1, bgcolor: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(8px)', px: 1.5, py: 0.6, borderRadius: 1.5 }}>
-              {micEnabled ? <MicIcon sx={{ color: '#fff', fontSize: 16 }} /> : <MicOffIcon sx={{ color: '#ea4335', fontSize: 16 }} />}
-              <Typography sx={{ color: '#fff', fontSize: 13, fontWeight: 500 }}>あなた（候補者）</Typography>
+          {/* エラーオーバーレイ */}
+          {status === 'error' && (
+            <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(0,0,0,0.75)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', p: 3, gap: 2 }}>
+              <Typography sx={{ color: '#f28b82', textAlign: 'center', fontSize: 14, lineHeight: 1.6 }}>{errorMessage}</Typography>
+              <Button variant="contained" startIcon={<RefreshIcon />} onClick={handleJoin}
+                sx={{ bgcolor: '#4285f4', '&:hover': { bgcolor: '#3367d6' }, textTransform: 'none' }}>
+                再接続する
+              </Button>
             </Box>
-            {/* Highlight border overlay */}
-            <Box sx={{ position: 'absolute', inset: 0, border: `2px solid rgba(236,91,19,0.25)`, borderRadius: 2, pointerEvents: 'none' }} />
-          </Box>
+          )}
         </Box>
 
-        {/* ── Right sidebar: Transcript ── */}
-        <Box sx={{ width: { xs: '100%', lg: 360 }, display: 'flex', flexDirection: 'column', bgcolor: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 2, overflow: 'hidden', flexShrink: 0 }}>
-          {/* Sidebar header */}
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 1.5, borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Box component="span" sx={{ fontSize: 20 }}>💬</Box>
-              <Typography sx={{ fontWeight: 700, color: '#e8eaed', fontSize: 14 }}>リアルタイム字幕</Typography>
-            </Box>
-            {isConnected && (
-              <Box sx={{ bgcolor: `${PRIMARY}20`, border: `1px solid ${PRIMARY}40`, px: 1, py: 0.3, borderRadius: 1 }}>
-                <Typography sx={{ color: PRIMARY, fontSize: 10, fontWeight: 700, letterSpacing: 1 }}>LIVE</Typography>
-              </Box>
-            )}
-          </Box>
+        {/* ── 右: チャット + コントロール ── */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1.5, minWidth: 0, overflow: 'hidden' }}>
 
-          {/* Transcript list */}
-          <Box sx={{ flex: 1, overflowY: 'auto', p: 2, display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+          {/* 発話履歴 */}
+          <Box sx={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 1.5, py: 1,
+            '&::-webkit-scrollbar': { width: 4 },
+            '&::-webkit-scrollbar-thumb': { bgcolor: 'rgba(255,255,255,0.2)', borderRadius: 2 },
+          }}>
             {utterances.length === 0 && !partialAi && (
-              <Typography sx={{ color: '#5f6368', fontSize: 13, textAlign: 'center', mt: 4 }}>
-                面接が始まると字幕がここに表示されます
+              <Typography sx={{ color: 'rgba(255,255,255,0.4)', fontSize: 13, textAlign: 'center', mt: 4 }}>
+                面接が始まると会話がここに表示されます
               </Typography>
             )}
             {utterances.map((u, i) => (
-              <Box key={i} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, alignItems: u.role === 'ai' ? 'flex-start' : 'flex-end' }}>
-                <Typography sx={{ fontSize: 10, fontWeight: 700, color: u.role === 'ai' ? '#9aa0a6' : PRIMARY, letterSpacing: 1, textTransform: 'uppercase' }}>
-                  {u.role === 'ai' ? `面接官AI（${isFemale ? '女性' : '男性'}）` : 'あなた'}
-                </Typography>
+              <Box key={i} sx={{ display: 'flex', flexDirection: 'column', gap: 0.3, alignItems: u.role === 'ai' ? 'flex-start' : 'flex-end' }}>
                 <Box sx={{
-                  bgcolor: u.role === 'ai' ? 'rgba(255,255,255,0.06)' : PRIMARY,
-                  px: 1.5, py: 1, borderRadius: u.role === 'ai' ? '0 12px 12px 12px' : '12px 0 12px 12px',
-                  maxWidth: '90%',
+                  bgcolor: u.role === 'ai' ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.18)',
+                  color: u.role === 'ai' ? '#1a1a1a' : '#fff',
+                  px: 2, py: 1.2,
+                  borderRadius: u.role === 'ai' ? '4px 16px 16px 16px' : '16px 4px 16px 16px',
+                  maxWidth: '88%',
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
                 }}>
-                  <Typography sx={{ fontSize: 13, color: '#e8eaed', lineHeight: 1.6 }}>{u.text}</Typography>
+                  <Typography sx={{ fontSize: 13.5, lineHeight: 1.65 }}>{u.text}</Typography>
                 </Box>
               </Box>
             ))}
 
-            {/* Partial AI (typing) */}
             {partialAi && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography sx={{ fontSize: 10, fontWeight: 700, color: '#9aa0a6', letterSpacing: 1, textTransform: 'uppercase' }}>
-                  面接官AI
-                </Typography>
-                <Box sx={{ bgcolor: 'rgba(255,255,255,0.06)', px: 1.5, py: 1, borderRadius: '0 12px 12px 12px', maxWidth: '90%', opacity: 0.7 }}>
-                  <Typography sx={{ fontSize: 13, color: '#e8eaed', lineHeight: 1.6 }}>{partialAi}</Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.3 }}>
+                <Box sx={{ bgcolor: 'rgba(255,255,255,0.7)', px: 2, py: 1.2, borderRadius: '4px 16px 16px 16px', maxWidth: '88%', opacity: 0.8 }}>
+                  <Typography sx={{ fontSize: 13.5, color: '#1a1a1a', lineHeight: 1.65 }}>{partialAi}</Typography>
                 </Box>
               </Box>
             )}
 
-            {/* Partial user (typing) */}
             {partialUser && (
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, alignItems: 'flex-end' }}>
-                <Typography sx={{ fontSize: 10, fontWeight: 700, color: PRIMARY, letterSpacing: 1, textTransform: 'uppercase' }}>あなた</Typography>
-                <Box sx={{ bgcolor: `${PRIMARY}80`, px: 1.5, py: 1, borderRadius: '12px 0 12px 12px', maxWidth: '90%', opacity: 0.7 }}>
-                  <Typography sx={{ fontSize: 13, color: '#fff', lineHeight: 1.6 }}>{partialUser}</Typography>
-                </Box>
-              </Box>
-            )}
-
-            {/* AI tip */}
-            {utterances.length >= 2 && (
-              <Box sx={{ p: 1.5, bgcolor: `${PRIMARY}10`, border: `1px solid ${PRIMARY}30`, borderRadius: 2, display: 'flex', gap: 1.5 }}>
-                <LightbulbIcon sx={{ color: PRIMARY, fontSize: 20, flexShrink: 0 }} />
-                <Box>
-                  <Typography sx={{ fontSize: 11, fontWeight: 700, color: PRIMARY, mb: 0.3 }}>AIヒント</Typography>
-                  <Typography sx={{ fontSize: 12, color: '#9aa0a6', lineHeight: 1.5 }}>
-                    具体的なエピソードを交えて回答すると、より説得力が増します。
-                  </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.3, alignItems: 'flex-end' }}>
+                <Box sx={{ bgcolor: 'rgba(255,255,255,0.12)', px: 2, py: 1.2, borderRadius: '16px 4px 16px 16px', maxWidth: '88%', opacity: 0.8 }}>
+                  <Typography sx={{ fontSize: 13.5, color: '#fff', lineHeight: 1.65 }}>{partialUser}</Typography>
                 </Box>
               </Box>
             )}
@@ -1639,151 +1651,85 @@ function InterviewContent() {
             <div ref={transcriptEndRef} />
           </Box>
 
-          {/* Note input */}
-          <Box sx={{ p: 1.5, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', bgcolor: 'rgba(255,255,255,0.06)', borderRadius: 2, px: 1.5, py: 0.5 }}>
-              <InputBase
-                value={noteInput}
-                onChange={e => setNoteInput(e.target.value)}
-                placeholder="メモやヒントのリクエストを入力..."
-                sx={{ flex: 1, color: '#e8eaed', fontSize: 13, '& ::placeholder': { color: '#5f6368' } }}
-              />
-              <IconButton size="small" sx={{ color: noteInput ? PRIMARY : '#5f6368' }}>
-                <SendIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          </Box>
-        </Box>
-      </Box>
-
-      {/* ── Bottom control bar ── */}
-      <Box sx={{
-        position: 'fixed', bottom: 0, left: 0, right: 0,
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        px: { xs: 2, md: 4 }, py: 1.5,
-        bgcolor: 'rgba(32,33,36,0.97)',
-        borderTop: '1px solid rgba(255,255,255,0.06)',
-        zIndex: 100,
-      }}>
-        {/* Left: session info */}
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 1 }}>
-          <Typography sx={{ fontSize: 13, color: '#9aa0a6', fontWeight: 500 }}>
-            {companyName} 面接
-          </Typography>
-          {isActive && (
-            <LinearProgress
-              variant="determinate"
-              value={progress}
-              sx={{ width: 80, height: 4, borderRadius: 2, bgcolor: '#3c4043', '& .MuiLinearProgress-bar': { bgcolor: PRIMARY } }}
-            />
-          )}
-        </Box>
-
-        {/* Center: controls */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, md: 1.5 }, mx: 'auto' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
-            <Tooltip title={
-              aiSpeaking ? 'AI発話中...' :
-              turnPending ? 'AIが考えています...' :
-              isRecording ? 'クリックして送信' :
-              'クリックして話す'
-            }>
-              <span>
-                <IconButton
-                  onClick={isRecording ? stopRecording : startRecording}
-                  disabled={!isConnected || turnPending || aiSpeaking}
-                  sx={{
-                    bgcolor: isRecording ? '#ea4335' : aiSpeaking ? `${PRIMARY}40` : 'rgba(255,255,255,0.08)',
-                    width: 52, height: 52,
-                    animation: isRecording ? 'micPulse 1s infinite' : 'none',
-                    '@keyframes micPulse': { '0%,100%': { boxShadow: `0 0 0 0 rgba(234,67,53,0.4)` }, '50%': { boxShadow: `0 0 0 8px rgba(234,67,53,0)` } },
-                    '&:hover': { bgcolor: isRecording ? '#c5221f' : 'rgba(255,255,255,0.15)' },
-                    '&:disabled': { bgcolor: 'rgba(255,255,255,0.04)' },
-                  }}
-                >
-                  {turnPending
-                    ? <CircularProgress size={22} sx={{ color: '#9aa0a6' }} />
-                    : aiSpeaking
-                      ? <VolumeUpIcon sx={{ color: PRIMARY }} />
-                      : isRecording
-                        ? <MicIcon sx={{ color: '#fff' }} />
-                        : <MicIcon sx={{ color: '#e8eaed' }} />
-                  }
+          {/* ── コントロールボタン ── */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, flexShrink: 0 }}>
+            {/* サブコントロール行 */}
+            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+              <Tooltip title={cameraEnabled ? 'カメラをオフ' : 'カメラをオン'}>
+                <span>
+                  <IconButton onClick={toggleCamera} disabled={!isConnected} size="small"
+                    sx={{ bgcolor: cameraEnabled ? 'rgba(255,255,255,0.15)' : '#ea4335', width: 36, height: 36, '&:hover': { bgcolor: cameraEnabled ? 'rgba(255,255,255,0.25)' : '#c5221f' }, '&:disabled': { bgcolor: 'rgba(255,255,255,0.06)' } }}>
+                    {cameraEnabled ? <VideocamIcon sx={{ color: '#fff', fontSize: 18 }} /> : <VideocamOffIcon sx={{ color: '#fff', fontSize: 18 }} />}
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title={captionsVisible ? '字幕をオフ' : '字幕をオン'}>
+                <IconButton onClick={() => setCaptionsVisible(p => !p)} size="small"
+                  sx={{ bgcolor: captionsVisible ? 'rgba(255,255,255,0.25)' : 'rgba(255,255,255,0.1)', width: 36, height: 36 }}>
+                  <ClosedCaptionIcon sx={{ color: captionsVisible ? '#fff' : 'rgba(255,255,255,0.5)', fontSize: 18 }} />
                 </IconButton>
-              </span>
-            </Tooltip>
-            <Typography sx={{ fontSize: 10, color: isRecording ? '#ea4335' : aiSpeaking ? PRIMARY : '#9aa0a6', fontWeight: 600, letterSpacing: 0.5, lineHeight: 1 }}>
-              {isRecording ? '録音中' : turnPending ? '処理中' : aiSpeaking ? 'AI発話中' : '話す'}
-            </Typography>
-          </Box>
-
-          <Tooltip title={cameraEnabled ? 'カメラをオフ' : 'カメラをオン'}>
-            <span>
-              <IconButton onClick={toggleCamera} disabled={!isConnected} sx={{ bgcolor: cameraEnabled ? 'rgba(255,255,255,0.08)' : '#ea4335', width: 48, height: 48, '&:hover': { bgcolor: cameraEnabled ? 'rgba(255,255,255,0.15)' : '#c5221f' }, '&:disabled': { bgcolor: 'rgba(255,255,255,0.04)' } }}>
-                {cameraEnabled ? <VideocamIcon sx={{ color: '#e8eaed' }} /> : <VideocamOffIcon sx={{ color: '#fff' }} />}
-              </IconButton>
-            </span>
-          </Tooltip>
-
-          <Tooltip title={captionsVisible ? '字幕をオフ' : '字幕をオン'}>
-            <IconButton onClick={() => setCaptionsVisible(p => !p)} sx={{ bgcolor: captionsVisible ? `${PRIMARY}30` : 'rgba(255,255,255,0.08)', width: 48, height: 48, '&:hover': { bgcolor: captionsVisible ? `${PRIMARY}40` : 'rgba(255,255,255,0.15)' } }}>
-              <ClosedCaptionIcon sx={{ color: captionsVisible ? PRIMARY : '#9aa0a6' }} />
-            </IconButton>
-          </Tooltip>
-
-          <Tooltip title={handsFreeMode ? 'ハンズフリーをオフ（ボタン操作に戻す）' : 'ハンズフリーをオン（声を検知して自動送信）'}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
-              <IconButton
-                onClick={() => setHandsFreeMode(p => !p)}
-                disabled={!isConnected}
-                sx={{
-                  bgcolor: handsFreeMode ? `${PRIMARY}30` : 'rgba(255,255,255,0.08)',
-                  width: 48, height: 48,
-                  '&:hover': { bgcolor: handsFreeMode ? `${PRIMARY}40` : 'rgba(255,255,255,0.15)' },
-                  '&:disabled': { bgcolor: 'rgba(255,255,255,0.04)' },
-                }}
-              >
-                <MicIcon sx={{ color: handsFreeMode ? PRIMARY : '#9aa0a6', fontSize: 20 }} />
-              </IconButton>
-              <Typography sx={{ fontSize: 9, color: handsFreeMode ? PRIMARY : '#9aa0a6', fontWeight: 600, letterSpacing: 0.3 }}>
-                {handsFreeMode ? 'AUTO' : 'ハンズフリー'}
-              </Typography>
+              </Tooltip>
+              <Tooltip title={handsFreeMode ? 'ハンズフリーをオフ' : 'ハンズフリーをオン'}>
+                <IconButton onClick={() => setHandsFreeMode(p => !p)} disabled={!isConnected} size="small"
+                  sx={{ bgcolor: handsFreeMode ? 'rgba(255,255,255,0.25)' : 'rgba(255,255,255,0.1)', width: 36, height: 36 }}>
+                  <MicIcon sx={{ color: handsFreeMode ? '#fff' : 'rgba(255,255,255,0.5)', fontSize: 18 }} />
+                </IconButton>
+              </Tooltip>
             </Box>
-          </Tooltip>
 
-          {/* End call / Join button */}
-          {!isActive ? (
-            <Button
-              variant="contained"
-              onClick={handleJoin}
-              sx={{ bgcolor: '#34a853', '&:hover': { bgcolor: '#2d8f47' }, borderRadius: 9999, px: 3, py: 1, fontWeight: 600, textTransform: 'none', fontSize: 14 }}
-            >
-              面接を開始
-            </Button>
-          ) : (
-            <Tooltip title="面接を終了">
-              <Button
-                variant="contained"
-                startIcon={<CallEndIcon />}
-                onClick={() => handleStop(false)}
-                sx={{ bgcolor: '#ea4335', '&:hover': { bgcolor: '#c5221f' }, borderRadius: 9999, px: 3, py: 1, fontWeight: 600, textTransform: 'none', fontSize: 14 }}
-              >
-                終了
-              </Button>
-            </Tooltip>
-          )}
-        </Box>
+            {/* 主要ボタン行 */}
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              {/* 録音 / 話す ボタン */}
+              <Tooltip title={aiSpeaking ? 'AI発話中...' : turnPending ? 'AIが考えています...' : isRecording ? 'クリックして送信' : 'クリックして話す'}>
+                <span style={{ flex: 1 }}>
+                  <Button
+                    fullWidth
+                    onClick={isRecording ? stopRecording : startRecording}
+                    disabled={!isConnected || turnPending || aiSpeaking}
+                    startIcon={
+                      turnPending
+                        ? <CircularProgress size={16} sx={{ color: 'inherit' }} />
+                        : aiSpeaking
+                          ? <VolumeUpIcon sx={{ fontSize: 18 }} />
+                          : <MicIcon sx={{ fontSize: 18 }} />
+                    }
+                    sx={{
+                      borderRadius: 9999, py: 1.1,
+                      bgcolor: isRecording ? 'rgba(234,67,53,0.25)' : 'rgba(255,255,255,0.18)',
+                      color: isRecording ? '#ff8a80' : 'rgba(255,255,255,0.9)',
+                      border: `1px solid ${isRecording ? 'rgba(234,67,53,0.5)' : 'rgba(255,255,255,0.25)'}`,
+                      textTransform: 'none', fontWeight: 600, fontSize: 13,
+                      animation: isRecording ? 'micPulse 1.4s ease-in-out infinite' : 'none',
+                      '@keyframes micPulse': { '0%,100%': { opacity: 1 }, '50%': { opacity: 0.75 } },
+                      '&:hover': { bgcolor: isRecording ? 'rgba(234,67,53,0.35)' : 'rgba(255,255,255,0.25)' },
+                      '&:disabled': { bgcolor: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.3)', border: '1px solid rgba(255,255,255,0.1)' },
+                    }}
+                  >
+                    {isRecording ? 'レコーディング中...' : turnPending ? '処理中...' : aiSpeaking ? 'AI発話中' : '話す'}
+                  </Button>
+                </span>
+              </Tooltip>
 
-        {/* Right: secondary actions */}
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 1 }}>
-          <Tooltip title="募集要項">
-            <IconButton sx={{ color: '#9aa0a6', '&:hover': { bgcolor: 'rgba(255,255,255,0.08)' } }} onClick={() => {}}>
-              <InfoOutlinedIcon />
-            </IconButton>
-          </Tooltip>
-          <Typography variant="caption" sx={{ color: '#5f6368', ml: 1 }}>
-            質問 {currentQuestionIndex}/{totalQuestionCount} • 残り {Math.floor(remainingSeconds / 60)}:{String(remainingSeconds % 60).padStart(2, '0')}
-          </Typography>
+              {/* 完了 / 開始ボタン */}
+              {!isActive ? (
+                <Button
+                  variant="contained"
+                  onClick={handleJoin}
+                  sx={{ borderRadius: 9999, px: 2.5, py: 1.1, fontWeight: 600, textTransform: 'none', fontSize: 13, bgcolor: '#34a853', '&:hover': { bgcolor: '#2d8f47' }, flexShrink: 0 }}
+                >
+                  面接を開始
+                </Button>
+              ) : (
+                <Button
+                  variant="contained"
+                  onClick={() => handleStop(false)}
+                  sx={{ borderRadius: 9999, px: 2.5, py: 1.1, fontWeight: 600, textTransform: 'none', fontSize: 13, bgcolor: 'rgba(255,255,255,0.22)', color: '#fff', border: '1px solid rgba(255,255,255,0.3)', boxShadow: 'none', '&:hover': { bgcolor: 'rgba(255,255,255,0.32)', boxShadow: 'none' }, flexShrink: 0 }}
+                >
+                  完了する
+                </Button>
+              )}
+            </Box>
+          </Box>
         </Box>
       </Box>
 

--- a/frontend/lib/avatar-loader.ts
+++ b/frontend/lib/avatar-loader.ts
@@ -94,7 +94,9 @@ function createGLTFLoader(): GLTFLoader {
   // Set up DRACO loader for compressed models
   const dracoLoader = new DRACOLoader()
   dracoLoader.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.5.6/')
-  dracoLoader.preload()
+  // preload() は外部CDNへの非同期フェッチを開始するため、ネットワーク不可環境では
+  // Failed to fetch エラーが Promise チェーンを通じてアバターロード全体を失敗させる。
+  // デコーダーはモデルの初回ロード時に自動的に取得されるため preload() は不要。
   loader.setDRACOLoader(dracoLoader)
 
   return loader

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -1,4 +1,5 @@
 import { BACKEND_URL } from './backend-url'
+import { authService } from './auth'
 
 const DEFAULT_INTERVIEW_MAX_MINUTES = 10
 const DEFAULT_INTERVIEW_QUESTION_DURATION_SECONDS = 180
@@ -90,7 +91,7 @@ export const interviewApi = {
   async createSession(userId: number, language = 'ja', interviewerGender?: string): Promise<InterviewSession> {
     const res = await fetch(`${BACKEND_URL}/api/interviews`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId, language, interviewer_gender: interviewerGender }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -100,7 +101,7 @@ export const interviewApi = {
   async startSession(sessionId: number, userId: number): Promise<InterviewSession> {
     const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/start`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -110,7 +111,7 @@ export const interviewApi = {
   async finishSession(sessionId: number, userId: number): Promise<InterviewSession> {
     const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/finish`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -120,7 +121,7 @@ export const interviewApi = {
   async saveUtterance(sessionId: number, userId: number, role: 'user' | 'ai', text: string): Promise<void> {
     const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/utterances`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId, role, text }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -128,20 +129,26 @@ export const interviewApi = {
 
   async getDetail(sessionId: number, userId: number, role?: string): Promise<InterviewDetail> {
     const roleParam = role ? `&role=${role}` : ''
-    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}?user_id=${userId}${roleParam}`)
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}?user_id=${userId}${roleParam}`, {
+      headers: { ...authService.getUserFetchHeaders() },
+    })
     if (!res.ok) throw new Error(await res.text())
     return res.json()
   },
 
   async getReport(sessionId: number, userId: number): Promise<InterviewReport | null> {
-    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/report?user_id=${userId}`)
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/report?user_id=${userId}`, {
+      headers: { ...authService.getUserFetchHeaders() },
+    })
     if (res.status === 404) return null
     if (!res.ok) throw new Error(await res.text())
     return res.json()
   },
 
   async listSessions(userId: number, page = 1, limit = 20): Promise<{ sessions: InterviewSession[]; total: number }> {
-    const res = await fetch(`${BACKEND_URL}/api/interviews?user_id=${userId}&page=${page}&limit=${limit}`)
+    const res = await fetch(`${BACKEND_URL}/api/interviews?user_id=${userId}&page=${page}&limit=${limit}`, {
+      headers: { ...authService.getUserFetchHeaders() },
+    })
     if (!res.ok) throw new Error(await res.text())
     return res.json()
   },
@@ -149,7 +156,7 @@ export const interviewApi = {
   async createRealtimeToken(userId: number, interviewId: number): Promise<string> {
     const res = await fetch(`${BACKEND_URL}/api/realtime/token`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId, interview_id: interviewId }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -158,7 +165,9 @@ export const interviewApi = {
   },
 
   async getPhraseSuggestions(sessionId: number, userId: number): Promise<PhraseSuggestion[]> {
-    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/phrase-suggestions?user_id=${userId}`)
+    const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/phrase-suggestions?user_id=${userId}`, {
+      headers: { ...authService.getUserFetchHeaders() },
+    })
     if (!res.ok) throw new Error(await res.text())
     const data = await res.json()
     return data.suggestions as PhraseSuggestion[]
@@ -166,7 +175,9 @@ export const interviewApi = {
 
   async getTrend(userId: number, limit = 0): Promise<InterviewTrendPoint[]> {
     const params = limit > 0 ? `?user_id=${userId}&limit=${limit}` : `?user_id=${userId}`
-    const res = await fetch(`${BACKEND_URL}/api/interviews/trend${params}`)
+    const res = await fetch(`${BACKEND_URL}/api/interviews/trend${params}`, {
+      headers: { ...authService.getUserFetchHeaders() },
+    })
     if (!res.ok) throw new Error(await res.text())
     const data = await res.json()
     return data.points as InterviewTrendPoint[]
@@ -175,7 +186,7 @@ export const interviewApi = {
   async sendReportEmail(sessionId: number, userId: number): Promise<{ message: string }> {
     const res = await fetch(`${BACKEND_URL}/api/interviews/${sessionId}/send-report`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
       body: JSON.stringify({ user_id: userId }),
     })
     if (!res.ok) throw new Error(await res.text())
@@ -195,6 +206,8 @@ export const interviewApi = {
 
       const xhr = new XMLHttpRequest()
       xhr.open('POST', `${BACKEND_URL}/api/interviews/${sessionId}/upload-video`)
+      const userHeaders = authService.getUserFetchHeaders()
+      Object.entries(userHeaders).forEach(([k, v]) => xhr.setRequestHeader(k, v))
 
       if (onProgress) {
         xhr.upload.onprogress = (e) => {

--- a/frontend/lib/interview.ts
+++ b/frontend/lib/interview.ts
@@ -1,7 +1,7 @@
 import { BACKEND_URL } from './backend-url'
 import { authService } from './auth'
 
-const DEFAULT_INTERVIEW_MAX_MINUTES = 10
+const DEFAULT_INTERVIEW_MAX_MINUTES = 30
 const DEFAULT_INTERVIEW_QUESTION_DURATION_SECONDS = 180
 
 export type InterviewSession = {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -16,8 +16,8 @@ const securityHeaders = [
       "img-src 'self' data: https:",
       // 開発モードでは webpack HMR の WebSocket 接続を許可
       isDev
-        ? "connect-src 'self' http://localhost:* https://api.openai.com ws://localhost:* wss://localhost:*"
-        : "connect-src 'self' https://api.openai.com",
+        ? "connect-src 'self' blob: http://localhost:* https://api.openai.com ws://localhost:* wss://localhost:*"
+        : "connect-src 'self' blob: https://api.openai.com",
       "frame-ancestors 'none'",
     ].join('; '),
   },
@@ -26,6 +26,12 @@ const securityHeaders = [
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
 ]
+
+// 面接ページはカメラ・マイクへのアクセスが必要なため Permissions-Policy を上書き
+const interviewPermissionsHeader = {
+  key: 'Permissions-Policy',
+  value: 'camera=(self), microphone=(self), geolocation=()',
+}
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -41,6 +47,14 @@ const nextConfig: NextConfig = {
       {
         source: '/(.*)',
         headers: securityHeaders,
+      },
+      {
+        // 面接ページのみカメラ・マイクを許可（他ページは securityHeaders で引き続き禁止）
+        source: '/interview(.*)',
+        headers: [
+          ...securityHeaders.filter((h) => h.key !== 'Permissions-Policy'),
+          interviewPermissionsHeader,
+        ],
       },
     ]
   },


### PR DESCRIPTION
## 概要
Issue #503 の実装。AI面接のUI改善と企業特化の質問対応を行います。

## 変更内容

### フロントエンド (`frontend/app/interview/page.tsx`)
- **ロビー画面**: 企業情報プレビューカード（企業文化・働き方・福利厚生）を追加
- **セッション画面**: アバター上部に `[企業名] 面接官` のロールラベルを常時表示
- **API送信データ強化**: `culture` / `work_style` / `welfare_details` を `company_info` に含めてバックエンドへ送信

### バックエンド (`Backend/internal/services/interview_service.go`)
- プロンプトの企業情報ラベルを「企業情報」に統一（公式サイト限定の表現を廃止）
- 企業文化・働き方情報を踏まえた深掘り質問の指示を追加
- SIerプロンプトに技術フェーズ（詳細設計・実装・テスト）と要件定義フェーズの確認項目を追加

## 受け入れ基準
- [x] 面接選択画面で企業を選ぶと `style_tags` + `top_questions` が表示される
- [x] ロビー画面に企業文化・働き方・福利厚生のプレビューカードが表示される
- [x] 面接中の画面でアバター上部に企業名 + 面接官ロールラベルが表示される
- [x] SIer企業の場合、技術・設計系の追加質問がAIから出される
- [x] UIがレスポンシブで既存の面接フローを壊さない

## 関連
- Closes #503
- Backlog: SOCAIAGENT-8