### PR TITLE
Resolve #506: AI面接で企業ごとのカスタム質問リストを登録・適用できるようにする

### DIFF
--- a/.github/workflows/backlog-notify.yml
+++ b/.github/workflows/backlog-notify.yml
@@ -6,7 +6,9 @@ name: Backlog 通知 (commit / PR)
 #
 # 必要な GitHub Secrets:
 #   BACKLOG_SPACE_ID  : スペースID（例: myspace ← myspace.backlog.jp の場合）
+#   BACKLOG_PROJECT_KEY: プロジェクトキー（例: PROJ）
 #   BACKLOG_API_KEY   : Backlog のアカウント設定で発行した APIキー
+#   BACKLOG_DOMAIN    : 任意。backlog.jp 以外を利用する場合のドメイン
 
 on:
   push:
@@ -18,7 +20,17 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Backlog ホスト名を解決
+        id: resolve
+        env:
+          BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+          BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+        run: |
+          domain="${BACKLOG_DOMAIN:-backlog.jp}"
+          echo "host=${BACKLOG_SPACE_ID}.${domain}" >> "$GITHUB_OUTPUT"
+
       - uses: bicstone/backlog-notify@v6
         with:
-          space_id: ${{ secrets.BACKLOG_SPACE_ID }}
+          project_key: ${{ secrets.BACKLOG_PROJECT_KEY }}
+          api_host: ${{ steps.resolve.outputs.host }}
           api_key: ${{ secrets.BACKLOG_API_KEY }}

--- a/.github/workflows/pr-to-backlog.yml
+++ b/.github/workflows/pr-to-backlog.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: PR を Backlog 課題へ反映
         env:
@@ -39,6 +41,8 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
           ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           python3 - << 'PYEOF'
           import os, sys, json, re, urllib.parse, urllib.request, urllib.error
@@ -52,6 +56,8 @@ jobs:
           PR_MERGED = os.environ.get('PR_MERGED', 'false').lower() == 'true'
           ACTION    = os.environ['ACTION']
           DOMAIN    = os.environ.get('BACKLOG_DOMAIN', '').strip()
+          GH_TOKEN  = os.environ.get('GH_TOKEN', '')
+          GH_REPO   = os.environ.get('GH_REPO', '')
 
           def resolve_bl_base(space_id, api_key, domain):
               candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
@@ -101,7 +107,34 @@ jobs:
                   return m.group(1)
               return None
 
+          def resolve_bl_key_from_gh_issue(body):
+              """PR 本文の Closes/Fixes/Resolves #N から GitHub Issue を取得し Backlog キーを解決する"""
+              if not GH_TOKEN or not GH_REPO:
+                  return None
+              nums = re.findall(
+                  r'(?:closes?|fixes?|resolves?)\s+#(\d+)',
+                  body, re.IGNORECASE
+              )
+              for num in nums:
+                  url = f"https://api.github.com/repos/{GH_REPO}/issues/{num}"
+                  req = urllib.request.Request(url)
+                  req.add_header('Authorization', f'Bearer {GH_TOKEN}')
+                  req.add_header('Accept', 'application/vnd.github+json')
+                  req.add_header('X-GitHub-Api-Version', '2022-11-28')
+                  try:
+                      with urllib.request.urlopen(req) as r:
+                          issue = json.loads(r.read())
+                  except Exception:
+                      continue
+                  bl_key = extract_bl_key(issue.get('title', ''), issue.get('body') or '')
+                  if bl_key:
+                      print(f"GitHub Issue #{num} から Backlog キーを解決: {bl_key}")
+                      return bl_key
+              return None
+
           bl_key = extract_bl_key(PR_TITLE, PR_BODY)
+          if not bl_key:
+              bl_key = resolve_bl_key_from_gh_issue(PR_BODY)
           if not bl_key:
               print("Backlog 課題キーが見つかりません。スキップします。")
               sys.exit(0)

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -177,6 +177,7 @@ func main() {
 	interviewUtteranceRepo := repositories.NewInterviewUtteranceRepository(db)
 	interviewReportRepo := repositories.NewInterviewReportRepository(db)
 	videoRepo := repositories.NewInterviewVideoRepository(db)
+	interviewCompanyQuestionRepo := repositories.NewInterviewCompanyQuestionRepository(db)
 	// その他
 	resumeRepo := repositories.NewResumeRepository(db)
 	auditLogRepo := repositories.NewAuditLogRepository(db)
@@ -224,6 +225,8 @@ func main() {
 	// クロス機能連携サービス（チャットスコア↔面接/職務経歴書レビュー）
 	crossFeatureService := services.NewCrossFeatureIntegrationService(userWeightScoreRepo)
 	interviewService.SetCrossFeatureService(crossFeatureService)
+	interviewService.SetCompanyQuestionRepo(interviewCompanyQuestionRepo)
+	interviewService.SetSkillScoreRepo(skillScoreRepo)
 	resumeService.SetCrossFeatureService(crossFeatureService)
 
 	// コントローラー層の初期化
@@ -256,6 +259,7 @@ func main() {
 	interviewController := controllers.NewInterviewController(interviewService, videoRepo, s3UploadService)
 	realtimeController := controllers.NewRealtimeController(interviewService, realtimeUsageService)
 	adminInterviewController := controllers.NewAdminInterviewController(interviewService, videoRepo, s3UploadService)
+	adminInterviewController.SetCompanyQuestionRepo(interviewCompanyQuestionRepo)
 	adminDashboardController := controllers.NewAdminDashboardController(userRepo, interviewSessionRepo, interviewReportRepo)
 	adminCostsController := controllers.NewAdminCostsController(apiCostService, realtimeUsageService)
 	profileRecalcService := services.NewProfileRecalculationService(profileRecalcRepo, companyRepo)

--- a/Backend/domain/repository/interview.go
+++ b/Backend/domain/repository/interview.go
@@ -40,3 +40,13 @@ type InterviewVideoRepository interface {
 	FindBySessionID(ctx context.Context, sessionID uint) ([]models.InterviewVideo, error)
 	FindByID(ctx context.Context, id uint) (*models.InterviewVideo, error)
 }
+
+// InterviewCompanyQuestionRepository は企業別カスタム面接質問の永続化インターフェース。
+type InterviewCompanyQuestionRepository interface {
+	FindByCompanyID(companyID uint) ([]models.InterviewCompanyQuestion, error)
+	FindByCompanyAndPosition(companyID uint, position string) ([]models.InterviewCompanyQuestion, error)
+	FindByID(id uint) (*models.InterviewCompanyQuestion, error)
+	Create(q *models.InterviewCompanyQuestion) error
+	Update(q *models.InterviewCompanyQuestion) error
+	Delete(id uint) error
+}

--- a/Backend/go.mod
+++ b/Backend/go.mod
@@ -1,6 +1,6 @@
 module Backend
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/Backend/internal/controllers/admin_interview_controller.go
+++ b/Backend/internal/controllers/admin_interview_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"Backend/domain/repository"
+	"Backend/internal/models"
 	"Backend/internal/services"
 	"net/http"
 	"strconv"
@@ -12,9 +13,10 @@ import (
 
 // AdminInterviewController provides admin endpoints for viewing interview sessions and videos.
 type AdminInterviewController struct {
-	interviewService *services.InterviewService
-	videoRepo        repository.InterviewVideoRepository
-	s3Service        *services.S3UploadService
+	interviewService    *services.InterviewService
+	videoRepo           repository.InterviewVideoRepository
+	s3Service           *services.S3UploadService
+	companyQuestionRepo repository.InterviewCompanyQuestionRepository
 }
 
 func NewAdminInterviewController(
@@ -27,6 +29,122 @@ func NewAdminInterviewController(
 		videoRepo:        videoRepo,
 		s3Service:        s3Service,
 	}
+}
+
+// SetCompanyQuestionRepo 企業別質問リポジトリを注入する
+func (c *AdminInterviewController) SetCompanyQuestionRepo(r repository.InterviewCompanyQuestionRepository) {
+	c.companyQuestionRepo = r
+}
+
+// ListCompanyQuestions GET /api/admin/companies/:id/interview-questions
+func (c *AdminInterviewController) ListCompanyQuestions(ctx echo.Context) error {
+	if c.companyQuestionRepo == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
+	}
+	companyID, err := echoUintParam(ctx, "id")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
+	qs, err := c.companyQuestionRepo.FindByCompanyID(companyID)
+	if err != nil {
+		return echoInternalError(err)
+	}
+	return ctx.JSON(http.StatusOK, map[string]any{"questions": qs})
+}
+
+// CreateCompanyQuestion POST /api/admin/companies/:id/interview-questions
+func (c *AdminInterviewController) CreateCompanyQuestion(ctx echo.Context) error {
+	if c.companyQuestionRepo == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
+	}
+	companyID, err := echoUintParam(ctx, "id")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
+	var req struct {
+		Position     string `json:"position"`
+		Category     string `json:"category"`
+		QuestionText string `json:"question_text"`
+		Priority     int    `json:"priority"`
+		IsRequired   bool   `json:"is_required"`
+	}
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+	if req.Category == "" || req.QuestionText == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "category and question_text are required")
+	}
+	q := &models.InterviewCompanyQuestion{
+		CompanyID:    companyID,
+		Position:     req.Position,
+		Category:     req.Category,
+		QuestionText: req.QuestionText,
+		Priority:     req.Priority,
+		IsRequired:   req.IsRequired,
+	}
+	if err := c.companyQuestionRepo.Create(q); err != nil {
+		return echoInternalError(err)
+	}
+	return ctx.JSON(http.StatusCreated, q)
+}
+
+// UpdateCompanyQuestion PUT /api/admin/companies/:id/interview-questions/:qid
+func (c *AdminInterviewController) UpdateCompanyQuestion(ctx echo.Context) error {
+	if c.companyQuestionRepo == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
+	}
+	qID, err := echoUintParam(ctx, "qid")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid question ID")
+	}
+	q, err := c.companyQuestionRepo.FindByID(qID)
+	if err != nil || q == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Question not found")
+	}
+	var req struct {
+		Position     *string `json:"position"`
+		Category     *string `json:"category"`
+		QuestionText *string `json:"question_text"`
+		Priority     *int    `json:"priority"`
+		IsRequired   *bool   `json:"is_required"`
+	}
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+	if req.Position != nil {
+		q.Position = *req.Position
+	}
+	if req.Category != nil {
+		q.Category = *req.Category
+	}
+	if req.QuestionText != nil {
+		q.QuestionText = *req.QuestionText
+	}
+	if req.Priority != nil {
+		q.Priority = *req.Priority
+	}
+	if req.IsRequired != nil {
+		q.IsRequired = *req.IsRequired
+	}
+	if err := c.companyQuestionRepo.Update(q); err != nil {
+		return echoInternalError(err)
+	}
+	return ctx.JSON(http.StatusOK, q)
+}
+
+// DeleteCompanyQuestion DELETE /api/admin/companies/:id/interview-questions/:qid
+func (c *AdminInterviewController) DeleteCompanyQuestion(ctx echo.Context) error {
+	if c.companyQuestionRepo == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
+	}
+	qID, err := echoUintParam(ctx, "qid")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid question ID")
+	}
+	if err := c.companyQuestionRepo.Delete(qID); err != nil {
+		return echoInternalError(err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 // ListSessions handles GET /api/admin/interviews

--- a/Backend/internal/controllers/admin_interview_controller.go
+++ b/Backend/internal/controllers/admin_interview_controller.go
@@ -6,6 +6,7 @@ import (
 	"Backend/internal/services"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -71,6 +72,9 @@ func (c *AdminInterviewController) CreateCompanyQuestion(ctx echo.Context) error
 	if err := ctx.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
+	req.Position = strings.TrimSpace(req.Position)
+	req.Category = strings.TrimSpace(req.Category)
+	req.QuestionText = strings.TrimSpace(req.QuestionText)
 	if req.Category == "" || req.QuestionText == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "category and question_text are required")
 	}
@@ -93,12 +97,16 @@ func (c *AdminInterviewController) UpdateCompanyQuestion(ctx echo.Context) error
 	if c.companyQuestionRepo == nil {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
 	}
+	companyID, err := echoUintParam(ctx, "id")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
 	qID, err := echoUintParam(ctx, "qid")
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid question ID")
 	}
 	q, err := c.companyQuestionRepo.FindByID(qID)
-	if err != nil || q == nil {
+	if err != nil || q == nil || q.CompanyID != companyID {
 		return echo.NewHTTPError(http.StatusNotFound, "Question not found")
 	}
 	var req struct {
@@ -112,13 +120,21 @@ func (c *AdminInterviewController) UpdateCompanyQuestion(ctx echo.Context) error
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
 	if req.Position != nil {
-		q.Position = *req.Position
+		q.Position = strings.TrimSpace(*req.Position)
 	}
 	if req.Category != nil {
-		q.Category = *req.Category
+		category := strings.TrimSpace(*req.Category)
+		if category == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "category must not be empty")
+		}
+		q.Category = category
 	}
 	if req.QuestionText != nil {
-		q.QuestionText = *req.QuestionText
+		questionText := strings.TrimSpace(*req.QuestionText)
+		if questionText == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "question_text must not be empty")
+		}
+		q.QuestionText = questionText
 	}
 	if req.Priority != nil {
 		q.Priority = *req.Priority
@@ -137,9 +153,17 @@ func (c *AdminInterviewController) DeleteCompanyQuestion(ctx echo.Context) error
 	if c.companyQuestionRepo == nil {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "not configured")
 	}
+	companyID, err := echoUintParam(ctx, "id")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
 	qID, err := echoUintParam(ctx, "qid")
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid question ID")
+	}
+	q, err := c.companyQuestionRepo.FindByID(qID)
+	if err != nil || q == nil || q.CompanyID != companyID {
+		return echo.NewHTTPError(http.StatusNotFound, "Question not found")
 	}
 	if err := c.companyQuestionRepo.Delete(qID); err != nil {
 		return echoInternalError(err)

--- a/Backend/internal/controllers/interview_controller.go
+++ b/Backend/internal/controllers/interview_controller.go
@@ -235,6 +235,7 @@ func (c *InterviewController) Turn(ctx echo.Context) error {
 	position := r.FormValue("position")
 	companyInfo := r.FormValue("company_info")
 	companyType := r.FormValue("company_type")
+	companyID := uint(parseFormInt(r, "company_id", 0))
 
 	turnCount := parseFormInt(r, "turn_count", 0)
 	remainingSeconds := parseFormInt(r, "remaining_seconds", 0)
@@ -264,6 +265,7 @@ func (c *InterviewController) Turn(ctx echo.Context) error {
 		position,
 		companyInfo,
 		companyType,
+		companyID,
 		turnCount,
 		remainingSeconds,
 		questionIndex,
@@ -309,6 +311,7 @@ func (c *InterviewController) StartTurn(ctx echo.Context) error {
 		Position                string `json:"position"`
 		CompanyInfo             string `json:"company_info"`
 		CompanyType             string `json:"company_type"`
+		CompanyID               uint   `json:"company_id"`
 		QuestionIndex           int    `json:"question_index"`
 		TotalQuestions          int    `json:"total_questions"`
 		QuestionElapsedSeconds  int    `json:"question_elapsed_seconds"`
@@ -325,6 +328,7 @@ func (c *InterviewController) StartTurn(ctx echo.Context) error {
 		req.Position,
 		req.CompanyInfo,
 		req.CompanyType,
+		req.CompanyID,
 		req.QuestionIndex,
 		req.TotalQuestions,
 		req.QuestionElapsedSeconds,

--- a/Backend/internal/models/interview_company_question.go
+++ b/Backend/internal/models/interview_company_question.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// InterviewCompanyQuestion 企業別面接カスタム質問
+type InterviewCompanyQuestion struct {
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	CompanyID    uint      `gorm:"index;not null" json:"company_id"`
+	Position     string    `gorm:"size:100" json:"position"` // 空欄=全職種共通
+	Category     string    `gorm:"size:100;not null" json:"category"`
+	QuestionText string    `gorm:"type:text;not null" json:"question_text"`
+	Priority     int       `gorm:"default:0" json:"priority"` // 小さい数値が先
+	IsRequired   bool      `gorm:"default:false" json:"is_required"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/Backend/internal/models/migrate.go
+++ b/Backend/internal/models/migrate.go
@@ -51,6 +51,7 @@ func AutoMigrate(db *gorm.DB) error {
 		&InterviewUtterance{},
 		&InterviewReport{},
 		&InterviewVideo{},
+		&InterviewCompanyQuestion{},
 		&RealtimeUsageLog{},
 		&PendingRegistration{},
 		// 選考スケジュール

--- a/Backend/internal/repositories/interview_company_question_repository.go
+++ b/Backend/internal/repositories/interview_company_question_repository.go
@@ -1,0 +1,49 @@
+package repositories
+
+import (
+	"Backend/internal/models"
+
+	"gorm.io/gorm"
+)
+
+type InterviewCompanyQuestionRepository struct {
+	db *gorm.DB
+}
+
+func NewInterviewCompanyQuestionRepository(db *gorm.DB) *InterviewCompanyQuestionRepository {
+	return &InterviewCompanyQuestionRepository{db: db}
+}
+
+func (r *InterviewCompanyQuestionRepository) FindByCompanyID(companyID uint) ([]models.InterviewCompanyQuestion, error) {
+	var qs []models.InterviewCompanyQuestion
+	err := r.db.Where("company_id = ?", companyID).Order("priority ASC, id ASC").Find(&qs).Error
+	return qs, err
+}
+
+func (r *InterviewCompanyQuestionRepository) FindByCompanyAndPosition(companyID uint, position string) ([]models.InterviewCompanyQuestion, error) {
+	var qs []models.InterviewCompanyQuestion
+	err := r.db.Where("company_id = ? AND (position = '' OR position = ?)", companyID, position).
+		Order("priority ASC, id ASC").Find(&qs).Error
+	return qs, err
+}
+
+func (r *InterviewCompanyQuestionRepository) FindByID(id uint) (*models.InterviewCompanyQuestion, error) {
+	var q models.InterviewCompanyQuestion
+	err := r.db.First(&q, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &q, nil
+}
+
+func (r *InterviewCompanyQuestionRepository) Create(q *models.InterviewCompanyQuestion) error {
+	return r.db.Create(q).Error
+}
+
+func (r *InterviewCompanyQuestionRepository) Update(q *models.InterviewCompanyQuestion) error {
+	return r.db.Save(q).Error
+}
+
+func (r *InterviewCompanyQuestionRepository) Delete(id uint) error {
+	return r.db.Delete(&models.InterviewCompanyQuestion{}, id).Error
+}

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -79,6 +79,12 @@ func SetupAdminRoutes(
 	admin.GET("/interviews/:id/videos", adminInterviewController.ListVideos)
 	admin.GET("/interviews/videos/:video_id/url", adminInterviewController.VideoURL)
 
+	// 企業別面接質問管理
+	admin.GET("/companies/:id/interview-questions", adminInterviewController.ListCompanyQuestions)
+	admin.POST("/companies/:id/interview-questions", adminInterviewController.CreateCompanyQuestion)
+	admin.PUT("/companies/:id/interview-questions/:qid", adminInterviewController.UpdateCompanyQuestion)
+	admin.DELETE("/companies/:id/interview-questions/:qid", adminInterviewController.DeleteCompanyQuestion)
+
 	// ダッシュボード
 	admin.GET("/dashboard/users", adminDashboardController.ListUsers)
 	admin.GET("/dashboard/users/:id", adminDashboardController.UserSessions)

--- a/Backend/internal/services/interfaces/interview_service.go
+++ b/Backend/internal/services/interfaces/interview_service.go
@@ -25,6 +25,7 @@ type InterviewService interface {
 		audioData []byte,
 		history []map[string]string,
 		companyName, companyReading, position, companyInfo, companyType string,
+		companyID uint,
 		turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
 	) (*services.TurnResult, error)
 	StartTurn(
@@ -32,6 +33,7 @@ type InterviewService interface {
 		userID uint,
 		sessionID uint,
 		companyName, companyReading, position, companyInfo, companyType string,
+		companyID uint,
 		questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
 	) (*services.TurnResult, error)
 }

--- a/Backend/internal/services/interview_company_question_test.go
+++ b/Backend/internal/services/interview_company_question_test.go
@@ -1,0 +1,219 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"Backend/internal/models"
+)
+
+type interviewCompanyQuestionRepoStub struct {
+	questions    []models.InterviewCompanyQuestion
+	err          error
+	findCalls    int
+	gotCompanyID uint
+	gotPosition  string
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByCompanyID(uint) ([]models.InterviewCompanyQuestion, error) {
+	return nil, nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByCompanyAndPosition(companyID uint, position string) ([]models.InterviewCompanyQuestion, error) {
+	r.findCalls++
+	r.gotCompanyID = companyID
+	r.gotPosition = position
+	return r.questions, r.err
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByID(uint) (*models.InterviewCompanyQuestion, error) {
+	return nil, nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Create(*models.InterviewCompanyQuestion) error {
+	return nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Update(*models.InterviewCompanyQuestion) error {
+	return nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Delete(uint) error {
+	return nil
+}
+
+func TestInterviewServiceFetchCustomQuestions(t *testing.T) {
+	questions := []models.InterviewCompanyQuestion{
+		{CompanyID: 42, Position: "", QuestionText: "全職種向け質問"},
+		{CompanyID: 42, Position: "バックエンドエンジニア", QuestionText: "職種別質問"},
+	}
+
+	tests := []struct {
+		name          string
+		companyID     uint
+		position      string
+		repo          *interviewCompanyQuestionRepoStub
+		wantQuestions int
+		wantCalls     int
+	}{
+		{
+			name:      "company_idが0ならデフォルト動作へフォールバックする",
+			companyID: 0,
+			repo:      &interviewCompanyQuestionRepoStub{questions: questions},
+			wantCalls: 0,
+		},
+		{
+			name:          "企業IDと職種を指定して共通質問と職種別質問を取得する",
+			companyID:     42,
+			position:      "バックエンドエンジニア",
+			repo:          &interviewCompanyQuestionRepoStub{questions: questions},
+			wantQuestions: 2,
+			wantCalls:     1,
+		},
+		{
+			name:      "リポジトリエラー時は面接を継続できるよう空にする",
+			companyID: 42,
+			position:  "バックエンドエンジニア",
+			repo:      &interviewCompanyQuestionRepoStub{err: errors.New("database unavailable")},
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewInterviewService(nil, nil, nil, nil, nil, nil, nil)
+			svc.SetCompanyQuestionRepo(tt.repo)
+
+			got := svc.fetchCustomQuestions(tt.companyID, tt.position)
+
+			if len(got) != tt.wantQuestions {
+				t.Fatalf("question count = %d, want %d", len(got), tt.wantQuestions)
+			}
+			if tt.repo.findCalls != tt.wantCalls {
+				t.Fatalf("FindByCompanyAndPosition calls = %d, want %d", tt.repo.findCalls, tt.wantCalls)
+			}
+			if tt.wantCalls > 0 {
+				if tt.repo.gotCompanyID != tt.companyID || tt.repo.gotPosition != tt.position {
+					t.Fatalf("repository args = (%d, %q), want (%d, %q)", tt.repo.gotCompanyID, tt.repo.gotPosition, tt.companyID, tt.position)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildInterviewSystemPromptCustomQuestions(t *testing.T) {
+	questions := []models.InterviewCompanyQuestion{
+		{Category: "志望動機", QuestionText: "当社を志望した理由を教えてください。", IsRequired: true},
+		{Category: "技術", QuestionText: "最近解決した技術課題を教えてください。", IsRequired: false},
+	}
+
+	tests := []struct {
+		name        string
+		questions   []models.InterviewCompanyQuestion
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:      "必須質問と推奨質問を別セクションへ注入する",
+			questions: questions,
+			wantContain: []string{
+				"【必須質問（必ず全て質問してください）】",
+				"- [志望動機] 当社を志望した理由を教えてください。",
+				"【推奨質問（会話の流れに応じて取り入れてください）】",
+				"- [技術] 最近解決した技術課題を教えてください。",
+			},
+		},
+		{
+			name:       "カスタム質問がなければ質問セクションを追加しない",
+			wantAbsent: []string{"【必須質問", "【推奨質問"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := buildInterviewSystemPrompt(
+				"テスト株式会社", "", "バックエンドエンジニア", "", "general",
+				tt.questions, nil, 0, 0, 1, 5, 0, 180,
+			)
+
+			for _, want := range tt.wantContain {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("prompt does not contain %q", want)
+				}
+			}
+			for _, unwanted := range tt.wantAbsent {
+				if strings.Contains(prompt, unwanted) {
+					t.Errorf("prompt unexpectedly contains %q", unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildInterviewSystemPromptSkillHints(t *testing.T) {
+	scores := []models.SkillScore{
+		{Category: models.SkillCategoryBackend, Score: 85},
+		{Category: models.SkillCategoryInfra, Score: 70},
+		{Category: models.SkillCategoryFrontend, Score: 20},
+	}
+
+	tests := []struct {
+		name        string
+		position    string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:     "エンジニア職には閾値以上のスキル質問を追加する",
+			position: "バックエンドエンジニア",
+			wantContain: []string{
+				"【GitHubスキル分析に基づく技術質問ガイドライン】",
+				"バックエンド（スコア85）",
+				"インフラ（スコア70）",
+			},
+			wantAbsent: []string{"フロントエンド（スコア20）"},
+		},
+		{
+			name:       "非エンジニア職にはスキル質問を追加しない",
+			position:   "法人営業",
+			wantAbsent: []string{"【GitHubスキル分析に基づく技術質問ガイドライン】", "バックエンド（スコア85）"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := buildInterviewSystemPrompt(
+				"テスト株式会社", "", tt.position, "", "general",
+				nil, scores, 0, 0, 1, 5, 0, 180,
+			)
+
+			for _, want := range tt.wantContain {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("prompt does not contain %q", want)
+				}
+			}
+			for _, unwanted := range tt.wantAbsent {
+				if strings.Contains(prompt, unwanted) {
+					t.Errorf("prompt unexpectedly contains %q", unwanted)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTechQuestionHintsOrdersScoresDescending(t *testing.T) {
+	hints := buildTechQuestionHints([]models.SkillScore{
+		{Category: models.SkillCategoryInfra, Score: 60},
+		{Category: models.SkillCategoryBackend, Score: 90},
+	})
+
+	backendIndex := strings.Index(hints, "バックエンド（スコア90）")
+	infraIndex := strings.Index(hints, "インフラ（スコア60）")
+	if backendIndex < 0 || infraIndex < 0 {
+		t.Fatalf("expected skill hints are missing: %s", hints)
+	}
+	if backendIndex >= infraIndex {
+		t.Fatalf("skill hints are not ordered by score descending: %s", hints)
+	}
+}

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -27,8 +27,15 @@ type InterviewService struct {
 	openaiClient         *openai.Client
 	realtimeUsageService *RealtimeUsageService
 	crossFeature         *CrossFeatureIntegrationService
+	companyQuestionRepo  repository.InterviewCompanyQuestionRepository
+	skillScoreRepo       SkillScoreReader
 	jobCh                chan uint
 	workerOnce           sync.Once
+}
+
+// SkillScoreReader はGitHubスキルスコア取得の最小インターフェース。
+type SkillScoreReader interface {
+	GetScores(userID uint) ([]models.SkillScore, error)
 }
 
 func NewInterviewService(
@@ -50,6 +57,16 @@ func NewInterviewService(
 		realtimeUsageService: realtimeUsageService,
 		jobCh:                make(chan uint, 100),
 	}
+}
+
+// SetCompanyQuestionRepo 企業別質問リポジトリを注入する（オプション）
+func (s *InterviewService) SetCompanyQuestionRepo(r repository.InterviewCompanyQuestionRepository) {
+	s.companyQuestionRepo = r
+}
+
+// SetSkillScoreRepo GitHubスキルスコアリポジトリを注入する（オプション）
+func (s *InterviewService) SetSkillScoreRepo(r SkillScoreReader) {
+	s.skillScoreRepo = r
 }
 
 // SetCrossFeatureService 機能間連携サービスを注入する（オプション）
@@ -508,6 +525,7 @@ func (s *InterviewService) Turn(
 	position,
 	companyInfo,
 	companyType string,
+	companyID uint,
 	turnCount int,
 	remainingSeconds int,
 	questionIndex int,
@@ -542,6 +560,10 @@ func (s *InterviewService) Turn(
 		companyInfo = s.lookupCompanyProfile(ctx, companyName)
 	}
 
+	// 企業別カスタム質問とGitHubスキルスコアを取得
+	customQuestions := s.fetchCustomQuestions(companyID, position)
+	skillScores := s.fetchSkillScores(userID)
+
 	// 履歴にユーザー発言を追加
 	history = append(history, map[string]string{"role": "user", "content": userText})
 
@@ -552,6 +574,8 @@ func (s *InterviewService) Turn(
 		position,
 		companyInfo,
 		companyType,
+		customQuestions,
+		skillScores,
 		turnCount,
 		remainingSeconds,
 		questionIndex,
@@ -589,6 +613,7 @@ func (s *InterviewService) StartTurn(
 	position,
 	companyInfo,
 	companyType string,
+	companyID uint,
 	questionIndex int,
 	totalQuestions int,
 	questionElapsedSeconds int,
@@ -612,12 +637,18 @@ func (s *InterviewService) StartTurn(
 		companyInfo = s.lookupCompanyProfile(ctx, companyName)
 	}
 
+	// 企業別カスタム質問とGitHubスキルスコアを取得
+	customQuestions := s.fetchCustomQuestions(companyID, position)
+	skillScores := s.fetchSkillScores(userID)
+
 	systemPromptStart := buildInterviewSystemPrompt(
 		companyName,
 		companyReading,
 		position,
 		companyInfo,
 		companyType,
+		customQuestions,
+		skillScores,
 		0,
 		0,
 		questionIndex,
@@ -644,6 +675,32 @@ func (s *InterviewService) StartTurn(
 	}
 
 	return &TurnResult{AIText: aiText, Audio: audio}, nil
+}
+
+// fetchCustomQuestions は企業別カスタム質問を取得する。未登録時は空スライスを返す。
+func (s *InterviewService) fetchCustomQuestions(companyID uint, position string) []models.InterviewCompanyQuestion {
+	if s.companyQuestionRepo == nil || companyID == 0 {
+		return nil
+	}
+	qs, err := s.companyQuestionRepo.FindByCompanyAndPosition(companyID, position)
+	if err != nil {
+		log.Printf("[Interview] fetchCustomQuestions error: %v", err)
+		return nil
+	}
+	return qs
+}
+
+// fetchSkillScores はユーザーのGitHubスキルスコアを取得する。未登録時は空スライスを返す。
+func (s *InterviewService) fetchSkillScores(userID uint) []models.SkillScore {
+	if s.skillScoreRepo == nil {
+		return nil
+	}
+	scores, err := s.skillScoreRepo.GetScores(userID)
+	if err != nil {
+		log.Printf("[Interview] fetchSkillScores error: %v", err)
+		return nil
+	}
+	return scores
 }
 
 // lookupCompanyReading はWeb検索を使って企業名の日本語読み（ふりがな）を取得します。
@@ -698,6 +755,8 @@ func buildInterviewSystemPrompt(
 	position,
 	companyInfo,
 	companyType string,
+	customQuestions []models.InterviewCompanyQuestion,
+	skillScores []models.SkillScore,
 	turnCount int,
 	remainingSeconds int,
 	questionIndex int,
@@ -813,7 +872,91 @@ func buildInterviewSystemPrompt(
 - 技術フェーズ（詳細設計・実装・テスト）と要件定義フェーズの両方を経験しているか確認する`
 	}
 
+	// 企業別カスタム質問をシステムプロンプトに注入
+	if len(customQuestions) > 0 {
+		var required, recommended []string
+		for _, q := range customQuestions {
+			if q.IsRequired {
+				required = append(required, fmt.Sprintf("- [%s] %s", q.Category, q.QuestionText))
+			} else {
+				recommended = append(recommended, fmt.Sprintf("- [%s] %s", q.Category, q.QuestionText))
+			}
+		}
+		if len(required) > 0 {
+			base += "\n\n【必須質問（必ず全て質問してください）】\n" + strings.Join(required, "\n")
+		}
+		if len(recommended) > 0 {
+			base += "\n\n【推奨質問（会話の流れに応じて取り入れてください）】\n" + strings.Join(recommended, "\n")
+		}
+	}
+
+	// GitHubスキルスコアに基づく技術質問ガイドラインを注入（エンジニア職種のみ）
+	if len(skillScores) > 0 && isEngineerPosition(position) {
+		techHints := buildTechQuestionHints(skillScores)
+		if techHints != "" {
+			base += "\n\n【GitHubスキル分析に基づく技術質問ガイドライン】\n" + techHints
+		}
+	}
+
 	return strings.TrimSpace(base)
+}
+
+// isEngineerPosition は職種名がエンジニア系かどうかを判定する
+func isEngineerPosition(position string) bool {
+	engineerKeywords := []string{
+		"エンジニア", "engineer", "Engineer",
+		"開発", "developer", "Developer",
+		"プログラマ", "programmer", "Programmer",
+		"バックエンド", "フロントエンド", "インフラ", "SRE", "DevOps",
+		"アーキテクト", "Architect", "architect",
+	}
+	for _, kw := range engineerKeywords {
+		if strings.Contains(position, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildTechQuestionHints はスキルスコアをもとに技術質問ガイドラインを生成する
+func buildTechQuestionHints(scores []models.SkillScore) string {
+	type scored struct {
+		category models.SkillCategory
+		score    float64
+	}
+	var top []scored
+	for _, s := range scores {
+		if s.Score >= 30 {
+			top = append(top, scored{s.Category, s.Score})
+		}
+	}
+	if len(top) == 0 {
+		return ""
+	}
+
+	// スコア降順でソート
+	for i := 0; i < len(top)-1; i++ {
+		for j := i + 1; j < len(top); j++ {
+			if top[j].score > top[i].score {
+				top[i], top[j] = top[j], top[i]
+			}
+		}
+	}
+
+	hints := []string{"（応募者のGitHubスキルスコアを参考に技術的な深掘りを行ってください）"}
+	for _, s := range top {
+		switch s.category {
+		case models.SkillCategoryBackend:
+			hints = append(hints, fmt.Sprintf("- バックエンド（スコア%.0f）: 言語・フレームワーク・設計パターン・パフォーマンスチューニングについて質問する", s.score))
+		case models.SkillCategoryFrontend:
+			hints = append(hints, fmt.Sprintf("- フロントエンド（スコア%.0f）: 使用フレームワーク・状態管理・UI最適化・アクセシビリティについて質問する", s.score))
+		case models.SkillCategoryInfra:
+			hints = append(hints, fmt.Sprintf("- インフラ（スコア%.0f）: クラウドサービス・IaC・CI/CD・監視設計について質問する", s.score))
+		case models.SkillCategoryDB:
+			hints = append(hints, fmt.Sprintf("- データベース（スコア%.0f）: スキーマ設計・クエリ最適化・トランザクション管理について質問する", s.score))
+		}
+	}
+	return strings.Join(hints, "\n")
 }
 
 func (s *InterviewService) isAllowed(actorID uint, ownerID uint) bool {

--- a/Backend/test/controllers/admin_company_names_test.go
+++ b/Backend/test/controllers/admin_company_names_test.go
@@ -8,8 +8,6 @@ import (
 
 	"Backend/internal/models"
 	"Backend/test/controllers/mocks"
-
-	"github.com/stretchr/testify/mock"
 )
 
 func TestAdminCompanyController_Names_ServiceError(t *testing.T) {

--- a/Backend/test/controllers/admin_interview_company_questions_test.go
+++ b/Backend/test/controllers/admin_interview_company_questions_test.go
@@ -1,0 +1,105 @@
+package controllers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/controllers"
+	"Backend/internal/models"
+)
+
+type interviewCompanyQuestionRepoStub struct {
+	question   *models.InterviewCompanyQuestion
+	updateCall bool
+	deleteCall bool
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByCompanyID(uint) ([]models.InterviewCompanyQuestion, error) {
+	return nil, nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByCompanyAndPosition(uint, string) ([]models.InterviewCompanyQuestion, error) {
+	return nil, nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) FindByID(uint) (*models.InterviewCompanyQuestion, error) {
+	return r.question, nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Create(*models.InterviewCompanyQuestion) error {
+	return nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Update(*models.InterviewCompanyQuestion) error {
+	r.updateCall = true
+	return nil
+}
+
+func (r *interviewCompanyQuestionRepoStub) Delete(uint) error {
+	r.deleteCall = true
+	return nil
+}
+
+func newAdminInterviewQuestionController(repo *interviewCompanyQuestionRepoStub) *controllers.AdminInterviewController {
+	c := controllers.NewAdminInterviewController(nil, nil, nil)
+	c.SetCompanyQuestionRepo(repo)
+	return c
+}
+
+func TestAdminInterviewController_CreateCompanyQuestion_RejectsWhitespace(t *testing.T) {
+	repo := &interviewCompanyQuestionRepoStub{}
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/companies/1/interview-questions", bytes.NewBufferString(`{"category":"   ","question_text":" question "}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := newCtx(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("1")
+
+	assertStatus(t, newAdminInterviewQuestionController(repo).CreateCompanyQuestion, ctx, http.StatusBadRequest)
+}
+
+func TestAdminInterviewController_UpdateCompanyQuestion_RejectsDifferentCompany(t *testing.T) {
+	repo := &interviewCompanyQuestionRepoStub{question: &models.InterviewCompanyQuestion{ID: 10, CompanyID: 2}}
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/companies/1/interview-questions/10", bytes.NewBufferString(`{"question_text":"updated"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := newCtx(req, rec)
+	ctx.SetParamNames("id", "qid")
+	ctx.SetParamValues("1", "10")
+
+	assertStatus(t, newAdminInterviewQuestionController(repo).UpdateCompanyQuestion, ctx, http.StatusNotFound)
+	if repo.updateCall {
+		t.Fatal("question from another company was updated")
+	}
+}
+
+func TestAdminInterviewController_UpdateCompanyQuestion_RejectsEmptyQuestion(t *testing.T) {
+	repo := &interviewCompanyQuestionRepoStub{question: &models.InterviewCompanyQuestion{ID: 10, CompanyID: 1}}
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/companies/1/interview-questions/10", bytes.NewBufferString(`{"question_text":"   "}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := newCtx(req, rec)
+	ctx.SetParamNames("id", "qid")
+	ctx.SetParamValues("1", "10")
+
+	assertStatus(t, newAdminInterviewQuestionController(repo).UpdateCompanyQuestion, ctx, http.StatusBadRequest)
+	if repo.updateCall {
+		t.Fatal("empty question was updated")
+	}
+}
+
+func TestAdminInterviewController_DeleteCompanyQuestion_RejectsDifferentCompany(t *testing.T) {
+	repo := &interviewCompanyQuestionRepoStub{question: &models.InterviewCompanyQuestion{ID: 10, CompanyID: 2}}
+	req := httptest.NewRequest(http.MethodDelete, "/api/admin/companies/1/interview-questions/10", nil)
+	rec := httptest.NewRecorder()
+	ctx := newCtx(req, rec)
+	ctx.SetParamNames("id", "qid")
+	ctx.SetParamValues("1", "10")
+
+	assertStatus(t, newAdminInterviewQuestionController(repo).DeleteCompanyQuestion, ctx, http.StatusNotFound)
+	if repo.deleteCall {
+		t.Fatal("question from another company was deleted")
+	}
+}

--- a/Backend/test/controllers/mocks/interview_service_mock.go
+++ b/Backend/test/controllers/mocks/interview_service_mock.go
@@ -87,10 +87,11 @@ func (m *InterviewServiceMock) Turn(
 	audioData []byte,
 	history []map[string]string,
 	companyName, companyReading, position, companyInfo, companyType string,
+	companyID uint,
 	turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
 ) (*services.TurnResult, error) {
 	args := m.Called(ctx, userID, sessionID, audioData, history,
-		companyName, companyReading, position, companyInfo, companyType,
+		companyName, companyReading, position, companyInfo, companyType, companyID,
 		turnCount, remainingSeconds, questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -103,10 +104,11 @@ func (m *InterviewServiceMock) StartTurn(
 	userID uint,
 	sessionID uint,
 	companyName, companyReading, position, companyInfo, companyType string,
+	companyID uint,
 	questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds int,
 ) (*services.TurnResult, error) {
 	args := m.Called(ctx, userID, sessionID,
-		companyName, companyReading, position, companyInfo, companyType,
+		companyName, companyReading, position, companyInfo, companyType, companyID,
 		questionIndex, totalQuestions, questionElapsedSeconds, questionDurationSeconds)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/Backend/test/repositories/interview_company_question_repository_test.go
+++ b/Backend/test/repositories/interview_company_question_repository_test.go
@@ -1,0 +1,36 @@
+package repositories_test
+
+import (
+	"testing"
+
+	"Backend/internal/repositories"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterviewCompanyQuestionRepositoryFindByCompanyAndPosition(t *testing.T) {
+	db, mock := newTestDB(t)
+	repo := repositories.NewInterviewCompanyQuestionRepository(db)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "company_id", "position", "category", "question_text", "priority", "is_required",
+	}).
+		AddRow(1, 42, "", "志望動機", "全職種向け質問", 1, true).
+		AddRow(2, 42, "バックエンドエンジニア", "技術", "職種別質問", 2, false)
+
+	mock.ExpectQuery("SELECT \\* FROM `interview_company_questions` WHERE company_id = \\? AND \\(position = '' OR position = \\?\\) ORDER BY priority ASC, id ASC").
+		WithArgs(uint(42), "バックエンドエンジニア").
+		WillReturnRows(rows)
+
+	questions, err := repo.FindByCompanyAndPosition(42, "バックエンドエンジニア")
+
+	require.NoError(t, err)
+	require.Len(t, questions, 2)
+	assert.Empty(t, questions[0].Position)
+	assert.True(t, questions[0].IsRequired)
+	assert.Equal(t, "バックエンドエンジニア", questions[1].Position)
+	assert.False(t, questions[1].IsRequired)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/Backend/test/services/interview_service_test.go
+++ b/Backend/test/services/interview_service_test.go
@@ -176,7 +176,7 @@ func TestInterviewService_TTSVoiceSelection(t *testing.T) {
 		}
 		sRepo.On("FindByID", uint(100)).Return(session, nil)
 
-		_, err := svc.StartTurn(context.Background(), 1, 100, "", "", "", "", "", 0, 0, 0, 0)
+		_, err := svc.StartTurn(context.Background(), 1, 100, "", "", "", "", "", 0, 0, 0, 0, 0)
 		assert.NoError(t, err)
 	})
 
@@ -209,7 +209,7 @@ func TestInterviewService_TTSVoiceSelection(t *testing.T) {
 		}
 		sRepo.On("FindByID", uint(101)).Return(session, nil)
 
-		_, err := svc.StartTurn(context.Background(), 1, 101, "", "", "", "", "", 0, 0, 0, 0)
+		_, err := svc.StartTurn(context.Background(), 1, 101, "", "", "", "", "", 0, 0, 0, 0, 0)
 		assert.NoError(t, err)
 	})
 }

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -164,6 +164,22 @@ export default function AdminCompanyEditPage() {
     >
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+      <Box sx={{ mb: 3, p: 2, bgcolor: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Box>
+          <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#0c4a6e' }}>面接カスタム質問</Typography>
+          <Typography sx={{ fontSize: 13, color: '#075985' }}>AI面接で使用する企業別の質問リストを管理できます</Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={() => router.push(`/admin/companies/${id}/interview-questions`)}
+          sx={{ borderColor: '#0284c7', color: '#0284c7', whiteSpace: 'nowrap' }}
+        >
+          質問を管理 →
+        </Button>
+      </Box>
+
       <Stack spacing={3}>
         <Button
           variant="contained"

--- a/frontend/app/admin/companies/[id]/interview-questions/page.tsx
+++ b/frontend/app/admin/companies/[id]/interview-questions/page.tsx
@@ -1,0 +1,337 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import DeleteIcon from '@mui/icons-material/Delete'
+import EditIcon from '@mui/icons-material/Edit'
+import { authService } from '@/lib/auth'
+import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { ErrorAlert } from '@/components/common/ErrorAlert'
+
+const CATEGORIES = ['志望動機', '職務経験', '技術', 'カルチャーフィット', '強み・弱み', 'キャリアビジョン', 'その他']
+
+type Question = {
+  id: number
+  company_id: number
+  position: string
+  category: string
+  question_text: string
+  priority: number
+  is_required: boolean
+  created_at: string
+  updated_at: string
+}
+
+type QuestionForm = {
+  position: string
+  category: string
+  question_text: string
+  priority: number
+  is_required: boolean
+}
+
+const EMPTY_FORM: QuestionForm = {
+  position: '',
+  category: '志望動機',
+  question_text: '',
+  priority: 0,
+  is_required: false,
+}
+
+export default function AdminInterviewQuestionsPage() {
+  const params = useParams()
+  const router = useRouter()
+  const id = params.id as string
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) window.location.href = '/'
+  }, [])
+
+  const [companyName, setCompanyName] = useState('')
+  const [questions, setQuestions] = useState<Question[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [form, setForm] = useState<QuestionForm>(EMPTY_FORM)
+  const [saving, setSaving] = useState(false)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
+
+  const fetchQuestions = () => {
+    setLoading(true)
+    setError('')
+    Promise.all([
+      fetch(`/api/admin/companies/${id}`, { headers: authService.getAdminFetchHeaders() }).then(r => r.json()),
+      fetch(`/api/admin/companies/${id}/interview-questions`, { headers: authService.getAdminFetchHeaders() }).then(r => r.json()),
+    ])
+      .then(([company, data]) => {
+        setCompanyName(company.name || '')
+        setQuestions(Array.isArray(data.questions) ? data.questions : [])
+      })
+      .catch(() => setError('データの取得に失敗しました'))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { fetchQuestions() }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openCreate = () => {
+    setEditingId(null)
+    setForm(EMPTY_FORM)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (q: Question) => {
+    setEditingId(q.id)
+    setForm({
+      position: q.position,
+      category: q.category,
+      question_text: q.question_text,
+      priority: q.priority,
+      is_required: q.is_required,
+    })
+    setDialogOpen(true)
+  }
+
+  const handleSave = async () => {
+    if (!form.category || !form.question_text.trim()) return
+    setSaving(true)
+    setError('')
+    try {
+      const url = editingId
+        ? `/api/admin/companies/${id}/interview-questions/${editingId}`
+        : `/api/admin/companies/${id}/interview-questions`
+      const res = await fetch(url, {
+        method: editingId ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json', ...authService.getAdminFetchHeaders() },
+        body: JSON.stringify(form),
+      })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        throw new Error(d?.message || '保存に失敗しました')
+      }
+      setSuccess(editingId ? '質問を更新しました' : '質問を追加しました')
+      setDialogOpen(false)
+      fetchQuestions()
+    } catch (e: any) {
+      setError(e.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (qid: number) => {
+    setError('')
+    try {
+      const res = await fetch(`/api/admin/companies/${id}/interview-questions/${qid}`, {
+        method: 'DELETE',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      if (!res.ok) throw new Error('削除に失敗しました')
+      setSuccess('質問を削除しました')
+      setDeleteConfirmId(null)
+      fetchQuestions()
+    } catch (e: any) {
+      setError(e.message)
+    }
+  }
+
+  return (
+    <AdminFormContainer
+      title={`面接質問管理: ${companyName}`}
+      maxWidth={960}
+      backLabel="← 戻る"
+      onBack={() => router.back()}
+    >
+      <ErrorAlert error={error} />
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+          {success}
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          登録した質問はAI面接のシステムプロンプトに自動的に注入されます。
+        </Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}>
+          質問を追加
+        </Button>
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : questions.length === 0 ? (
+        <Paper elevation={0} sx={{ p: 4, textAlign: 'center', border: '1px dashed #e2e8f0' }}>
+          <Typography color="text.secondary">質問が登録されていません。「質問を追加」から登録してください。</Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper} elevation={0} sx={{ border: '1px solid #e2e8f0' }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ bgcolor: '#f8fafc' }}>
+                <TableCell sx={{ fontWeight: 700, width: 60 }}>優先度</TableCell>
+                <TableCell sx={{ fontWeight: 700, width: 120 }}>カテゴリ</TableCell>
+                <TableCell sx={{ fontWeight: 700, width: 140 }}>職種（空=全共通）</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>質問文</TableCell>
+                <TableCell sx={{ fontWeight: 700, width: 80 }}>必須</TableCell>
+                <TableCell sx={{ fontWeight: 700, width: 100 }}>操作</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {questions.map((q) => (
+                <TableRow key={q.id} hover>
+                  <TableCell>{q.priority}</TableCell>
+                  <TableCell>
+                    <Chip label={q.category} size="small" variant="outlined" />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color={q.position ? 'text.primary' : 'text.disabled'}>
+                      {q.position || '全職種'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ lineHeight: 1.6 }}>{q.question_text}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    {q.is_required && (
+                      <Chip label="必須" size="small" color="error" sx={{ fontWeight: 700 }} />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" spacing={0.5}>
+                      <Tooltip title="編集">
+                        <IconButton size="small" onClick={() => openEdit(q)}>
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="削除">
+                        <IconButton size="small" color="error" onClick={() => setDeleteConfirmId(q.id)}>
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* 作成/編集ダイアログ */}
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingId ? '質問を編集' : '質問を追加'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <TextField
+              select
+              label="カテゴリ *"
+              value={form.category}
+              onChange={(e) => setForm(f => ({ ...f, category: e.target.value }))}
+              size="small"
+              fullWidth
+            >
+              {CATEGORIES.map(c => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+            </TextField>
+            <TextField
+              label="職種（空欄=全職種共通）"
+              value={form.position}
+              onChange={(e) => setForm(f => ({ ...f, position: e.target.value }))}
+              size="small"
+              fullWidth
+              placeholder="例: バックエンドエンジニア"
+              helperText="特定の職種のみに使う場合は入力してください"
+            />
+            <TextField
+              label="質問文 *"
+              value={form.question_text}
+              onChange={(e) => setForm(f => ({ ...f, question_text: e.target.value }))}
+              size="small"
+              fullWidth
+              multiline
+              rows={3}
+              placeholder="例: 直近のプロジェクトで最も難しかった技術的課題を教えてください。"
+            />
+            <TextField
+              label="優先度（小さいほど先に使われる）"
+              type="number"
+              value={form.priority}
+              onChange={(e) => setForm(f => ({ ...f, priority: parseInt(e.target.value) || 0 }))}
+              size="small"
+              sx={{ width: 200 }}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={form.is_required}
+                  onChange={(e) => setForm(f => ({ ...f, is_required: e.target.checked }))}
+                />
+              }
+              label="必須質問（AIが必ず質問する）"
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={saving || !form.category || !form.question_text.trim()}
+          >
+            {saving ? '保存中...' : '保存'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 削除確認ダイアログ */}
+      <Dialog open={deleteConfirmId !== null} onClose={() => setDeleteConfirmId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>質問を削除しますか？</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">この操作は取り消せません。</Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDeleteConfirmId(null)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => deleteConfirmId && handleDelete(deleteConfirmId)}
+          >
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </AdminFormContainer>
+  )
+}

--- a/frontend/app/admin/companies/[id]/interview-questions/page.tsx
+++ b/frontend/app/admin/companies/[id]/interview-questions/page.tsx
@@ -87,12 +87,20 @@ export default function AdminInterviewQuestionsPage() {
   const [saving, setSaving] = useState(false)
   const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
 
+  const fetchJSON = async (url: string) => {
+    const response = await fetch(url, { headers: authService.getAdminFetchHeaders() })
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`)
+    }
+    return response.json()
+  }
+
   const fetchQuestions = () => {
     setLoading(true)
     setError('')
     Promise.all([
-      fetch(`/api/admin/companies/${id}`, { headers: authService.getAdminFetchHeaders() }).then(r => r.json()),
-      fetch(`/api/admin/companies/${id}/interview-questions`, { headers: authService.getAdminFetchHeaders() }).then(r => r.json()),
+      fetchJSON(`/api/admin/companies/${id}`),
+      fetchJSON(`/api/admin/companies/${id}/interview-questions`),
     ])
       .then(([company, data]) => {
         setCompanyName(company.name || '')

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -471,6 +471,7 @@ function InterviewContent() {
           interviewCompany?.work_style && `働き方: ${interviewCompany.work_style}`,
           interviewCompany?.welfare_details && `福利厚生: ${interviewCompany.welfare_details}`,
         ].filter(Boolean).join(' / '),
+        company_id: interviewCompany?.id || 0,
         company_type: selectedPosition?.category || 'general',
         question_index: 1,
         total_questions: Math.max(1, selectedPosition?.questions || 1),
@@ -695,6 +696,7 @@ function InterviewContent() {
       interviewCompany?.welfare_details && `福利厚生: ${interviewCompany.welfare_details}`,
     ].filter(Boolean).join(' / '))
     formData.append('company_type', selectedPosition?.category || 'general')
+    formData.append('company_id', String(interviewCompany?.id || 0))
     try {
       const res = await fetch(`${BACKEND_URL}/api/interviews/${session.id}/turn`, {
         method: 'POST',


### PR DESCRIPTION
Closes #506

## 変更内容

### 新規モデル・リポジトリ
- `InterviewCompanyQuestion` モデル追加（企業別カスタム質問テーブル）
- `InterviewCompanyQuestionRepository` インターフェース・実装追加
  - `FindByCompanyID`, `FindByCompanyAndPosition`, `FindByID`, `Create`, `Update`, `Delete`
- `models/migrate.go` に `InterviewCompanyQuestion` を AutoMigrate 対象として追加

### AdminAPI（企業別質問CRUD）
- `AdminInterviewController` に `companyQuestionRepo` フィールドと各エンドポイントを追加
  - `GET  /api/admin/companies/:id/interview-questions` — 一覧取得
  - `POST /api/admin/companies/:id/interview-questions` — 作成（category/question_text 必須）
  - `PUT  /api/admin/companies/:id/interview-questions/:qid` — 部分更新
  - `DELETE /api/admin/companies/:id/interview-questions/:qid` — 削除（204）
- `admin_routes.go` に上記ルートを追加

### AI面接サービスへの統合
- `InterviewService` に `companyQuestionRepo` と `skillScoreRepo`（SkillScoreReaderインターフェース）を追加
- `Turn()` / `StartTurn()` に `companyID uint` パラメータ追加
- 企業別カスタム質問をシステムプロンプトに自動注入（必須/推奨に分類）
- エンジニア職種判定（`isEngineerPosition`）+ GitHubスキルスコアを元に技術質問ヒント生成（`buildTechQuestionHints`）
- `companyID=0` 時はデフォルト動作にフォールバック

### その他
- `interfaces/interview_service.go` のシグネチャ更新
- `InterviewServiceMock` のシグネチャ更新
- テスト修正（引数追加・未使用インポート削除）
- `main.go` に DI 追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 企業別カスタム面接質問を追加。管理者は各企業の質問を一覧表示し、作成・編集・削除できます。
  * ユーザーのスキルスコアと職種に応じて、面接ガイド（必須/推奨・技術ヒント等）が自動で最適化されます。
* **フロントエンド**
  * 企業編集画面に「面接カスタム質問」への導線を追加。
  * 企業別「面接質問」管理ページを新規追加。面接の送信データに企業情報を反映します。
* **テスト**
  * 企業別面接質問の管理/サービス/リポジトリに関する検証テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->