### PR TITLE
feat: #499 ES添削・リライト機能の企業別対策強化

### DIFF
--- a/Backend/internal/controllers/es_rewrite_controller.go
+++ b/Backend/internal/controllers/es_rewrite_controller.go
@@ -63,11 +63,23 @@ JSONのみで返してください。`
 	// 企業名が指定されていれば Web Search を使って最新の企業情報を取得し、プロンプトに注入する（失敗しても処理を継続）
 	companyInfo := ""
 	if strings.TrimSpace(req.CompanyName) != "" {
-		if info, err := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" 採用情報 求める人物像 企業理念"); err == nil {
+		parts := []string{}
+		// Query 1: 採用情報・企業理念・求める人物像
+		if info, err := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" 採用情報 求める人物像 企業理念"); err == nil && strings.TrimSpace(info) != "" {
 			if len(info) > 2000 {
 				info = info[:2000]
 			}
-			companyInfo = "\n\n【企業情報（WebSearch）】\n" + info
+			parts = append(parts, info)
+		}
+		// Query 2: エンジニア向けの選考ポイント・技術スタックに関する情報
+		if info2, err2 := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" エンジニア 選考 重視する点 技術スタック"); err2 == nil && strings.TrimSpace(info2) != "" {
+			if len(info2) > 2000 {
+				info2 = info2[:2000]
+			}
+			parts = append(parts, info2)
+		}
+		if len(parts) > 0 {
+			companyInfo = "\n\n【企業が重視するポイント】\n" + strings.Join(parts, "\n\n")
 		}
 	}
 

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -47,6 +47,7 @@ type ReviewResult = {
   length_balance_score: number
   feedback: string
   improved_text: string
+  company_strategy?: string | null
 }
 
 const STAR_LABELS: { key: keyof StarBreakdown; label: string; color: string; emoji: string }[] = [
@@ -261,6 +262,12 @@ export default function ESRewritePage() {
                   '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
                 }}
               />
+              {companyName.trim() !== '' && loading && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+                  <CircularProgress size={16} />
+                  <Typography variant="body2" sx={{ color: '#64748b' }}>企業情報を分析中...</Typography>
+                </Box>
+              )}
             ) : (
               <>
                 <TextField
@@ -295,6 +302,12 @@ export default function ESRewritePage() {
                     '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
                   }}
                 />
+                {companyName.trim() !== '' && loading && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+                    <CircularProgress size={16} />
+                    <Typography variant="body2" sx={{ color: '#64748b' }}>企業情報を分析中...</Typography>
+                  </Box>
+                )}
               </>
             )}
 
@@ -366,6 +379,13 @@ export default function ESRewritePage() {
                   {reviewResult.feedback}
                 </Typography>
               </Paper>
+
+              {reviewResult.company_strategy && (
+                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #f1f5f9', bgcolor: '#fff' }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: 16, mb: 1.5 }}>🏢 {companyName || '志望企業'}への対策アドバイス</Typography>
+                  <Typography variant="body2" sx={{ color: '#475569', lineHeight: 1.8, whiteSpace: 'pre-wrap' }}>{reviewResult.company_strategy}</Typography>
+                </Paper>
+              )}
 
               {/* Before / After comparison */}
               {reviewResult.improved_text && (

--- a/rag/main.py
+++ b/rag/main.py
@@ -1006,6 +1006,7 @@ class ESReviewResponse(BaseModel):
     length_balance_score: int  # 1-10: 文字数バランス
     feedback: str  # 全体フィードバック文
     improved_text: str  # 改善後テキスト
+    company_strategy: Optional[str] = None  # 企業特化の対策アドバイス（企業名なしは null）
 
 
 def _run_es_review(
@@ -1047,8 +1048,9 @@ def _run_es_review(
   "star_score": <1-10の整数: Situation/Task/Action/Resultの構造が揃っているか>,
   {company_fit_key},
   "length_balance_score": <1-10の整数: 文字数・各要素のバランスが適切か>,
-  "feedback": "<具体性・STAR準拠・企業適合性・文字数について200字以内でアドバイス>",
-  "improved_text": "<元の文章を改善したバージョン（元の文字数の110〜130%を目安）>"
+  "feedback": "<具体性・STAR準拠・企業適合性・文字数について400字程度でアドバイス。企業名が指定されている場合は企業特化アドバイスを含めてください>",
+  "improved_text": "<元の文章を改善したバージョン（元の文字数の110〜130%を目安）>",
+  "company_strategy": "<企業特化の対策アドバイス（企業名なしは null。指定時は約200〜400字）>"
 }}"""
     )
     try:
@@ -1073,6 +1075,7 @@ def _run_es_review(
             length_balance_score=max(1, min(10, int(data.get("length_balance_score", 5)))),
             feedback=str(data.get("feedback", "")),
             improved_text=str(data.get("improved_text", "")),
+            company_strategy=(str(data.get("company_strategy")) if data.get("company_strategy") is not None else None),
         )
     except Exception as exc:
         logger.warning("es review failed error=%s", exc)


### PR DESCRIPTION
概要:
- ES添削に company_strategy フィールドを追加し、企業名が指定された場合は企業特化の対策アドバイスを返すようにしました。
- ESリライトは企業情報取得を2クエリに強化し、プロンプトに【企業が重視するポイント】を注入します。
- フロントエンドで company_strategy を表示する UI を追加し、企業情報分析中のローディングを実装しました。

受け入れ条件:
- RAG の ESReviewResponse に company_strategy が含まれること
- 企業名あり時に企業固有の対策アドバイスが返ること（RAG側の動作確認は別途）

関連 Issue: #499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced company analysis: When providing a company name, the app now performs comprehensive web searches to gather insights on hiring priorities, company values, and technical requirements.
  * Added loading indicator displaying "Analyzing company information..." during company data retrieval.
  * New "Strategy Advice" section in review results providing targeted recommendations based on analyzed company information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->