### PR TITLE
feat: #499 ES添削・リライトの企業別対策強化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7003,3 +7003,8 @@ mysql/logs/
 /rag/.venv/lib/python3.12/site-packages/six.py
 /rag/.venv/lib/python3.12/site-packages/typing_extensions.py
 /rag/.venv/pyvenv.cfg
+
+# Ignore rag virtualenv
+rag/.venv/
+__pycache__/
+*.pyc

--- a/Backend/internal/controllers/es_rewrite_controller.go
+++ b/Backend/internal/controllers/es_rewrite_controller.go
@@ -63,11 +63,23 @@ JSONのみで返してください。`
 	// 企業名が指定されていれば Web Search を使って最新の企業情報を取得し、プロンプトに注入する（失敗しても処理を継続）
 	companyInfo := ""
 	if strings.TrimSpace(req.CompanyName) != "" {
-		if info, err := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" 採用情報 求める人物像 企業理念"); err == nil {
+		parts := []string{}
+		// Query 1: 採用情報・企業理念・求める人物像
+		if info, err := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" 採用情報 求める人物像 企業理念"); err == nil && strings.TrimSpace(info) != "" {
 			if len(info) > 2000 {
 				info = info[:2000]
 			}
-			companyInfo = "\n\n【企業情報（WebSearch）】\n" + info
+			parts = append(parts, info)
+		}
+		// Query 2: エンジニア向けの選考ポイント・技術スタックに関する情報
+		if info2, err2 := c.openaiClient.WebSearchQuery(context.Background(), "企業名: "+req.CompanyName+" エンジニア 選考 重視する点 技術スタック"); err2 == nil && strings.TrimSpace(info2) != "" {
+			if len(info2) > 2000 {
+				info2 = info2[:2000]
+			}
+			parts = append(parts, info2)
+		}
+		if len(parts) > 0 {
+			companyInfo = "\n\n【企業が重視するポイント】\n" + strings.Join(parts, "\n\n")
 		}
 	}
 

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -47,6 +47,7 @@ type ReviewResult = {
   length_balance_score: number
   feedback: string
   improved_text: string
+  company_strategy?: string | null
 }
 
 const STAR_LABELS: { key: keyof StarBreakdown; label: string; color: string; emoji: string }[] = [
@@ -261,6 +262,12 @@ export default function ESRewritePage() {
                   '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
                 }}
               />
+              {companyName.trim() !== '' && loading && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+                  <CircularProgress size={16} />
+                  <Typography variant="body2" sx={{ color: '#64748b' }}>企業情報を分析中...</Typography>
+                </Box>
+              )}
             ) : (
               <>
                 <TextField
@@ -295,6 +302,12 @@ export default function ESRewritePage() {
                     '& .MuiInputLabel-root.Mui-focused': { color: PRIMARY },
                   }}
                 />
+                {companyName.trim() !== '' && loading && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+                    <CircularProgress size={16} />
+                    <Typography variant="body2" sx={{ color: '#64748b' }}>企業情報を分析中...</Typography>
+                  </Box>
+                )}
               </>
             )}
 
@@ -366,6 +379,13 @@ export default function ESRewritePage() {
                   {reviewResult.feedback}
                 </Typography>
               </Paper>
+
+              {reviewResult.company_strategy && (
+                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #f1f5f9', bgcolor: '#fff' }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: 16, mb: 1.5 }}>🏢 {companyName || '志望企業'}への対策アドバイス</Typography>
+                  <Typography variant="body2" sx={{ color: '#475569', lineHeight: 1.8, whiteSpace: 'pre-wrap' }}>{reviewResult.company_strategy}</Typography>
+                </Paper>
+              )}
 
               {/* Before / After comparison */}
               {reviewResult.improved_text && (

--- a/rag/main.py
+++ b/rag/main.py
@@ -1006,6 +1006,7 @@ class ESReviewResponse(BaseModel):
     length_balance_score: int  # 1-10: 文字数バランス
     feedback: str  # 全体フィードバック文
     improved_text: str  # 改善後テキスト
+    company_strategy: Optional[str] = None  # 企業特化の対策アドバイス（企業名なしは null）
 
 
 def _run_es_review(
@@ -1047,8 +1048,9 @@ def _run_es_review(
   "star_score": <1-10の整数: Situation/Task/Action/Resultの構造が揃っているか>,
   {company_fit_key},
   "length_balance_score": <1-10の整数: 文字数・各要素のバランスが適切か>,
-  "feedback": "<具体性・STAR準拠・企業適合性・文字数について200字以内でアドバイス>",
-  "improved_text": "<元の文章を改善したバージョン（元の文字数の110〜130%を目安）>"
+  "feedback": "<具体性・STAR準拠・企業適合性・文字数について400字程度でアドバイス。企業名が指定されている場合は企業特化アドバイスを含めてください>",
+  "improved_text": "<元の文章を改善したバージョン（元の文字数の110〜130%を目安）>",
+  "company_strategy": "<企業特化の対策アドバイス（企業名なしは null。指定時は約200〜400字）>"
 }}"""
     )
     try:
@@ -1073,6 +1075,7 @@ def _run_es_review(
             length_balance_score=max(1, min(10, int(data.get("length_balance_score", 5)))),
             feedback=str(data.get("feedback", "")),
             improved_text=str(data.get("improved_text", "")),
+            company_strategy=(str(data.get("company_strategy")) if data.get("company_strategy") is not None else None),
         )
     except Exception as exc:
         logger.warning("es review failed error=%s", exc)

--- a/rag/main.py
+++ b/rag/main.py
@@ -1095,9 +1095,16 @@ def es_review(request: ESReviewRequest) -> ESReviewResponse:
         if not context_docs:
             logger.info("es review web search start company=%s", safe_company_name)
             try:
-                summary = _run_async(_run_web_search_pipeline, safe_company_name, "")
-                if summary:
-                    context_docs = [summary]
+                # 段階的に2回の軽量Web Searchパイプラインを実行して、採用情報（一般）とエンジニア向け観点を取得する
+                summary_general = _run_async(_run_web_search_pipeline, safe_company_name, "")
+                summary_engineer = _run_async(_run_web_search_pipeline, safe_company_name, "エンジニア")
+                parts = [s for s in (summary_general, summary_engineer) if s]
+                if parts:
+                    combined = "\n\n".join(parts)
+                    # 先頭2000文字に制限してコンテキストに注入（プロンプト長を考慮）
+                    if len(combined) > 2000:
+                        combined = combined[:2000]
+                    context_docs = [combined]
                     set_cached_context(cache_key, context_docs)
             except Exception as exc:
                 logger.warning("es review web search failed company=%s error=%s", safe_company_name, exc)

--- a/rag/tests/test_es_review_schema.py
+++ b/rag/tests/test_es_review_schema.py
@@ -1,0 +1,20 @@
+import unittest
+import re
+from pathlib import Path
+
+
+class TestESReviewSchema(unittest.TestCase):
+    def test_company_strategy_field_exists(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        main_py = repo_root / "main.py"
+        self.assertTrue(main_py.exists(), f"{main_py} does not exist")
+        text = main_py.read_text(encoding="utf-8")
+        # Find the ESReviewResponse class block
+        m = re.search(r"class ESReviewResponse\(BaseModel\):([\s\S]*?)(?=\n\nclass |\n\n@|\n\ndef |\Z)", text)
+        self.assertIsNotNone(m, "ESReviewResponse class not found in main.py")
+        class_block = m.group(1)
+        self.assertIn("company_strategy", class_block, "company_strategy field missing in ESReviewResponse class")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ES添削で企業特化アドバイス(company_strategy)を含めるためのRAG検索強化。rag/main.pyで企業名指定時に一般+エンジニア観点の2段階検索を実行し要約を結合してプロンプトに注入します.

関連: Issue #499

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## 追記: CI失敗対応方針とローカル検証手順

### 1) CI (Go Unit Tests) の失敗について
- 現状: GitHub Actions の `Go Unit Tests` が失敗しています。ログ: https://github.com/ISCProduct/soc-ai-agent/actions/runs/27645437949/job/81755979333
- 対応方針:
  1. 上記 Actions ログを確認して失敗箇所を特定
  2. 該当のユニットテストまたは実装を最小限修正（本PRでの変更に起因する場合は修正を追加）
  3. ローカルでテストを再現・修正後に push して CI を再実行

### 2) ローカルでの再現手順
- RAG (Python):
  ```bash
  cd rag
  python3 -m venv .venv
  . .venv/bin/activate
  pip install -r constraints.txt
  python3 main.py
  ```
- Backend (Go):
  ```bash
  cd Backend
  go run ./cmd/server
  ```
- Frontend (Next.js):
  ```bash
  cd frontend
  npm install
  npm run dev
  ```
- 手順: フロントの ES 添削画面で会社名を入力して添削を実行し、API レスポンスに company_strategy が含まれ、画面に表示されることを確認してください。

### 3) レビューで見てほしい点
- Backend の API スキーマ変更（ESReviewResponse に company_strategy 追加）による互換性問題
- キャッシュキー/キャッシュ期間に関する想定挙動 ("{company}::es_review") を維持
- run_web_search_pipeline を2回呼ぶことによるパフォーマンス懸念（必要なら軽量化の提案）

### 4) 注意事項
- .gitignore を更新して rag/.venv/, __pycache__/, *.pyc を除外しました。
- 作業中に未追跡の仮想環境をワークツリーから削除しています。必要であれば再作成してください（上記手順参照）。

---

## 追記: 受け入れ条件と実装メモ

### 受け入れ条件
- ES添削レスポンスに `company_strategy` フィールドが追加されている（企業名なし時は `null`）
- 企業名あり時の添削フィードバックに企業固有の対策が含まれている（UIに表示されること）
- ESリライトの企業情報取得が最大2クエリに強化されている
- フロントエンドで `company_strategy` が表示される
- 既存の `ESReviewResponse` スキーマ変更が RAG 型定義・Backend 転送と整合している
- `ESReviewRequest` の `company_name` が空でも後方互換で動作する

### 実装メモ / 技術的注意点
- run_deep_research は CrewAI を用いるため遅延が大きい（~30s）。本PRでは軽量な `_run_web_search_pipeline` を2回（一般 + エンジニア視点）呼ぶ方式で妥協しています。
- API の `feedback` は約400字程度を目安に企業特化アドバイスを含めるようプロンプトを設計しています。
- キャッシュキーは `"{company}::es_review"` を継続使用し、 `company_strategy` をキャッシュ対象に含める想定です。
- 既存クライアントが `company_strategy` を扱わない場合でも後退互換が保てるよう、フィールドは `null` 許容とします。

関連: Issue #499