### PR TITLE
Resolve #523: スコア精度検証機能の複数バグ修正とNext.js route handler追加

### DIFF
--- a/Backend/internal/controllers/admin_score_validation_controller.go
+++ b/Backend/internal/controllers/admin_score_validation_controller.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	"Backend/internal/services"
 	"Backend/internal/services/interfaces"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -52,7 +54,10 @@ func (c *AdminScoreValidationController) GetCalibration(ctx echo.Context) error 
 func (c *AdminScoreValidationController) RunCalibration(ctx echo.Context) error {
 	result, err := c.svc.RunCalibration()
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		if errors.Is(err, services.ErrInsufficientSamples) {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		return echoInternalError(err)
 	}
 	return ctx.JSON(http.StatusCreated, result)
 }

--- a/Backend/internal/repositories/score_validation_repository.go
+++ b/Backend/internal/repositories/score_validation_repository.go
@@ -194,13 +194,14 @@ func (r *ScoreValidationRepository) GetLatestCalibrationWeights() ([]models.Scor
 }
 
 func (r *ScoreValidationRepository) SaveCalibrationWeights(weights []models.ScoreCalibrationWeight) error {
-	// 現行アクティブ版を非アクティブ化
-	if err := r.db.Model(&models.ScoreCalibrationWeight{}).
-		Where("is_active = ?", true).
-		Update("is_active", false).Error; err != nil {
-		return err
-	}
-	return r.db.Create(&weights).Error
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.ScoreCalibrationWeight{}).
+			Where("is_active = ?", true).
+			Update("is_active", false).Error; err != nil {
+			return err
+		}
+		return tx.Create(&weights).Error
+	})
 }
 
 // CategoryPassStats キャリブレーション計算用の生データ

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -109,7 +109,7 @@ func SetupAdminRoutes(
 	admin.GET("/score-validation/calibration/history", scoreValidationController.GetCalibrationHistory)
 	admin.GET("/score-validation/variants", scoreValidationController.ListVariants)
 	admin.POST("/score-validation/variants", scoreValidationController.CreateVariant)
-	admin.GET("/score-validation/variants/:id/results", scoreValidationController.GetVariantResults)
+	admin.GET("/score-validation/variants/results", scoreValidationController.GetVariantResults)
 
 	// 集合知管理
 	admin.POST("/collective-insights/rebuild-summaries", collectiveInsightController.RebuildSummaries)

--- a/Backend/internal/services/score_validation_service.go
+++ b/Backend/internal/services/score_validation_service.go
@@ -3,10 +3,14 @@ package services
 import (
 	"Backend/internal/models"
 	"Backend/internal/repositories"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
 )
+
+// ErrInsufficientSamples サンプル数不足でキャリブレーションが実行できない場合
+var ErrInsufficientSamples = errors.New("キャリブレーションに必要なサンプル数が不足しています（各カテゴリ5件以上必要）")
 
 // ScoreValidationService チャット分析スコアの精度検証・改善サービス
 type ScoreValidationService struct {
@@ -206,7 +210,7 @@ func (s *ScoreValidationService) RunCalibration() (*CalibrationResult, error) {
 		return nil, fmt.Errorf("統計取得エラー: %w", err)
 	}
 	if len(stats) == 0 {
-		return nil, fmt.Errorf("キャリブレーションに必要なサンプル数が不足しています（各カテゴリ5件以上必要）")
+		return nil, ErrInsufficientSamples
 	}
 
 	// 全体の平均通過率を基準にして重みを計算

--- a/frontend/app/admin/score-validation/page.tsx
+++ b/frontend/app/admin/score-validation/page.tsx
@@ -95,7 +95,7 @@ function CorrelationTab({ headers }: { headers: Record<string, string> }) {
   useEffect(() => {
     setLoading(true)
     fetch('/api/admin/score-validation/correlation', { headers })
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => setData(d))
       .catch(() => setError('相関データの取得に失敗しました'))
       .finally(() => setLoading(false))
@@ -166,7 +166,7 @@ function PhaseMetricsTab({ headers }: { headers: Record<string, string> }) {
   useEffect(() => {
     setLoading(true)
     fetch('/api/admin/score-validation/phase-metrics', { headers })
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => setData(d))
       .catch(() => setError('フェーズ別メトリクスの取得に失敗しました'))
       .finally(() => setLoading(false))
@@ -226,7 +226,7 @@ function ABTestTab({ headers }: { headers: Record<string, string> }) {
   const fetchVariants = useCallback(() => {
     setLoading(true)
     fetch('/api/admin/score-validation/variants', { headers })
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => setVariants(d.experiments ?? []))
       .catch(() => setError('バリアント一覧の取得に失敗しました'))
       .finally(() => setLoading(false))
@@ -237,7 +237,7 @@ function ABTestTab({ headers }: { headers: Record<string, string> }) {
   const fetchResults = useCallback((exp: string) => {
     if (!exp) return
     fetch(`/api/admin/score-validation/variants/results?experiment=${encodeURIComponent(exp)}`, { headers })
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => setResults(d.results ?? []))
       .catch(() => setResults([]))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -418,7 +418,7 @@ function CalibrationTab({ headers }: { headers: Record<string, string> }) {
   const fetchHistory = useCallback(() => {
     setLoading(true)
     fetch('/api/admin/score-validation/calibration/history', { headers })
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json() })
       .then(d => setHistory(d.history ?? []))
       .catch(() => setError('キャリブレーション履歴の取得に失敗しました'))
       .finally(() => setLoading(false))

--- a/frontend/app/api/admin/score-validation/calibration/history/route.ts
+++ b/frontend/app/api/admin/score-validation/calibration/history/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams.toString()
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/calibration/history${query ? `?${query}` : ''}`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/calibration/route.ts
+++ b/frontend/app/api/admin/score-validation/calibration/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/calibration`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/calibration/run/route.ts
+++ b/frontend/app/api/admin/score-validation/calibration/run/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/calibration/run`, {
+    method: 'POST',
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/correlation/route.ts
+++ b/frontend/app/api/admin/score-validation/correlation/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/correlation`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/phase-metrics/route.ts
+++ b/frontend/app/api/admin/score-validation/phase-metrics/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/phase-metrics`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/variants/results/route.ts
+++ b/frontend/app/api/admin/score-validation/variants/results/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams.toString()
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/variants/results${query ? `?${query}` : ''}`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/score-validation/variants/route.ts
+++ b/frontend/app/api/admin/score-validation/variants/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/variants`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/score-validation/variants`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+    body,
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try { data = JSON.parse(raw) } catch { data = response.ok ? { message: raw } : { error: raw } }
+  }
+  return NextResponse.json(data, { status: response.status })
+}


### PR DESCRIPTION
Closes #523

## 変更内容

### バグ① ルート定義とコントローラーの不一致を修正
- `Backend/internal/routes/admin_routes.go`
- `GET /score-validation/variants/:id/results` → `GET /score-validation/variants/results` に変更し、フロントエンド・コントローラーのクエリパラメータ方式（`?experiment=xxx`）に統一

### バグ② キャリブレーション保存のトランザクション非アトミックを修正
- `Backend/internal/repositories/score_validation_repository.go`
- `SaveCalibrationWeights` を `db.Transaction` でラップし、既存重みの非アクティブ化と新重みの保存をアトミックに実行（①失敗時のロールバックを保証）

### バグ③ フロントエンド fetch の HTTP エラーステータス無視を修正
- `frontend/app/admin/score-validation/page.tsx`
- 5箇所の fetch（CorrelationTab/PhaseMetricsTab/ABTestTab×2/CalibrationTab）に `r.ok` チェックを追加し、4xx/5xx レスポンスを確実に `.catch()` で捕捉してエラーメッセージを表示

### バグ④ RunCalibration が全エラーを 400 で返す問題を修正
- `Backend/internal/services/score_validation_service.go`: `ErrInsufficientSamples` sentinel error を定義
- `Backend/internal/controllers/admin_score_validation_controller.go`: `errors.Is` でサンプル不足（ユーザー起因）は 400、DB 接続エラー等の内部エラーは 500 に使い分け

### 既存バグ追加対応: Next.js route handler の追加
- `frontend/app/api/admin/score-validation/` 配下に 7 本の route handler を新規作成
- `/admin/score-validation` 画面の全タブ（相関分析・フェーズ別メトリクス・A/Bテスト・キャリブレーション）がバックエンドに正常通信できるよう修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * キャリブレーション実行時のサンプル不足エラーハンドリングを改善
  * キャリブレーション重みの保存処理の信頼性を向上

* **New Features**
  * 管理者向けスコア検証APIエンドポイントを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->