### PR TITLE
fix: フロントエンド不具合4件を修正

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -55,8 +55,7 @@ function OAuthCallbackContent() {
       }
 
       const userParam = searchParams.get('user')
-      const provider = searchParams.get('provider')
-      
+
       if (!userParam) {
         setError('ユーザー情報が見つかりません')
         return

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -56,7 +56,7 @@ export default function OnboardingPage() {
   const [completedSteps, setCompletedSteps] = useState<boolean[]>([false, false, false])
 
   useEffect(() => {
-    const hasChatSession = !!(localStorage.getItem('chat_session_id') || localStorage.getItem('currentSessionId'))
+    const hasChatSession = !!(sessionStorage.getItem('chatSessionId') || localStorage.getItem('currentSessionId'))
     const hasResults = hasChatSession // マッチング結果はチャット完了後に閲覧可能
     const hasInterview = !!localStorage.getItem('interview_session_id')
     const completed = [hasChatSession, hasResults, hasInterview]

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -333,8 +333,8 @@ function ResultsContent() {
   }
 
   const handleReset = () => {
-    localStorage.clear()
-    sessionStorage.clear()
+    sessionStorage.removeItem('chatSessionId')
+    localStorage.removeItem('currentSessionId')
     router.push('/')
   }
 
@@ -366,7 +366,7 @@ function ResultsContent() {
     try {
       const res = await fetch('/api/applications', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
         body: JSON.stringify({
           user_id: Number(userId),
           company_id: Number(company.id),

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -94,7 +94,6 @@ function ResumeContent() {
     }
     if (typeof window !== 'undefined') {
       const storedSession =
-        localStorage.getItem('chat_session_id') ||
         sessionStorage.getItem('chatSessionId') ||
         localStorage.getItem('currentSessionId') ||
         ''


### PR DESCRIPTION
## 概要

Issues #539 #540 #541 #542 で報告されたフロントエンド不具合を1つのPRでまとめて修正します。

## 修正内容

### #539 リセット操作で認証情報・全保存データが消去される
**`frontend/app/results/page.tsx`**
- `localStorage.clear()` / `sessionStorage.clear()` → チャット関連キー（`chatSessionId`, `currentSessionId`）のみを `removeItem` で削除するよう変更
- 認証情報や他機能の保存データが消えなくなる

### #540 応募APIで認証ヘッダーが付与されていない
**`frontend/app/results/page.tsx`**
- `/api/applications` の `fetch` ヘッダーに `...authService.getUserFetchHeaders()` を追加
- 認証必須エンドポイントで 401/403 が発生しなくなる

### #541 セッションID保存キーの不整合
**`frontend/app/onboarding/page.tsx`**
- `localStorage.getItem('chat_session_id')` → `sessionStorage.getItem('chatSessionId')` に修正（`chat_session_id` は書き込み箇所が存在しない未使用キー）

**`frontend/app/resume/page.tsx`**
- セッションID取得ロジックから `localStorage.getItem('chat_session_id')` を除去
- `mui-chat.tsx` が書き込む `sessionStorage.chatSessionId` を最優先に統一

### #542 OAuthコールバックで provider パラメータが未使用
**`frontend/app/auth/callback/page.tsx`**
- `const provider = searchParams.get('provider')` を削除
- `oauth_provider` はすでに `validatedData` 経由でペイロードから取得されており重複していた

## テスト観点

- [ ] ログイン済みで結果画面のリセット → 認証状態が維持されている
- [ ] 結果画面から応募 → ネットワークタブで `X-User-Token` ヘッダーが付与されている
- [ ] チャット完了後にオンボーディング画面を確認 → ステップ完了が正しく表示される
- [ ] レジュメ画面でセッションIDが正しく引き継がれる
- [ ] OAuth ログイン → コールバック後に正常遷移する