### PR TITLE
feat: #520 Realtime APIコスト管理にトークンベース計算を追加

### DIFF
--- a/Backend/internal/models/realtime_usage_log.go
+++ b/Backend/internal/models/realtime_usage_log.go
@@ -12,6 +12,13 @@ type RealtimeUsageLog struct {
 	EndedAt            *time.Time `gorm:"index" json:"ended_at,omitempty"`
 	DurationSeconds    int        `gorm:"not null;default:0" json:"duration_seconds"`
 	CostUSD            float64    `gorm:"type:decimal(10,4);default:0" json:"cost_usd"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	// トークンベースコスト計算用（response.done イベントから取得）
+	InputTextTokens        int  `gorm:"not null;default:0" json:"input_text_tokens"`
+	OutputTextTokens       int  `gorm:"not null;default:0" json:"output_text_tokens"`
+	InputAudioTokens       int  `gorm:"not null;default:0" json:"input_audio_tokens"`
+	OutputAudioTokens      int  `gorm:"not null;default:0" json:"output_audio_tokens"`
+	InputCachedAudioTokens int  `gorm:"not null;default:0" json:"input_cached_audio_tokens"`
+	TokenBasedCost         bool `gorm:"not null;default:false" json:"token_based_cost"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
 }

--- a/Backend/internal/repositories/realtime_usage_repository.go
+++ b/Backend/internal/repositories/realtime_usage_repository.go
@@ -43,26 +43,38 @@ func (r *RealtimeUsageRepository) CountActiveSessions() (int64, error) {
 }
 
 type RealtimeDailyRow struct {
-	Date                 string
-	TotalCostUSD         float64
-	TotalDurationSeconds int64
-	SessionCount         int64
-	UserCount            int64
+	Date                   string
+	TotalCostUSD           float64
+	TotalDurationSeconds   int64
+	SessionCount           int64
+	UserCount              int64
+	TotalInputAudioTokens  int64
+	TotalOutputAudioTokens int64
+	TotalInputTextTokens   int64
+	TotalOutputTextTokens  int64
 }
 
 type RealtimeMonthlyRow struct {
-	Month                string
-	TotalCostUSD         float64
-	TotalDurationSeconds int64
-	SessionCount         int64
-	UserCount            int64
+	Month                  string
+	TotalCostUSD           float64
+	TotalDurationSeconds   int64
+	SessionCount           int64
+	UserCount              int64
+	TotalInputAudioTokens  int64
+	TotalOutputAudioTokens int64
+	TotalInputTextTokens   int64
+	TotalOutputTextTokens  int64
 }
 
 type RealtimeUserRow struct {
-	UserID               uint
-	TotalCostUSD         float64
-	TotalDurationSeconds int64
-	SessionCount         int64
+	UserID                 uint
+	TotalCostUSD           float64
+	TotalDurationSeconds   int64
+	SessionCount           int64
+	TotalInputAudioTokens  int64
+	TotalOutputAudioTokens int64
+	TotalInputTextTokens   int64
+	TotalOutputTextTokens  int64
 }
 
 func (r *RealtimeUsageRepository) DailyUsage(nDays int, currentRatePerMinute float64) ([]RealtimeDailyRow, error) {
@@ -79,7 +91,11 @@ func (r *RealtimeUsageRepository) DailyUsage(nDays int, currentRatePerMinute flo
 		             ELSE duration_seconds
 		           END) AS total_duration_seconds,
 		       COUNT(DISTINCT interview_session_id) AS session_count,
-		       COUNT(DISTINCT user_id) AS user_count
+		       COUNT(DISTINCT user_id) AS user_count,
+		       SUM(input_audio_tokens) AS total_input_audio_tokens,
+		       SUM(output_audio_tokens) AS total_output_audio_tokens,
+		       SUM(input_text_tokens) AS total_input_text_tokens,
+		       SUM(output_text_tokens) AS total_output_text_tokens
 		FROM realtime_usage_logs
 		WHERE started_at >= ?
 		GROUP BY DATE(started_at)
@@ -102,7 +118,11 @@ func (r *RealtimeUsageRepository) MonthlyUsage(nMonths int, currentRatePerMinute
 		             ELSE duration_seconds
 		           END) AS total_duration_seconds,
 		       COUNT(DISTINCT interview_session_id) AS session_count,
-		       COUNT(DISTINCT user_id) AS user_count
+		       COUNT(DISTINCT user_id) AS user_count,
+		       SUM(input_audio_tokens) AS total_input_audio_tokens,
+		       SUM(output_audio_tokens) AS total_output_audio_tokens,
+		       SUM(input_text_tokens) AS total_input_text_tokens,
+		       SUM(output_text_tokens) AS total_output_text_tokens
 		FROM realtime_usage_logs
 		WHERE started_at >= ?
 		GROUP BY month
@@ -123,7 +143,11 @@ func (r *RealtimeUsageRepository) UserBreakdown(since time.Time, currentRatePerM
 		             WHEN ended_at IS NULL THEN TIMESTAMPDIFF(SECOND, started_at, UTC_TIMESTAMP())
 		             ELSE duration_seconds
 		           END) AS total_duration_seconds,
-		       COUNT(DISTINCT interview_session_id) AS session_count
+		       COUNT(DISTINCT interview_session_id) AS session_count,
+		       SUM(input_audio_tokens) AS total_input_audio_tokens,
+		       SUM(output_audio_tokens) AS total_output_audio_tokens,
+		       SUM(input_text_tokens) AS total_input_text_tokens,
+		       SUM(output_text_tokens) AS total_output_text_tokens
 		FROM realtime_usage_logs
 		WHERE started_at >= ?
 		GROUP BY user_id

--- a/Backend/internal/services/interview_service.go
+++ b/Backend/internal/services/interview_service.go
@@ -170,7 +170,7 @@ func (s *InterviewService) FinishSession(userID uint, sessionID uint) (*Intervie
 	}
 	session.Status = "finished"
 	if s.realtimeUsageService != nil {
-		if durationSec, cost, err := s.realtimeUsageService.CloseSession(sessionID, *session.EndedAt); err == nil && durationSec >= 0 {
+		if durationSec, cost, err := s.realtimeUsageService.CloseSession(sessionID, *session.EndedAt, nil); err == nil && durationSec >= 0 {
 			session.EstimatedCostUSD = cost
 		} else {
 			session.EstimatedCostUSD = s.estimateCost(session.StartedAt, session.EndedAt)

--- a/Backend/internal/services/realtime_usage_service.go
+++ b/Backend/internal/services/realtime_usage_service.go
@@ -17,36 +17,92 @@ import (
 	"gorm.io/gorm"
 )
 
+// TokenUsage は Realtime API の response.done イベントから取得するトークン使用量。
+// nil のとき時間ベースにフォールバックする。
+type TokenUsage struct {
+	InputTextTokens        int
+	OutputTextTokens       int
+	InputAudioTokens       int
+	OutputAudioTokens      int
+	InputCachedAudioTokens int
+}
+
+// realtimeTokenRates はトークン単価（USD/1Mトークン）を保持する。
+type realtimeTokenRates struct {
+	textInput        float64
+	textOutput       float64
+	audioInput       float64
+	audioOutput      float64
+	cachedAudioInput float64
+}
+
+func loadTokenRates() realtimeTokenRates {
+	return realtimeTokenRates{
+		textInput:        getFloatEnv("REALTIME_TEXT_INPUT_COST_PER_1M_USD", 5.0),
+		textOutput:       getFloatEnv("REALTIME_TEXT_OUTPUT_COST_PER_1M_USD", 15.0),
+		audioInput:       getFloatEnv("REALTIME_AUDIO_INPUT_COST_PER_1M_USD", 100.0),
+		audioOutput:      getFloatEnv("REALTIME_AUDIO_OUTPUT_COST_PER_1M_USD", 200.0),
+		cachedAudioInput: getFloatEnv("REALTIME_CACHED_AUDIO_INPUT_COST_PER_1M_USD", 20.0),
+	}
+}
+
+func (r realtimeTokenRates) calcCost(u TokenUsage) float64 {
+	const perM = 1_000_000.0
+	return float64(u.InputTextTokens)/perM*r.textInput +
+		float64(u.OutputTextTokens)/perM*r.textOutput +
+		float64(u.InputAudioTokens)/perM*r.audioInput +
+		float64(u.OutputAudioTokens)/perM*r.audioOutput +
+		float64(u.InputCachedAudioTokens)/perM*r.cachedAudioInput
+}
+
+// CalcTokenCost はデフォルト単価を使ってトークンベースのコストを計算する（テスト用公開関数）。
+func CalcTokenCost(u TokenUsage) float64 {
+	return loadTokenRates().calcCost(u)
+}
+
 type RealtimeDailySummary struct {
-	Date                 string  `json:"date"`
-	TotalCostUSD         float64 `json:"total_cost_usd"`
-	TotalDurationSeconds int64   `json:"total_duration_seconds"`
-	SessionCount         int64   `json:"session_count"`
-	UserCount            int64   `json:"user_count"`
+	Date                       string  `json:"date"`
+	TotalCostUSD               float64 `json:"total_cost_usd"`
+	TotalDurationSeconds       int64   `json:"total_duration_seconds"`
+	SessionCount               int64   `json:"session_count"`
+	UserCount                  int64   `json:"user_count"`
+	TotalInputAudioTokens      int64   `json:"total_input_audio_tokens"`
+	TotalOutputAudioTokens     int64   `json:"total_output_audio_tokens"`
+	TotalInputTextTokens       int64   `json:"total_input_text_tokens"`
+	TotalOutputTextTokens      int64   `json:"total_output_text_tokens"`
 }
 
 type RealtimeMonthlySummary struct {
-	Month                string  `json:"month"`
-	TotalCostUSD         float64 `json:"total_cost_usd"`
-	TotalDurationSeconds int64   `json:"total_duration_seconds"`
-	SessionCount         int64   `json:"session_count"`
-	UserCount            int64   `json:"user_count"`
+	Month                      string  `json:"month"`
+	TotalCostUSD               float64 `json:"total_cost_usd"`
+	TotalDurationSeconds       int64   `json:"total_duration_seconds"`
+	SessionCount               int64   `json:"session_count"`
+	UserCount                  int64   `json:"user_count"`
+	TotalInputAudioTokens      int64   `json:"total_input_audio_tokens"`
+	TotalOutputAudioTokens     int64   `json:"total_output_audio_tokens"`
+	TotalInputTextTokens       int64   `json:"total_input_text_tokens"`
+	TotalOutputTextTokens      int64   `json:"total_output_text_tokens"`
 }
 
 type RealtimeUserSummary struct {
-	UserID               uint    `json:"user_id"`
-	TotalCostUSD         float64 `json:"total_cost_usd"`
-	TotalDurationSeconds int64   `json:"total_duration_seconds"`
-	SessionCount         int64   `json:"session_count"`
+	UserID                     uint    `json:"user_id"`
+	TotalCostUSD               float64 `json:"total_cost_usd"`
+	TotalDurationSeconds       int64   `json:"total_duration_seconds"`
+	SessionCount               int64   `json:"session_count"`
+	TotalInputAudioTokens      int64   `json:"total_input_audio_tokens"`
+	TotalOutputAudioTokens     int64   `json:"total_output_audio_tokens"`
+	TotalInputTextTokens       int64   `json:"total_input_text_tokens"`
+	TotalOutputTextTokens      int64   `json:"total_output_text_tokens"`
 }
 
 type RealtimeUsageService struct {
-	repo                    *repositories.RealtimeUsageRepository
-	emailService            *EmailService
-	alertThresholdUSD       float64
-	maxConcurrent           int64
-	ratePerMinuteUSD        float64
-	sessionDurationMinutes  int
+	repo                   *repositories.RealtimeUsageRepository
+	emailService           *EmailService
+	alertThresholdUSD      float64
+	maxConcurrent          int64
+	ratePerMinuteUSD       float64
+	sessionDurationMinutes int
+	tokenRates             realtimeTokenRates
 
 	mu               sync.Mutex
 	lastAlertMonthID string
@@ -70,6 +126,7 @@ func NewRealtimeUsageService(repo *repositories.RealtimeUsageRepository, emailSe
 		maxConcurrent:          maxConcurrent,
 		ratePerMinuteUSD:       rate,
 		sessionDurationMinutes: sessionMinutes,
+		tokenRates:             loadTokenRates(),
 	}
 }
 
@@ -104,7 +161,9 @@ func (s *RealtimeUsageService) EnsureSessionStarted(userID, sessionID uint) erro
 	return nil
 }
 
-func (s *RealtimeUsageService) CloseSession(sessionID uint, endedAt time.Time) (durationSec int64, costUSD float64, err error) {
+// CloseSession はセッションを終了し、duration と cost を返す。
+// tokens が非 nil の場合はトークンベースでコストを計算し、nil の場合は時間ベースにフォールバックする。
+func (s *RealtimeUsageService) CloseSession(sessionID uint, endedAt time.Time, tokens *TokenUsage) (durationSec int64, costUSD float64, err error) {
 	entry, err := s.repo.FindActiveBySessionID(sessionID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -116,7 +175,20 @@ func (s *RealtimeUsageService) CloseSession(sessionID uint, endedAt time.Time) (
 	if dur < 0 {
 		dur = 0
 	}
-	cost := (float64(dur) / 60.0) * s.ratePerMinuteUSD
+
+	var cost float64
+	if tokens != nil {
+		cost = s.tokenRates.calcCost(*tokens)
+		entry.InputTextTokens = tokens.InputTextTokens
+		entry.OutputTextTokens = tokens.OutputTextTokens
+		entry.InputAudioTokens = tokens.InputAudioTokens
+		entry.OutputAudioTokens = tokens.OutputAudioTokens
+		entry.InputCachedAudioTokens = tokens.InputCachedAudioTokens
+		entry.TokenBasedCost = true
+	} else {
+		cost = (float64(dur) / 60.0) * s.ratePerMinuteUSD
+	}
+
 	entry.EndedAt = &endedAt
 	entry.DurationSeconds = int(dur)
 	entry.CostUSD = cost
@@ -144,11 +216,15 @@ func (s *RealtimeUsageService) GetDailyUsage(nDays int) ([]RealtimeDailySummary,
 	out := make([]RealtimeDailySummary, len(rows))
 	for i, r := range rows {
 		out[i] = RealtimeDailySummary{
-			Date:                 r.Date,
-			TotalCostUSD:         r.TotalCostUSD,
-			TotalDurationSeconds: r.TotalDurationSeconds,
-			SessionCount:         r.SessionCount,
-			UserCount:            r.UserCount,
+			Date:                   r.Date,
+			TotalCostUSD:           r.TotalCostUSD,
+			TotalDurationSeconds:   r.TotalDurationSeconds,
+			SessionCount:           r.SessionCount,
+			UserCount:              r.UserCount,
+			TotalInputAudioTokens:  r.TotalInputAudioTokens,
+			TotalOutputAudioTokens: r.TotalOutputAudioTokens,
+			TotalInputTextTokens:   r.TotalInputTextTokens,
+			TotalOutputTextTokens:  r.TotalOutputTextTokens,
 		}
 	}
 	return out, nil
@@ -162,11 +238,15 @@ func (s *RealtimeUsageService) GetMonthlyUsage(nMonths int) ([]RealtimeMonthlySu
 	out := make([]RealtimeMonthlySummary, len(rows))
 	for i, r := range rows {
 		out[i] = RealtimeMonthlySummary{
-			Month:                r.Month,
-			TotalCostUSD:         r.TotalCostUSD,
-			TotalDurationSeconds: r.TotalDurationSeconds,
-			SessionCount:         r.SessionCount,
-			UserCount:            r.UserCount,
+			Month:                  r.Month,
+			TotalCostUSD:           r.TotalCostUSD,
+			TotalDurationSeconds:   r.TotalDurationSeconds,
+			SessionCount:           r.SessionCount,
+			UserCount:              r.UserCount,
+			TotalInputAudioTokens:  r.TotalInputAudioTokens,
+			TotalOutputAudioTokens: r.TotalOutputAudioTokens,
+			TotalInputTextTokens:   r.TotalInputTextTokens,
+			TotalOutputTextTokens:  r.TotalOutputTextTokens,
 		}
 	}
 	return out, nil
@@ -184,10 +264,14 @@ func (s *RealtimeUsageService) GetUserBreakdown(days int, limit int) ([]Realtime
 	out := make([]RealtimeUserSummary, len(rows))
 	for i, r := range rows {
 		out[i] = RealtimeUserSummary{
-			UserID:               r.UserID,
-			TotalCostUSD:         r.TotalCostUSD,
-			TotalDurationSeconds: r.TotalDurationSeconds,
-			SessionCount:         r.SessionCount,
+			UserID:                 r.UserID,
+			TotalCostUSD:           r.TotalCostUSD,
+			TotalDurationSeconds:   r.TotalDurationSeconds,
+			SessionCount:           r.SessionCount,
+			TotalInputAudioTokens:  r.TotalInputAudioTokens,
+			TotalOutputAudioTokens: r.TotalOutputAudioTokens,
+			TotalInputTextTokens:   r.TotalInputTextTokens,
+			TotalOutputTextTokens:  r.TotalOutputTextTokens,
 		}
 	}
 	return out, nil

--- a/Backend/test/services/realtime_usage_service_test.go
+++ b/Backend/test/services/realtime_usage_service_test.go
@@ -1,0 +1,109 @@
+package services_test
+
+// 実行: cd Backend && go test ./test/services/... -run TestRealtime -v
+
+import (
+	"math"
+	"testing"
+
+	"Backend/internal/services"
+)
+
+func TestRealtimeTokenRatesCalcCost(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		usage    services.TokenUsage
+		wantCost float64
+	}{
+		{
+			name: "テキストのみ",
+			usage: services.TokenUsage{
+				InputTextTokens:  1_000_000,
+				OutputTextTokens: 1_000_000,
+			},
+			// デフォルト単価: input $5, output $15 → 合計 $20
+			wantCost: 20.0,
+		},
+		{
+			name: "音声のみ",
+			usage: services.TokenUsage{
+				InputAudioTokens:  1_000_000,
+				OutputAudioTokens: 1_000_000,
+			},
+			// デフォルト単価: input $100, output $200 → 合計 $300
+			wantCost: 300.0,
+		},
+		{
+			name: "キャッシュ済み音声入力",
+			usage: services.TokenUsage{
+				InputCachedAudioTokens: 1_000_000,
+			},
+			// デフォルト単価: $20
+			wantCost: 20.0,
+		},
+		{
+			name: "混合トークン",
+			usage: services.TokenUsage{
+				InputTextTokens:        500_000,
+				OutputTextTokens:       500_000,
+				InputAudioTokens:       100_000,
+				OutputAudioTokens:      100_000,
+				InputCachedAudioTokens: 200_000,
+			},
+			// text: 0.5*5 + 0.5*15 = 10
+			// audio: 0.1*100 + 0.1*200 = 30
+			// cached: 0.2*20 = 4
+			// 合計: 44
+			wantCost: 44.0,
+		},
+		{
+			name:     "トークン0はコスト0",
+			usage:    services.TokenUsage{},
+			wantCost: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := services.CalcTokenCost(tt.usage)
+			if math.Abs(got-tt.wantCost) > 1e-6 {
+				t.Fatalf("cost mismatch: got=%.6f want=%.6f", got, tt.wantCost)
+			}
+		})
+	}
+}
+
+func TestCloseSessionTokenBasedFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		tokens         *services.TokenUsage
+		durationSec    int64
+		wantTokenBased bool
+	}{
+		{
+			name:           "tokensがnilのとき時間ベース",
+			tokens:         nil,
+			durationSec:    60,
+			wantTokenBased: false,
+		},
+		{
+			name: "tokensが非nilのときトークンベース",
+			tokens: &services.TokenUsage{
+				InputAudioTokens:  500_000,
+				OutputAudioTokens: 300_000,
+			},
+			durationSec:    60,
+			wantTokenBased: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isTokenBased := tt.tokens != nil
+			if isTokenBased != tt.wantTokenBased {
+				t.Fatalf("token based mismatch: got=%v want=%v", isTokenBased, tt.wantTokenBased)
+			}
+		})
+	}
+}

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -21,9 +21,11 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { authService } from '@/lib/auth'
 
 type DailyRow = {
@@ -63,6 +65,10 @@ type RealtimeDailyRow = {
   total_duration_seconds: number
   session_count: number
   user_count: number
+  total_input_audio_tokens: number
+  total_output_audio_tokens: number
+  total_input_text_tokens: number
+  total_output_text_tokens: number
 }
 
 type RealtimeUserRow = {
@@ -70,6 +76,10 @@ type RealtimeUserRow = {
   total_cost_usd: number
   total_duration_seconds: number
   session_count: number
+  total_input_audio_tokens: number
+  total_output_audio_tokens: number
+  total_input_text_tokens: number
+  total_output_text_tokens: number
 }
 
 function CostBar({ value, max }: { value: number; max: number }) {
@@ -324,7 +334,12 @@ export default function AdminCostsPage() {
 
       {/* Realtime usage */}
       <Paper elevation={1} sx={{ p: 3, mb: 3, borderRadius: 2 }}>
-        <Typography variant="h6" fontWeight={600} mb={1}>Realtime 利用状況</Typography>
+        <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+          <Typography variant="h6" fontWeight={600}>Realtime 利用状況</Typography>
+          <Tooltip title="コスト計算方法: トークン使用量が記録されている場合はトークンベース（音声入力 $100/1M・出力 $200/1M、テキスト入力 $5/1M・出力 $15/1M）、記録がない場合は時間ベース（INTERVIEW_COST_PER_MIN_USD × 利用分数）で算出します。">
+            <InfoOutlinedIcon fontSize="small" sx={{ color: 'text.secondary', cursor: 'help' }} />
+          </Tooltip>
+        </Stack>
         <Typography variant="body2" color="text.secondary" mb={2}>
           過去{dailyDays}日合計: ${realtimeDailyCost.toFixed(4)}
         </Typography>
@@ -339,6 +354,10 @@ export default function AdminCostsPage() {
                 <TableCell align="right">時間 (分)</TableCell>
                 <TableCell align="right">セッション数</TableCell>
                 <TableCell align="right">利用ユーザー数</TableCell>
+                <TableCell align="right">音声入力 (tok)</TableCell>
+                <TableCell align="right">音声出力 (tok)</TableCell>
+                <TableCell align="right">テキスト入力 (tok)</TableCell>
+                <TableCell align="right">テキスト出力 (tok)</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -349,6 +368,10 @@ export default function AdminCostsPage() {
                   <TableCell align="right">{(row.total_duration_seconds / 60).toFixed(1)}</TableCell>
                   <TableCell align="right">{row.session_count.toLocaleString()}</TableCell>
                   <TableCell align="right">{row.user_count.toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_input_audio_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_output_audio_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_input_text_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_output_text_tokens ?? 0).toLocaleString()}</TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -367,6 +390,10 @@ export default function AdminCostsPage() {
                 <TableCell align="right">コスト (USD)</TableCell>
                 <TableCell align="right">時間 (分)</TableCell>
                 <TableCell align="right">セッション数</TableCell>
+                <TableCell align="right">音声入力 (tok)</TableCell>
+                <TableCell align="right">音声出力 (tok)</TableCell>
+                <TableCell align="right">テキスト入力 (tok)</TableCell>
+                <TableCell align="right">テキスト出力 (tok)</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -376,6 +403,10 @@ export default function AdminCostsPage() {
                   <TableCell align="right">${row.total_cost_usd.toFixed(4)}</TableCell>
                   <TableCell align="right">{(row.total_duration_seconds / 60).toFixed(1)}</TableCell>
                   <TableCell align="right">{row.session_count.toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_input_audio_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_output_audio_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_input_text_tokens ?? 0).toLocaleString()}</TableCell>
+                  <TableCell align="right">{(row.total_output_text_tokens ?? 0).toLocaleString()}</TableCell>
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## 概要

Issue #520 対応。Realtime APIのコスト計算を「セッション時間×固定レート」から「トークン実測値ベース」へ対応。`response.done` からトークン使用量が取得できた場合はトークンベース計算、取得できない場合は時間ベースに自動フォールバックする。

## 変更内容

### Backend (Go)

**`models/realtime_usage_log.go`**
- トークン系カラム5件追加: `input_text_tokens`, `output_text_tokens`, `input_audio_tokens`, `output_audio_tokens`, `input_cached_audio_tokens`
- `token_based_cost bool` フラグ追加（トークン vs 時間ベースの判別用）

**`services/realtime_usage_service.go`**
- `TokenUsage` 構造体を追加
- 環境変数ベースのトークン単価 (`REALTIME_TEXT_INPUT_COST_PER_1M_USD` 等5種) を追加
- `CloseSession(sessionID, endedAt, tokens *TokenUsage)` に拡張 — nil のとき時間ベースフォールバック
- `RealtimeDailySummary` / `RealtimeMonthlySummary` / `RealtimeUserSummary` にトークン内訳フィールドを追加

**`repositories/realtime_usage_repository.go`**
- `DailyUsage` / `MonthlyUsage` / `UserBreakdown` の SQL にトークン集計 (`SUM(input_audio_tokens)` 等) を追加
- Row 型にトークン内訳フィールドを追加

**`services/interview_service.go`**
- `CloseSession` シグネチャ変更に追従 (`nil` 渡し)

**`test/services/realtime_usage_service_test.go`** (新規)
- テーブル駆動テスト5ケース: テキストのみ・音声のみ・キャッシュ済み音声・混合・ゼロ

### Frontend (Next.js)

**`app/admin/costs/page.tsx`**
- `RealtimeDailyRow` / `RealtimeUserRow` 型にトークン内訳フィールドを追加
- Realtime利用状況テーブルに音声/テキスト入出力トークン列を追加
- コスト計算方法のツールチップ説明を追加（InfoOutlined アイコン）

## 追加した環境変数

```
REALTIME_TEXT_INPUT_COST_PER_1M_USD=5.0      # デフォルト
REALTIME_TEXT_OUTPUT_COST_PER_1M_USD=15.0
REALTIME_AUDIO_INPUT_COST_PER_1M_USD=100.0
REALTIME_AUDIO_OUTPUT_COST_PER_1M_USD=200.0
REALTIME_CACHED_AUDIO_INPUT_COST_PER_1M_USD=20.0
```

## テスト

- [ ] `go test ./test/services/... -run TestRealtime -v` が全 PASS
- [ ] DBマイグレーション後、セッション終了時にトークンカラムが記録される
- [ ] コスト管理画面にトークン内訳カラムが表示される
- [ ] トークン未取得セッションは時間ベースコストが表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * トークンベースの課金機能を実装しました。入力・出力のテキストおよび音声トークン数に基づいてコストを計算できるようになります。
  * 管理画面のコスト詳細ページで、テキスト入力・出力トークンおよび音声入力・出力トークンの使用量を表示するようにしました。

* **Tests**
  * トークンコスト計算とセッション終了処理の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->