### PR TITLE
feat: #519 管理者機能の整備（ダッシュボード拡充・UI改善）

### DIFF
--- a/frontend/app/admin/collective-insights/page.tsx
+++ b/frontend/app/admin/collective-insights/page.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { authService } from '@/lib/auth'
+
+export default function AdminCollectiveInsightsPage() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  const handleRebuild = async () => {
+    setLoading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const headers = authService.getAdminFetchHeaders()
+      const res = await fetch('/api/admin/collective-insights/rebuild-summaries', {
+        method: 'POST',
+        headers,
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'サマリー再構築に失敗しました')
+        return
+      }
+      setSuccess('全企業の集合知サマリーを再構築しました')
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 720, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <IconButton component={Link} href="/admin"><ArrowBackIcon /></IconButton>
+        <Typography variant="h4" fontWeight="bold">
+          集合知サマリー管理
+        </Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        ユーザー行動データをもとに全企業の集合知サマリーを再集計します。
+      </Typography>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+      {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>{success}</Alert>}
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>サマリー再構築</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+            全企業の行動サマリーをバッチ処理で再集計します。データ整合性の確保やプロファイル更新後に実行してください。
+            処理はバックグラウンドで実行されます。
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleRebuild}
+            disabled={loading}
+            startIcon={loading ? <CircularProgress size={16} /> : undefined}
+          >
+            {loading ? '再構築中...' : 'サマリーを再構築'}
+          </Button>
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import Grid from '@mui/material/GridLegacy'
+import Grid from '@mui/material/Grid'
 import { authService } from '@/lib/auth'
 
 export default function AdminDashboardPage() {
@@ -61,7 +61,7 @@ export default function AdminDashboardPage() {
       </Typography>
 
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -82,7 +82,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -103,7 +103,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -119,7 +119,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -135,7 +135,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -151,7 +151,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -167,7 +167,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -183,7 +183,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -199,7 +199,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -215,7 +215,7 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
@@ -231,20 +231,55 @@ export default function AdminDashboardPage() {
             </CardContent>
           </Card>
         </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                プロファイル再計算
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                企業マッチングプロファイルを一括または個別に再計算します。ロールバックも可能です。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/profile-recalculation">
+                プロファイル再計算へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                集合知サマリー再構築
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                全企業の行動サマリーをバッチ再集計します。データの整合性を保つ際に使用します。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/collective-insights">
+                集合知管理へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                スクレイパーセッション
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                クローリングに使用するサイトごとのセッション（Cookie）を管理します。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/scraper-sessions">
+                セッション管理へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
       </Grid>
-
-      <Stack spacing={2}>
-        <Card>
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              近日追加予定
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              ユーザー権限管理、監査ログ、通知設定などを順次追加します。
-            </Typography>
-          </CardContent>
-        </Card>
-      </Stack>
     </Box>
   )
 }

--- a/frontend/app/admin/profile-recalculation/page.tsx
+++ b/frontend/app/admin/profile-recalculation/page.tsx
@@ -1,0 +1,355 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { authService } from '@/lib/auth'
+
+type RecalcResult = {
+  company_id: number
+  company_name: string
+  updated: boolean
+  sample_count: number
+  message?: string
+}
+
+type HistoryEntry = {
+  id: number
+  company_id: number
+  trigger: string
+  sample_count: number
+  created_at: string
+}
+
+export default function AdminProfileRecalculationPage() {
+  const [loading, setLoading] = useState(false)
+  const [results, setResults] = useState<RecalcResult[]>([])
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [minSamples, setMinSamples] = useState('3')
+
+  const [individualCompanyId, setIndividualCompanyId] = useState('')
+  const [individualLoading, setIndividualLoading] = useState(false)
+  const [individualResult, setIndividualResult] = useState<RecalcResult | null>(null)
+
+  const [historyCompanyId, setHistoryCompanyId] = useState('')
+  const [histories, setHistories] = useState<HistoryEntry[]>([])
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  const [rollbackCompanyId, setRollbackCompanyId] = useState<number | null>(null)
+  const [rollbackLoading, setRollbackLoading] = useState(false)
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  const headers = authService.getAdminFetchHeaders()
+
+  const handleBulkRecalculate = async () => {
+    setLoading(true)
+    setError('')
+    setSuccess('')
+    setResults([])
+    try {
+      const res = await fetch('/api/admin/profile-recalculation', {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ min_samples: parseInt(minSamples) || 3 }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || '一括再計算に失敗しました')
+        return
+      }
+      setResults(data.results || [])
+      setSuccess(`完了: ${data.updated_count} 件更新, ${data.skipped_count} 件スキップ (合計 ${data.total} 件)`)
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleIndividualRecalculate = async () => {
+    if (!individualCompanyId) return
+    setIndividualLoading(true)
+    setError('')
+    setIndividualResult(null)
+    try {
+      const res = await fetch(`/api/admin/profile-recalculation/${individualCompanyId}`, {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ min_samples: parseInt(minSamples) || 3 }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || '再計算に失敗しました')
+        return
+      }
+      setIndividualResult(data)
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setIndividualLoading(false)
+    }
+  }
+
+  const handleLoadHistory = async () => {
+    if (!historyCompanyId) return
+    setHistoryLoading(true)
+    setHistories([])
+    try {
+      const res = await fetch(`/api/admin/profile-recalculation/${historyCompanyId}`, {
+        headers,
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || '履歴取得に失敗しました')
+        return
+      }
+      setHistories(data.histories || [])
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
+
+  const handleRollback = async () => {
+    if (rollbackCompanyId === null) return
+    setRollbackLoading(true)
+    try {
+      const res = await fetch(`/api/admin/profile-recalculation/${rollbackCompanyId}/rollback`, {
+        method: 'POST',
+        headers,
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'ロールバックに失敗しました')
+      } else {
+        setSuccess(data.message || 'ロールバックしました')
+      }
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setRollbackLoading(false)
+      setRollbackCompanyId(null)
+    }
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 960, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <IconButton component={Link} href="/admin"><ArrowBackIcon /></IconButton>
+        <Typography variant="h4" fontWeight="bold">
+          プロファイル再計算
+        </Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        企業マッチングプロファイルを再計算します。サンプル数が少ない企業はスキップされます。
+      </Typography>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+      {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>{success}</Alert>}
+
+      <Stack spacing={3}>
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>一括再計算</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              全企業のプロファイルを一括で再計算します。最小サンプル数以上の企業のみ更新されます。
+            </Typography>
+            <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+              <TextField
+                label="最小サンプル数"
+                type="number"
+                size="small"
+                value={minSamples}
+                onChange={(e) => setMinSamples(e.target.value)}
+                sx={{ width: 160 }}
+              />
+              <Button
+                variant="contained"
+                onClick={handleBulkRecalculate}
+                disabled={loading}
+                startIcon={loading ? <CircularProgress size={16} /> : undefined}
+              >
+                一括再計算を実行
+              </Button>
+            </Stack>
+            {results.length > 0 && (
+              <>
+                <Divider sx={{ mb: 2 }} />
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>企業ID</TableCell>
+                      <TableCell>企業名</TableCell>
+                      <TableCell>サンプル数</TableCell>
+                      <TableCell>状態</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {results.map((r) => (
+                      <TableRow key={r.company_id}>
+                        <TableCell>{r.company_id}</TableCell>
+                        <TableCell>{r.company_name}</TableCell>
+                        <TableCell>{r.sample_count}</TableCell>
+                        <TableCell>
+                          <Chip
+                            label={r.updated ? '更新済み' : 'スキップ'}
+                            color={r.updated ? 'success' : 'default'}
+                            size="small"
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>個別再計算</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              特定企業のプロファイルを再計算します。
+            </Typography>
+            <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+              <TextField
+                label="企業ID"
+                type="number"
+                size="small"
+                value={individualCompanyId}
+                onChange={(e) => setIndividualCompanyId(e.target.value)}
+                sx={{ width: 160 }}
+              />
+              <Button
+                variant="outlined"
+                onClick={handleIndividualRecalculate}
+                disabled={individualLoading || !individualCompanyId}
+                startIcon={individualLoading ? <CircularProgress size={16} /> : undefined}
+              >
+                再計算
+              </Button>
+              <Button
+                variant="outlined"
+                color="warning"
+                onClick={() => setRollbackCompanyId(parseInt(individualCompanyId))}
+                disabled={!individualCompanyId}
+              >
+                ロールバック
+              </Button>
+            </Stack>
+            {individualResult && (
+              <Alert severity={individualResult.updated ? 'success' : 'info'}>
+                企業ID {individualResult.company_id} ({individualResult.company_name}):
+                {individualResult.updated ? ' 更新完了' : ' スキップ'} (サンプル数: {individualResult.sample_count})
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>再計算履歴</Typography>
+            <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+              <TextField
+                label="企業ID"
+                type="number"
+                size="small"
+                value={historyCompanyId}
+                onChange={(e) => setHistoryCompanyId(e.target.value)}
+                sx={{ width: 160 }}
+              />
+              <Button
+                variant="outlined"
+                onClick={handleLoadHistory}
+                disabled={historyLoading || !historyCompanyId}
+                startIcon={historyLoading ? <CircularProgress size={16} /> : undefined}
+              >
+                履歴を表示
+              </Button>
+            </Stack>
+            {histories.length > 0 && (
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>企業ID</TableCell>
+                    <TableCell>トリガー</TableCell>
+                    <TableCell>サンプル数</TableCell>
+                    <TableCell>実行日時</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {histories.map((h) => (
+                    <TableRow key={h.id}>
+                      <TableCell>{h.id}</TableCell>
+                      <TableCell>{h.company_id}</TableCell>
+                      <TableCell>{h.trigger}</TableCell>
+                      <TableCell>{h.sample_count}</TableCell>
+                      <TableCell>{new Date(h.created_at).toLocaleString('ja-JP')}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+            {histories.length === 0 && historyCompanyId && !historyLoading && (
+              <Typography variant="body2" color="text.secondary">履歴がありません</Typography>
+            )}
+          </CardContent>
+        </Card>
+      </Stack>
+
+      <Dialog open={rollbackCompanyId !== null} onClose={() => setRollbackCompanyId(null)}>
+        <DialogTitle>ロールバックの確認</DialogTitle>
+        <DialogContent>
+          <Typography>
+            企業ID {rollbackCompanyId} のプロファイルを直前のバージョンにロールバックします。よろしいですか？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRollbackCompanyId(null)}>キャンセル</Button>
+          <Button
+            color="warning"
+            variant="contained"
+            onClick={handleRollback}
+            disabled={rollbackLoading}
+            startIcon={rollbackLoading ? <CircularProgress size={16} /> : undefined}
+          >
+            ロールバック
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}

--- a/frontend/app/admin/scraper-sessions/page.tsx
+++ b/frontend/app/admin/scraper-sessions/page.tsx
@@ -1,0 +1,277 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import DeleteIcon from '@mui/icons-material/Delete'
+import { authService } from '@/lib/auth'
+
+type ScraperSession = {
+  id: number
+  site_key: string
+  cookies: string
+  expires_at?: string
+  updated_at: string
+}
+
+export default function AdminScraperSessionsPage() {
+  const [sessions, setSessions] = useState<ScraperSession[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const [siteKey, setSiteKey] = useState('')
+  const [cookies, setCookies] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  const headers = authService.getAdminFetchHeaders()
+
+  const loadSessions = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/admin/scraper-sessions', { headers })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'セッション一覧の取得に失敗しました')
+        return
+      }
+      setSessions(data.sessions || [])
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadSessions()
+  }, [])
+
+  const handleUpsert = async () => {
+    if (!siteKey || !cookies) return
+    setSaving(true)
+    setError('')
+    setSuccess('')
+    try {
+      const body: Record<string, string> = { site_key: siteKey, cookies }
+      if (expiresAt) body.expires_at = new Date(expiresAt).toISOString()
+
+      const res = await fetch('/api/admin/scraper-sessions', {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'セッションの保存に失敗しました')
+        return
+      }
+      setSuccess(`セッション "${siteKey}" を保存しました`)
+      setSiteKey('')
+      setCookies('')
+      setExpiresAt('')
+      await loadSessions()
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/admin/scraper-sessions/${encodeURIComponent(deleteTarget)}`, {
+        method: 'DELETE',
+        headers,
+      })
+      if (res.ok || res.status === 204) {
+        setSuccess(`セッション "${deleteTarget}" を削除しました`)
+        await loadSessions()
+      } else {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error || '削除に失敗しました')
+      }
+    } catch {
+      setError('通信エラーが発生しました')
+    } finally {
+      setDeleting(false)
+      setDeleteTarget(null)
+    }
+  }
+
+  const isExpired = (expiresAt?: string) => {
+    if (!expiresAt) return false
+    return new Date(expiresAt) < new Date()
+  }
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 960, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <IconButton component={Link} href="/admin"><ArrowBackIcon /></IconButton>
+        <Typography variant="h4" fontWeight="bold">
+          スクレイパーセッション管理
+        </Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        クローリングに使用するサイトごとのセッション（Cookie）を管理します。
+      </Typography>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+      {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>{success}</Alert>}
+
+      <Stack spacing={3}>
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>セッション一覧</Typography>
+            {loading ? (
+              <CircularProgress size={24} />
+            ) : sessions.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">登録されたセッションはありません</Typography>
+            ) : (
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>サイトキー</TableCell>
+                    <TableCell>有効期限</TableCell>
+                    <TableCell>最終更新</TableCell>
+                    <TableCell>操作</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sessions.map((s) => (
+                    <TableRow key={s.site_key}>
+                      <TableCell>{s.site_key}</TableCell>
+                      <TableCell>
+                        {s.expires_at ? (
+                          <Chip
+                            label={new Date(s.expires_at).toLocaleString('ja-JP')}
+                            color={isExpired(s.expires_at) ? 'error' : 'success'}
+                            size="small"
+                          />
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">なし</Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>{new Date(s.updated_at).toLocaleString('ja-JP')}</TableCell>
+                      <TableCell>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => setDeleteTarget(s.site_key)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>セッションを追加・更新</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              同じサイトキーが存在する場合は上書きします。
+            </Typography>
+            <Stack spacing={2}>
+              <TextField
+                label="サイトキー"
+                size="small"
+                value={siteKey}
+                onChange={(e) => setSiteKey(e.target.value)}
+                placeholder="例: career_tasu"
+              />
+              <TextField
+                label="Cookie文字列"
+                size="small"
+                multiline
+                rows={4}
+                value={cookies}
+                onChange={(e) => setCookies(e.target.value)}
+                placeholder="ブラウザのCookieをそのまま貼り付けてください"
+              />
+              <TextField
+                label="有効期限（任意）"
+                size="small"
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+              <Divider />
+              <Button
+                variant="contained"
+                onClick={handleUpsert}
+                disabled={saving || !siteKey || !cookies}
+                startIcon={saving ? <CircularProgress size={16} /> : undefined}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                保存
+              </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Stack>
+
+      <Dialog open={deleteTarget !== null} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>削除の確認</DialogTitle>
+        <DialogContent>
+          <Typography>
+            セッション &quot;{deleteTarget}&quot; を削除します。よろしいですか？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>キャンセル</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={handleDelete}
+            disabled={deleting}
+            startIcon={deleting ? <CircularProgress size={16} /> : undefined}
+          >
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}

--- a/frontend/app/api/admin/collective-insights/rebuild-summaries/route.ts
+++ b/frontend/app/api/admin/collective-insights/rebuild-summaries/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/collective-insights/rebuild-summaries`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: Record<string, unknown> = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/profile-recalculation/[company_id]/rollback/route.ts
+++ b/frontend/app/api/admin/profile-recalculation/[company_id]/rollback/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+function adminHeaders(request: NextRequest) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+}
+
+async function parseResponse(response: Response) {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return response.ok ? { message: raw } : { error: raw }
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ company_id: string }> }
+) {
+  const { company_id } = await params
+  const response = await fetch(`${BACKEND_URL}/api/admin/profile-recalculation/${company_id}/rollback`, {
+    method: 'POST',
+    headers: adminHeaders(request),
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}

--- a/frontend/app/api/admin/profile-recalculation/[company_id]/route.ts
+++ b/frontend/app/api/admin/profile-recalculation/[company_id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+function adminHeaders(request: NextRequest) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+}
+
+async function parseResponse(response: Response) {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return response.ok ? { message: raw } : { error: raw }
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ company_id: string }> }
+) {
+  const { company_id } = await params
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/profile-recalculation/${company_id}`, {
+    method: 'POST',
+    headers: adminHeaders(request),
+    body,
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ company_id: string }> }
+) {
+  const { company_id } = await params
+  const response = await fetch(`${BACKEND_URL}/api/admin/profile-recalculation/${company_id}/history`, {
+    headers: adminHeaders(request),
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}

--- a/frontend/app/api/admin/profile-recalculation/route.ts
+++ b/frontend/app/api/admin/profile-recalculation/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+function adminHeaders(request: NextRequest) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+}
+
+async function parseResponse(response: Response) {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return response.ok ? { message: raw } : { error: raw }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/profile-recalculation`, {
+    method: 'POST',
+    headers: adminHeaders(request),
+    body,
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}

--- a/frontend/app/api/admin/scraper-sessions/[site_key]/route.ts
+++ b/frontend/app/api/admin/scraper-sessions/[site_key]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+function adminHeaders(request: NextRequest) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ site_key: string }> }
+) {
+  const { site_key } = await params
+  const response = await fetch(`${BACKEND_URL}/api/admin/scraper-sessions/${site_key}`, {
+    method: 'DELETE',
+    headers: adminHeaders(request),
+  })
+  if (response.status === 204) {
+    return new NextResponse(null, { status: 204 })
+  }
+  const raw = await response.text()
+  let data: Record<string, unknown> = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/scraper-sessions/route.ts
+++ b/frontend/app/api/admin/scraper-sessions/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+function adminHeaders(request: NextRequest) {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+}
+
+async function parseResponse(response: Response) {
+  const raw = await response.text()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return response.ok ? { message: raw } : { error: raw }
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/scraper-sessions`, {
+    headers: adminHeaders(request),
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  const response = await fetch(`${BACKEND_URL}/api/admin/scraper-sessions`, {
+    method: 'POST',
+    headers: adminHeaders(request),
+    body,
+  })
+  return NextResponse.json(await parseResponse(response), { status: response.status })
+}


### PR DESCRIPTION
## Summary
- `GridLegacy` → `Grid` (MUI v6) に移行（`/admin/page.tsx`）
- ダッシュボードに3つの新規カードを追加: プロファイル再計算、集合知サマリー再構築、スクレイパーセッション管理
- 「近日追加予定」セクションを削除

## 新規ページ
- `/admin/profile-recalculation`: 一括/個別再計算、ロールバック、履歴表示
- `/admin/collective-insights`: バッチサマリー再構築
- `/admin/scraper-sessions`: セッション一覧・追加（Upsert）・削除

## API Route Handlers
- `POST /api/admin/profile-recalculation` (RecalculateAll)
- `POST /api/admin/profile-recalculation/[company_id]` (RecalculateOne)
- `GET /api/admin/profile-recalculation/[company_id]` (GetHistory)
- `POST /api/admin/profile-recalculation/[company_id]/rollback`
- `POST /api/admin/collective-insights/rebuild-summaries`
- `GET/POST /api/admin/scraper-sessions`
- `DELETE /api/admin/scraper-sessions/[site_key]`

## Test plan
- [ ] 管理者ダッシュボードで3つの新規カードが表示されること
- [ ] GridLegacy削除によるレイアウト崩れがないこと
- [ ] プロファイル再計算ページで一括実行が動作すること
- [ ] スクレイパーセッションページでCRUDが動作すること
- [ ] 集合知サマリー再構築が実行できること
- [ ] `npm run build` が正常に完了すること（CI確認）