### PR TITLE
Resolve #518: 管理者機能にOpenAI Web Searchで企業情報を自動取得する処理を追加

### DIFF
--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -23,12 +23,14 @@ type AdminCompanyController struct {
 	audit        ifaces.AuditLogService
 	gbiz         *services.GBizInfoService
 	openaiClient *openai.Client
+	infoFetcher  *services.CompanyInfoFetcher
 }
 
 func NewAdminCompanyController(repo repository.CompanyRepository, audit ifaces.AuditLogService, gbiz *services.GBizInfoService, openaiClient ...*openai.Client) *AdminCompanyController {
 	ctrl := &AdminCompanyController{repo: repo, audit: audit, gbiz: gbiz}
 	if len(openaiClient) > 0 {
 		ctrl.openaiClient = openaiClient[0]
+		ctrl.infoFetcher = services.NewCompanyInfoFetcher(repo, openaiClient[0])
 	}
 	return ctrl
 }
@@ -353,6 +355,30 @@ func (c *AdminCompanyController) FetchTechStack(ctx echo.Context) error {
 		"cicd_tools":        result.CicdTools,
 		"development_style": result.DevelopmentStyle,
 	})
+}
+
+// FetchCompanyInfo POST /api/admin/companies/:id/fetch-info
+// 企業IDからOpenAI WebSearchで基本情報を取得してDBに反映する
+func (c *AdminCompanyController) FetchCompanyInfo(ctx echo.Context) error {
+	id, err := strconv.ParseUint(ctx.Param("id"), 10, 32)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid company id")
+	}
+	if c.infoFetcher == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "openai client not configured")
+	}
+
+	result, err := c.infoFetcher.FetchAndSave(ctx.Request().Context(), uint(id))
+	if err != nil {
+		return echoInternalError(err)
+	}
+
+	actor := ctx.Request().Header.Get("X-Admin-Email")
+	c.audit.Record(actor, "company.fetch_info", "company", uint(id), map[string]any{
+		"industry": result.Industry,
+	})
+
+	return ctx.JSON(http.StatusOK, result)
 }
 
 func applyCompanyDefaults(company *models.Company) {

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -45,6 +45,7 @@ func SetupAdminRoutes(
 	admin.GET("/companies/:id/gbiz-search", adminCompanyController.SearchGBiz)
 	admin.POST("/companies/:id/gbiz-sync", adminCompanyController.SyncGBiz)
 	admin.POST("/companies/:id/fetch-tech-stack", adminCompanyController.FetchTechStack)
+	admin.POST("/companies/:id/fetch-info", adminCompanyController.FetchCompanyInfo)
 
 	// クロールソース管理
 	admin.GET("/crawl-sources", adminCrawlController.ListSources)

--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"Backend/domain/repository"
+	"Backend/internal/openai"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CompanyInfoResult はWebSearchで取得した企業基本情報。
+type CompanyInfoResult struct {
+	Description   string `json:"description"`
+	Industry      string `json:"industry"`
+	Location      string `json:"location"`
+	WebsiteURL    string `json:"website_url"`
+	FoundedYear   int    `json:"founded_year"`
+	EmployeeCount int    `json:"employee_count"`
+	MainBusiness  string `json:"main_business"`
+	Culture       string `json:"culture"`
+	WorkStyle     string `json:"work_style"`
+}
+
+// CompanyInfoFetcher はOpenAI WebSearchを使って企業基本情報を取得・保存するサービス。
+type CompanyInfoFetcher struct {
+	repo         repository.CompanyRepository
+	openaiClient *openai.Client
+}
+
+func NewCompanyInfoFetcher(repo repository.CompanyRepository, client *openai.Client) *CompanyInfoFetcher {
+	return &CompanyInfoFetcher{repo: repo, openaiClient: client}
+}
+
+// FetchAndSave は指定企業のWebSearch情報を取得してDBに保存し、取得結果を返す。
+// 取得失敗時は既存データを変更しない。
+func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint) (*CompanyInfoResult, error) {
+	company, err := f.repo.FindByID(companyID)
+	if err != nil {
+		return nil, fmt.Errorf("company not found: %w", err)
+	}
+
+	prompt := fmt.Sprintf(
+		`「%s」という企業の情報を調査してください。以下のJSON形式のみで回答してください（余分な説明は不要）。
+{
+  "description": "企業概要（100〜200文字程度）",
+  "industry": "業種（例: IT・ソフトウェア, 金融, 製造業）",
+  "location": "本社所在地（例: 東京都渋谷区）",
+  "website_url": "公式サイトURL（https://から始まる）",
+  "founded_year": 設立年（整数、不明なら0）,
+  "employee_count": 従業員数（整数、不明なら0）,
+  "main_business": "主要事業内容（50〜100文字程度）",
+  "culture": "企業文化・働き方の特徴（50〜100文字程度）",
+  "work_style": "勤務スタイル（リモート / ハイブリッド / オフィス のいずれか、不明なら空文字）"
+}`,
+		company.Name,
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	text, err := f.openaiClient.WebSearchQuery(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("web search failed: %w", err)
+	}
+
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start == -1 || end == -1 || end <= start {
+		return nil, fmt.Errorf("failed to parse web search response: no valid JSON found")
+	}
+
+	var result CompanyInfoResult
+	if err := json.Unmarshal([]byte(text[start:end+1]), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse company info json: %w", err)
+	}
+
+	if result.Description != "" {
+		company.Description = result.Description
+	}
+	if result.Industry != "" {
+		company.Industry = result.Industry
+	}
+	if result.Location != "" {
+		company.Location = result.Location
+	}
+	if result.WebsiteURL != "" {
+		company.WebsiteURL = result.WebsiteURL
+	}
+	if result.FoundedYear > 0 {
+		company.FoundedYear = result.FoundedYear
+	}
+	if result.EmployeeCount > 0 {
+		company.EmployeeCount = result.EmployeeCount
+	}
+	if result.MainBusiness != "" {
+		company.MainBusiness = result.MainBusiness
+	}
+	if result.Culture != "" {
+		company.Culture = result.Culture
+	}
+	if result.WorkStyle != "" {
+		company.WorkStyle = result.WorkStyle
+	}
+
+	if err := f.repo.Update(company); err != nil {
+		return nil, fmt.Errorf("failed to update company: %w", err)
+	}
+
+	return &result, nil
+}

--- a/Backend/test/services/company_info_fetcher_test.go
+++ b/Backend/test/services/company_info_fetcher_test.go
@@ -1,0 +1,181 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"Backend/internal/models"
+	"Backend/internal/openai"
+	"Backend/internal/services"
+	"Backend/test/controllers/mocks"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func makeWebSearchServer(t *testing.T, responseText string, statusCode int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		resp := map[string]any{
+			"output_text": responseText,
+			"usage": map[string]any{
+				"input_tokens":  10,
+				"output_tokens": 5,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func validCompanyInfoJSON() string {
+	return `{"description":"テスト企業の概要","industry":"IT・ソフトウェア","location":"東京都渋谷区","website_url":"https://example.com","founded_year":2010,"employee_count":500,"main_business":"クラウドサービスの開発","culture":"フラットな組織文化","work_style":"ハイブリッド"}`
+}
+
+func TestCompanyInfoFetcher_FetchAndSave(t *testing.T) {
+	baseCompany := func() *models.Company {
+		return &models.Company{
+			ID:          1,
+			Name:        "テスト株式会社",
+			Description: "旧概要",
+			Industry:    "製造業",
+		}
+	}
+
+	tests := []struct {
+		name           string
+		setupMock      func(*mocks.CompanyRepositoryMock)
+		serverResponse string
+		serverStatus   int
+		wantErr        bool
+		wantErrContain string
+		checkResult    func(*testing.T, *services.CompanyInfoResult)
+	}{
+		{
+			name: "正常系: 全フィールドが更新される",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				m.On("FindByID", uint(1)).Return(baseCompany(), nil)
+				m.On("Update", mock.AnythingOfType("*models.Company")).Return(nil)
+			},
+			serverResponse: validCompanyInfoJSON(),
+			serverStatus:   http.StatusOK,
+			wantErr:        false,
+			checkResult: func(t *testing.T, r *services.CompanyInfoResult) {
+				assert.Equal(t, "テスト企業の概要", r.Description)
+				assert.Equal(t, "IT・ソフトウェア", r.Industry)
+				assert.Equal(t, "東京都渋谷区", r.Location)
+				assert.Equal(t, "https://example.com", r.WebsiteURL)
+				assert.Equal(t, 2010, r.FoundedYear)
+				assert.Equal(t, 500, r.EmployeeCount)
+				assert.Equal(t, "クラウドサービスの開発", r.MainBusiness)
+				assert.Equal(t, "フラットな組織文化", r.Culture)
+				assert.Equal(t, "ハイブリッド", r.WorkStyle)
+			},
+		},
+		{
+			name: "正常系: レスポンスに余分なテキストが含まれていてもJSONを抽出できる",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				m.On("FindByID", uint(1)).Return(baseCompany(), nil)
+				m.On("Update", mock.AnythingOfType("*models.Company")).Return(nil)
+			},
+			serverResponse: "こちらが企業情報です：\n" + validCompanyInfoJSON() + "\n以上です。",
+			serverStatus:   http.StatusOK,
+			wantErr:        false,
+			checkResult: func(t *testing.T, r *services.CompanyInfoResult) {
+				assert.Equal(t, "テスト企業の概要", r.Description)
+				assert.Equal(t, "IT・ソフトウェア", r.Industry)
+			},
+		},
+		{
+			name: "正常系: 空文字フィールドは既存データを上書きしない",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				c := baseCompany()
+				c.Industry = "既存業種"
+				m.On("FindByID", uint(1)).Return(c, nil)
+				m.On("Update", mock.AnythingOfType("*models.Company")).Return(nil)
+			},
+			serverResponse: `{"description":"新概要","industry":"","location":"","website_url":"","founded_year":0,"employee_count":0,"main_business":"","culture":"","work_style":""}`,
+			serverStatus:   http.StatusOK,
+			wantErr:        false,
+			checkResult: func(t *testing.T, r *services.CompanyInfoResult) {
+				assert.Equal(t, "新概要", r.Description)
+				assert.Equal(t, "", r.Industry)
+			},
+		},
+		{
+			name: "異常系: 企業が見つからない場合はエラー",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				m.On("FindByID", uint(99)).Return(nil, errors.New("record not found"))
+			},
+			serverResponse: validCompanyInfoJSON(),
+			serverStatus:   http.StatusOK,
+			wantErr:        true,
+			wantErrContain: "company not found",
+		},
+		{
+			name: "異常系: WebSearchが不正なJSONを返した場合はエラー",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				m.On("FindByID", uint(1)).Return(baseCompany(), nil)
+			},
+			serverResponse: "JSONではないテキスト",
+			serverStatus:   http.StatusOK,
+			wantErr:        true,
+			wantErrContain: "failed to parse web search response",
+		},
+		{
+			name: "異常系: DB更新が失敗した場合はエラー",
+			setupMock: func(m *mocks.CompanyRepositoryMock) {
+				m.On("FindByID", uint(1)).Return(baseCompany(), nil)
+				m.On("Update", mock.AnythingOfType("*models.Company")).Return(errors.New("db error"))
+			},
+			serverResponse: validCompanyInfoJSON(),
+			serverStatus:   http.StatusOK,
+			wantErr:        true,
+			wantErrContain: "failed to update company",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := makeWebSearchServer(t, tc.serverResponse, tc.serverStatus)
+			defer srv.Close()
+
+			repo := &mocks.CompanyRepositoryMock{}
+			tc.setupMock(repo)
+
+			client := openai.NewWithBaseURL(srv.URL, "gpt-4o-search-preview")
+			fetcher := services.NewCompanyInfoFetcher(repo, client)
+
+			companyID := uint(1)
+			if tc.wantErrContain == "company not found" {
+				companyID = 99
+			}
+
+			result, err := fetcher.FetchAndSave(context.Background(), companyID)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContain != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContain)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tc.checkResult != nil {
+				tc.checkResult(t, result)
+			}
+		})
+	}
+}

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -6,7 +6,11 @@ import {
   Alert,
   Box,
   Button,
+  Card,
+  CardContent,
   Chip,
+  CircularProgress,
+  Collapse,
   Divider,
   MenuItem,
   Stack,
@@ -16,6 +20,18 @@ import {
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
+
+type CompanyInfoResult = {
+  description: string
+  industry: string
+  location: string
+  website_url: string
+  founded_year: number
+  employee_count: number
+  main_business: string
+  culture: string
+  work_style: string
+}
 
 const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
 
@@ -83,6 +99,8 @@ export default function AdminCompanyEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
+  const [infoLoading, setInfoLoading] = useState(false)
+  const [infoPreview, setInfoPreview] = useState<CompanyInfoResult | null>(null)
   const [name, setName] = useState('')
   const [techStack, setTechStack] = useState<string[]>([])
   const [infraStack, setInfraStack] = useState<string[]>([])
@@ -104,6 +122,28 @@ export default function AdminCompanyEditPage() {
       })
       .catch(() => setError('企業情報の取得に失敗しました'))
   }, [id])
+
+  const handleFetchInfo = async () => {
+    setInfoLoading(true)
+    setError('')
+    setInfoPreview(null)
+    try {
+      const res = await fetch(`/api/admin/companies/${id}/fetch-info`, {
+        method: 'POST',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        setError(d?.message || '企業情報の自動取得に失敗しました')
+        return
+      }
+      const data: CompanyInfoResult = await res.json()
+      setInfoPreview(data)
+      setSuccess('企業基本情報を取得してDBに保存しました')
+    } finally {
+      setInfoLoading(false)
+    }
+  }
 
   const handleAiFill = async () => {
     setAiLoading(true)
@@ -181,6 +221,66 @@ export default function AdminCompanyEditPage() {
       </Box>
 
       <Stack spacing={3}>
+        <Box sx={{ p: 2, bgcolor: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: 2 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#14532d', mb: 1 }}>
+            企業基本情報の自動取得
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: '#166534', mb: 2 }}>
+            OpenAI Web Searchで企業概要・業種・所在地・公式URL・事業内容などを取得してDBに保存します。
+          </Typography>
+          <Button
+            variant="contained"
+            color="success"
+            onClick={handleFetchInfo}
+            disabled={infoLoading}
+            startIcon={infoLoading ? <CircularProgress size={16} color="inherit" /> : undefined}
+            sx={{ mb: 2 }}
+          >
+            {infoLoading ? '取得中...' : '🔍 企業基本情報を自動取得'}
+          </Button>
+
+          <Collapse in={infoPreview !== null}>
+            {infoPreview && (
+              <Card variant="outlined" sx={{ mt: 1 }}>
+                <CardContent>
+                  <Typography variant="subtitle2" sx={{ mb: 1, color: '#166534' }}>取得結果プレビュー（DB保存済み）</Typography>
+                  <Stack spacing={0.5}>
+                    {infoPreview.description && (
+                      <Typography variant="body2"><strong>概要:</strong> {infoPreview.description}</Typography>
+                    )}
+                    {infoPreview.industry && (
+                      <Typography variant="body2"><strong>業種:</strong> {infoPreview.industry}</Typography>
+                    )}
+                    {infoPreview.location && (
+                      <Typography variant="body2"><strong>所在地:</strong> {infoPreview.location}</Typography>
+                    )}
+                    {infoPreview.website_url && (
+                      <Typography variant="body2"><strong>公式URL:</strong> <a href={infoPreview.website_url} target="_blank" rel="noopener noreferrer">{infoPreview.website_url}</a></Typography>
+                    )}
+                    {infoPreview.founded_year > 0 && (
+                      <Typography variant="body2"><strong>設立年:</strong> {infoPreview.founded_year}年</Typography>
+                    )}
+                    {infoPreview.employee_count > 0 && (
+                      <Typography variant="body2"><strong>従業員数:</strong> {infoPreview.employee_count.toLocaleString()}名</Typography>
+                    )}
+                    {infoPreview.main_business && (
+                      <Typography variant="body2"><strong>主要事業:</strong> {infoPreview.main_business}</Typography>
+                    )}
+                    {infoPreview.culture && (
+                      <Typography variant="body2"><strong>企業文化:</strong> {infoPreview.culture}</Typography>
+                    )}
+                    {infoPreview.work_style && (
+                      <Typography variant="body2"><strong>勤務スタイル:</strong> {infoPreview.work_style}</Typography>
+                    )}
+                  </Stack>
+                </CardContent>
+              </Card>
+            )}
+          </Collapse>
+        </Box>
+
+        <Divider />
+
         <Button
           variant="contained"
           color="secondary"


### PR DESCRIPTION
Closes #518

## 変更内容

### Backend (Go)

- **`internal/services/company_info_fetcher.go`** — 新規サービス `CompanyInfoFetcher` を追加
  - 企業IDを受け取りDBから企業名を取得 → OpenAI Web Search APIを呼び出し → 取得結果をDBに保存する `FetchAndSave` メソッドを実装
  - 空フィールドは既存データを上書きしない安全設計（取得失敗時はDB変更なし）
  - 取得対象: 会社概要・業種・所在地・公式URL・設立年・従業員数・主要事業・企業文化・勤務スタイル

- **`internal/controllers/admin_company_controller.go`** — `FetchCompanyInfo` ハンドラを追加
  - `POST /admin/companies/:id/fetch-info` エンドポイントを実装
  - OpenAI クライアント未設定時は `503 Service Unavailable` を返す
  - 実行後に監査ログ（`company.fetch_info`）を記録

- **`internal/routes/admin_routes.go`** — 新ルートを登録
  - `admin.POST("/companies/:id/fetch-info", adminCompanyController.FetchCompanyInfo)`

- **`test/services/company_info_fetcher_test.go`** — テーブル駆動テスト6件を追加
  - 正常系3件: 全フィールド更新 / 余分テキスト付きJSONの抽出 / 空フィールドは既存データを保持
  - 異常系3件: 企業未発見エラー / 不正JSONレスポンスエラー / DB更新失敗エラー

### Frontend (Next.js)

- **`app/admin/companies/[id]/edit/page.tsx`** — 企業編集ページに自動取得UIを追加
  - 「企業基本情報を自動取得」ボタンを設置（OpenAI Web Search実行）
  - 取得中はローディングスピナーを表示
  - 取得完了後、DB保存済みの内容をプレビューカードで表示（概要・業種・所在地・URL・設立年・従業員数・事業内容・企業文化・勤務スタイル）
  - 取得失敗時はエラーメッセージを表示し既存データを保持

## 受け入れ条件の対応

- ✅ 管理者が企業名登録済みの状態で「自動取得」を実行するとWebSearch結果がDBに反映される
- ✅ 取得失敗時はエラーメッセージを表示し既存データを上書きしない
- ✅ APIキー（`OPENAI_API_KEY`）は環境変数経由で管理（ハードコードなし）
- ✅ Go側でテーブル駆動テストを実装