### PR TITLE
Resolve #395: 選考ステータス状態遷移エンジンの実装

### DIFF
--- a/Backend/internal/controllers/application_controller.go
+++ b/Backend/internal/controllers/application_controller.go
@@ -55,9 +55,10 @@ func (c *ApplicationController) UpdateStatus(ctx echo.Context) error {
 	}
 
 	var req struct {
-		UserID uint   `json:"user_id"`
-		Status string `json:"status"`
-		Notes  string `json:"notes"`
+		UserID  uint   `json:"user_id"`
+		Status  string `json:"status"`
+		Notes   string `json:"notes"`
+		IsAdmin bool   `json:"is_admin"`
 	}
 	if err := ctx.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
@@ -66,7 +67,7 @@ func (c *ApplicationController) UpdateStatus(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "user_id と status は必須です")
 	}
 
-	app, err := c.appService.UpdateStatus(uint(id), req.UserID, req.Status, req.Notes)
+	app, err := c.appService.UpdateStatus(uint(id), req.UserID, req.Status, req.Notes, req.IsAdmin)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}

--- a/Backend/internal/services/application_service.go
+++ b/Backend/internal/services/application_service.go
@@ -4,6 +4,7 @@ import (
 	"Backend/domain/entity"
 	"Backend/internal/repositories"
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -20,24 +21,58 @@ func NewApplicationService(
 	return &ApplicationService{appRepo: appRepo, matchRepo: matchRepo}
 }
 
-// ValidStatuses 有効な選考ステータス一覧
+// ValidStatuses 有効な選考ステータス一覧（docs/requirements/application-status-transition.md §6）
 var ValidStatuses = []string{
-	"applied",          // 応募済み
-	"document_passed",  // 書類通過
-	"interview",        // 面接中
-	"offered",          // 内定
-	"accepted",         // 内定承諾
-	"declined",         // 辞退
-	"rejected",         // 不合格
+	"not_applied",           // 未応募
+	"applied",               // 応募済み
+	"document_screening",    // 書類選考中
+	"document_passed",       // 書類通過
+	"interview_scheduled",   // 面接予定
+	"interview_in_progress", // 面接中
+	"offered",               // 内定
+	"accepted",              // 内定承諾（終了状態）
+	"withdrawn",             // 辞退（終了状態）
+	"rejected",              // 不採用（終了状態）
+}
+
+// terminalStatuses 終了状態：原則として通常更新を受け付けない
+var terminalStatuses = map[string]bool{
+	"accepted": true,
+	"withdrawn": true,
+	"rejected":  true,
+}
+
+// userAllowedTransitions ユーザーが実行できる遷移（辞退・内定承諾のみ）
+var userAllowedTransitions = map[string][]string{
+	"applied":               {"withdrawn"},
+	"document_screening":    {"withdrawn"},
+	"document_passed":       {"withdrawn"},
+	"interview_scheduled":   {"withdrawn"},
+	"interview_in_progress": {"withdrawn"},
+	"offered":               {"accepted", "withdrawn"},
+}
+
+// adminAllowedTransitions 管理者が実行できる遷移（ユーザー遷移 + 選考進捗更新）
+var adminAllowedTransitions = map[string][]string{
+	"not_applied":           {"applied"},
+	"applied":               {"document_screening", "withdrawn"},
+	"document_screening":    {"document_passed", "rejected", "withdrawn"},
+	"document_passed":       {"interview_scheduled", "withdrawn"},
+	"interview_scheduled":   {"interview_in_progress", "withdrawn"},
+	"interview_in_progress": {"offered", "rejected", "withdrawn"},
+	"offered":               {"accepted", "withdrawn"},
 }
 
 func isValidStatus(status string) bool {
-	for _, s := range ValidStatuses {
-		if s == status {
-			return true
-		}
+	return slices.Contains(ValidStatuses, status)
+}
+
+// CanTransition 現在のステータスから次のステータスへの遷移が許可されているか検証する
+func CanTransition(current, next string, isAdmin bool) bool {
+	if isAdmin {
+		return slices.Contains(adminAllowedTransitions[current], next)
 	}
-	return false
+	return slices.Contains(userAllowedTransitions[current], next)
 }
 
 // Apply 企業への応募を登録する
@@ -70,18 +105,29 @@ func (s *ApplicationService) Apply(userID, companyID, matchID uint) (*entity.Use
 }
 
 // UpdateStatus 選考ステータスを更新する
-func (s *ApplicationService) UpdateStatus(applicationID uint, userID uint, status, notes string) (*entity.UserApplicationStatus, error) {
+// isAdmin=true の場合は管理者権限の遷移が許可される
+func (s *ApplicationService) UpdateStatus(applicationID uint, userID uint, status, notes string, isAdmin bool) (*entity.UserApplicationStatus, error) {
 	if !isValidStatus(status) {
 		return nil, fmt.Errorf("無効なステータス: %s", status)
 	}
 
-	// 所有権確認
+	// 所有権確認（非管理者は自分の応募のみ更新可能）
 	app, err := s.appRepo.FindByID(applicationID)
 	if err != nil {
 		return nil, fmt.Errorf("応募データが見つかりません: %w", err)
 	}
-	if app.UserID != userID {
+	if !isAdmin && app.UserID != userID {
 		return nil, fmt.Errorf("権限がありません")
+	}
+
+	// 終了状態チェック（管理者による訂正は別エンドポイントで対応予定）
+	if terminalStatuses[app.Status] {
+		return nil, fmt.Errorf("application_already_closed: ステータス %s は終了状態のため更新できません", app.Status)
+	}
+
+	// 状態遷移の検証
+	if !CanTransition(app.Status, status, isAdmin) {
+		return nil, fmt.Errorf("invalid_status_transition: %s から %s への遷移は許可されていません", app.Status, status)
 	}
 
 	if err := s.appRepo.UpdateStatus(applicationID, status, notes); err != nil {

--- a/Backend/internal/services/interfaces/application_service.go
+++ b/Backend/internal/services/interfaces/application_service.go
@@ -4,7 +4,7 @@ import "Backend/domain/entity"
 
 type ApplicationService interface {
 	Apply(userID, companyID, matchID uint) (*entity.UserApplicationStatus, error)
-	UpdateStatus(applicationID uint, userID uint, status, notes string) (*entity.UserApplicationStatus, error)
+	UpdateStatus(applicationID uint, userID uint, status, notes string, isAdmin bool) (*entity.UserApplicationStatus, error)
 	GetApplicationsByUser(userID uint) ([]*entity.UserApplicationStatus, error)
 	GetCorrelation(companyID uint) ([]map[string]any, error)
 }

--- a/Backend/test/controllers/application_controller_test.go
+++ b/Backend/test/controllers/application_controller_test.go
@@ -127,10 +127,10 @@ func TestApplicationController_UpdateStatus_MissingFields(t *testing.T) {
 
 func TestApplicationController_UpdateStatus_Success(t *testing.T) {
 	svc := &mocks.ApplicationServiceMock{}
-	app := &entity.UserApplicationStatus{Status: "interview", Notes: "通過"}
-	svc.On("UpdateStatus", uint(1), uint(1), "interview", "通過").Return(app, nil)
+	app := &entity.UserApplicationStatus{Status: "interview_in_progress", Notes: "通過"}
+	svc.On("UpdateStatus", uint(1), uint(1), "interview_in_progress", "通過", false).Return(app, nil)
 
-	body, _ := json.Marshal(map[string]any{"user_id": 1, "status": "interview", "notes": "通過"})
+	body, _ := json.Marshal(map[string]any{"user_id": 1, "status": "interview_in_progress", "notes": "通過"})
 	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -141,7 +141,23 @@ func TestApplicationController_UpdateStatus_Success(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, "interview", resp["status"])
+	assert.Equal(t, "interview_in_progress", resp["status"])
+	svc.AssertExpectations(t)
+}
+
+func TestApplicationController_UpdateStatus_AdminSuccess(t *testing.T) {
+	svc := &mocks.ApplicationServiceMock{}
+	app := &entity.UserApplicationStatus{Status: "document_screening", Notes: "書類選考開始"}
+	svc.On("UpdateStatus", uint(1), uint(1), "document_screening", "書類選考開始", true).Return(app, nil)
+
+	body, _ := json.Marshal(map[string]any{"user_id": 1, "status": "document_screening", "notes": "書類選考開始", "is_admin": true})
+	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, newApplicationController(svc).UpdateStatus, c, http.StatusOK)
 	svc.AssertExpectations(t)
 }
 

--- a/Backend/test/controllers/mocks/application_service_mock.go
+++ b/Backend/test/controllers/mocks/application_service_mock.go
@@ -18,8 +18,8 @@ func (m *ApplicationServiceMock) Apply(userID, companyID, matchID uint) (*entity
 	return args.Get(0).(*entity.UserApplicationStatus), args.Error(1)
 }
 
-func (m *ApplicationServiceMock) UpdateStatus(applicationID uint, userID uint, status, notes string) (*entity.UserApplicationStatus, error) {
-	args := m.Called(applicationID, userID, status, notes)
+func (m *ApplicationServiceMock) UpdateStatus(applicationID uint, userID uint, status, notes string, isAdmin bool) (*entity.UserApplicationStatus, error) {
+	args := m.Called(applicationID, userID, status, notes, isAdmin)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/Backend/test/services/application_service_test.go
+++ b/Backend/test/services/application_service_test.go
@@ -1,0 +1,130 @@
+package services_test
+
+// ApplicationServiceの状態遷移エンジンテスト
+//
+// 実行: cd Backend && go test ./test/services/... -run Application -v
+
+import (
+	"testing"
+
+	"Backend/internal/services"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---- ValidStatuses ----
+
+func TestApplicationService_ValidStatuses_ContainsExpected(t *testing.T) {
+	expected := []string{
+		"not_applied",
+		"applied",
+		"document_screening",
+		"document_passed",
+		"interview_scheduled",
+		"interview_in_progress",
+		"offered",
+		"accepted",
+		"withdrawn",
+		"rejected",
+	}
+	for _, s := range expected {
+		assert.Contains(t, services.ValidStatuses, s, "ValidStatuses に %s が含まれていない", s)
+	}
+}
+
+func TestApplicationService_ValidStatuses_DoesNotContainLegacy(t *testing.T) {
+	legacy := []string{"interview", "declined"}
+	for _, s := range legacy {
+		assert.NotContains(t, services.ValidStatuses, s, "ValidStatuses に廃止ステータス %s が含まれている", s)
+	}
+}
+
+// ---- canTransition (exported via CanTransition for testing) ----
+// サービス内部の canTransition を間接検証するため UpdateStatus のロジックを
+// テーブル駆動テストで網羅する。
+
+type transitionCase struct {
+	name    string
+	current string
+	next    string
+	isAdmin bool
+	allowed bool
+}
+
+func TestCanTransition_UserTransitions(t *testing.T) {
+	cases := []transitionCase{
+		// 許可: ユーザーによる辞退
+		{"applied→withdrawn", "applied", "withdrawn", false, true},
+		{"document_screening→withdrawn", "document_screening", "withdrawn", false, true},
+		{"document_passed→withdrawn", "document_passed", "withdrawn", false, true},
+		{"interview_scheduled→withdrawn", "interview_scheduled", "withdrawn", false, true},
+		{"interview_in_progress→withdrawn", "interview_in_progress", "withdrawn", false, true},
+		{"offered→withdrawn", "offered", "withdrawn", false, true},
+		// 許可: ユーザーによる内定承諾
+		{"offered→accepted", "offered", "accepted", false, true},
+		// 禁止: ユーザーは選考進捗を進められない
+		{"applied→document_screening (user)", "applied", "document_screening", false, false},
+		{"document_screening→document_passed (user)", "document_screening", "document_passed", false, false},
+		{"document_passed→interview_scheduled (user)", "document_passed", "interview_scheduled", false, false},
+		{"interview_scheduled→interview_in_progress (user)", "interview_scheduled", "interview_in_progress", false, false},
+		{"interview_in_progress→offered (user)", "interview_in_progress", "offered", false, false},
+		{"interview_in_progress→rejected (user)", "interview_in_progress", "rejected", false, false},
+		// 禁止: 後戻り
+		{"document_passed→applied (user)", "document_passed", "applied", false, false},
+		{"offered→applied (user)", "offered", "applied", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := services.CanTransition(tc.current, tc.next, tc.isAdmin)
+			assert.Equal(t, tc.allowed, got)
+		})
+	}
+}
+
+func TestCanTransition_AdminTransitions(t *testing.T) {
+	cases := []transitionCase{
+		// 許可: 管理者による選考進捗
+		{"not_applied→applied (admin)", "not_applied", "applied", true, true},
+		{"applied→document_screening (admin)", "applied", "document_screening", true, true},
+		{"document_screening→document_passed (admin)", "document_screening", "document_passed", true, true},
+		{"document_screening→rejected (admin)", "document_screening", "rejected", true, true},
+		{"document_passed→interview_scheduled (admin)", "document_passed", "interview_scheduled", true, true},
+		{"interview_scheduled→interview_in_progress (admin)", "interview_scheduled", "interview_in_progress", true, true},
+		{"interview_in_progress→offered (admin)", "interview_in_progress", "offered", true, true},
+		{"interview_in_progress→rejected (admin)", "interview_in_progress", "rejected", true, true},
+		// 許可: 管理者による辞退・承諾
+		{"applied→withdrawn (admin)", "applied", "withdrawn", true, true},
+		{"offered→accepted (admin)", "offered", "accepted", true, true},
+		// 禁止: offered→rejected は直接遷移禁止（要件定義 §7.2 R-4）
+		{"offered→rejected (admin)", "offered", "rejected", true, false},
+		// 禁止: 後戻り
+		{"document_screening→applied (admin)", "document_screening", "applied", true, false},
+		{"offered→applied (admin)", "offered", "applied", true, false},
+		// 禁止: 終了状態からの遷移（通常更新）
+		{"accepted→applied (admin)", "accepted", "applied", true, false},
+		{"withdrawn→applied (admin)", "withdrawn", "applied", true, false},
+		{"rejected→applied (admin)", "rejected", "applied", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := services.CanTransition(tc.current, tc.next, tc.isAdmin)
+			assert.Equal(t, tc.allowed, got)
+		})
+	}
+}
+
+func TestCanTransition_TerminalStatuses(t *testing.T) {
+	// 終了状態からはユーザー・管理者とも通常遷移不可
+	terminals := []string{"accepted", "withdrawn", "rejected"}
+	nexts := []string{"applied", "document_screening", "offered", "accepted"}
+	for _, terminal := range terminals {
+		for _, next := range nexts {
+			t.Run(terminal+"→"+next, func(t *testing.T) {
+				assert.False(t, services.CanTransition(terminal, next, false))
+				assert.False(t, services.CanTransition(terminal, next, true))
+			})
+		}
+	}
+}


### PR DESCRIPTION
Closes #395

## 変更内容

### 選考ステータスコードの修正
- `ValidStatuses` を要件定義書（`docs/requirements/application-status-transition.md`）準拠に更新
  - `interview` → `interview_scheduled` / `interview_in_progress` に分割
  - `declined` → `withdrawn` に変更
  - `not_applied` を追加

### State Machine（状態遷移エンジン）の追加
- `CanTransition(current, next string, isAdmin bool) bool` を新規実装
- ユーザー許可遷移テーブル（`userAllowedTransitions`）
  - 辞退（`withdrawn`）と内定承諾（`accepted`）のみ許可
- 管理者許可遷移テーブル（`adminAllowedTransitions`）
  - 選考進捗全般（書類選考・面接・内定・不採用）を許可
  - `offered → rejected` の直接遷移は禁止（要件定義 §7.2 R-4 準拠）

### `UpdateStatus()` の強化
- 終了状態チェック（`accepted` / `withdrawn` / `rejected` → `application_already_closed` エラー）
- 状態遷移の検証（許可されていない遷移 → `invalid_status_transition` エラー）
- `isAdmin bool` パラメータを追加してユーザー/管理者の権限を分離
- 非管理者は自分の応募のみ更新可能な所有権チェックを維持

### インターフェース・コントローラー更新
- `ApplicationService` インターフェースに `isAdmin bool` を追加
- コントローラーのリクエストボディに `is_admin` フィールドを追加

### テスト追加（`Backend/test/services/application_service_test.go`）
- `TestApplicationService_ValidStatuses_ContainsExpected` : 新ステータスコードの網羅確認
- `TestApplicationService_ValidStatuses_DoesNotContainLegacy` : 廃止コードの排除確認
- `TestCanTransition_UserTransitions` : ユーザー許可・禁止遷移 15 ケース
- `TestCanTransition_AdminTransitions` : 管理者許可・禁止遷移 16 ケース
- `TestCanTransition_TerminalStatuses` : 終了状態からの全遷移禁止 12 ケース（合計 43 テストケース全 PASS）

### コントローラーテスト更新
- `UpdateStatus` のモック呼び出しに `isAdmin` パラメータを追加
- `TestApplicationController_UpdateStatus_AdminSuccess` を新規追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 選考ステータス更新時に管理者かどうかを判定し、権限に応じた更新操作ができるようになりました。
  * ステータス遷移ルールが整理され、許可される更新範囲がより明確になりました。

* **不具合修正**
  * 終了済みの選考ステータスに対する更新が行われないようになりました。
  * 旧式のステータスが更新対象に含まれないように調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->