### PR TITLE
Resolve #563: 応募・選考APIの認証認可と選考管理の未ログインUX修正

### DIFF
--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -330,7 +330,7 @@ func main() {
 	routes.SetupESRoutes(api, esRewriteController, esReviewController)
 	routes.SetupScheduleRoutes(api, scheduleController)
 	routes.SetupGoogleCalendarRoutes(api, googleCalendarController, cfg.UserSecret)
-	routes.SetupApplicationRoutes(api, appController)
+	routes.SetupApplicationRoutes(api, appController, cfg.UserSecret)
 	routes.SetupUserRoutes(api, integratedProfileController)
 	routes.SetupCollectiveInsightRoutes(api, collectiveInsightController, cfg.UserSecret)
 	api.POST("/company-entry", companyEntryController.Submit)

--- a/Backend/internal/controllers/application_controller.go
+++ b/Backend/internal/controllers/application_controller.go
@@ -19,19 +19,24 @@ func NewApplicationController(appService interfaces.ApplicationService) *Applica
 
 // Apply POST /api/applications - 企業への応募登録
 func (c *ApplicationController) Apply(ctx echo.Context) error {
+	userID, ok := echoUserID(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証が必要です")
+	}
+
 	var req struct {
-		UserID    uint `json:"user_id"`
+		UserID    uint `json:"user_id"` // 互換のため受け取るが無視する
 		CompanyID uint `json:"company_id"`
 		MatchID   uint `json:"match_id"`
 	}
 	if err := ctx.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
-	if req.UserID == 0 || req.CompanyID == 0 || req.MatchID == 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "user_id, company_id, match_id は必須です")
+	if req.CompanyID == 0 || req.MatchID == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "company_id, match_id は必須です")
 	}
 
-	app, err := c.appService.Apply(req.UserID, req.CompanyID, req.MatchID)
+	app, err := c.appService.Apply(userID, req.CompanyID, req.MatchID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -48,6 +53,11 @@ func (c *ApplicationController) Apply(ctx echo.Context) error {
 
 // UpdateStatus PUT /api/applications/{id} - 選考ステータス更新
 func (c *ApplicationController) UpdateStatus(ctx echo.Context) error {
+	userID, ok := echoUserID(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証が必要です")
+	}
+
 	idStr := ctx.Param("id")
 	id, err := strconv.ParseUint(idStr, 10, 64)
 	if err != nil || id == 0 {
@@ -55,19 +65,19 @@ func (c *ApplicationController) UpdateStatus(ctx echo.Context) error {
 	}
 
 	var req struct {
-		UserID  uint   `json:"user_id"`
+		UserID  uint   `json:"user_id"` // 互換のため受け取るが無視する
 		Status  string `json:"status"`
 		Notes   string `json:"notes"`
-		IsAdmin bool   `json:"is_admin"`
+		IsAdmin bool   `json:"is_admin"` // クライアント指定は無視（権限昇格防止）
 	}
 	if err := ctx.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
-	if req.UserID == 0 || req.Status == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "user_id と status は必須です")
+	if req.Status == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "status は必須です")
 	}
 
-	app, err := c.appService.UpdateStatus(uint(id), req.UserID, req.Status, req.Notes, req.IsAdmin)
+	app, err := c.appService.UpdateStatus(uint(id), userID, req.Status, req.Notes, false)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -79,27 +89,26 @@ func (c *ApplicationController) UpdateStatus(ctx echo.Context) error {
 	})
 }
 
-// List GET /api/applications?user_id=X - ユーザーの応募一覧取得
+// List GET /api/applications - 認証ユーザーの応募一覧取得
 func (c *ApplicationController) List(ctx echo.Context) error {
-	userIDStr := ctx.QueryParam("user_id")
-	userID, err := strconv.ParseUint(userIDStr, 10, 64)
-	if err != nil || userID == 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "user_id は必須です")
+	userID, ok := echoUserID(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証が必要です")
 	}
 
-	apps, err := c.appService.GetApplicationsByUser(uint(userID))
+	apps, err := c.appService.GetApplicationsByUser(userID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "データ取得エラー")
 	}
 
 	type AppResponse struct {
-		ID              uint        `json:"id"`
-		CompanyID       uint        `json:"company_id"`
-		CompanyName     string      `json:"company_name"`
-		CompanyIndustry string      `json:"company_industry"`
-		MatchID         uint        `json:"match_id"`
-		Status          string      `json:"status"`
-		Notes           string      `json:"notes"`
+		ID              uint `json:"id"`
+		CompanyID       uint `json:"company_id"`
+		CompanyName     string `json:"company_name"`
+		CompanyIndustry string `json:"company_industry"`
+		MatchID         uint `json:"match_id"`
+		Status          string `json:"status"`
+		Notes           string `json:"notes"`
 		AppliedAt       any `json:"applied_at"`
 		StatusUpdatedAt any `json:"status_updated_at"`
 	}
@@ -133,6 +142,10 @@ func (c *ApplicationController) List(ctx echo.Context) error {
 
 // GetCorrelation GET /api/applications/correlation?company_id=X - 相関分析データ取得
 func (c *ApplicationController) GetCorrelation(ctx echo.Context) error {
+	if _, ok := echoUserID(ctx); !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "認証が必要です")
+	}
+
 	companyIDStr := ctx.QueryParam("company_id")
 	var companyID uint
 	if companyIDStr != "" {

--- a/Backend/internal/routes/application_routes.go
+++ b/Backend/internal/routes/application_routes.go
@@ -7,8 +7,8 @@ import (
 )
 
 // SetupApplicationRoutes 応募・選考ステータス管理のルーティング設定
-func SetupApplicationRoutes(api *echo.Group, appController *controllers.ApplicationController) {
-	applications := api.Group("/applications")
+func SetupApplicationRoutes(api *echo.Group, appController *controllers.ApplicationController, userSecret string) {
+	applications := api.Group("/applications", EchoUserAuth(userSecret))
 	// POST /api/applications       → 応募登録
 	// GET  /api/applications       → 応募一覧取得
 	applications.POST("", appController.Apply)

--- a/Backend/test/controllers/application_controller_test.go
+++ b/Backend/test/controllers/application_controller_test.go
@@ -27,9 +27,17 @@ func newApplicationController(svc *mocks.ApplicationServiceMock) *controllers.Ap
 
 // ---- Apply ----
 
+func TestApplicationController_Apply_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/applications", bytes.NewBufferString(`{"company_id":1,"match_id":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	assertStatus(t, controllers.NewApplicationController(nil).Apply, newCtx(req, rec), http.StatusUnauthorized)
+}
+
 func TestApplicationController_Apply_InvalidBody(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/applications", bytes.NewBufferString("invalid json"))
 	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, controllers.NewApplicationController(nil).Apply, newCtx(req, rec), http.StatusBadRequest)
 }
@@ -39,15 +47,15 @@ func TestApplicationController_Apply_MissingFields(t *testing.T) {
 		name string
 		body map[string]any
 	}{
-		{"user_id=0", map[string]any{"user_id": 0, "company_id": 1, "match_id": 1}},
-		{"company_id=0", map[string]any{"user_id": 1, "company_id": 0, "match_id": 1}},
-		{"match_id=0", map[string]any{"user_id": 1, "company_id": 1, "match_id": 0}},
+		{"company_id=0", map[string]any{"company_id": 0, "match_id": 1}},
+		{"match_id=0", map[string]any{"company_id": 1, "match_id": 0}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			body, _ := json.Marshal(tc.body)
 			req := httptest.NewRequest(http.MethodPost, "/api/applications", bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
+			req = withUserID(req, 1)
 			rec := httptest.NewRecorder()
 			assertStatus(t, controllers.NewApplicationController(nil).Apply, newCtx(req, rec), http.StatusBadRequest)
 		})
@@ -58,9 +66,10 @@ func TestApplicationController_Apply_ServiceError(t *testing.T) {
 	svc := &mocks.ApplicationServiceMock{}
 	svc.On("Apply", uint(1), uint(2), uint(3)).Return(nil, errors.New("already applied"))
 
-	body, _ := json.Marshal(map[string]any{"user_id": 1, "company_id": 2, "match_id": 3})
+	body, _ := json.Marshal(map[string]any{"user_id": 999, "company_id": 2, "match_id": 3})
 	req := httptest.NewRequest(http.MethodPost, "/api/applications", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, newApplicationController(svc).Apply, newCtx(req, rec), http.StatusBadRequest)
 	svc.AssertExpectations(t)
@@ -72,9 +81,11 @@ func TestApplicationController_Apply_Success(t *testing.T) {
 	app := &entity.UserApplicationStatus{UserID: 1, CompanyID: 2, MatchID: 3, Status: "applied", AppliedAt: &now}
 	svc.On("Apply", uint(1), uint(2), uint(3)).Return(app, nil)
 
-	body, _ := json.Marshal(map[string]any{"user_id": 1, "company_id": 2, "match_id": 3})
+	// body の user_id は無視され、認証ユーザーIDが使われる
+	body, _ := json.Marshal(map[string]any{"user_id": 999, "company_id": 2, "match_id": 3})
 	req := httptest.NewRequest(http.MethodPost, "/api/applications", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, newApplicationController(svc).Apply, newCtx(req, rec), http.StatusCreated)
 
@@ -86,6 +97,17 @@ func TestApplicationController_Apply_Success(t *testing.T) {
 
 // ---- UpdateStatus ----
 
+func TestApplicationController_UpdateStatus_Unauthorized(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"status": "interview"})
+	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, controllers.NewApplicationController(nil).UpdateStatus, c, http.StatusUnauthorized)
+}
+
 func TestApplicationController_UpdateStatus_InvalidID(t *testing.T) {
 	tests := []struct{ name, id string }{
 		{"non-numeric", "abc"},
@@ -94,6 +116,7 @@ func TestApplicationController_UpdateStatus_InvalidID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPut, "/api/applications/"+tc.id, nil)
+			req = withUserID(req, 1)
 			rec := httptest.NewRecorder()
 			c := newCtx(req, rec)
 			c.SetParamNames("id")
@@ -104,25 +127,15 @@ func TestApplicationController_UpdateStatus_InvalidID(t *testing.T) {
 }
 
 func TestApplicationController_UpdateStatus_MissingFields(t *testing.T) {
-	tests := []struct {
-		name string
-		body map[string]any
-	}{
-		{"user_id=0", map[string]any{"user_id": 0, "status": "applied"}},
-		{"status empty", map[string]any{"user_id": 1, "status": ""}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			body, _ := json.Marshal(tc.body)
-			req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
-			req.Header.Set("Content-Type", "application/json")
-			rec := httptest.NewRecorder()
-			c := newCtx(req, rec)
-			c.SetParamNames("id")
-			c.SetParamValues("1")
-			assertStatus(t, controllers.NewApplicationController(nil).UpdateStatus, c, http.StatusBadRequest)
-		})
-	}
+	body, _ := json.Marshal(map[string]any{"status": ""})
+	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
+	rec := httptest.NewRecorder()
+	c := newCtx(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+	assertStatus(t, controllers.NewApplicationController(nil).UpdateStatus, c, http.StatusBadRequest)
 }
 
 func TestApplicationController_UpdateStatus_Success(t *testing.T) {
@@ -130,9 +143,10 @@ func TestApplicationController_UpdateStatus_Success(t *testing.T) {
 	app := &entity.UserApplicationStatus{Status: "interview_in_progress", Notes: "通過"}
 	svc.On("UpdateStatus", uint(1), uint(1), "interview_in_progress", "通過", false).Return(app, nil)
 
-	body, _ := json.Marshal(map[string]any{"user_id": 1, "status": "interview_in_progress", "notes": "通過"})
+	body, _ := json.Marshal(map[string]any{"user_id": 999, "status": "interview_in_progress", "notes": "通過"})
 	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	c := newCtx(req, rec)
 	c.SetParamNames("id")
@@ -145,14 +159,16 @@ func TestApplicationController_UpdateStatus_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestApplicationController_UpdateStatus_AdminSuccess(t *testing.T) {
+func TestApplicationController_UpdateStatus_IgnoresClientIsAdmin(t *testing.T) {
 	svc := &mocks.ApplicationServiceMock{}
 	app := &entity.UserApplicationStatus{Status: "document_screening", Notes: "書類選考開始"}
-	svc.On("UpdateStatus", uint(1), uint(1), "document_screening", "書類選考開始", true).Return(app, nil)
+	// is_admin=true を送ってもサービスには false が渡る
+	svc.On("UpdateStatus", uint(1), uint(1), "document_screening", "書類選考開始", false).Return(app, nil)
 
 	body, _ := json.Marshal(map[string]any{"user_id": 1, "status": "document_screening", "notes": "書類選考開始", "is_admin": true})
 	req := httptest.NewRequest(http.MethodPut, "/api/applications/1", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	c := newCtx(req, rec)
 	c.SetParamNames("id")
@@ -163,30 +179,18 @@ func TestApplicationController_UpdateStatus_AdminSuccess(t *testing.T) {
 
 // ---- List ----
 
-func TestApplicationController_List_MissingUserID(t *testing.T) {
-	tests := []struct{ name, userID string }{
-		{"missing", ""},
-		{"non-numeric", "abc"},
-		{"zero", "0"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			url := "/api/applications"
-			if tc.userID != "" {
-				url += "?user_id=" + tc.userID
-			}
-			req := httptest.NewRequest(http.MethodGet, url, nil)
-			rec := httptest.NewRecorder()
-			assertStatus(t, controllers.NewApplicationController(nil).List, newCtx(req, rec), http.StatusBadRequest)
-		})
-	}
+func TestApplicationController_List_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/applications", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, controllers.NewApplicationController(nil).List, newCtx(req, rec), http.StatusUnauthorized)
 }
 
 func TestApplicationController_List_ServiceError(t *testing.T) {
 	svc := &mocks.ApplicationServiceMock{}
 	svc.On("GetApplicationsByUser", uint(1)).Return(nil, errors.New("DB error"))
 
-	req := httptest.NewRequest(http.MethodGet, "/api/applications?user_id=1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/applications", nil)
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, newApplicationController(svc).List, newCtx(req, rec), http.StatusInternalServerError)
 	svc.AssertExpectations(t)
@@ -200,7 +204,8 @@ func TestApplicationController_List_Success(t *testing.T) {
 	}
 	svc.On("GetApplicationsByUser", uint(1)).Return(apps, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/applications?user_id=1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/applications?user_id=999", nil)
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, newApplicationController(svc).List, newCtx(req, rec), http.StatusOK)
 
@@ -212,12 +217,19 @@ func TestApplicationController_List_Success(t *testing.T) {
 
 // ---- GetCorrelation ----
 
+func TestApplicationController_GetCorrelation_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/applications/correlation", nil)
+	rec := httptest.NewRecorder()
+	assertStatus(t, controllers.NewApplicationController(nil).GetCorrelation, newCtx(req, rec), http.StatusUnauthorized)
+}
+
 func TestApplicationController_GetCorrelation_Success(t *testing.T) {
 	svc := &mocks.ApplicationServiceMock{}
 	data := []map[string]any{{"company_id": 1, "pass_rate": 0.75}}
 	svc.On("GetCorrelation", uint(0)).Return(data, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/applications/correlation", nil)
+	req = withUserID(req, 1)
 	rec := httptest.NewRecorder()
 	assertStatus(t, newApplicationController(svc).GetCorrelation, newCtx(req, rec), http.StatusOK)
 

--- a/frontend/app/api/applications/[id]/route.ts
+++ b/frontend/app/api/applications/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -8,7 +11,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     const body = await request.json()
     const response = await fetch(`${BACKEND_URL}/api/applications/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
+      },
       body: JSON.stringify(body),
     })
     const text = await response.text()

--- a/frontend/app/api/applications/route.ts
+++ b/frontend/app/api/applications/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { extractUserAuthHeaders } from '@/lib/api-proxy'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const response = await fetch(`${BACKEND_URL}/api/applications`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...extractUserAuthHeaders(request),
+      },
       body: JSON.stringify(body),
     })
     const text = await response.text()
@@ -23,12 +29,18 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = new URL(request.url)
-    const userId = searchParams.get('user_id')
-    if (!userId) {
-      return NextResponse.json({ error: 'user_id is required' }, { status: 400 })
+    const authHeaders = extractUserAuthHeaders(request)
+    if (!authHeaders['X-User-Token']) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
     }
-    const response = await fetch(`${BACKEND_URL}/api/applications?user_id=${userId}`)
+    const response = await fetch(`${BACKEND_URL}/api/applications`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+      },
+      cache: 'no-store',
+    })
     const text = await response.text()
     if (!response.ok) {
       return NextResponse.json({ error: text }, { status: response.status })

--- a/frontend/app/applications/page.tsx
+++ b/frontend/app/applications/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, Suspense } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import {
   Box,
   Paper,
@@ -22,6 +22,7 @@ import {
   IconButton,
 } from '@mui/material'
 import { ArrowBack, Edit, Check } from '@mui/icons-material'
+import { authService } from '@/lib/auth'
 
 const STATUS_LABELS: Record<string, string> = {
   applied: '応募済み',
@@ -57,8 +58,6 @@ interface Application {
 
 function ApplicationsContent() {
   const router = useRouter()
-  const searchParams = useSearchParams()
-  const userId = searchParams.get('user_id')
 
   const [applications, setApplications] = useState<Application[]>([])
   const [loading, setLoading] = useState(true)
@@ -73,10 +72,18 @@ function ApplicationsContent() {
   })
 
   useEffect(() => {
-    if (!userId) return
+    const user = authService.getStoredUser()
+    if (!user || user.is_guest) {
+      router.replace('/login')
+      return
+    }
+
     const load = async () => {
       try {
-        const res = await fetch(`/api/applications?user_id=${userId}`)
+        const res = await fetch('/api/applications', {
+          headers: authService.getUserFetchHeaders(),
+          cache: 'no-store',
+        })
         if (!res.ok) throw new Error('取得失敗')
         const data = await res.json()
         setApplications(data.applications || [])
@@ -86,8 +93,8 @@ function ApplicationsContent() {
         setLoading(false)
       }
     }
-    load()
-  }, [userId])
+    void load()
+  }, [router])
 
   const startEdit = (app: Application) => {
     setEditingId(app.id)
@@ -102,13 +109,15 @@ function ApplicationsContent() {
   }
 
   const saveEdit = async (appId: number) => {
-    if (!userId) return
     setSaving(true)
     try {
       const res = await fetch(`/api/applications/${appId}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ user_id: Number(userId), status: editStatus, notes: editNotes }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...authService.getUserFetchHeaders(),
+        },
+        body: JSON.stringify({ status: editStatus, notes: editNotes }),
       })
       if (!res.ok) throw new Error('更新失敗')
       setApplications(prev =>
@@ -145,7 +154,7 @@ function ApplicationsContent() {
       {applications.length === 0 ? (
         <Paper sx={{ p: 4, textAlign: 'center' }}>
           <Typography color="text.secondary">応募した企業はまだありません</Typography>
-          <Button variant="contained" sx={{ mt: 2 }} onClick={() => router.push(`/results?user_id=${userId}`)}>
+          <Button variant="contained" sx={{ mt: 2 }} onClick={() => router.push('/results')}>
             マッチング結果に戻る
           </Button>
         </Paper>

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -1293,7 +1293,7 @@ function ResultsContent() {
               <Button
                 variant="outlined"
                 size="large"
-                onClick={() => router.push(`/applications?user_id=${userId}`)}
+                onClick={() => router.push('/applications')}
               >
                 選考管理を見る
               </Button>


### PR DESCRIPTION
Closes #563

## 変更内容

### Backend
- `/api/applications` に `EchoUserAuth` を適用し、未認証アクセスを拒否
- `Apply` / `UpdateStatus` / `List` / `GetCorrelation` で JWT 由来の `user_id` を使用（リクエスト body/query の `user_id` は無視）
- `UpdateStatus` の body `is_admin` を無視し、権限昇格を防止（常に `isAdmin=false`）

### Frontend
- Next.js プロキシ（`/api/applications`）で `X-User-Token` / `X-User-ID` を Backend へ転送
- 選考管理ページは `authService.getStoredUser()` からユーザーを取得し、未ログイン時は `/login` へリダイレクト（無限ローディング解消）
- `?user_id=` クエリ依存を廃止（結果ページのリンクも `/applications` に変更）

### Tests
- 認証必須・body `user_id` 無視・`is_admin` 無視のテストを追加・更新

## Test plan
- [ ] 未ログインで `/applications` にアクセスすると `/login` へ遷移する
- [ ] ログイン済みユーザーで応募一覧・ステータス更新が動作する
- [ ] 他ユーザーの `user_id` を body/query に指定しても自ユーザーのデータのみ扱われる（403/自データ）
- [ ] `is_admin: true` を送っても管理者遷移が許可されない
- [ ] `cd Backend && go test ./test/controllers/ -run Application -count=1` が通る


Made with [Cursor](https://cursor.com)