### PR TITLE
fix: Backlog→GitHub 同期の 401（apiKey クエリ二重付与）を修正

### DIFF
--- a/.github/scripts/backlog_client.py
+++ b/.github/scripts/backlog_client.py
@@ -1,0 +1,167 @@
+"""Backlog API 共通クライアント（GitHub Actions 用）"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def env_required(name: str) -> str:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        print(
+            f"エラー: GitHub Secret `{name}` が未設定または空です。"
+            f" Repository Settings → Secrets and variables → Actions で設定してください。",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return str(raw).strip()
+
+
+def env_optional(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def normalize_space_id(space_id: str) -> str:
+    """myspace.backlog.jp 形式で入っていてもスペースIDだけにする。"""
+    s = space_id.strip()
+    for suffix in (".backlog.jp", ".backlog.com", ".backlogtool.com"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)]
+    if "://" in s:
+        # https://myspace.backlog.jp → myspace
+        host = urllib.parse.urlparse(s if "://" in s else f"https://{s}").hostname or s
+        s = host.split(".")[0]
+    return s.strip()
+
+
+def _api_key_query(api_key: str) -> str:
+    return urllib.parse.urlencode({"apiKey": api_key})
+
+
+def build_url(base: str, path: str, api_key: str, extra_query: str = "") -> str:
+    """path に既存クエリがあっても apiKey を正しく付与する。"""
+    path = path if path.startswith("/") else f"/{path}"
+    url = f"{base}{path}"
+    parts = [ _api_key_query(api_key) ]
+    if extra_query:
+        parts.append(extra_query.lstrip("?&"))
+    if "?" in url:
+        return f"{url}&{'&'.join(parts)}"
+    return f"{url}?{'&'.join(parts)}"
+
+
+def resolve_bl_base(space_id: str, api_key: str, domain: str = "") -> tuple[str, str]:
+    """ドメインを自動判定して Backlog API のベース URL を返す。"""
+    space_id = normalize_space_id(space_id)
+    candidates = [domain] if domain else ["backlog.jp", "backlog.com"]
+    last_auth_error: str | None = None
+
+    for d in candidates:
+        url = build_url(f"https://{space_id}.{d}/api/v2", "/space", api_key)
+        try:
+            with urllib.request.urlopen(urllib.request.Request(url), timeout=30) as r:
+                r.read()
+            print(f"Backlog ドメイン: {d}", flush=True)
+            return f"https://{space_id}.{d}/api/v2", d
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            # スペース未存在 → 別ドメインを試す
+            if e.code == 404 and '"code":6' in body:
+                print(f"  {d}: スペース未検出、次を試行", flush=True)
+                continue
+            # 自動判定時の 401 はドメイン違いの可能性もあるため次を試す
+            if e.code == 401 and not domain:
+                last_auth_error = body
+                print(f"  {d}: 認証失敗、次を試行", flush=True)
+                continue
+            _print_auth_help(e.code, body, space_id, d)
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(f"  {d}: 接続失敗 ({e.reason})、次を試行", flush=True)
+            continue
+
+    if last_auth_error:
+        _print_auth_help(401, last_auth_error, space_id, candidates[-1])
+        sys.exit(1)
+
+    print(
+        f"エラー: スペース '{space_id}' が backlog.jp / backlog.com のいずれにも見つかりませんでした。"
+        f" BACKLOG_SPACE_ID / BACKLOG_DOMAIN を確認してください。",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _print_auth_help(code: int, body: str, space_id: str, domain: str) -> None:
+    print(f"Backlog API エラー {code}: {body}", file=sys.stderr)
+    print(f"接続先: https://{space_id}.{domain}/api/v2", file=sys.stderr)
+    if code == 401:
+        print(
+            "対処: Backlog → 個人設定 → API → APIキー を再発行し、"
+            "GitHub Secrets の BACKLOG_API_KEY を更新してください。"
+            "（前後の空白・改行が入っていると 401 になります）",
+            file=sys.stderr,
+        )
+
+
+def bl_request(
+    base: str,
+    api_key: str,
+    method: str,
+    path: str,
+    data: dict | None = None,
+    *,
+    fatal: bool = True,
+):
+    """Backlog API を呼び出す。fatal=True のとき失敗でプロセス終了。"""
+    extra = ""
+    body = None
+    headers = {}
+    if data is not None and method.upper() == "GET":
+        extra = urllib.parse.urlencode(data, doseq=True)
+    elif data is not None:
+        body = urllib.parse.urlencode(data, doseq=True).encode()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+    # path が "?foo=bar" 付きのレガシー呼び出しにも対応
+    if "?" in path:
+        path_only, q = path.split("?", 1)
+        extra = "&".join(p for p in (q, extra) if p)
+        path = path_only
+
+    url = build_url(base, path, api_key, extra)
+    req = urllib.request.Request(url, data=body, method=method.upper())
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode(errors="replace")
+        print(f"Backlog API エラー {e.code}: {err_body}", file=sys.stderr)
+        print(f"リクエスト: {method.upper()} {path}", file=sys.stderr)
+        if e.code == 401:
+            print(
+                "対処: BACKLOG_API_KEY が無効か期限切れです。GitHub Secrets を更新してください。",
+                file=sys.stderr,
+            )
+        if fatal:
+            sys.exit(1)
+        return None
+
+
+def load_backlog_env() -> tuple[str, str, str, str]:
+    """API_KEY, SPACE_ID, PROJECT_KEY, DOMAIN を読み込む。"""
+    api_key = env_required("BACKLOG_API_KEY")
+    space_id = normalize_space_id(env_required("BACKLOG_SPACE_ID"))
+    proj_key = env_required("BACKLOG_PROJECT_KEY")
+    domain = env_optional("BACKLOG_DOMAIN")
+    # 鍵の中身は出さず、設定漏れ検知用に長さだけ出す
+    print(f"Backlog 設定: space={space_id}, project={proj_key}, apiKey_len={len(api_key)}", flush=True)
+    return api_key, space_id, proj_key, domain

--- a/.github/workflows/backlog-to-github-issue.yml
+++ b/.github/workflows/backlog-to-github-issue.yml
@@ -8,7 +8,7 @@ name: Backlog 課題 → GitHub Issue
 #
 # 必要な GitHub Secrets:
 #   BACKLOG_SPACE_ID    : スペースID（例: myspace ← myspace.backlog.jp の場合）
-#   BACKLOG_API_KEY     : Backlog APIキー
+#   BACKLOG_API_KEY     : Backlog APIキー（個人設定で発行。前後空白なし）
 #   BACKLOG_PROJECT_KEY : プロジェクトキー（例: PROJ）
 #   BACKLOG_DOMAIN      : ドメイン（任意。省略時は backlog.jp → backlog.com の順に自動判定）
 #   GH_TOKEN            : GitHub PAT（issues 読み書き権限）
@@ -31,6 +31,9 @@ jobs:
       issues: write
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Backlog 課題を GitHub Issue へ同期
         env:
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
@@ -45,59 +48,26 @@ jobs:
           import os, sys, json, urllib.parse, urllib.request, urllib.error
           from datetime import datetime, timezone, timedelta
 
-          API_KEY    = os.environ['BACKLOG_API_KEY']
-          SPACE_ID   = os.environ['BACKLOG_SPACE_ID']
-          PROJ_KEY   = os.environ['BACKLOG_PROJECT_KEY']
-          GH_TOKEN   = os.environ['GH_TOKEN']
-          GH_REPO    = os.environ['GH_REPO']
-          MINUTES    = int(os.environ.get('MINUTES_BACK', '20'))
-          DOMAIN     = os.environ.get('BACKLOG_DOMAIN', '').strip()
+          sys.path.insert(0, ".github/scripts")
+          from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+
+          API_KEY, SPACE_ID, PROJ_KEY, DOMAIN = load_backlog_env()
+          GH_TOKEN = os.environ["GH_TOKEN"]
+          GH_REPO = os.environ["GH_REPO"]
+          MINUTES = int(os.environ.get("MINUTES_BACK", "20"))
 
           GH_BASE = "https://api.github.com"
-
-          def resolve_bl_base(space_id, api_key, domain):
-              """ドメインを自動判定して Backlog API のベース URL を返す"""
-              candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
-              for d in candidates:
-                  url = f"https://{space_id}.{d}/api/v2/space?apiKey={api_key}"
-                  try:
-                      with urllib.request.urlopen(urllib.request.Request(url)) as r:
-                          r.read()
-                          return f"https://{space_id}.{d}/api/v2", d
-                  except urllib.error.HTTPError as e:
-                      body = e.read().decode()
-                      if e.code == 404 and '"code":6' in body:
-                          continue
-                      print(f"Backlog API エラー {e.code}: {body}", file=sys.stderr)
-                      sys.exit(1)
-              print(f"エラー: スペース '{space_id}' が backlog.jp / backlog.com のいずれにも見つかりませんでした。", file=sys.stderr)
-              sys.exit(1)
-
           BL_BASE, BL_DOMAIN = resolve_bl_base(SPACE_ID, API_KEY, DOMAIN)
-          print(f"Backlog ドメイン: {BL_DOMAIN}")
-
-          def bl_request(method, path, data=None):
-              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
-              body = urllib.parse.urlencode(data).encode() if data else None
-              req = urllib.request.Request(url, data=body, method=method)
-              if body:
-                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      return json.loads(r.read())
-              except urllib.error.HTTPError as e:
-                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
-                  sys.exit(1)
 
           def gh_request(method, path, data=None):
               url = f"{GH_BASE}{path}"
               body = json.dumps(data).encode() if data else None
               req = urllib.request.Request(url, data=body, method=method)
-              req.add_header('Authorization', f'Bearer {GH_TOKEN}')
-              req.add_header('Accept', 'application/vnd.github+json')
-              req.add_header('X-GitHub-Api-Version', '2022-11-28')
+              req.add_header("Authorization", f"Bearer {GH_TOKEN}")
+              req.add_header("Accept", "application/vnd.github+json")
+              req.add_header("X-GitHub-Api-Version", "2022-11-28")
               if body:
-                  req.add_header('Content-Type', 'application/json')
+                  req.add_header("Content-Type", "application/json")
               try:
                   with urllib.request.urlopen(req) as r:
                       return json.loads(r.read())
@@ -106,41 +76,50 @@ jobs:
                   return None
 
           def gh_search_issue(bl_key):
-              """GitHub Issue を Backlog キーで検索する（タイトルの [PROJ-N] プレフィックスで照合）"""
               q = urllib.parse.quote(f"[{bl_key}] repo:{GH_REPO} in:title is:issue")
-              result = gh_request('GET', f"/search/issues?q={q}&per_page=5")
+              result = gh_request("GET", f"/search/issues?q={q}&per_page=5")
               if not result:
                   return None
-              for item in result.get('items', []):
-                  if item['title'].startswith(f"[{bl_key}]"):
+              for item in result.get("items", []):
+                  if item["title"].startswith(f"[{bl_key}]"):
                       return item
               return None
 
-          project    = bl_request('GET', f"/projects/{PROJ_KEY}")
-          project_id = project['id']
+          project = bl_request(BL_BASE, API_KEY, "GET", f"/projects/{PROJ_KEY}")
+          project_id = project["id"]
 
-          since  = (datetime.now(timezone.utc) - timedelta(minutes=MINUTES)).strftime('%Y-%m-%dT%H:%M:%SZ')
-          issues = bl_request('GET', f"/issues?projectId[]={project_id}&updatedSince={since}&count=100&sort=updated&order=desc")
+          since = (datetime.now(timezone.utc) - timedelta(minutes=MINUTES)).strftime("%Y-%m-%dT%H:%M:%SZ")
+          issues = bl_request(
+              BL_BASE,
+              API_KEY,
+              "GET",
+              "/issues",
+              {
+                  "projectId[]": project_id,
+                  "updatedSince": since,
+                  "count": 100,
+                  "sort": "updated",
+                  "order": "desc",
+              },
+          )
 
-          print(f"{len(issues)} 件の Backlog 課題を取得しました（直近 {MINUTES} 分）。")
+          print(f"{len(issues)} 件の Backlog 課題を取得しました（直近 {MINUTES} 分）。", flush=True)
 
           CLOSED_STATUS_IDS = {3, 4}  # 処理済み / 完了
 
           for issue in issues:
-              bl_key       = issue['issueKey']
-              bl_summary   = issue['summary']
-              bl_desc      = issue.get('description') or ''
-              bl_url       = f"https://{SPACE_ID}.{BL_DOMAIN}/view/{bl_key}"
-              bl_status_id = issue['status']['id']
+              bl_key = issue["issueKey"]
+              bl_summary = issue["summary"]
+              bl_desc = issue.get("description") or ""
+              bl_url = f"https://{SPACE_ID}.{BL_DOMAIN}/view/{bl_key}"
+              bl_status_id = issue["status"]["id"]
 
-              # GitHub 側から作成された課題はスキップ（説明に "GitHub Issue:" を含む）
-              if 'GitHub Issue:' in bl_desc:
-                  print(f"  スキップ（GitHub 起源）: {bl_key}")
+              if "GitHub Issue:" in bl_desc:
+                  print(f"  スキップ（GitHub 起源）: {bl_key}", flush=True)
                   continue
 
-              # GitHub Issue のタイトル・本文
               gh_title = f"[{bl_key}] {bl_summary}"
-              gh_body  = (
+              gh_body = (
                   f"<!-- backlog-synced -->\n"
                   f"<!-- backlog-key:{bl_key} -->\n\n"
                   f"**Backlog 課題:** [{bl_key}]({bl_url})\n\n"
@@ -150,23 +129,23 @@ jobs:
               existing_gh = gh_search_issue(bl_key)
 
               if existing_gh is None:
-                  result = gh_request('POST', f"/repos/{GH_REPO}/issues", {
-                      'title': gh_title,
-                      'body':  gh_body,
+                  result = gh_request("POST", f"/repos/{GH_REPO}/issues", {
+                      "title": gh_title,
+                      "body": gh_body,
                   })
                   if result:
-                      print(f"  GitHub Issue を作成しました: #{result['number']} ← {bl_key}")
+                      print(f"  GitHub Issue を作成しました: #{result['number']} ← {bl_key}", flush=True)
                       if bl_status_id in CLOSED_STATUS_IDS:
-                          gh_request('PATCH', f"/repos/{GH_REPO}/issues/{result['number']}", {'state': 'closed'})
+                          gh_request("PATCH", f"/repos/{GH_REPO}/issues/{result['number']}", {"state": "closed"})
               else:
-                  gh_num         = existing_gh['number']
-                  gh_curr_state  = existing_gh['state']
-                  new_state      = 'closed' if bl_status_id in CLOSED_STATUS_IDS else 'open'
-                  update_data    = {'title': gh_title, 'body': gh_body}
+                  gh_num = existing_gh["number"]
+                  gh_curr_state = existing_gh["state"]
+                  new_state = "closed" if bl_status_id in CLOSED_STATUS_IDS else "open"
+                  update_data = {"title": gh_title, "body": gh_body}
                   if gh_curr_state != new_state:
-                      update_data['state'] = new_state
-                  gh_request('PATCH', f"/repos/{GH_REPO}/issues/{gh_num}", update_data)
-                  print(f"  GitHub Issue を更新しました: #{gh_num} ← {bl_key} (state: {new_state})")
+                      update_data["state"] = new_state
+                  gh_request("PATCH", f"/repos/{GH_REPO}/issues/{gh_num}", update_data)
+                  print(f"  GitHub Issue を更新しました: #{gh_num} ← {bl_key} (state: {new_state})", flush=True)
 
-          print("同期完了。")
+          print("同期完了。", flush=True)
           PYEOF

--- a/.github/workflows/backlog-to-github-issue.yml
+++ b/.github/workflows/backlog-to-github-issue.yml
@@ -88,7 +88,8 @@ jobs:
           project = bl_request(BL_BASE, API_KEY, "GET", f"/projects/{PROJ_KEY}")
           project_id = project["id"]
 
-          since = (datetime.now(timezone.utc) - timedelta(minutes=MINUTES)).strftime("%Y-%m-%dT%H:%M:%SZ")
+          # Backlog API の updatedSince は yyyy-MM-dd のみ受け付ける（ISO datetime は 400）
+          since = (datetime.now(timezone.utc) - timedelta(minutes=MINUTES)).strftime("%Y-%m-%d")
           issues = bl_request(
               BL_BASE,
               API_KEY,
@@ -103,7 +104,7 @@ jobs:
               },
           )
 
-          print(f"{len(issues)} 件の Backlog 課題を取得しました（直近 {MINUTES} 分）。", flush=True)
+          print(f"{len(issues)} 件の Backlog 課題を取得しました（updatedSince={since}, minutes_back={MINUTES}）。", flush=True)
 
           CLOSED_STATUS_IDS = {3, 4}  # 処理済み / 完了
 

--- a/.github/workflows/bulk-sync-existing-issues-to-backlog.yml
+++ b/.github/workflows/bulk-sync-existing-issues-to-backlog.yml
@@ -37,6 +37,9 @@ jobs:
       issues: write
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: 既存 GitHub Issue を Backlog へ一括登録
         env:
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
@@ -52,12 +55,12 @@ jobs:
           import os, sys, json, re, urllib.parse, urllib.request, urllib.error
           from time import sleep
 
-          API_KEY   = os.environ['BACKLOG_API_KEY']
-          SPACE_ID  = os.environ['BACKLOG_SPACE_ID']
-          PROJ_KEY  = os.environ['BACKLOG_PROJECT_KEY']
+          sys.path.insert(0, ".github/scripts")
+          from backlog_client import load_backlog_env, resolve_bl_base, bl_request as _bl_request
+
+          API_KEY, SPACE_ID, PROJ_KEY, DOMAIN = load_backlog_env()
           GH_TOKEN  = os.environ['GH_TOKEN']
           GH_REPO   = os.environ['GH_REPO']
-          DOMAIN    = os.environ.get('BACKLOG_DOMAIN', '').strip()
           ISSUE_STATE = os.environ.get('ISSUE_STATE', 'open')
           DRY_RUN   = os.environ.get('DRY_RUN', 'false').lower() == 'true'
 
@@ -66,38 +69,10 @@ jobs:
           if DRY_RUN:
               print("=== ドライランモード: Backlog への書き込みはスキップされます ===")
 
-          def resolve_bl_base(space_id, api_key, domain):
-              candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
-              for d in candidates:
-                  url = f"https://{space_id}.{d}/api/v2/space?apiKey={api_key}"
-                  try:
-                      with urllib.request.urlopen(urllib.request.Request(url)) as r:
-                          r.read()
-                          return f"https://{space_id}.{d}/api/v2", d
-                  except urllib.error.HTTPError as e:
-                      body = e.read().decode()
-                      if e.code == 404 and '"code":6' in body:
-                          continue
-                      print(f"Backlog API エラー {e.code}: {body}", file=sys.stderr)
-                      sys.exit(1)
-              print(f"エラー: スペース '{space_id}' が見つかりません。", file=sys.stderr)
-              sys.exit(1)
-
           BL_BASE, BL_DOMAIN = resolve_bl_base(SPACE_ID, API_KEY, DOMAIN)
-          print(f"Backlog ドメイン: {BL_DOMAIN}")
 
           def bl_request(method, path, data=None):
-              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
-              body = urllib.parse.urlencode(data).encode() if data else None
-              req = urllib.request.Request(url, data=body, method=method)
-              if body:
-                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      return json.loads(r.read())
-              except urllib.error.HTTPError as e:
-                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
-                  sys.exit(1)
+              return _bl_request(BL_BASE, API_KEY, method, path, data)
 
           def gh_request(method, path, data=None):
               url = f"{GH_BASE}{path}"

--- a/.github/workflows/github-issue-to-backlog.yml
+++ b/.github/workflows/github-issue-to-backlog.yml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: GitHub Issue を Backlog 課題へ同期
         env:
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
@@ -37,11 +40,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           python3 - << 'PYEOF'
-          import os, sys, json, re, urllib.parse, urllib.request, urllib.error
+          import os, sys, json, re, urllib.request, urllib.error
 
-          API_KEY   = os.environ['BACKLOG_API_KEY']
-          SPACE_ID  = os.environ['BACKLOG_SPACE_ID']
-          PROJ_KEY  = os.environ['BACKLOG_PROJECT_KEY']
+          sys.path.insert(0, ".github/scripts")
+          from backlog_client import load_backlog_env, resolve_bl_base, bl_request as _bl_request
+
+          API_KEY, SPACE_ID, PROJ_KEY, DOMAIN = load_backlog_env()
           GH_NUMBER = os.environ['GH_NUMBER']
           GH_TITLE  = os.environ.get('GH_TITLE', '')
           GH_BODY   = os.environ.get('GH_BODY') or ''
@@ -49,30 +53,9 @@ jobs:
           ACTION    = os.environ['ACTION']
           GH_TOKEN  = os.environ['GH_TOKEN']
           GH_REPO   = os.environ['GH_REPO']
-          DOMAIN    = os.environ.get('BACKLOG_DOMAIN', '').strip()
 
           GH_BASE = "https://api.github.com"
-
-          def resolve_bl_base(space_id, api_key, domain):
-              """ドメインを自動判定して Backlog API のベース URL を返す"""
-              candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
-              for d in candidates:
-                  url = f"https://{space_id}.{d}/api/v2/space?apiKey={api_key}"
-                  try:
-                      with urllib.request.urlopen(urllib.request.Request(url)) as r:
-                          r.read()
-                          return f"https://{space_id}.{d}/api/v2", d
-                  except urllib.error.HTTPError as e:
-                      body = e.read().decode()
-                      if e.code == 404 and '"code":6' in body:
-                          continue
-                      print(f"Backlog API エラー {e.code}: {body}", file=sys.stderr)
-                      sys.exit(1)
-              print(f"エラー: スペース '{space_id}' が backlog.jp / backlog.com のいずれにも見つかりませんでした。", file=sys.stderr)
-              sys.exit(1)
-
           BL_BASE, BL_DOMAIN = resolve_bl_base(SPACE_ID, API_KEY, DOMAIN)
-          print(f"Backlog ドメイン: {BL_DOMAIN}")
 
           # Backlog 側から同期された Issue はスキップ（ループ防止）
           if '<!-- backlog-synced -->' in GH_BODY:
@@ -80,17 +63,7 @@ jobs:
               sys.exit(0)
 
           def bl_request(method, path, data=None):
-              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
-              body = urllib.parse.urlencode(data).encode() if data else None
-              req = urllib.request.Request(url, data=body, method=method)
-              if body:
-                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      return json.loads(r.read())
-              except urllib.error.HTTPError as e:
-                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
-                  sys.exit(1)
+              return _bl_request(BL_BASE, API_KEY, method, path, data)
 
           def gh_update_issue(number, data):
               """github.token を使用するため、この更新は issues/edited イベントを再トリガーしない"""

--- a/.github/workflows/pr-to-backlog.yml
+++ b/.github/workflows/pr-to-backlog.yml
@@ -30,6 +30,9 @@ jobs:
       issues: read
       pull-requests: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: PR を Backlog 課題へ反映
         env:
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
@@ -45,52 +48,24 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           python3 - << 'PYEOF'
-          import os, sys, json, re, urllib.parse, urllib.request, urllib.error
+          import os, sys, json, re, urllib.request
 
-          API_KEY   = os.environ['BACKLOG_API_KEY']
-          SPACE_ID  = os.environ['BACKLOG_SPACE_ID']
-          PROJ_KEY  = os.environ['BACKLOG_PROJECT_KEY']
+          sys.path.insert(0, ".github/scripts")
+          from backlog_client import load_backlog_env, resolve_bl_base, bl_request as _bl_request
+
+          API_KEY, SPACE_ID, PROJ_KEY, DOMAIN = load_backlog_env()
           PR_TITLE  = os.environ.get('PR_TITLE', '')
           PR_BODY   = os.environ.get('PR_BODY') or ''
           PR_URL    = os.environ['PR_URL']
           PR_MERGED = os.environ.get('PR_MERGED', 'false').lower() == 'true'
           ACTION    = os.environ['ACTION']
-          DOMAIN    = os.environ.get('BACKLOG_DOMAIN', '').strip()
           GH_TOKEN  = os.environ.get('GH_TOKEN', '')
           GH_REPO   = os.environ.get('GH_REPO', '')
 
-          def resolve_bl_base(space_id, api_key, domain):
-              candidates = [domain] if domain else ['backlog.jp', 'backlog.com']
-              for d in candidates:
-                  url = f"https://{space_id}.{d}/api/v2/space?apiKey={api_key}"
-                  try:
-                      with urllib.request.urlopen(urllib.request.Request(url)) as r:
-                          r.read()
-                          return f"https://{space_id}.{d}/api/v2", d
-                  except urllib.error.HTTPError as e:
-                      body = e.read().decode()
-                      if e.code == 404 and '"code":6' in body:
-                          continue
-                      print(f"Backlog API エラー {e.code}: {body}", file=sys.stderr)
-                      sys.exit(1)
-              print(f"エラー: スペース '{space_id}' が見つかりませんでした。", file=sys.stderr)
-              sys.exit(1)
-
           BL_BASE, BL_DOMAIN = resolve_bl_base(SPACE_ID, API_KEY, DOMAIN)
-          print(f"Backlog ドメイン: {BL_DOMAIN}")
 
           def bl_request(method, path, data=None):
-              url = f"{BL_BASE}{path}?apiKey={API_KEY}"
-              body = urllib.parse.urlencode(data).encode() if data else None
-              req = urllib.request.Request(url, data=body, method=method)
-              if body:
-                  req.add_header('Content-Type', 'application/x-www-form-urlencoded')
-              try:
-                  with urllib.request.urlopen(req) as r:
-                      return json.loads(r.read())
-              except urllib.error.HTTPError as e:
-                  print(f"Backlog API エラー {e.code}: {e.read().decode()}", file=sys.stderr)
-                  return None
+              return _bl_request(BL_BASE, API_KEY, method, path, data, fatal=False)
 
           def extract_bl_key(title, body):
               # 1. タイトルの [PROJ-N] プレフィックス


### PR DESCRIPTION
## Summary
- `Backlog 課題 → GitHub Issue` が常時 401 になっていた原因は、APIキー無効ではなく **課題一覧 URL の `?` 二重付与**（`...&order=desc?apiKey=...`）だった
- `.github/scripts/backlog_client.py` でクエリ結合・シークレット検証を共通化し、関連 4 workflow を利用するよう統一

## Test plan
- [ ] このブランチで `Backlog 課題 → GitHub Issue` を workflow_dispatch 実行し、401 が出ないこと
- [ ] ログに `Backlog ドメイン` と取得件数（または 0 件）が出ること
- [ ] `PR → Backlog` / `Issue → Backlog` が従来どおり動くこと


Made with [Cursor](https://cursor.com)