### PR TITLE
Resolve #579: 履歴書アップロードと企業検索の失敗を修正

### DIFF
--- a/Backend/internal/controllers/resume_controller.go
+++ b/Backend/internal/controllers/resume_controller.go
@@ -55,6 +55,10 @@ func (c *ResumeController) Upload(ctx echo.Context) error {
 
 	result, err := c.resumeService.Upload(uint(userID), sessionID, sourceType, sourceURL, fileHeader)
 	if err != nil {
+		var ve *services.ValidationError
+		if errors.As(err, &ve) {
+			return echo.NewHTTPError(http.StatusUnprocessableEntity, ve.Message)
+		}
 		return echoInternalError(err)
 	}
 

--- a/Backend/internal/services/company_validation_service.go
+++ b/Backend/internal/services/company_validation_service.go
@@ -172,7 +172,8 @@ func (s *CompanyValidationService) SearchCandidates(ctx context.Context, query s
 
 	validated, err := s.Validate(ctx, q)
 	if err != nil {
-		return out, err
+		// WEB 補完失敗時も DB 結果（空）を返し、UI でメッセージ表示できるようにする
+		return out, nil
 	}
 	if validated.Exists {
 		key := normalizeCompanyKey(validated.CanonicalName)
@@ -205,7 +206,15 @@ exists=false の場合は canonical_name を空文字、evidence_urls を空配�
 	text, err := s.openaiClient.WebSearchJSON(ctx, prompt, companyValidationMaxTok)
 	if err != nil {
 		log.Printf("[CompanyValidation] web search failed query=%q err=%v", query, err)
-		return nil, fmt.Errorf("企業の実在確認に失敗しました: %w", err)
+		// Search 失敗でも 500 にせず、未確認として呼び出し側で再試行できるようにする
+		return &CompanyValidationResult{
+			Exists:        false,
+			CanonicalName: "",
+			Source:        "web_search",
+			Confidence:    "low",
+			Query:         query,
+			Description:   "WEB検索による実在確認に失敗しました。企業名を変えるか、しばらくしてから再度お試しください",
+		}, nil
 	}
 
 	parsed, parseErr := parseValidationJSON(text)

--- a/Backend/internal/services/company_validation_service_test.go
+++ b/Backend/internal/services/company_validation_service_test.go
@@ -124,3 +124,14 @@ func TestCompanyValidationService_NoOpenAIReturnsNotExists(t *testing.T) {
 		t.Fatalf("source=%q", result.Source)
 	}
 }
+
+func TestCompanyValidationService_SearchCandidatesWebFailureReturnsEmpty(t *testing.T) {
+	svc := NewCompanyValidationService(&fakeCompanyLookup{exact: map[string]*models.Company{}}, nil)
+	results, err := svc.SearchCandidates(context.Background(), "未知企業ABC", true)
+	if err != nil {
+		t.Fatalf("WEB補完失敗でもエラーにしない: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("候補なしを期待: %+v", results)
+	}
+}

--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -42,13 +42,9 @@ var allowedMIMETypes = map[string]bool{
 // pdfMagicBytes はPDFファイルの先頭シグネチャ（%PDF）
 var pdfMagicBytes = []byte{0x25, 0x50, 0x44, 0x46}
 
-// validateFileUpload はMIMEタイプとファイルシグネチャ（magic bytes）を検証する
+// validateFileUpload はMIMEタイプとファイルシグネチャ（magic bytes）を検証する。
+// Content-Type が空や application/octet-stream でも、magic bytes が一致すれば許可する。
 func validateFileUpload(fileHeader *multipart.FileHeader) error {
-	mimeType := fileHeader.Header.Get("Content-Type")
-	if !allowedMIMETypes[mimeType] {
-		return &ValidationError{Message: "unsupported file type: only PDF and Word documents are allowed"}
-	}
-
 	f, err := fileHeader.Open()
 	if err != nil {
 		return fmt.Errorf("failed to open uploaded file: %w", err)
@@ -57,22 +53,21 @@ func validateFileUpload(fileHeader *multipart.FileHeader) error {
 
 	buf := make([]byte, 4)
 	if _, err := io.ReadFull(f, buf); err != nil {
-		return &ValidationError{Message: "file too small to validate"}
+		return &ValidationError{Message: "ファイルが小さすぎるか破損しています"}
 	}
 
-	// PDFシグネチャ: %PDF
-	if bytes.HasPrefix(buf, pdfMagicBytes) {
+	magicOK := bytes.HasPrefix(buf, pdfMagicBytes) ||
+		bytes.HasPrefix(buf, []byte{0x50, 0x4B, 0x03, 0x04}) || // DOCX (ZIP)
+		bytes.HasPrefix(buf, []byte{0xD0, 0xCF, 0x11, 0xE0})     // DOC (OLE2)
+	if magicOK {
 		return nil
 	}
-	// DOCX/XLSX (ZIP): PK\x03\x04
-	if bytes.HasPrefix(buf, []byte{0x50, 0x4B, 0x03, 0x04}) {
-		return nil
+
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if allowedMIMETypes[mimeType] {
+		return &ValidationError{Message: "ファイル内容が PDF / Word 形式と一致しません"}
 	}
-	// DOC (OLE2): D0 CF 11 E0
-	if bytes.HasPrefix(buf, []byte{0xD0, 0xCF, 0x11, 0xE0}) {
-		return nil
-	}
-	return &ValidationError{Message: "file content does not match declared type"}
+	return &ValidationError{Message: "PDF または Word（.doc/.docx）のみアップロードできます"}
 }
 
 // validateURL はSSRF対策のためURLスキームとIPアドレス範囲を検証する
@@ -145,13 +140,7 @@ func (s *ResumeService) Upload(userID uint, sessionID, sourceType, sourceURL str
 		sourceType = "pdf"
 	}
 	if fileHeader == nil && strings.TrimSpace(sourceURL) == "" {
-		return nil, errors.New("file or source_url is required")
-	}
-	if err := s.ensureS3Available(); err != nil {
-		return nil, err
-	}
-	if s.s3 == nil || !s.s3.isEnabled() {
-		return nil, errors.New("s3 is required")
+		return nil, &ValidationError{Message: "ファイルまたは source_url が必要です"}
 	}
 
 	doc := &models.ResumeDocument{
@@ -199,17 +188,38 @@ func (s *ResumeService) Upload(userID uint, sessionID, sourceType, sourceURL str
 	}
 	if doc.StoredPath != "" {
 		filename := filepath.Base(doc.StoredPath)
-		s3Path, err := s.uploadToS3(context.Background(), doc, doc.StoredPath, filename)
+		storedPath, err := s.persistUploadedFile(doc, doc.StoredPath, filename)
 		if err != nil {
 			return nil, err
 		}
-		doc.StoredPath = s3Path
+		doc.StoredPath = storedPath
 		if err := s.repo.UpdateDocument(doc); err != nil {
 			return nil, fmt.Errorf("failed to update document: %w", err)
 		}
 	}
 
 	return &ResumeUploadResult{Document: doc}, nil
+}
+
+// persistUploadedFile は S3 が使える場合は S3 へ、不可ならローカル storageDir へ永続化する。
+func (s *ResumeService) persistUploadedFile(doc *models.ResumeDocument, localPath, filename string) (string, error) {
+	if s.s3 != nil && s.s3.isEnabled() {
+		if err := s.ensureS3Available(); err != nil {
+			return "", &ValidationError{Message: "ファイルストレージの準備に失敗しました。しばらくしてから再度お試しください"}
+		}
+		return s.uploadToS3(context.Background(), doc, localPath, filename)
+	}
+
+	dir := filepath.Join(s.storageDir, fmt.Sprintf("%d", doc.UserID), fmt.Sprintf("%d", doc.ID))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create local storage dir: %w", err)
+	}
+	dest := filepath.Join(dir, filename)
+	if err := copyFile(localPath, dest); err != nil {
+		return "", fmt.Errorf("failed to store file locally: %w", err)
+	}
+	log.Printf("resume_upload: stored locally path=%s (S3 unavailable)", dest)
+	return dest, nil
 }
 
 func (s *ResumeService) ReviewDocument(documentID uint, requestingUserID uint, companyName string, jobTitle string, candidateType string) (*models.ResumeReview, []models.ResumeReviewItem, error) {
@@ -219,9 +229,6 @@ func (s *ResumeService) ReviewDocument(documentID uint, requestingUserID uint, c
 	}
 	if doc.UserID != requestingUserID {
 		return nil, nil, ErrForbidden
-	}
-	if s.s3 == nil || !s.s3.isEnabled() {
-		return nil, nil, errors.New("s3 is required")
 	}
 	if strings.TrimSpace(companyName) == "" && strings.TrimSpace(jobTitle) == "" {
 		return nil, nil, &ValidationError{Message: "応募企業名または応募職種を入力してください"}
@@ -912,10 +919,6 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	if doc.UserID != requestingUserID {
 		sendEvent(map[string]any{"type": "error", "message": "forbidden"})
 		return ErrForbidden
-	}
-	if s.s3 == nil || !s.s3.isEnabled() {
-		sendEvent(map[string]any{"type": "error", "message": "s3 is required"})
-		return errors.New("s3 is required")
 	}
 	if strings.TrimSpace(companyName) == "" && strings.TrimSpace(jobTitle) == "" {
 		msg := "応募企業名または応募職種を入力してください"

--- a/Backend/internal/services/resume_service_test.go
+++ b/Backend/internal/services/resume_service_test.go
@@ -7,20 +7,65 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http/httptest"
+	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"Backend/internal/models"
 )
 
+func makeUploadedFileHeader(t *testing.T, filename string, content []byte, contentType string) *multipart.FileHeader {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, filename))
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	part, err := w.CreatePart(h)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	r := multipart.NewReader(&buf, w.Boundary())
+	form, err := r.ReadForm(10 << 20)
+	if err != nil {
+		t.Fatalf("ReadForm: %v", err)
+	}
+	files := form.File["file"]
+	if len(files) == 0 {
+		t.Fatal("file part missing")
+	}
+	return files[0]
+}
+
 type resumeRepoStub struct {
 	doc *models.ResumeDocument
 }
 
-func (r *resumeRepoStub) CreateDocument(doc *models.ResumeDocument) error { return nil }
-func (r *resumeRepoStub) UpdateDocument(doc *models.ResumeDocument) error { return nil }
+func (r *resumeRepoStub) CreateDocument(doc *models.ResumeDocument) error {
+	if doc.ID == 0 {
+		doc.ID = 1
+	}
+	r.doc = doc
+	return nil
+}
+func (r *resumeRepoStub) UpdateDocument(doc *models.ResumeDocument) error {
+	r.doc = doc
+	return nil
+}
 func (r *resumeRepoStub) FindDocumentByID(id uint) (*models.ResumeDocument, error) {
 	if r.doc == nil || r.doc.ID != id {
 		return nil, errors.New("not found")
@@ -114,6 +159,48 @@ func TestNewSeekableReader_SeekWorks(t *testing.T) {
 	}
 	if string(buf) != "FGH" {
 		t.Errorf("Seek後の読み込み結果が不正: got %q, want %q", buf, "FGH")
+	}
+}
+
+func TestValidateFileUpload_AllowsOctetStreamWithPDFMagic(t *testing.T) {
+	fh := makeUploadedFileHeader(t, "resume.pdf", []byte("%PDF-1.4\n%mock"), "application/octet-stream")
+	if err := validateFileUpload(fh); err != nil {
+		t.Fatalf("PDF magic + octet-stream は許可すべき: %v", err)
+	}
+}
+
+func TestValidateFileUpload_RejectsNonDocument(t *testing.T) {
+	fh := makeUploadedFileHeader(t, "notes.txt", []byte("hello world text"), "text/plain")
+	err := validateFileUpload(fh)
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("ValidationError を期待: got %v", err)
+	}
+}
+
+func TestResumeService_UploadStoresLocallyWithoutS3(t *testing.T) {
+	dir := t.TempDir()
+	repo := &resumeRepoStub{}
+	svc := &ResumeService{repo: repo, storageDir: dir}
+	fh := makeUploadedFileHeader(t, "resume.pdf", []byte("%PDF-1.4\n%mock-content"), "application/octet-stream")
+
+	result, err := svc.Upload(7, "sess-1", "pdf", "", fh)
+	if err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+	if result.Document == nil || result.Document.ID == 0 {
+		t.Fatalf("document missing: %+v", result)
+	}
+	stored := result.Document.StoredPath
+	if !strings.HasPrefix(stored, dir) {
+		t.Fatalf("local path expected under %s, got %s", dir, stored)
+	}
+	if _, err := os.Stat(stored); err != nil {
+		t.Fatalf("stored file missing: %v", err)
+	}
+	wantSuffix := filepath.Join("7", "1", "original.pdf")
+	if !strings.HasSuffix(stored, wantSuffix) {
+		t.Fatalf("unexpected path layout: got %s want suffix %s", stored, wantSuffix)
 	}
 }
 

--- a/frontend/app/api/companies/web-search/route.ts
+++ b/frontend/app/api/companies/web-search/route.ts
@@ -19,13 +19,19 @@ export async function GET(request: NextRequest) {
     })
 
     if (!response.ok) {
-      return NextResponse.json({ results: [] }, { status: response.status })
+      return NextResponse.json(
+        { results: [], message: '企業検索に失敗しました。しばらくしてから再度お試しください' },
+        { status: response.status },
+      )
     }
 
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
     console.error('[API] Web search error:', error)
-    return NextResponse.json({ results: [] }, { status: 500 })
+    return NextResponse.json(
+      { results: [], message: 'バックエンドに接続できません。BACKEND_URL を確認してください' },
+      { status: 502 },
+    )
   }
 }

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -153,7 +153,17 @@ function ResumeContent() {
     try {
       if (!includeWebSearch) {
         const res = await fetch(`/api/companies?name=${encodeURIComponent(q)}&limit=5`, { cache: 'no-store' })
-        if (!res.ok) throw new Error('DB検索に失敗しました')
+        if (!res.ok) {
+          const errText = await res.text()
+          let message = 'DB検索に失敗しました'
+          try {
+            const parsed = JSON.parse(errText)
+            message = parsed?.message || parsed?.error || message
+          } catch {
+            /* keep default */
+          }
+          throw new Error(message)
+        }
         const data = await res.json()
         const companies = (data.companies || data || []) as { id?: number; name?: string; description?: string }[]
         const list = (Array.isArray(companies) ? companies : [])
@@ -173,31 +183,39 @@ function ResumeContent() {
         return
       }
 
-      const res = await fetch('/api/companies/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: q }),
-      })
-      const data = await res.json()
+      // WEB: 候補一覧 API（DB優先 + WEB補完）。単体 validate より候補選択しやすい
+      const res = await fetch(`/api/companies/web-search?q=${encodeURIComponent(q)}`, { cache: 'no-store' })
+      const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        throw new Error(data?.message || data?.error || '実在確認に失敗しました')
+        throw new Error(data?.message || data?.error || 'WEB検索に失敗しました')
       }
-      if (!data.exists) {
+      const results = (data.results || []) as {
+        name?: string
+        description?: string
+        source?: string
+        exists?: boolean
+        confidence?: string
+        company_id?: number
+        evidence_urls?: string[]
+      }[]
+      const list = (Array.isArray(results) ? results : [])
+        .filter((c) => c?.name && c.exists !== false)
+        .map((c) => ({
+          name: c.name as string,
+          description: c.description || '',
+          source: c.source || 'web_search',
+          exists: true,
+          confidence: c.confidence,
+          company_id: c.company_id,
+          evidence_urls: c.evidence_urls || [],
+        }))
+      setCompanyCandidates(list)
+      if (list.length === 0) {
         setCompanyValidated(false)
         setSelectedCompanyMeta(null)
         setCompanyName('')
-        setCompanySearchError('実在が確認できませんでした。別の企業名で検索してください')
-        return
+        setCompanySearchError('候補が見つかりませんでした。企業名を変えて再検索するか、職種のみでレビューしてください')
       }
-      selectCompany({
-        name: data.canonical_name || q,
-        description: data.description || '',
-        source: data.source || 'web_search',
-        exists: true,
-        confidence: data.confidence,
-        company_id: data.company_id,
-        evidence_urls: data.evidence_urls || [],
-      })
     } catch (err) {
       setCompanySearchError(err instanceof Error ? err.message : '企業検索に失敗しました')
     } finally {
@@ -459,6 +477,12 @@ function ResumeContent() {
                 setCompanyValidated(false)
                 setSelectedCompanyMeta(null)
                 setCompanyName('')
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  void handleSearchCompanies(false)
+                }
               }}
               fullWidth
               helperText={companyValidated ? `選択済み: ${companyName}` : '未選択（職種のみレビュー可）'}


### PR DESCRIPTION
Closes #579

## 変更内容
- 履歴書アップロードで S3 未設定時にローカル `storageDir` へフォールバック保存するよう変更
- MIME 判定を magic bytes（PDF/DOC/DOCX）優先にし、`application/octet-stream` でも実ファイルなら許可
- `ValidationError` を Upload コントローラで 422 として返すよう修正（不明瞭な 500 を回避）
- 企業 WEB 実在確認・候補検索の失敗を soft-fail にし、500 ではなく未確認/空候補として返す
- 履歴書画面の「WEBで実在確認」を `/api/companies/web-search` の候補選択 UI に変更（Enter で DB 検索）
- web-search プロキシが失敗時にメッセージを返すよう改善
- ローカル保存・MIME・WEB候補 soft-fail のユニットテストを追加

## Test plan
- [ ] S3 未設定のローカル環境で履歴書 PDF をアップロードできる
- [ ] Content-Type が `application/octet-stream` の PDF でもアップロードできる
- [ ] 不正ファイルは 422 と日本語エラーメッセージになる
- [ ] DB に無い企業名で「WEBで実在確認」し、候補選択または分かりやすい警告が出る（500 にならない）
- [ ] `go test ./internal/services/ -run 'TestValidateFileUpload|TestResumeService_UploadStoresLocally|TestCompanyValidationService_'` が通る

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 履歴書ファイルの形式検証を強化し、PDF・Wordファイルをより正確に判定できるようになりました。
  * 外部ストレージが利用できない場合、履歴書をローカルに保存できるようになりました。
  * 企業検索でWeb検索候補を表示し、Enterキーでも検索できるようになりました。

* **改善**
  * ファイル検証や企業検索の失敗時に、状況に応じた分かりやすいエラーメッセージを表示します。
  * Web検索に失敗しても、候補一覧の表示処理を継続できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->