### PR TITLE
Resolve #582: チャット選択肢の自由入力バグを修正

### DIFF
--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -144,7 +144,17 @@ func (s *ChatService) validateAnswerRelevance(ctx context.Context, question, ans
 		return isLikelyAnswer(answer, question), nil
 	}
 
-	// 選択肢型の質問: AI判定を使用
+	// 選択肢型の質問: 記号・ラベル一致、またはその他相当の自由記述はローカルで受理
+	resolved := ResolveChoiceAnswer(question, answer)
+	if resolved.IsChoice {
+		log.Printf("[Validation] Choice answer matched locally: %s\n", resolved.Letter)
+		return true, nil
+	}
+	if len([]rune(strings.TrimSpace(answer))) >= 2 {
+		log.Printf("[Validation] Accepting free-text answer on choice question (その他経路)\n")
+		return true, nil
+	}
+
 	log.Printf("[Validation] Choice-based question detected, using AI validation\n")
 
 	systemPrompt := prompts.AnswerValidationSystemPrompt

--- a/Backend/internal/services/chat_score_updater.go
+++ b/Backend/internal/services/chat_score_updater.go
@@ -38,9 +38,18 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 	}
 
 	targetCategory := s.inferCategoryFromQuestion(lastQuestion)
-	isChoice := !isTextBasedQuestion(lastQuestion)
+	scoreAnswer := message
+	isChoice := false
+	if !isTextBasedQuestion(lastQuestion) {
+		resolved := ResolveChoiceAnswer(lastQuestion, message)
+		if resolved.IsChoice {
+			isChoice = true
+			scoreAnswer = resolved.Letter
+		}
+		// マッチしない自由記述（その他）は isChoice=false で文章採点する
+	}
 
-	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, message, isChoice, jobCategoryID != 0, nil)
+	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, scoreAnswer, isChoice, jobCategoryID != 0, nil)
 	if result.Action == PrecheckSkip {
 		// 「わかりません」などのスキップフレーズは進捗カウントしない
 		log.Printf("Skipping progress: skip phrase detected (%s)\n", result.Reason)

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -375,19 +375,28 @@ func (s *ChatService) ProcessChat(ctx context.Context, req ChatRequest) (*ChatRe
 	// 3. ユーザーの回答から重み係数を判定・更新し、回答品質に応じてフェーズ進捗を更新
 	// isQualityAnswer: スキップフレーズ・極短回答・スコア0でなければ true（進捗カウント対象）
 	trimmedAnswer := strings.TrimSpace(req.Message)
-	log.Printf("[ProcessChat] Checking if choice answer: '%s' (len=%d)\n", trimmedAnswer, len(trimmedAnswer))
+	lastAssistantQuestion := ""
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "assistant" {
+			lastAssistantQuestion = history[i].Content
+			break
+		}
+	}
+	resolved := ResolveChoiceAnswer(lastAssistantQuestion, trimmedAnswer)
+	log.Printf("[ProcessChat] Checking answer: raw=%q resolved_choice=%v letter=%q free_text=%v\n",
+		trimmedAnswer, resolved.IsChoice, resolved.Letter, resolved.IsFreeText)
 	isQualityAnswer := false
-	if len(trimmedAnswer) <= 3 && s.isChoiceAnswer(trimmedAnswer) {
+	if resolved.IsChoice && s.isChoiceAnswer(resolved.Letter) {
 		log.Printf("[ProcessChat] Processing as choice answer\n")
 		var err error
-		isQualityAnswer, err = s.processChoiceAnswer(ctx, req.UserID, req.SessionID, trimmedAnswer, history, jobCategoryID)
+		isQualityAnswer, err = s.processChoiceAnswer(ctx, req.UserID, req.SessionID, resolved.Letter, history, jobCategoryID)
 		if err != nil {
 			log.Printf("Warning: failed to process choice answer: %v\n", err)
 		}
 	} else {
 		log.Printf("[ProcessChat] Processing as text answer\n")
 		var err error
-		isQualityAnswer, err = s.analyzeAndUpdateWeights(ctx, req.UserID, req.SessionID, req.Message, jobCategoryID)
+		isQualityAnswer, err = s.analyzeAndUpdateWeights(ctx, req.UserID, req.SessionID, resolved.Text, jobCategoryID)
 		if err != nil {
 			log.Printf("Warning: failed to update weights: %v\n", err)
 		}

--- a/Backend/internal/services/choice_answer.go
+++ b/Backend/internal/services/choice_answer.go
@@ -1,0 +1,121 @@
+package services
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// ParsedChoice は質問文から抽出した選択肢。
+type ParsedChoice struct {
+	Value string // A-E または 1-5
+	Text  string
+}
+
+var (
+	choiceLetterLine = regexp.MustCompile(`^([A-Ea-e])[)）：、.．]\s*(.+)$`)
+	choiceNumberLine = regexp.MustCompile(`^([1-5])[)）．.]\s*(.+)$`)
+)
+
+// ParseChoiceOptions は質問文から A)/1. 形式の選択肢を抽出する。
+func ParseChoiceOptions(question string) []ParsedChoice {
+	var out []ParsedChoice
+	for _, line := range strings.Split(question, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if m := choiceLetterLine.FindStringSubmatch(trimmed); m != nil {
+			out = append(out, ParsedChoice{Value: strings.ToUpper(m[1]), Text: strings.TrimSpace(m[2])})
+			continue
+		}
+		if m := choiceNumberLine.FindStringSubmatch(trimmed); m != nil {
+			out = append(out, ParsedChoice{Value: m[1], Text: strings.TrimSpace(m[2])})
+		}
+	}
+	return out
+}
+
+func isOtherChoiceText(text string) bool {
+	return strings.Contains(text, "その他")
+}
+
+func normalizeChoiceKey(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		switch r {
+		case '、', '。', '・', '（', '）', '(', ')', ':', '：', '.', '．', '/', '／':
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func choiceTextsMatch(answer, option string) bool {
+	a := normalizeChoiceKey(answer)
+	o := normalizeChoiceKey(option)
+	if a == "" || o == "" {
+		return false
+	}
+	if a == o {
+		return true
+	}
+	// 短すぎる部分一致は誤爆しやすいので 4 文字以上に限定
+	if len([]rune(a)) >= 4 && len([]rune(o)) >= 4 {
+		return strings.Contains(a, o) || strings.Contains(o, a)
+	}
+	return false
+}
+
+// ChoiceResolution はユーザー入力を選択肢記号または自由記述へ正規化した結果。
+type ChoiceResolution struct {
+	Letter     string // 選択肢記号（IsChoice=true のとき）
+	IsChoice   bool   // processChoiceAnswer 経路
+	IsFreeText bool   // 文章採点経路（その他・非選択肢質問含む）
+	Text       string // 採点・保存に使う本文
+}
+
+// ResolveChoiceAnswer は選択肢質問に対する自由入力を記号へ寄せる。
+// マッチしない自由記述・「その他」は IsFreeText=true（scoreChoice default 60 を避ける）。
+func ResolveChoiceAnswer(question, answer string) ChoiceResolution {
+	answer = strings.TrimSpace(answer)
+	options := ParseChoiceOptions(question)
+	if len(options) == 0 {
+		return ChoiceResolution{IsFreeText: true, Text: answer}
+	}
+
+	upper := strings.ToUpper(answer)
+	if isChoiceToken(upper) {
+		for _, opt := range options {
+			if strings.EqualFold(opt.Value, upper) {
+				return ChoiceResolution{Letter: opt.Value, IsChoice: true, Text: opt.Value}
+			}
+		}
+		return ChoiceResolution{Letter: upper, IsChoice: true, Text: upper}
+	}
+
+	for _, opt := range options {
+		if isOtherChoiceText(opt.Text) {
+			continue
+		}
+		if choiceTextsMatch(answer, opt.Text) {
+			return ChoiceResolution{Letter: opt.Value, IsChoice: true, Text: opt.Value}
+		}
+	}
+
+	return ChoiceResolution{IsFreeText: true, Text: answer}
+}
+
+func isChoiceToken(answer string) bool {
+	switch answer {
+	case "A", "B", "C", "D", "E", "1", "2", "3", "4", "5":
+		return true
+	default:
+		return false
+	}
+}

--- a/Backend/internal/services/choice_answer_test.go
+++ b/Backend/internal/services/choice_answer_test.go
@@ -1,0 +1,59 @@
+package services
+
+import "testing"
+
+func TestParseChoiceOptions(t *testing.T) {
+	q := `興味のある働き方はどれですか？
+
+1) 新しい技術やツールに触れる
+2) 仕組みを考えたり設計する
+3) 人と関わりながら進める
+4) コツコツ改善・整理する
+5) その他（自由記述）`
+	got := ParseChoiceOptions(q)
+	if len(got) != 5 {
+		t.Fatalf("len=%d want 5: %+v", len(got), got)
+	}
+	if got[0].Value != "1" || got[0].Text != "新しい技術やツールに触れる" {
+		t.Fatalf("first option: %+v", got[0])
+	}
+	if got[4].Value != "5" || !isOtherChoiceText(got[4].Text) {
+		t.Fatalf("other option: %+v", got[4])
+	}
+}
+
+func TestResolveChoiceAnswer_LetterAndLabel(t *testing.T) {
+	q := `どれに近いですか？
+A) 自分から主導して進める
+B) みんなで協力して進める
+C) その他（自由記述）`
+
+	cases := []struct {
+		in           string
+		wantChoice   bool
+		wantLetter   string
+		wantFreeText bool
+	}{
+		{"A", true, "A", false},
+		{"a", true, "A", false},
+		{"自分から主導して進める", true, "A", false},
+		{"みんなで協力して進める", true, "B", false},
+		{"チームで相談しながら進めたいです", false, "", true},
+		{"その他（自由記述）", false, "", true},
+	}
+	for _, tc := range cases {
+		got := ResolveChoiceAnswer(q, tc.in)
+		if got.IsChoice != tc.wantChoice || got.IsFreeText != tc.wantFreeText || got.Letter != tc.wantLetter {
+			t.Fatalf("in=%q got=%+v want choice=%v letter=%q free=%v",
+				tc.in, got, tc.wantChoice, tc.wantLetter, tc.wantFreeText)
+		}
+	}
+}
+
+func TestResolveChoiceAnswer_NonChoiceQuestion(t *testing.T) {
+	q := "具体的なエピソードを教えてください。"
+	got := ResolveChoiceAnswer(q, "インターンでAPIを作りました")
+	if !got.IsFreeText || got.IsChoice {
+		t.Fatalf("expected free text: %+v", got)
+	}
+}

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -22,6 +22,7 @@ import {
 import { Send, SmartToy, Person, Refresh, Business, LocationOn, People, TrendingUp as TrendingUpIcon } from '@mui/icons-material'
 import { sendChatMessage, getChatHistory, getUserScores, ChatRequest, ChatResponse } from '@/lib/api'
 import { authService } from '@/lib/auth'
+import { resolveChatOutgoingMessage } from '@/lib/chat-choices'
 
 interface Message {
   id: string
@@ -266,9 +267,17 @@ export function MuiChat() {
   }, [])
 
   const handleSend = async (overrideMessage?: string) => {
-    const messageText = (overrideMessage ?? input).trim()
-    if (!messageText || isLoading || !sessionId || !userId) return
-    
+    const rawText = (overrideMessage ?? input).trim()
+    if (!rawText || isLoading || !sessionId || !userId) return
+
+    // ボタン送信はそのまま。自由入力は直近の選択肢ラベルを記号へ正規化する
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant')
+    const currentChoices = lastAssistant ? extractChoices(lastAssistant.content) : []
+    const messageText =
+      overrideMessage !== undefined
+        ? rawText
+        : resolveChatOutgoingMessage(rawText, currentChoices, otherChoiceActive)
+
     // 分析完了後はメッセージ送信を無効化
     if (analysisComplete) {
       console.log('[MUI Chat] Analysis already complete, ignoring message')
@@ -521,7 +530,11 @@ export function MuiChat() {
   const lastAssistantMessage = [...messages].reverse().find((msg) => msg.role === 'assistant')
   const choiceOptions = lastAssistantMessage ? extractChoices(lastAssistantMessage.content) : []
   const showChoiceButtons = choiceOptions.length >= 2 && !analysisComplete
-  const inputPlaceholder = otherChoiceActive ? 'その他の内容を入力...' : 'メッセージを入力...'
+  const inputPlaceholder = otherChoiceActive
+    ? 'その他の内容を入力...'
+    : showChoiceButtons
+      ? '選択肢と同じ内容を入力しても送信できます'
+      : 'メッセージを入力...'
 
   useEffect(() => {
     if (!showChoiceButtons) {
@@ -894,7 +907,7 @@ export function MuiChat() {
                 }}
               >
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-                  選択肢を選んでください
+                  選択肢を選んでください（同じ内容を入力しても構いません。「その他」は自由記述）
                 </Typography>
                 <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
                   {choiceOptions.map((choice) => {
@@ -929,7 +942,6 @@ export function MuiChat() {
                 placeholder={inputPlaceholder}
                 value={input}
                 onChange={(e) => {
-                  console.log('[MUI Chat] Rendering input field (analysisComplete=false)')
                   setInput(e.target.value)
                 }}
                 onKeyPress={(e) => {

--- a/frontend/lib/chat-choices.ts
+++ b/frontend/lib/chat-choices.ts
@@ -1,0 +1,54 @@
+export type ChatChoiceOption = {
+  value: string
+  label: string
+  text: string
+}
+
+function normalizeChoiceKey(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[\s　、。・（）()：:．.／/]/g, '')
+}
+
+function isOtherChoice(text: string): boolean {
+  return text.includes('その他')
+}
+
+function choiceTextsMatch(answer: string, option: string): boolean {
+  const a = normalizeChoiceKey(answer)
+  const o = normalizeChoiceKey(option)
+  if (!a || !o) return false
+  if (a === o) return true
+  if ([...a].length >= 4 && [...o].length >= 4) {
+    return a.includes(o) || o.includes(a)
+  }
+  return false
+}
+
+/**
+ * 選択肢表示中の自由入力を、可能な限り選択肢記号へ正規化する。
+ * 「その他」活性時やラベル不一致の自由記述はそのまま返す。
+ */
+export function resolveChatOutgoingMessage(
+  input: string,
+  choices: ChatChoiceOption[],
+  otherChoiceActive: boolean,
+): string {
+  const trimmed = input.trim()
+  if (!trimmed) return trimmed
+  if (choices.length === 0 || otherChoiceActive) return trimmed
+
+  const upper = trimmed.toUpperCase()
+  if (/^[A-E]$/.test(upper)) return upper
+  if (/^[1-5]$/.test(trimmed)) return trimmed
+
+  for (const choice of choices) {
+    if (isOtherChoice(choice.text)) continue
+    if (choiceTextsMatch(trimmed, choice.text)) {
+      return choice.value
+    }
+  }
+
+  return trimmed
+}

--- a/frontend/tests/lib/chat-choices.test.ts
+++ b/frontend/tests/lib/chat-choices.test.ts
@@ -1,0 +1,33 @@
+import { resolveChatOutgoingMessage, type ChatChoiceOption } from '@/lib/chat-choices'
+
+const choices: ChatChoiceOption[] = [
+  { value: '1', label: '1', text: '新しい技術やツールに触れる' },
+  { value: '2', label: '2', text: '仕組みを考えたり設計する' },
+  { value: '3', label: '3', text: '人と関わりながら進める' },
+  { value: '5', label: '5', text: 'その他（自由記述）' },
+]
+
+describe('resolveChatOutgoingMessage', () => {
+  it('選択肢記号はそのまま返す', () => {
+    expect(resolveChatOutgoingMessage('1', choices, false)).toBe('1')
+    expect(resolveChatOutgoingMessage('a', [{ value: 'A', label: 'A', text: '主導' }], false)).toBe('A')
+  })
+
+  it('選択肢ラベルの自由入力を記号へ正規化する', () => {
+    expect(resolveChatOutgoingMessage('新しい技術やツールに触れる', choices, false)).toBe('1')
+    expect(resolveChatOutgoingMessage('仕組みを考えたり設計する', choices, false)).toBe('2')
+  })
+
+  it('その他活性時や不一致の自由記述は原文のまま', () => {
+    expect(resolveChatOutgoingMessage('自分のペースで学びたい', choices, true)).toBe(
+      '自分のペースで学びたい',
+    )
+    expect(resolveChatOutgoingMessage('自分のペースで学びたい', choices, false)).toBe(
+      '自分のペースで学びたい',
+    )
+  })
+
+  it('選択肢が無いときは原文のまま', () => {
+    expect(resolveChatOutgoingMessage('こんにちは', [], false)).toBe('こんにちは')
+  })
+})


### PR DESCRIPTION
Closes #582

## 変更内容
- 選択肢ラベルの手入力を記号（A–E / 1–5）へ正規化する FE ヘルパー `resolveChatOutgoingMessage` を追加
- BE に `ResolveChoiceAnswer` を追加し、ラベル一致は choice 採点、不一致の自由記述は text 採点へ振り分け
- 選択肢質問でも「その他」相当の自由記述をバリデーションでローカル受理し、AI 誤却下を回避
- `analyzeAndUpdateWeights` が選択肢質問の自由入力を `scoreChoice` default 60 に落とさないよう修正
- Go / Jest のユニットテストを追加

## Test plan
- [ ] 選択肢ボタンをクリックすると従来どおり進む
- [ ] 選択肢と同じ文言を TextField に入力して送信すると、ボタン選択と同様に進む
- [ ] 「その他」を押して自由記述を送ると、エラーにならず進捗・スコアが更新される
- [ ] 選択肢と無関係な短文が不当に default スコア 60 だけになる経路に入らない
- [ ] `go test ./internal/services/ -run 'TestParseChoiceOptions|TestResolveChoiceAnswer'`
- [ ] `npm test -- --testPathPatterns=chat-choices`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 選択肢の記号・文言を自動認識し、対応する選択肢として送信できるようになりました。
  - 選択肢に一致しない回答や「その他（自由記述）」は、自由入力として処理されます。
  - 入力内容に応じて、案内文やプレースホルダーが切り替わるようになりました。

- **改善**
  - 選択肢回答の判定と採点がより正確になりました。
  - 選択肢の文言を入力した場合も、適切な回答形式に自動変換されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->