### PR TITLE
feat: #586 L1シード投入と日次warm自動化

### DIFF
--- a/Backend/config/l1_catalog_seed.sample.csv
+++ b/Backend/config/l1_catalog_seed.sample.csv
@@ -1,0 +1,21 @@
+name,industry,segment,website_url,publish
+# Core（例: メガベンチャー / 大手IT / 主要SIer）— 実運用では 200〜300 社に拡張
+株式会社リクルート,情報通信業,core,,true
+株式会社サイバーエージェント,情報通信業,core,,true
+楽天グループ株式会社,情報通信業,core,,true
+LINEヤフー株式会社,情報通信業,core,,true
+株式会社メルカリ,情報通信業,core,,true
+富士通株式会社,情報通信業,core,,true
+日本電気株式会社,情報通信業,core,,true
+株式会社NTTデータ,情報通信業,core,,true
+株式会社野村総合研究所,情報通信業,core,,true
+株式会社日立製作所,情報通信業,core,,true
+# 中小SI / 受託・SES寄り（例）— Year1 は 1,000〜2,000 社規模へ拡張
+株式会社アイエスエフネット,情報サービス・SI,sme_si,,true
+株式会社システムズ,情報サービス・SI,sme_si,,true
+株式会社テクノプロ,情報サービス・SI,sme_si,,true
+パーソルクロステクノロジー株式会社,情報サービス・SI,sme_si,,true
+株式会社エスワイシステム,情報サービス・SI,sme_si,,true
+株式会社フォーラムエンジニアリング,情報サービス・SI,sme_si,,true
+株式会社ユニリタ,情報サービス・SI,sme_si,,true
+株式会社インテック,情報サービス・SI,sme_si,,true

--- a/Backend/config/l1_warm.env.example
+++ b/Backend/config/l1_warm.env.example
@@ -1,0 +1,5 @@
+# L1 カタログ温存（#586）
+# 1実行あたりの処理上限（日次 warm_l1_catalog / admin warm-l1）
+L1_WARM_BATCH_LIMIT=100
+# 日次ジョブの実行時刻（HH:MM、サーバローカル時刻）
+L1_WARM_SCHEDULE_TIME=03:00

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -7,7 +7,11 @@ import (
 	"Backend/internal/services"
 	ifaces "Backend/internal/services/interfaces"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -338,6 +342,58 @@ func (c *AdminCompanyController) FetchPersona(ctx echo.Context) error {
 	})
 
 	return ctx.JSON(http.StatusOK, profile)
+}
+
+// SeedL1Catalog POST /api/admin/companies/seed-l1
+// multipart file=csv または body に CSV テキスト。未指定時は sample CSV を読む。
+func (c *AdminCompanyController) SeedL1Catalog(ctx echo.Context) error {
+	var reader io.Reader
+	file, err := ctx.FormFile("file")
+	if err == nil && file != nil {
+		f, openErr := file.Open()
+		if openErr != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, openErr.Error())
+		}
+		defer f.Close()
+		reader = f
+	} else if body := ctx.Request().Body; body != nil && ctx.Request().ContentLength > 0 &&
+		strings.Contains(ctx.Request().Header.Get("Content-Type"), "text/csv") {
+		reader = body
+	} else {
+		path := strings.TrimSpace(ctx.QueryParam("path"))
+		if path == "" {
+			path = "config/l1_catalog_seed.sample.csv"
+		}
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			// Backend 作業ディレクトリ差を吸収
+			alt := filepath.Join("Backend", path)
+			f2, err2 := os.Open(alt)
+			if err2 != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("seed file not found: %v", openErr))
+			}
+			defer f2.Close()
+			reader = f2
+		} else {
+			defer f.Close()
+			reader = f
+		}
+	}
+	rows, err := services.ParseL1SeedCSV(reader)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	result, err := services.ImportL1Seed(c.repo, rows)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	actor := ctx.Request().Header.Get("X-Admin-Email")
+	c.audit.Record(actor, "company.seed_l1", "company", 0, map[string]any{
+		"total":   result.Total,
+		"created": result.Created,
+		"updated": result.Updated,
+	})
+	return ctx.JSON(http.StatusOK, result)
 }
 
 // GetL1Coverage GET /api/admin/companies/l1-coverage

--- a/Backend/internal/models/crawl.go
+++ b/Backend/internal/models/crawl.go
@@ -9,8 +9,8 @@ type CrawlSource struct {
 	TargetType   string     `gorm:"type:varchar(50);not null" json:"target_type"`   // company, popular_companies, etc
 	SourceType   string     `gorm:"type:varchar(50)" json:"source_type"`            // official, job_site, manual
 	SourceURL    string     `gorm:"type:varchar(500)" json:"source_url"`            // crawler target URL
-	ScheduleType string     `gorm:"type:varchar(20);not null" json:"schedule_type"` // weekly, monthly
-	ScheduleDay  int        `gorm:"default:1" json:"schedule_day"`                  // 0-6 (weekly) or 1-31 (monthly)
+	ScheduleType string     `gorm:"type:varchar(20);not null" json:"schedule_type"` // daily, weekly, monthly
+	ScheduleDay  int        `gorm:"default:1" json:"schedule_day"`                  // unused for daily; 0-6 weekly; 1-31 monthly
 	ScheduleTime string     `gorm:"type:varchar(10);not null" json:"schedule_time"` // HH:MM
 	IsActive     bool       `gorm:"default:true" json:"is_active"`
 	LastRunAt    *time.Time `json:"last_run_at,omitempty"`

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -40,6 +40,7 @@ func SetupAdminRoutes(
 	admin.GET("/companies/names", adminCompanyController.Names)
 	admin.GET("/companies/l1-coverage", adminCompanyController.GetL1Coverage)
 	admin.POST("/companies/warm-l1", adminCompanyController.WarmL1Catalog)
+	admin.POST("/companies/seed-l1", adminCompanyController.SeedL1Catalog)
 	admin.GET("/companies/:id", adminCompanyController.Get)
 	admin.PUT("/companies/:id", adminCompanyController.Update)
 	admin.POST("/companies/:id/publish", adminCompanyController.Publish)

--- a/Backend/internal/services/catalog_warm_service.go
+++ b/Backend/internal/services/catalog_warm_service.go
@@ -38,12 +38,16 @@ func NewCatalogWarmService(
 
 // L1Coverage は公開カタログの L1 充足率。
 type L1Coverage struct {
-	PublishedTotal int64   `json:"published_total"`
-	InfoFresh      int64   `json:"info_fresh"`
-	HasProfile     int64   `json:"has_profile"`
-	NeedsWarm      int64   `json:"needs_warm"`
-	InfoRate       float64 `json:"info_rate"`
-	ProfileRate    float64 `json:"profile_rate"`
+	PublishedTotal int64    `json:"published_total"`
+	InfoFresh      int64    `json:"info_fresh"`
+	HasProfile     int64    `json:"has_profile"`
+	NeedsWarm      int64    `json:"needs_warm"`
+	InfoRate       float64  `json:"info_rate"`
+	ProfileRate    float64  `json:"profile_rate"`
+	InfoTarget     float64  `json:"info_target"`
+	ProfileTarget  float64  `json:"profile_target"`
+	BelowTarget    bool     `json:"below_target"`
+	Alerts         []string `json:"alerts,omitempty"`
 }
 
 // L1WarmOptions はバッチ実行オプション。
@@ -94,10 +98,23 @@ func (s *CatalogWarmService) Coverage(ctx context.Context) (*L1Coverage, error) 
 		InfoFresh:      stats.InfoFresh,
 		HasProfile:     stats.HasProfile,
 		NeedsWarm:      stats.NeedsWarm,
+		InfoTarget:     0.80,
+		ProfileTarget:  0.95,
 	}
 	if stats.PublishedTotal > 0 {
 		cov.InfoRate = float64(stats.InfoFresh) / float64(stats.PublishedTotal)
 		cov.ProfileRate = float64(stats.HasProfile) / float64(stats.PublishedTotal)
+	}
+	if cov.InfoRate < cov.InfoTarget {
+		cov.BelowTarget = true
+		cov.Alerts = append(cov.Alerts, fmt.Sprintf("info_rate=%.0f%% < target %.0f%%", cov.InfoRate*100, cov.InfoTarget*100))
+	}
+	if cov.ProfileRate < cov.ProfileTarget {
+		cov.BelowTarget = true
+		cov.Alerts = append(cov.Alerts, fmt.Sprintf("profile_rate=%.0f%% < target %.0f%%", cov.ProfileRate*100, cov.ProfileTarget*100))
+	}
+	if cov.BelowTarget {
+		log.Printf("l1_coverage ALERT published=%d needs_warm=%d alerts=%v", cov.PublishedTotal, cov.NeedsWarm, cov.Alerts)
 	}
 	return cov, nil
 }

--- a/Backend/internal/services/catalog_warm_service_test.go
+++ b/Backend/internal/services/catalog_warm_service_test.go
@@ -107,4 +107,10 @@ func TestCoverage_Rates(t *testing.T) {
 	if cov.ProfileRate != 0.5 {
 		t.Fatalf("profile_rate=%v want 0.5", cov.ProfileRate)
 	}
+	if !cov.BelowTarget {
+		t.Fatal("expected below_target")
+	}
+	if len(cov.Alerts) == 0 {
+		t.Fatal("expected alerts")
+	}
 }

--- a/Backend/internal/services/crawl_service.go
+++ b/Backend/internal/services/crawl_service.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -137,11 +138,50 @@ func (s *CrawlService) RunSource(id uint) (*models.CrawlRun, error) {
 }
 
 func (s *CrawlService) StartScheduler() {
+	s.EnsureL1WarmCrawlSource()
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 	for range ticker.C {
 		s.runDueSources()
 	}
+}
+
+// EnsureL1WarmCrawlSource は日次 L1 温存ジョブが無ければ作成する（#586）。
+func (s *CrawlService) EnsureL1WarmCrawlSource() {
+	sources, err := s.repo.ListSources()
+	if err != nil {
+		log.Printf("ensure warm_l1_catalog: list failed: %v", err)
+		return
+	}
+	for _, src := range sources {
+		if src.TargetType == "warm_l1_catalog" {
+			return
+		}
+	}
+	timeOfDay := strings.TrimSpace(os.Getenv("L1_WARM_SCHEDULE_TIME"))
+	if timeOfDay == "" {
+		timeOfDay = "03:00"
+	}
+	source := &models.CrawlSource{
+		Name:         "L1 catalog daily warm",
+		TargetType:   "warm_l1_catalog",
+		SourceType:   "manual",
+		ScheduleType: "daily",
+		ScheduleDay:  0,
+		ScheduleTime: timeOfDay,
+		IsActive:     true,
+	}
+	if err := validateCrawlSource(source); err != nil {
+		log.Printf("ensure warm_l1_catalog: invalid: %v", err)
+		return
+	}
+	now := time.Now()
+	source.NextRunAt = computeNextRun(now, source)
+	if err := s.repo.CreateSource(source); err != nil {
+		log.Printf("ensure warm_l1_catalog: create failed: %v", err)
+		return
+	}
+	log.Printf("ensure warm_l1_catalog: created id=%d next_run_at=%v", source.ID, source.NextRunAt)
 }
 
 func (s *CrawlService) RunDueSources() {
@@ -250,14 +290,15 @@ func validateCrawlSource(source *models.CrawlSource) error {
 	if urlRequiredTypes[source.TargetType] && strings.TrimSpace(source.SourceURL) == "" {
 		return fmt.Errorf("source_url is required for %s", source.TargetType)
 	}
-	if source.ScheduleType != "weekly" && source.ScheduleType != "monthly" {
-		return errors.New("schedule_type must be weekly or monthly")
+	if source.ScheduleType != "daily" && source.ScheduleType != "weekly" && source.ScheduleType != "monthly" {
+		return errors.New("schedule_type must be daily, weekly or monthly")
 	}
 	if source.ScheduleType == "weekly" {
 		if source.ScheduleDay < 0 || source.ScheduleDay > 6 {
 			return errors.New("schedule_day must be 0-6 for weekly")
 		}
-	} else {
+	}
+	if source.ScheduleType == "monthly" {
 		if source.ScheduleDay < 1 || source.ScheduleDay > 31 {
 			return errors.New("schedule_day must be 1-31 for monthly")
 		}
@@ -1066,14 +1107,20 @@ func computeNextRun(now time.Time, source *models.CrawlSource) *time.Time {
 	min := hourMin.Minute()
 	loc := now.Location()
 	var next time.Time
-	if source.ScheduleType == "weekly" {
+	switch source.ScheduleType {
+	case "daily":
+		next = time.Date(now.Year(), now.Month(), now.Day(), hour, min, 0, 0, loc)
+		if !next.After(now) {
+			next = next.AddDate(0, 0, 1)
+		}
+	case "weekly":
 		target := time.Weekday(source.ScheduleDay)
 		days := (int(target) - int(now.Weekday()) + 7) % 7
 		next = time.Date(now.Year(), now.Month(), now.Day(), hour, min, 0, 0, loc).AddDate(0, 0, days)
 		if !next.After(now) {
 			next = next.AddDate(0, 0, 7)
 		}
-	} else {
+	default: // monthly
 		day := source.ScheduleDay
 		year, month := now.Year(), now.Month()
 		lastDay := lastDayOfMonth(year, month, loc)

--- a/Backend/internal/services/l1_seed_service.go
+++ b/Backend/internal/services/l1_seed_service.go
@@ -1,0 +1,191 @@
+package services
+
+import (
+	"Backend/domain/repository"
+	"Backend/internal/models"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+)
+
+// L1SeedRow はカタログシード CSV の1行。
+type L1SeedRow struct {
+	Name       string
+	Industry   string
+	Segment    string // core | sme_si | extended
+	WebsiteURL string
+	Publish    bool
+}
+
+// L1SeedResult は投入結果。
+type L1SeedResult struct {
+	Total   int `json:"total"`
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Skipped int `json:"skipped"`
+	Errors  []string `json:"errors,omitempty"`
+}
+
+// ParseL1SeedCSV は name,industry,segment,website_url,publish 形式を読む。
+func ParseL1SeedCSV(r io.Reader) ([]L1SeedRow, error) {
+	cr := csv.NewReader(r)
+	cr.TrimLeadingSpace = true
+	cr.FieldsPerRecord = -1
+	records, err := cr.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("empty csv")
+	}
+	start := 0
+	header := map[string]int{}
+	if looksLikeL1Header(records[0]) {
+		for i, h := range records[0] {
+			header[strings.ToLower(strings.TrimSpace(h))] = i
+		}
+		start = 1
+	} else {
+		header = map[string]int{"name": 0, "industry": 1, "segment": 2, "website_url": 3, "publish": 4}
+	}
+	nameIdx, ok := header["name"]
+	if !ok {
+		return nil, fmt.Errorf("csv must include name column")
+	}
+	var rows []L1SeedRow
+	for i := start; i < len(records); i++ {
+		rec := records[i]
+		if len(rec) <= nameIdx {
+			continue
+		}
+		name := strings.TrimSpace(rec[nameIdx])
+		if name == "" || strings.HasPrefix(name, "#") {
+			continue
+		}
+		row := L1SeedRow{Name: name}
+		if idx, ok := header["industry"]; ok && idx < len(rec) {
+			row.Industry = strings.TrimSpace(rec[idx])
+		}
+		if idx, ok := header["segment"]; ok && idx < len(rec) {
+			row.Segment = normalizeL1Segment(rec[idx])
+		} else {
+			row.Segment = "extended"
+		}
+		if idx, ok := header["website_url"]; ok && idx < len(rec) {
+			row.WebsiteURL = strings.TrimSpace(rec[idx])
+		}
+		if idx, ok := header["publish"]; ok && idx < len(rec) {
+			row.Publish = parseBoolish(rec[idx])
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func looksLikeL1Header(rec []string) bool {
+	for _, c := range rec {
+		if strings.EqualFold(strings.TrimSpace(c), "name") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeL1Segment(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	switch s {
+	case "core", "sme_si", "sme-si", "中小si", "si":
+		if s == "sme-si" || s == "中小si" || s == "si" {
+			return "sme_si"
+		}
+		return s
+	case "extended", "ext", "":
+		return "extended"
+	default:
+		return "extended"
+	}
+}
+
+func parseBoolish(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "y", "published", "publish":
+		return true
+	default:
+		return false
+	}
+}
+
+// ImportL1Seed はシード行を companies に upsert する（Search しない）。
+func ImportL1Seed(repo repository.CompanyRepository, rows []L1SeedRow) (*L1SeedResult, error) {
+	if repo == nil {
+		return nil, fmt.Errorf("company repo is nil")
+	}
+	res := &L1SeedResult{Total: len(rows)}
+	for _, row := range rows {
+		existing, err := repo.FindByName(row.Name)
+		if err == nil && existing != nil {
+			changed := false
+			if row.Industry != "" && existing.Industry == "" {
+				existing.Industry = row.Industry
+				changed = true
+			}
+			if row.WebsiteURL != "" && existing.WebsiteURL == "" {
+				existing.WebsiteURL = row.WebsiteURL
+				changed = true
+			}
+			if row.Publish && existing.DataStatus != "published" {
+				existing.DataStatus = "published"
+				existing.IsActive = true
+				existing.IsProvisional = false
+				changed = true
+			}
+			// segment を industry 接頭辞で残す（専用カラムなし）
+			if row.Segment == "core" || row.Segment == "sme_si" {
+				tag := "[L1:" + row.Segment + "]"
+				if !strings.Contains(existing.Description, tag) {
+					existing.Description = strings.TrimSpace(tag + " " + existing.Description)
+					changed = true
+				}
+			}
+			if changed {
+				if err := repo.Update(existing); err != nil {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: update %v", row.Name, err))
+					continue
+				}
+				res.Updated++
+			} else {
+				res.Skipped++
+			}
+			continue
+		}
+		c := &models.Company{
+			Name:          row.Name,
+			Industry:      row.Industry,
+			WebsiteURL:    row.WebsiteURL,
+			SourceType:    "manual",
+			IsActive:      true,
+			IsProvisional: !row.Publish,
+			DataStatus:    "draft",
+		}
+		if row.Segment == "core" || row.Segment == "sme_si" {
+			c.Description = "[L1:" + row.Segment + "]"
+		}
+		if row.Publish {
+			c.DataStatus = "published"
+			c.IsProvisional = false
+		}
+		if row.Industry == "" && row.Segment == "sme_si" {
+			c.Industry = "情報サービス・SI"
+		}
+		if err := repo.Create(c); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: create %v", row.Name, err))
+			continue
+		}
+		res.Created++
+	}
+	log.Printf("l1_seed: total=%d created=%d updated=%d skipped=%d errors=%d",
+		res.Total, res.Created, res.Updated, res.Skipped, len(res.Errors))
+	return res, nil
+}

--- a/Backend/internal/services/l1_seed_service_test.go
+++ b/Backend/internal/services/l1_seed_service_test.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseL1SeedCSV_WithHeader(t *testing.T) {
+	csv := "name,industry,segment,website_url,publish\n" +
+		"株式会社コアテック,情報通信,core,https://example.com,true\n" +
+		"中小SI株式会社,,sme_si,,1\n" +
+		"# comment,,,,\n"
+	rows, err := ParseL1SeedCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len=%d want 2", len(rows))
+	}
+	if rows[0].Segment != "core" || !rows[0].Publish {
+		t.Fatalf("row0=%+v", rows[0])
+	}
+	if rows[1].Segment != "sme_si" || !rows[1].Publish {
+		t.Fatalf("row1=%+v", rows[1])
+	}
+}
+
+func TestNormalizeL1Segment(t *testing.T) {
+	if normalizeL1Segment("SI") != "sme_si" {
+		t.Fatal(normalizeL1Segment("SI"))
+	}
+}

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -41,6 +41,10 @@ type L1Coverage = {
   needs_warm: number
   info_rate: number
   profile_rate: number
+  info_target?: number
+  profile_target?: number
+  below_target?: boolean
+  alerts?: string[]
 }
 
 const sourceLabel = (sourceType?: string) => {
@@ -101,6 +105,30 @@ export default function AdminCompaniesPage() {
   const handlePageChange = (_: React.ChangeEvent<unknown>, value: number) => {
     setPage(value)
     fetchCompanies(value)
+  }
+
+  const handleSeedL1 = async () => {
+    setWarming(true)
+    setWarmMessage('')
+    setError('')
+    try {
+      const res = await fetch('/api/admin/companies/seed-l1', {
+        method: 'POST',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || data?.message || 'L1シード投入に失敗しました')
+        return
+      }
+      setWarmMessage(
+        `シード投入: 作成 ${data.created ?? 0} / 更新 ${data.updated ?? 0} / スキップ ${data.skipped ?? 0}`,
+      )
+      await fetchCoverage()
+      await fetchCompanies(page)
+    } finally {
+      setWarming(false)
+    }
   }
 
   const handleWarmL1 = async (dryRun: boolean) => {
@@ -206,16 +234,35 @@ export default function AdminCompaniesPage() {
               {coverage && (
                 <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 1.5 }}>
                   <Chip size="small" label={`公開 ${coverage.published_total}`} />
-                  <Chip size="small" color="success" label={`Info ${pct(coverage.info_rate)}`} />
-                  <Chip size="small" color="info" label={`Profile ${pct(coverage.profile_rate)}`} />
+                  <Chip
+                    size="small"
+                    color={coverage.info_rate < (coverage.info_target ?? 0.8) ? 'error' : 'success'}
+                    label={`Info ${pct(coverage.info_rate)} / 目標 ${pct(coverage.info_target ?? 0.8)}`}
+                  />
+                  <Chip
+                    size="small"
+                    color={coverage.profile_rate < (coverage.profile_target ?? 0.95) ? 'error' : 'info'}
+                    label={`Profile ${pct(coverage.profile_rate)} / 目標 ${pct(coverage.profile_target ?? 0.95)}`}
+                  />
                   <Chip size="small" color="warning" label={`要温存 ${coverage.needs_warm}`} />
+                  {coverage.below_target && (
+                    <Chip size="small" color="error" label="閾値割れ" />
+                  )}
                 </Stack>
               )}
+              {coverage?.alerts?.length ? (
+                <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+                  {coverage.alerts.join(' / ')}
+                </Typography>
+              ) : null}
               {warmMessage && (
                 <Typography variant="body2" sx={{ mt: 1 }}>{warmMessage}</Typography>
               )}
             </Box>
-            <Stack direction="row" spacing={1}>
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              <Button variant="outlined" size="small" disabled={warming} onClick={() => handleSeedL1()}>
+                サンプルシード投入
+              </Button>
               <Button variant="outlined" size="small" disabled={warming} onClick={() => handleWarmL1(true)}>
                 ドライラン
               </Button>

--- a/frontend/app/api/admin/companies/seed-l1/route.ts
+++ b/frontend/app/api/admin/companies/seed-l1/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const contentType = request.headers.get('content-type') || ''
+  const headers: HeadersInit = {
+    'X-Admin-Email': request.headers.get('x-admin-email') || '',
+    'X-Admin-Token': request.headers.get('x-admin-token') || '',
+  }
+  let body: BodyInit | undefined
+  if (contentType.includes('multipart/form-data')) {
+    body = await request.formData()
+  } else {
+    headers['Content-Type'] = contentType || 'text/csv'
+    body = await request.text()
+  }
+  const qs = request.nextUrl.searchParams.toString()
+  const response = await fetch(
+    `${BACKEND_URL}/api/admin/companies/seed-l1${qs ? `?${qs}` : ''}`,
+    { method: 'POST', headers, body },
+  )
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}


### PR DESCRIPTION
## Summary
- Closes #586
- `Backend/config/l1_catalog_seed.sample.csv` + `POST /admin/companies/seed-l1`
- crawl `schedule_type=daily` + 起動時に `warm_l1_catalog` ソースを自動作成（`L1_WARM_SCHEDULE_TIME`）
- L1 coverage に info≥80% / profile≥95% 閾値と `alerts` / admin UI 警告

## Test plan
- [x] `go test ./internal/services/ -run 'L1Seed|L1Warm|Coverage' -count=1`
- [ ] admin「サンプルシード投入」→ 企業が増える
- [ ] サーバ起動後 crawl-sources に `warm_l1_catalog` (daily) がある
- [ ] coverage 不足時に alerts / 閾値割れチップが出る


Made with [Cursor](https://cursor.com)