### PR TITLE
feat: #588 マッチング理由をDB briefのみに

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -45,6 +45,8 @@ RAG_ALLOW_WEB_SEARCH_FALLBACK=false
 RAG_USE_DEEP_RESEARCH=false
 # L1 カタログ温存バッチ（1実行あたり上限。日次クロール warm_l1_catalog でも使用）
 L1_WARM_BATCH_LIMIT=100
+# マッチング理由の AI 生成（既定オフ。テンプレ+DBのみ）#588
+# MATCHING_REASON_USE_AI=true
 # Chroma（compose profile=rag）
 CHROMA_HOST=localhost
 CHROMA_PORT=8000

--- a/Backend/internal/services/match_reason_builder.go
+++ b/Backend/internal/services/match_reason_builder.go
@@ -150,29 +150,35 @@ func buildCompanyContext(company *entity.Company) string {
 	if company == nil {
 		return "事業内容や開発環境に合った適性が活かせる企業です。"
 	}
+	// DB に載っている事実のみ（Search / 都度 LLM 調査はしない）#588
 	parts := []string{}
 	if strings.TrimSpace(company.MainBusiness) != "" {
-		parts = append(parts, fmt.Sprintf("主な事業は「%s」です。", company.MainBusiness))
+		parts = append(parts, fmt.Sprintf("主な事業は「%s」です。", trimReasonText(company.MainBusiness, 120)))
+	} else if strings.TrimSpace(company.Description) != "" {
+		parts = append(parts, fmt.Sprintf("概要として「%s」が登録されています。", trimReasonText(company.Description, 120)))
 	}
 	if strings.TrimSpace(company.Culture) != "" {
-		parts = append(parts, fmt.Sprintf("企業文化として「%s」が特徴です。", company.Culture))
+		parts = append(parts, fmt.Sprintf("企業文化として「%s」が特徴です。", trimReasonText(company.Culture, 80)))
 	}
 	if strings.TrimSpace(company.WorkStyle) != "" {
-		parts = append(parts, fmt.Sprintf("働き方は「%s」を想定しています。", company.WorkStyle))
+		parts = append(parts, fmt.Sprintf("働き方は「%s」です。", company.WorkStyle))
 	}
-	if strings.TrimSpace(company.DevelopmentStyle) != "" {
-		parts = append(parts, fmt.Sprintf("開発スタイルは「%s」です。", company.DevelopmentStyle))
-	}
-	if strings.TrimSpace(company.TechStack) != "" {
-		stack := parseTechStack(company.TechStack)
-		if len(stack) > 0 {
-			parts = append(parts, fmt.Sprintf("技術スタックは%sが中心です。", strings.Join(stack, " / ")))
-		}
+	if strings.TrimSpace(company.TechStack) != "" && company.TechStack != "null" && company.TechStack != "[]" {
+		parts = append(parts, fmt.Sprintf("技術スタックには「%s」などがあります。", trimReasonText(company.TechStack, 80)))
 	}
 	if len(parts) == 0 {
-		return "事業内容や開発環境に合った適性が活かせる企業です。"
+		return "登録済みの企業プロファイルに基づき、志向の一致を重視した候補です。"
 	}
-	return strings.Join(parts, " ")
+	return strings.Join(parts, "")
+}
+
+func trimReasonText(s string, max int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if max <= 0 || len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }
 
 func filterNonEmpty(parts []string) []string {

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"os"
 	"sort"
 	"strings"
 )
@@ -203,7 +204,8 @@ func (s *MatchingService) GetDiagnostics(userID uint, sessionID string) (*Matchi
 	}, nil
 }
 
-// GenerateMatchReason AIを使ってマッチング理由を生成（オプション）
+// GenerateMatchReason はマッチング理由を返す。
+// 既定は DB/テンプレのみ（#588）。AI 生成は MATCHING_REASON_USE_AI=true のときだけ。
 func (s *MatchingService) GenerateMatchReason(ctx context.Context, match *entity.UserCompanyMatch, userScores []entity.UserWeightScore) (string, error) {
 	if match == nil {
 		return "", fmt.Errorf("match is nil")
@@ -211,7 +213,7 @@ func (s *MatchingService) GenerateMatchReason(ctx context.Context, match *entity
 	if match.Company == nil {
 		return "", fmt.Errorf("company is nil")
 	}
-	if s.aiClient == nil {
+	if !matchingReasonUseAI() || s.aiClient == nil {
 		return BuildMatchReason(match, userScores), nil
 	}
 
@@ -223,14 +225,20 @@ func (s *MatchingService) GenerateMatchReason(ctx context.Context, match *entity
 		0.4,
 	)
 	if err != nil {
-		return "", err
+		log.Printf("[GenerateMatchReason] AI failed, fallback to template: %v", err)
+		return BuildMatchReason(match, userScores), nil
 	}
 
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
-		return "", fmt.Errorf("empty matching reason response")
+		return BuildMatchReason(match, userScores), nil
 	}
 	return reason, nil
+}
+
+func matchingReasonUseAI() bool {
+	v := strings.TrimSpace(os.Getenv("MATCHING_REASON_USE_AI"))
+	return strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
 }
 
 func buildMatchingReasonUserPrompt(match *entity.UserCompanyMatch, userScores []entity.UserWeightScore) string {

--- a/Backend/internal/services/matching_service_test.go
+++ b/Backend/internal/services/matching_service_test.go
@@ -55,3 +55,28 @@ func TestGenerateMatchReasonFallbackWhenAIClientNil(t *testing.T) {
 		t.Fatalf("expected company name in reason, got: %q", got)
 	}
 }
+
+func TestGenerateMatchReason_DefaultSkipsAI(t *testing.T) {
+	t.Setenv("MATCHING_REASON_USE_AI", "")
+	if matchingReasonUseAI() {
+		t.Fatal("AI should be off by default")
+	}
+	svc := &MatchingService{aiClient: nil}
+	match := &entity.UserCompanyMatch{
+		MatchScore: 70,
+		Company: &entity.Company{
+			ID: 2, Name: "DBのみ株式会社", Industry: "SI", MainBusiness: "受託開発",
+		},
+	}
+	got, err := svc.GenerateMatchReason(t.Context(), match, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "DBのみ株式会社") {
+		t.Fatalf("got %q", got)
+	}
+	if !strings.Contains(got, "受託開発") {
+		t.Fatalf("expected DB business fact, got %q", got)
+	}
+}
+


### PR DESCRIPTION
## Summary
- Closes #588
- `GenerateMatchReason` 既定はテンプレ + DB 企業事実のみ
- AI 生成は `MATCHING_REASON_USE_AI=true` のときだけ
- company_context を DB フィールド（事業/文化/働き方/tech）に限定

## Test plan
- [x] `go test ./internal/services/ -run 'MatchReason|GenerateMatchReason' -count=1`
- [ ] チャット完了→マッチング結果の理由文がテンプレ由来で、OpenAI Responses が増えない


Made with [Cursor](https://cursor.com)