### PR TITLE
feat: #585 旧 Persistent Chroma データを独立 Chroma へ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,10 @@ docker compose up -d --build
 重いサービス（RAG）を後から起動する場合:
 
 ```sh
-docker compose --profile rag up -d rag-review
+docker compose --profile rag up -d chroma rag-review
 ```
+
+`chroma` は named volume `chroma_data` で永続化されます。旧 PersistentClient（コンテナ内 `/app/chroma_db`）からの移行は [docs/wiki/chroma-migration.md](docs/wiki/chroma-migration.md)（#585）を参照してください。
 
 ---
 

--- a/docs/wiki/chroma-migration.md
+++ b/docs/wiki/chroma-migration.md
@@ -1,0 +1,82 @@
+# Chroma データ移行（Persistent → Http）#585
+
+旧 RAG コンテナ内の `/app/chroma_db`（PersistentClient）から、独立 `soc-ai-chroma`（HttpClient）へ移行する手順です。
+
+## 前提
+
+- `compose.yml` の `chroma` は volume `chroma_data` で永続化される（再作成しても消えない）
+- 旧 RAG は volume 未マウントだったため、**再作成前に必ず退避**する
+
+## 1. 退避（移行前バックアップ）
+
+```sh
+# 稼働中の旧 rag-review から
+docker cp soc-ai-rag-review:/app/chroma_db ./backup/chroma_db_$(date +%Y%m%d)
+
+# または検証時の退避先
+# /tmp/soc-ai-chroma-backup/chroma_db
+```
+
+## 2. 新構成の起動
+
+```sh
+make rag-up
+# chroma :8000 / rag-review :9000
+curl -s http://localhost:9000/health
+# → vector_store.ok=true, detail に chromadb http://chroma:8000
+```
+
+## 3. ドライラン → 本番移行
+
+```sh
+cd rag
+# venv がある場合
+.venv/bin/python scripts/migrate_persistent_to_http.py \
+  --source /tmp/soc-ai-chroma-backup/chroma_db \
+  --host 127.0.0.1 --port 8000 --dry-run
+
+.venv/bin/python scripts/migrate_persistent_to_http.py \
+  --source /tmp/soc-ai-chroma-backup/chroma_db \
+  --host 127.0.0.1 --port 8000
+```
+
+旧コレクション名（`hints_______39722` 等）はメタデータ付きで
+
+- `interview_hints` / `es_review` / `company_context`
+
+へ集約されます。
+
+## 4. 確認
+
+```sh
+curl -s http://localhost:9000/vector/status
+# total_documents が増えていること
+
+# 企業フィルタ（社名は RAG の sanitize 後キー。旧 ID 由来は legacyid39722 形式）
+curl -sG 'http://localhost:9000/vector/status' --data-urlencode 'company=legacyid39722'
+```
+
+旧コレクション名から推測した企業キーは `legacy_id_39722` → sanitize 後 `legacyid39722` になります（`/vector/status` のクエリと同じ規則）。
+
+## 5. ロールバック
+
+Http 側が壊れた・移行失敗時:
+
+1. `rag-review` を止め、`CHROMA_HOST` を空にする（Persistent フォールバック）
+2. 退避した `chroma_db` を `RAG_CHROMA_DATA_DIR`（既定 `/app/chroma_db`）にマウントして再起動
+
+```yaml
+# 一時的な compose override 例
+services:
+  rag-review:
+    environment:
+      - CHROMA_HOST=
+      - RAG_CHROMA_DATA_DIR=/data/chroma_db
+    volumes:
+      - ./backup/chroma_db_YYYYMMDD:/data/chroma_db
+```
+
+## 関連
+
+- Issue #585
+- `make rag-up` / #589

--- a/docs/wiki/rag-service.md
+++ b/docs/wiki/rag-service.md
@@ -11,7 +11,9 @@ SOC AI Agent の RAG（Retrieval-Augmented Generation）サービスは Python /
 | 既定 | Docker Compose の `chroma` サービス（`chromadb/chroma:0.6.3`） |
 | RAG 接続 | `CHROMA_HOST` / `CHROMA_PORT` → `HttpClient` |
 | フォールバック | `CHROMA_HOST` 未設定時は `PersistentClient`（ローカル開発・単体テスト） |
+| 永続化 | compose named volume `chroma_data`（`chroma` 再作成でも保持） |
 | コレクション | `company_context` / `interview_hints` / `es_review`（企業メタデータ付き） |
+| 旧データ移行 | [chroma-migration.md](./chroma-migration.md)（#585） |
 | 設計 | `docs/design/vector-db.md` |
 
 ---
@@ -99,17 +101,17 @@ SOC AI Agent の RAG（Retrieval-Augmented Generation）サービスは Python /
 ### 設定
 
 ```env
-# ChromaDB データディレクトリ（デフォルト: /app/chroma_db）
+# 独立 Chroma（推奨）
+CHROMA_HOST=chroma
+CHROMA_PORT=8000
+
+# CHROMA_HOST 未設定時のみ PersistentClient 用
 RAG_CHROMA_DATA_DIR=/app/chroma_db
 ```
 
 ### キャッシュのリセット
 
-```sh
-# Docker Compose 環境の場合
-docker compose exec rag-review rm -rf /app/chroma_db
-docker compose restart rag-review
-```
+HttpClient 構成では RAG コンテナ内の `/app/chroma_db` 削除では消えません。`/vector/reembed` または Chroma 側コレクション削除を使います。ロールバックは [chroma-migration.md](./chroma-migration.md) を参照。
 
 ---
 

--- a/rag/scripts/migrate_persistent_to_http.py
+++ b/rag/scripts/migrate_persistent_to_http.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""旧 PersistentClient (/app/chroma_db) → 独立 Chroma HttpClient への移行 (#585)。
+
+使い方（ホストから）:
+  # 1) 旧データを退避済みであること（例: /tmp/soc-ai-chroma-backup/chroma_db）
+  # 2) chroma + rag-review が起動していること（make rag-up）
+  cd rag && .venv/bin/python scripts/migrate_persistent_to_http.py \\
+    --source /tmp/soc-ai-chroma-backup/chroma_db \\
+    --host 127.0.0.1 --port 8000 --dry-run
+
+  # 本番投入
+  ... --dry-run を外す
+
+ロールバック:
+  rag-review の CHROMA_HOST を空にし、RAG_CHROMA_DATA_DIR に旧 path をマウントして再起動。
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from typing import Any, Dict, List
+
+import chromadb
+
+
+NEW_COLLECTIONS = ("company_context", "interview_hints", "es_review")
+
+
+def _names(client: Any) -> List[str]:
+    raw = client.list_collections()
+    out: List[str] = []
+    for c in raw:
+        if isinstance(c, str):
+            out.append(c)
+        else:
+            name = getattr(c, "name", "") or ""
+            if name:
+                out.append(name)
+    return out
+
+
+def map_target_collection(src_name: str) -> str:
+    n = src_name.lower()
+    if "hint" in n:
+        return "interview_hints"
+    if "es_review" in n or n.endswith("es_review"):
+        return "es_review"
+    if src_name in NEW_COLLECTIONS:
+        return src_name
+    return "company_context"
+
+
+def sanitize_company(company_name: str) -> str:
+    """rag/main.py の _sanitize_company_name_for_query と同等。"""
+    sanitized = re.sub(r"[^0-9A-Za-zぁ-んァ-ン一-龥ー々〆ヵヶ・\s]", "", company_name)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    return sanitized or "unknown"
+
+
+def infer_company(src_name: str, metadata: Dict[str, Any] | None) -> str:
+    if metadata and metadata.get("company"):
+        return sanitize_company(str(metadata["company"]))
+    # 旧命名: hints_______39722 / 39722_______es_review など
+    digits = re.findall(r"\d{4,}", src_name)
+    if digits:
+        return sanitize_company(f"legacy_id_{digits[-1]}")
+    cleaned = re.sub(r"[^0-9A-Za-z一-龥ぁ-んァ-ヶー]+", "_", src_name).strip("_")
+    return sanitize_company(cleaned or "unknown")
+
+
+def migrate(source: str, host: str, port: int, dry_run: bool, limit_per_col: int) -> int:
+    src = chromadb.PersistentClient(path=source)
+    dst = chromadb.HttpClient(host=host, port=port)
+    src_names = _names(src)
+    print(f"source collections={len(src_names)} path={source}")
+    print(f"dest http://{host}:{port}")
+
+    moved = 0
+    mapped: Dict[str, int] = {k: 0 for k in NEW_COLLECTIONS}
+    skipped_no_emb = 0
+    for name in src_names:
+        target = map_target_collection(name)
+        scol = src.get_collection(name)
+        try:
+            count = scol.count()
+        except Exception as exc:
+            print(f"  skip {name}: count failed {exc}")
+            continue
+        if count == 0:
+            continue
+        print(f"  {name} ({count}) -> {target}")
+        if dry_run:
+            moved += count
+            mapped[target] = mapped.get(target, 0) + count
+            continue
+        # 全件取得（中規模想定）。巨大な場合は limit で分割。
+        got = scol.get(include=["documents", "metadatas", "embeddings"])
+        ids = got.get("ids") or []
+        docs = got.get("documents") or []
+        metas = got.get("metadatas") or []
+        embs = got.get("embeddings")
+        if embs is None:
+            print(f"  skip {name}: no embeddings")
+            skipped_no_emb += 1
+            continue
+        dcol = dst.get_or_create_collection(target)
+        batch_ids: List[str] = []
+        batch_docs: List[str] = []
+        batch_metas: List[Dict[str, Any]] = []
+        batch_embs: List[List[float]] = []
+        for i, doc_id in enumerate(ids):
+            if limit_per_col > 0 and i >= limit_per_col:
+                break
+            doc = docs[i] if i < len(docs) else None
+            if not doc:
+                continue
+            md = dict(metas[i] or {}) if i < len(metas) else {}
+            md.setdefault("company", infer_company(name, md))
+            md.setdefault("role", md.get("role") or "general")
+            md.setdefault("doc_type", target if target != "company_context" else "company_research")
+            md.setdefault("source", md.get("source") or "migrate_persistent")
+            md["migrated_from"] = name
+            emb = embs[i] if i < len(embs) else None
+            if emb is None:
+                continue
+            new_id = f"mig_{name}_{doc_id}"[:64]
+            batch_ids.append(new_id)
+            batch_docs.append(doc)
+            batch_metas.append(md)
+            batch_embs.append(list(emb))
+        if not batch_ids:
+            continue
+        # chroma upsert は大きすぎると失敗しうるので分割
+        chunk = 50
+        for start in range(0, len(batch_ids), chunk):
+            dcol.upsert(
+                ids=batch_ids[start : start + chunk],
+                documents=batch_docs[start : start + chunk],
+                metadatas=batch_metas[start : start + chunk],
+                embeddings=batch_embs[start : start + chunk],
+            )
+        moved += len(batch_ids)
+        mapped[target] = mapped.get(target, 0) + len(batch_ids)
+        print(f"    upserted {len(batch_ids)}")
+    print(f"done moved_docs={moved} dry_run={dry_run} mapped={mapped} skipped_no_emb={skipped_no_emb}")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    p = argparse.ArgumentParser(description="Migrate Persistent Chroma to Http Chroma (#585)")
+    p.add_argument("--source", required=True, help="PersistentClient path")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--limit-per-collection", type=int, default=0, help="0=all")
+    args = p.parse_args(argv)
+    return migrate(args.source, args.host, args.port, args.dry_run, args.limit_per_collection)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- 旧 PersistentClient（`/app/chroma_db`）→ Http Chroma 移行スクリプト `rag/scripts/migrate_persistent_to_http.py` を追加
- 移行・確認・ロールバック手順を `docs/wiki/chroma-migration.md` に文書化
- `chroma_data` volume 永続化と README / rag-service からの導線を明記

## Test plan
- [ ] `make rag-up` または `docker compose --profile rag up -d chroma rag-review`
- [ ] dry-run: `rag/.venv/bin/python rag/scripts/migrate_persistent_to_http.py --source <backup> --host 127.0.0.1 --port 8000 --dry-run`
- [ ] 本番移行後 `curl -s http://localhost:9000/vector/status` で件数増加を確認
- [ ] `curl -sG .../vector/status --data-urlencode 'company=legacyid39722'` で企業フィルタ確認
- [ ] ロールバック手順（`CHROMA_HOST` 空 + Persistent マウント）が docs に従えること

Closes #585


Made with [Cursor](https://cursor.com)