### PR TITLE
feat: #590 企業 Search Provider 抽象化と Brave 切替

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -70,6 +70,12 @@ OPENAI_COMPANY_PARSE_MODEL=gpt-4o-mini
 # 長文（有報・IR）からの関係抽出など高精度 Parse（必要時のみ）
 OPENAI_COMPANY_PARSE_MODEL_ADVANCED=gpt-4o
 
+# 企業 Search Provider（#590）openai | brave
+COMPANY_SEARCH_PROVIDER=openai
+# Brave 利用時（COMPANY_SEARCH_PROVIDER=brave）
+# BRAVE_SEARCH_API_KEY=
+# BRAVE_SEARCH_BASE_URL=https://api.search.brave.com/res/v1/web/search
+
 # Base URL (for OAuth callbacks)
 BASE_URL=http://localhost:8080
 APP_URL=http://localhost:3000

--- a/Backend/internal/companyfetch/llm.go
+++ b/Backend/internal/companyfetch/llm.go
@@ -10,6 +10,15 @@ import (
 // LLM は企業情報パイプライン用の OpenAI ラッパ。
 type LLM struct {
 	Client *openai.Client
+	Search CompanySearchProvider // 未設定時は OpenAI Search Lite
+}
+
+// NewLLM は Client と env 由来の Search Provider を束ねる。
+func NewLLM(client *openai.Client) *LLM {
+	return &LLM{
+		Client: client,
+		Search: NewSearchProviderFromEnv(client),
+	}
 }
 
 // ExtractJSON は与えられたテキスト前提のプロンプトから JSON を抽出する（Extract モデル）。
@@ -25,17 +34,19 @@ func (l *LLM) ExtractJSON(ctx context.Context, systemPrompt, userPrompt string, 
 	return text, model, err
 }
 
-// SearchLiteJSON は安価な Search モデルのみを使う（deep search-preview は使わない）。
+// SearchLiteJSON は CompanySearchProvider 経由で検索する（既定: OpenAI Search Lite）。
 func (l *LLM) SearchLiteJSON(ctx context.Context, userPrompt string, maxTokens int) (text string, model string, err error) {
-	if l == nil || l.Client == nil {
+	if l == nil {
 		return "", "", fmt.Errorf("openai client is nil")
 	}
 	if maxTokens <= 0 {
 		maxTokens = 1200
 	}
-	model = SearchModel()
-	text, err = l.Client.WebSearchJSON(ctx, userPrompt, maxTokens, model)
-	return text, model, err
+	provider := l.ensureProvider()
+	if provider == nil {
+		return "", "", fmt.Errorf("search provider is nil")
+	}
+	return provider.Search(ctx, userPrompt, maxTokens)
 }
 
 // SearchJSON は互換のため残す。企業情報パイプラインでは SearchLiteJSON を使うこと。

--- a/Backend/internal/companyfetch/provider.go
+++ b/Backend/internal/companyfetch/provider.go
@@ -1,0 +1,63 @@
+package companyfetch
+
+import (
+	"Backend/internal/openai"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// CompanySearchProvider は企業情報 Write 用の Web 検索抽象（#590）。
+// OpenAI Search Lite / Brave 等を差し替え可能にする。
+type CompanySearchProvider interface {
+	Name() string
+	Search(ctx context.Context, query string, maxTokens int) (text string, providerID string, err error)
+}
+
+// NewSearchProviderFromEnv は COMPANY_SEARCH_PROVIDER に従い Provider を生成する。
+// 未設定・不明値は openai。brave でキー未設定の場合はエラーを返す Provider ではなく openai にフォールバックし警告ログ相当の文言を Name に残す。
+func NewSearchProviderFromEnv(client *openai.Client) CompanySearchProvider {
+	name := strings.ToLower(strings.TrimSpace(os.Getenv("COMPANY_SEARCH_PROVIDER")))
+	switch name {
+	case "brave":
+		key := strings.TrimSpace(os.Getenv("BRAVE_SEARCH_API_KEY"))
+		if key == "" {
+			// キー無しでは Brave を起動できないため OpenAI にフォールバック
+			return NewOpenAISearchProvider(client)
+		}
+		return NewBraveSearchProvider(key, client)
+	default:
+		return NewOpenAISearchProvider(client)
+	}
+}
+
+// ResolveSearchProviderName は実際に選ばれる Provider 名を返す（診断用）。
+func ResolveSearchProviderName() string {
+	name := strings.ToLower(strings.TrimSpace(os.Getenv("COMPANY_SEARCH_PROVIDER")))
+	if name == "brave" && strings.TrimSpace(os.Getenv("BRAVE_SEARCH_API_KEY")) != "" {
+		return "brave"
+	}
+	if name == "brave" {
+		return "openai(fallback:brave_key_missing)"
+	}
+	return "openai"
+}
+
+// ensureProvider は LLM に Search が無いとき OpenAI を返す。
+func (l *LLM) ensureProvider() CompanySearchProvider {
+	if l == nil {
+		return nil
+	}
+	if l.Search != nil {
+		return l.Search
+	}
+	if l.Client == nil {
+		return nil
+	}
+	return NewOpenAISearchProvider(l.Client)
+}
+
+func providerSearchError(provider string, err error) error {
+	return fmt.Errorf("%s search failed: %w", provider, err)
+}

--- a/Backend/internal/companyfetch/provider_brave.go
+++ b/Backend/internal/companyfetch/provider_brave.go
@@ -1,0 +1,113 @@
+package companyfetch
+
+import (
+	"Backend/internal/openai"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// BraveSearchProvider は Brave Search API でスニペットを取得し、必要なら Parse 用テキストを返す。
+// OpenAI Search ツール料金を避けるための差し込み実装（#590）。
+type BraveSearchProvider struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+	// ParseClient は任意。設定時は Brave 結果を JSON っぽく整えるために mini Parse を使えるが、
+	// 既定では生スニペット連結のみ（追加 LLM 課金なし）。
+	ParseClient *openai.Client
+}
+
+func NewBraveSearchProvider(apiKey string, parseClient *openai.Client) *BraveSearchProvider {
+	base := strings.TrimSpace(os.Getenv("BRAVE_SEARCH_BASE_URL"))
+	if base == "" {
+		base = "https://api.search.brave.com/res/v1/web/search"
+	}
+	return &BraveSearchProvider{
+		APIKey:      apiKey,
+		BaseURL:     base,
+		HTTPClient:  &http.Client{Timeout: 20 * time.Second},
+		ParseClient: parseClient,
+	}
+}
+
+func (p *BraveSearchProvider) Name() string { return "brave" }
+
+type braveSearchResponse struct {
+	Web *struct {
+		Results []struct {
+			Title       string `json:"title"`
+			URL         string `json:"url"`
+			Description string `json:"description"`
+		} `json:"results"`
+	} `json:"web"`
+}
+
+func (p *BraveSearchProvider) Search(ctx context.Context, query string, maxTokens int) (string, string, error) {
+	if p == nil || strings.TrimSpace(p.APIKey) == "" {
+		return "", "", fmt.Errorf("brave search provider: api key is empty")
+	}
+	if maxTokens <= 0 {
+		maxTokens = 1200
+	}
+	endpoint, err := url.Parse(p.BaseURL)
+	if err != nil {
+		return "", "", providerSearchError("brave", err)
+	}
+	q := endpoint.Query()
+	q.Set("q", query)
+	q.Set("count", "8")
+	q.Set("search_lang", "jp")
+	q.Set("country", "JP")
+	endpoint.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return "", "", providerSearchError("brave", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Subscription-Token", p.APIKey)
+
+	client := p.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", providerSearchError("brave", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", "", providerSearchError("brave", err)
+	}
+	if resp.StatusCode >= 300 {
+		return "", "", providerSearchError("brave", fmt.Errorf("status=%d body=%s", resp.StatusCode, TrimText(string(body), 200)))
+	}
+
+	var parsed braveSearchResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", "", providerSearchError("brave", err)
+	}
+	var b strings.Builder
+	b.WriteString("Brave Search 結果:\n")
+	count := 0
+	if parsed.Web != nil {
+		for _, r := range parsed.Web.Results {
+			count++
+			fmt.Fprintf(&b, "%d. %s\nURL: %s\n%s\n\n", count, r.Title, r.URL, r.Description)
+		}
+	}
+	text := strings.TrimSpace(b.String())
+	if text == "" || count == 0 {
+		return "", "", providerSearchError("brave", fmt.Errorf("no results"))
+	}
+	text = TrimText(text, maxTokens*4) // 粗い文字上限（トークン近似）
+	return text, "brave-search", nil
+}

--- a/Backend/internal/companyfetch/provider_openai.go
+++ b/Backend/internal/companyfetch/provider_openai.go
@@ -1,0 +1,37 @@
+package companyfetch
+
+import (
+	"Backend/internal/openai"
+	"context"
+	"fmt"
+)
+
+// OpenAISearchProvider は既存の OpenAI Web Search（Search Lite）実装。
+type OpenAISearchProvider struct {
+	Client *openai.Client
+	Model  string
+}
+
+func NewOpenAISearchProvider(client *openai.Client) *OpenAISearchProvider {
+	return &OpenAISearchProvider{Client: client, Model: SearchModel()}
+}
+
+func (p *OpenAISearchProvider) Name() string { return "openai" }
+
+func (p *OpenAISearchProvider) Search(ctx context.Context, query string, maxTokens int) (string, string, error) {
+	if p == nil || p.Client == nil {
+		return "", "", fmt.Errorf("openai search provider: client is nil")
+	}
+	if maxTokens <= 0 {
+		maxTokens = 1200
+	}
+	model := p.Model
+	if model == "" {
+		model = SearchModel()
+	}
+	text, err := p.Client.WebSearchJSON(ctx, query, maxTokens, model)
+	if err != nil {
+		return "", model, providerSearchError("openai", err)
+	}
+	return text, model, nil
+}

--- a/Backend/internal/companyfetch/provider_test.go
+++ b/Backend/internal/companyfetch/provider_test.go
@@ -1,0 +1,61 @@
+package companyfetch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResolveSearchProviderName(t *testing.T) {
+	t.Setenv("COMPANY_SEARCH_PROVIDER", "")
+	t.Setenv("BRAVE_SEARCH_API_KEY", "")
+	if got := ResolveSearchProviderName(); got != "openai" {
+		t.Fatalf("default=%q", got)
+	}
+	t.Setenv("COMPANY_SEARCH_PROVIDER", "brave")
+	if got := ResolveSearchProviderName(); !strings.Contains(got, "fallback") {
+		t.Fatalf("brave without key=%q", got)
+	}
+	t.Setenv("BRAVE_SEARCH_API_KEY", "test-key")
+	if got := ResolveSearchProviderName(); got != "brave" {
+		t.Fatalf("brave with key=%q", got)
+	}
+}
+
+func TestBraveSearchProvider_Search(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Subscription-Token") != "test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"web":{"results":[{"title":"Acme","url":"https://acme.example","description":"IT企業"}]}}`))
+	}))
+	defer srv.Close()
+
+	p := &BraveSearchProvider{
+		APIKey:     "test-key",
+		BaseURL:    srv.URL,
+		HTTPClient: srv.Client(),
+	}
+	text, id, err := p.Search(context.Background(), "Acme 株式会社", 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "brave-search" {
+		t.Fatalf("id=%q", id)
+	}
+	if !strings.Contains(text, "Acme") || !strings.Contains(text, "https://acme.example") {
+		t.Fatalf("text=%q", text)
+	}
+}
+
+func TestNewSearchProviderFromEnv_OpenAIDefault(t *testing.T) {
+	t.Setenv("COMPANY_SEARCH_PROVIDER", "openai")
+	p := NewSearchProviderFromEnv(nil)
+	if p.Name() != "openai" {
+		t.Fatalf("name=%q", p.Name())
+	}
+}

--- a/Backend/internal/scraper/careers_scraper.go
+++ b/Backend/internal/scraper/careers_scraper.go
@@ -33,7 +33,7 @@ type CareersScraper struct {
 
 // NewCareersScraper は CareersScraper を生成する。
 func NewCareersScraper(client *openai.Client) *CareersScraper {
-	return &CareersScraper{llm: &companyfetch.LLM{Client: client}}
+	return &CareersScraper{llm: companyfetch.NewLLM(client)}
 }
 
 const jobsJSONSchema = `

--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -38,7 +38,7 @@ type CompanyInfoFetcher struct {
 }
 
 func NewCompanyInfoFetcher(repo repository.CompanyRepository, client *openai.Client, gbiz ...*GBizInfoService) *CompanyInfoFetcher {
-	f := &CompanyInfoFetcher{repo: repo, llm: &companyfetch.LLM{Client: client}}
+	f := &CompanyInfoFetcher{repo: repo, llm: companyfetch.NewLLM(client)}
 	if len(gbiz) > 0 {
 		f.gbiz = gbiz[0]
 	}

--- a/Backend/internal/services/tech_stack_fetcher.go
+++ b/Backend/internal/services/tech_stack_fetcher.go
@@ -31,7 +31,7 @@ type TechStackFetcher struct {
 }
 
 func NewTechStackFetcher(repo repository.CompanyRepository, client *openai.Client) *TechStackFetcher {
-	return &TechStackFetcher{repo: repo, llm: &companyfetch.LLM{Client: client}}
+	return &TechStackFetcher{repo: repo, llm: companyfetch.NewLLM(client)}
 }
 
 const techStackJSONSchema = `{

--- a/docs/design/company-info-acquisition.md
+++ b/docs/design/company-info-acquisition.md
@@ -439,6 +439,7 @@ OPENAI_COMPANY_PARSE_MODEL_ADVANCED=gpt-4o
 | 利点 | OpenAI Search 以外の検索コスト最適化、根拠 URL の明示 |
 | 欠点 | 運用面（API キー・MCP プロセス）、Go サービスからの直接呼び出し設計が未整備 |
 | 本設計での位置づけ | **Phase 2 候補**。Phase 1 は OpenAI Search-Lite/Full で統一し、インターフェース（`CompanySearchProvider`）だけ抽象化して後から Brave を差し込めるようにする |
+| 実装 (#590) | `Backend/internal/companyfetch/provider*.go` / 切替 `COMPANY_SEARCH_PROVIDER` / コスト比較 [search-provider-cost.md](../wiki/search-provider-cost.md) |
 
 ---
 

--- a/docs/wiki/search-provider-cost.md
+++ b/docs/wiki/search-provider-cost.md
@@ -1,0 +1,47 @@
+# 企業 Search Provider コスト比較（#590）
+
+企業情報 Write の Web 検索を `CompanySearchProvider` 経由に抽象化し、単価の高い OpenAI Search から Brave 等へ切り替えられるようにした。
+
+## 切替
+
+```bash
+# 既定
+COMPANY_SEARCH_PROVIDER=openai
+
+# Brave Search API
+COMPANY_SEARCH_PROVIDER=brave
+BRAVE_SEARCH_API_KEY=BSA...
+# 任意
+# BRAVE_SEARCH_BASE_URL=https://api.search.brave.com/res/v1/web/search
+```
+
+`brave` 指定でも `BRAVE_SEARCH_API_KEY` が空なら **OpenAI にフォールバック**する。
+
+実装: `Backend/internal/companyfetch/provider*.go`。呼び出しは `LLM.SearchLiteJSON` → Provider.Search。
+
+## 単価感（目安・2026-07 設計値）
+
+| Provider | 1 クエリ目安 | 備考 |
+|----------|-------------|------|
+| OpenAI Search Lite（`gpt-4o-mini-search-preview`） | **≈ $0.025** | ツール料金が支配的。実測は企業基本情報 Search→Parse で約この水準 |
+| Brave Search API（Web Search） | **≈ $0.005 未満/クエリ帯**（プラン次第） | スニペット取得のみ。構造化は既存 Parse（mini）を別途課金 |
+| OpenAI deep（`gpt-4o-search-preview`） | Search Lite より高い | 企業パイプラインでは使わない |
+
+月 2,000 回の Write Search を仮定:
+
+| 構成 | 概算 |
+|------|------|
+| すべて OpenAI Search Lite | ≈ **$50** |
+| Brave + mini Parse（Parse を $0.002/回相当と仮置き） | ≈ **$10〜20** 台（プラン・Parse 回数に依存） |
+
+※ Brave の正確な単価は契約プランで変わる。導入前に [Brave Search API Pricing](https://brave.com/search/api/) で確認すること。
+
+## 品質差
+
+- OpenAI Search: モデルが検索結果を要約/JSON 寄りに返すことがある（現行プロンプト前提）
+- Brave: タイトル・URL・description の連結テキスト。**必ず Parse 段**で JSON 化する現行 `SearchLiteThenParse` と相性が良い
+
+## 関連
+
+- Issue #590 / 設計 `docs/design/company-info-acquisition.md` §9・R1
+- 月次件数ガードは #587


### PR DESCRIPTION
## Summary
- `CompanySearchProvider` インターフェースと OpenAI / Brave 実装を追加
- `LLM.SearchLiteJSON` は Provider 経由（既定 openai）
- `COMPANY_SEARCH_PROVIDER=brave` + `BRAVE_SEARCH_API_KEY` で切替（キー無しは openai フォールバック）
- コスト比較メモ: `docs/wiki/search-provider-cost.md`

## Test plan
- [ ] `go test ./internal/companyfetch/ -count=1`
- [ ] 既定のまま企業 info fetch が従来どおり OpenAI Search Lite 経由で動く
- [ ] `COMPANY_SEARCH_PROVIDER=brave` + 有効キーで Brave 結果が Parse 段に渡る
- [ ] キー無し brave 指定時に openai へフォールバックする

Closes #590


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 企業情報のWeb検索で、OpenAIとBrave Searchを切り替えられるようになりました。
  * Braveの設定が不足している場合は、OpenAI検索へ自動的に切り替わります。
  * 検索プロバイダーの設定例とコスト比較資料を追加しました。

* **ドキュメント**
  * 企業情報取得における検索プロバイダーの選択方法と運用上の注意点を記載しました。

* **テスト**
  * 検索プロバイダーの選択、フォールバック、Brave検索の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->