### PR TITLE
fix: #569 チャット履歴取得失敗時に新規セッションと誤表示しない

### DIFF
--- a/frontend/components/job-agent-chat.tsx
+++ b/frontend/components/job-agent-chat.tsx
@@ -96,6 +96,8 @@ export function JobAgentChat() {
   const [userScores, setUserScores] = useState<UserScore[]>([])
   const [progress, setProgress] = useState({ questions: 0, total: 15, categories: 0, totalCategories: 10 })
   const [showCustomInput, setShowCustomInput] = useState(false) // カスタム入力モード
+  const [historyLoadError, setHistoryLoadError] = useState<string | null>(null)
+  const [historyRetrying, setHistoryRetrying] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   // メッセージが更新されたらキャッシュに保存
@@ -120,92 +122,115 @@ export function JobAgentChat() {
     }
   }, [sessionId])
 
+  const applyHistoryOrStartSession = async (history: Awaited<ReturnType<typeof getChatHistory>>) => {
+    setHistoryLoadError(null)
+    if (history.length > 0) {
+      const loadedMessages: Message[] = history.map((msg) => ({
+        id: msg.id.toString(),
+        role: msg.role === "assistant" ? "agent" : "user",
+        content: msg.content,
+      }))
+      setMessages(loadedMessages)
+
+      try {
+        const scoresData = await getUserScores(sessionId)
+        if (scoresData && scoresData.length > 0) {
+          const scores: UserScore[] = scoresData.map((s: ChatScore) => ({
+            category: s.weight_category || s.category,
+            score: s.score || 0,
+            reason: s.reason || '',
+          }))
+          setUserScores(scores)
+          setProgress({
+            questions: history.length,
+            total: 15,
+            categories: scores.length,
+            totalCategories: 10,
+          })
+        }
+      } catch (error) {
+        console.error("Failed to load scores:", error)
+      }
+
+      const lastMessage = history[history.length - 1]
+      if (lastMessage.role === "assistant" &&
+          (lastMessage.content.includes("分析が完了しました") ||
+           lastMessage.content.includes("診断が完了しました"))) {
+        setIsComplete(true)
+      }
+      return
+    }
+
+    // 履歴 0 件（新規セッション）: 従来どおり最初の質問を生成
+    setIsTyping(true)
+    try {
+      const response = await sendChatMessage({
+        user_id: userId,
+        session_id: sessionId,
+        message: "START_SESSION",
+        industry_id: industryId,
+        job_category_id: jobCategoryId,
+      })
+      setMessages([{
+        id: "1",
+        role: "agent",
+        content: response.response,
+      }])
+    } finally {
+      setIsTyping(false)
+    }
+  }
+
   const initializeChat = async () => {
     if (!sessionId) {
       console.log('[Frontend] Session ID not ready yet')
       return
     }
-    
+
     try {
       console.log('[Frontend] Initializing chat with sessionId:', sessionId)
-      
-      // バックエンドからチャット履歴を取得
-      const history = await getChatHistory(sessionId)
-      console.log('[Frontend] Chat history loaded:', history.length, 'messages')
-      
-      if (history.length > 0) {
-        // 既存の履歴がある場合は復元
-        const loadedMessages: Message[] = history.map((msg) => ({
-          id: msg.id.toString(),
-          role: msg.role === "assistant" ? "agent" : "user",
-          content: msg.content,
-        }))
-        setMessages(loadedMessages)
-        console.log('[Frontend] Messages restored from backend')
-        
-        // バックエンドからスコアと進捗を取得
-        try {
-          const scoresData = await getUserScores(sessionId)
-          console.log('[Frontend] Scores loaded:', scoresData)
-          if (scoresData && scoresData.length > 0) {
-            const scores: UserScore[] = scoresData.map((s: ChatScore) => ({
-              category: s.weight_category || s.category,
-              score: s.score || 0,
-              reason: s.reason || ''
-            }))
-            setUserScores(scores)
-            
-            // 進捗状況を計算（スコアの数から）
-            setProgress({
-              questions: history.length,
-              total: 15,
-              categories: scores.length,
-              totalCategories: 10,
-            })
-          }
-        } catch (error) {
-          console.error("Failed to load scores:", error)
-        }
-        
-        // 完了状態をチェック（診断完了の特別なメッセージを確認）
-        const lastMessage = history[history.length - 1]
-        if (lastMessage.role === "assistant" && 
-            (lastMessage.content.includes("分析が完了しました") || 
-             lastMessage.content.includes("診断が完了しました"))) {
-          setIsComplete(true)
-        }
-      } else {
-        console.log('[Frontend] No history found, starting new session')
-        // 新規セッション：AIに最初の質問を生成させる
-        setIsTyping(true)
-        const response = await sendChatMessage({
-          user_id: userId,
-          session_id: sessionId,
-          message: "START_SESSION",
-          industry_id: industryId,
-          job_category_id: jobCategoryId,
-        })
-        
-        setMessages([
-          {
-            id: "1",
-            role: "agent",
-            content: response.response,
-          },
-        ])
-        setIsTyping(false)
+      let history
+      try {
+        history = await getChatHistory(sessionId)
+      } catch (error) {
+        console.error("Failed to load chat history:", error)
+        // #569: 履歴取得失敗時は挨拶ではなくエラー UI
+        setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
+        setMessages([])
+        return
       }
+      console.log('[Frontend] Chat history loaded:', history.length, 'messages')
+      await applyHistoryOrStartSession(history)
     } catch (error) {
-      console.error("Failed to initialize chat:", error)
-      // エラー時はデフォルトメッセージ
-      setMessages([
-        {
-          id: "1",
-          role: "agent",
-          content: "こんにちは！IT業界専門のキャリアエージェントです。あなたに最適な企業を見つけるため、いくつか質問させてください。まず、どのような職種に興味がありますか？",
-        },
-      ])
+      console.error("Failed to start new chat session:", error)
+      setHistoryLoadError('チャットの開始に失敗しました。もう一度お試しください。')
+      setMessages([])
     } finally {
+      setIsInitializing(false)
+    }
+  }
+
+  const handleRetryHistoryLoad = async () => {
+    if (!sessionId || historyRetrying) return
+    setHistoryRetrying(true)
+    setIsInitializing(true)
+    try {
+      let history
+      try {
+        history = await getChatHistory(sessionId)
+      } catch (error) {
+        console.error("Failed to load history (retry):", error)
+        setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
+        setMessages([])
+        return
+      }
+      await applyHistoryOrStartSession(history)
+    } catch (error) {
+      console.error("Failed to start new chat session (retry):", error)
+      setHistoryLoadError('チャットの開始に失敗しました。もう一度お試しください。')
+      setMessages([])
+    } finally {
+      setHistoryRetrying(false)
       setIsInitializing(false)
     }
   }
@@ -412,6 +437,21 @@ export function JobAgentChat() {
                   <p className="text-sm text-muted-foreground">チャットを準備中...</p>
                 </div>
               </div>
+            ) : historyLoadError ? (
+              <div className="flex items-center justify-center h-full px-4">
+                <div className="text-center space-y-4 max-w-md">
+                  <p className="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-4 py-3">
+                    {historyLoadError}
+                  </p>
+                  <Button
+                    variant="default"
+                    onClick={handleRetryHistoryLoad}
+                    disabled={historyRetrying}
+                  >
+                    {historyRetrying ? '再読み込み中...' : '再試行'}
+                  </Button>
+                </div>
+              </div>
             ) : (
               <>
                 {messages.map((message, index) => {
@@ -488,7 +528,7 @@ export function JobAgentChat() {
           </div>
 
           <div className="border-t p-4">
-            {hasChoicesInLastMessage && !showCustomInput ? (
+            {historyLoadError ? null : hasChoicesInLastMessage && !showCustomInput ? (
               // 選択肢がある場合は「その他を入力」ボタンのみ表示
               <div className="flex justify-center">
                 <Button

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   CircularProgress,
   Button,
+  Alert,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -43,6 +44,9 @@ interface PhaseProgress {
 }
 
 const makeMessageId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+const INITIAL_GREETING =
+  'こんにちは！IT業界専門のキャリアエージェントです。\n\nこれから約10-15問の質問を通じて、あなたの適性を分析し、最適な企業をご提案します。\n質問は動的に生成されるため、あなたの回答に応じて変化します。\n\nまず、どのようなIT職種に興味がありますか？\n\n例：\n- Webエンジニア\n- インフラエンジニア\n- データサイエンティスト\n- セキュリティエンジニア\n- モバイルアプリ開発者'
 
 interface ChoiceOption {
   value: string
@@ -122,6 +126,8 @@ export function MuiChat() {
   const [showTerminationModal, setShowTerminationModal] = useState(false)
   const [otherChoiceActive, setOtherChoiceActive] = useState(false)
   const [phaseProgresses, setPhaseProgresses] = useState<PhaseProgress[] | null>(null)
+  const [historyLoadError, setHistoryLoadError] = useState<string | null>(null)
+  const [historyRetrying, setHistoryRetrying] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -148,6 +154,79 @@ export function MuiChat() {
   useEffect(() => {
     scrollToBottom()
   }, [messages, isLoading])
+
+  const applyHistoryOrGreeting = (history: Awaited<ReturnType<typeof getChatHistory>>) => {
+    setHistoryLoadError(null)
+    if (history && history.length > 0) {
+      const restoredMessages: Message[] = history.map((msg) => ({
+        id: String(msg.id),
+        role: msg.role,
+        content: msg.content,
+        timestamp: new Date(msg.created_at),
+      }))
+      setMessages(restoredMessages)
+      const userQuestionCount = history.filter(msg => msg.role === 'user').length
+      setQuestionCount(userQuestionCount)
+
+      const savedTotalQuestions = sessionStorage.getItem('totalQuestions')
+      const restoredTotalQuestions = savedTotalQuestions ? parseInt(savedTotalQuestions) : 15
+      setTotalQuestions(restoredTotalQuestions)
+      const savedPhases = sessionStorage.getItem('phaseProgress')
+      const restoredPhases = savedPhases ? JSON.parse(savedPhases) : null
+      if (Array.isArray(restoredPhases)) {
+        setPhaseProgresses(restoredPhases)
+      }
+
+      setTimeout(() => {
+        window.dispatchEvent(new CustomEvent('chatProgress', {
+          detail: {
+            messageCount: restoredMessages.length,
+            questionCount: userQuestionCount,
+            totalQuestions: restoredTotalQuestions,
+            phases: restoredPhases,
+          }
+        }))
+      }, 100)
+
+      const lastMessage = history[history.length - 1]
+      const isCompletionMessage = lastMessage?.content?.includes('分析が完了しました') ||
+        lastMessage?.content?.includes('全てのフェーズが完了') ||
+        lastMessage?.content?.includes('最適な企業をマッチング')
+
+      if (isCompletionMessage) {
+        setAnalysisComplete(true)
+        setAllPhasesCompleted(true)
+      }
+      return
+    }
+
+    // 履歴 0 件（新規セッション）: 従来どおり挨拶表示
+    setMessages([{
+      id: '0',
+      role: 'assistant',
+      content: INITIAL_GREETING,
+      timestamp: new Date(),
+    }])
+  }
+
+  const loadChatHistory = async (targetSessionId: string) => {
+    const history = await getChatHistory(targetSessionId)
+    applyHistoryOrGreeting(history)
+  }
+
+  const handleRetryHistoryLoad = async () => {
+    if (!sessionId || historyRetrying) return
+    setHistoryRetrying(true)
+    try {
+      await loadChatHistory(sessionId)
+    } catch (error) {
+      console.error('[MUI Chat] Failed to load history (retry):', error)
+      setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
+      setMessages([])
+    } finally {
+      setHistoryRetrying(false)
+    }
+  }
 
   useEffect(() => {
     setMounted(true)
@@ -183,83 +262,14 @@ export function MuiChat() {
       sessionStorage.setItem('chatSessionId', storedSessionId)
       setSessionId(storedSessionId)
       
-      // バックエンドからチャット履歴を取得
       try {
         console.log('[MUI Chat] Loading history for session:', storedSessionId)
-        const history = await getChatHistory(storedSessionId)
-        console.log('[MUI Chat] History loaded:', history?.length, 'messages')
-        
-        if (history && history.length > 0) {
-          // 履歴が存在する場合は復元
-          const restoredMessages: Message[] = history.map((msg) => ({
-            id: String(msg.id),
-            role: msg.role,
-            content: msg.content,
-            timestamp: new Date(msg.created_at),
-          }))
-          setMessages(restoredMessages)
-          const userQuestionCount = history.filter(msg => msg.role === 'user').length
-          setQuestionCount(userQuestionCount)
-          
-          // sessionStorageから総質問数を復元（なければデフォルト15）
-          const savedTotalQuestions = sessionStorage.getItem('totalQuestions')
-          const restoredTotalQuestions = savedTotalQuestions ? parseInt(savedTotalQuestions) : 15
-          setTotalQuestions(restoredTotalQuestions)
-          const savedPhases = sessionStorage.getItem('phaseProgress')
-          const restoredPhases = savedPhases ? JSON.parse(savedPhases) : null
-          if (Array.isArray(restoredPhases)) {
-            setPhaseProgresses(restoredPhases)
-          }
-          
-          // 進捗状況を通知（履歴復元時）
-          setTimeout(() => {
-            window.dispatchEvent(new CustomEvent('chatProgress', { 
-              detail: { 
-                messageCount: restoredMessages.length,
-                questionCount: userQuestionCount,
-                totalQuestions: restoredTotalQuestions,
-                phases: restoredPhases,
-              } 
-            }))
-            console.log('[MUI Chat] Progress restored:', userQuestionCount, '/', restoredTotalQuestions)
-          }, 100)
-          
-          // 最後のメッセージが完了メッセージかチェック
-          const lastMessage = history[history.length - 1]
-          const isCompletionMessage = lastMessage?.content?.includes('分析が完了しました') || 
-                                     lastMessage?.content?.includes('全てのフェーズが完了') ||
-                                     lastMessage?.content?.includes('最適な企業をマッチング')
-          
-          if (isCompletionMessage) {
-            console.log('[MUI Chat] Session already completed, showing completion state')
-            setAnalysisComplete(true)
-            setAllPhasesCompleted(true)
-          }
-        } else {
-          // 履歴がない場合: AIのあいさつメッセージを表示（バックエンドには送信しない）
-          console.log('[MUI Chat] No history found, displaying initial greeting')
-          
-          // AIのあいさつメッセージ（フロントエンドのみで表示）
-          const greetingMessage = 'こんにちは！IT業界専門のキャリアエージェントです。\n\nこれから約10-15問の質問を通じて、あなたの適性を分析し、最適な企業をご提案します。\n質問は動的に生成されるため、あなたの回答に応じて変化します。\n\nまず、どのようなIT職種に興味がありますか？\n\n例：\n- Webエンジニア\n- インフラエンジニア\n- データサイエンティスト\n- セキュリティエンジニア\n- モバイルアプリ開発者'
-          
-          const initialMessage: Message = {
-            id: '0',
-            role: 'assistant',
-            content: greetingMessage,
-            timestamp: new Date(),
-          }
-          setMessages([initialMessage])
-        }
+        await loadChatHistory(storedSessionId)
       } catch (error) {
         console.error('[MUI Chat] Failed to load history:', error)
-        // エラー時は初回メッセージを表示
-        const initialMessage: Message = {
-          id: '0',
-          role: 'assistant',
-          content: 'こんにちは！IT業界専門のキャリアエージェントです。\n\nこれから約10-15問の質問を通じて、あなたの適性を分析し、最適な企業をご提案します。\n質問は動的に生成されるため、あなたの回答に応じて変化します。\n\nまず、どのようなIT職種に興味がありますか？\n\n例：\n- Webエンジニア\n- インフラエンジニア\n- データサイエンティスト\n- セキュリティエンジニア\n- モバイルアプリ開発者',
-          timestamp: new Date(),
-        }
-        setMessages([initialMessage])
+        // #569: 失敗時は挨拶ではなくエラー UI（再試行で復元）
+        setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
+        setMessages([])
       }
     }
     
@@ -268,7 +278,7 @@ export function MuiChat() {
 
   const handleSend = async (overrideMessage?: string) => {
     const rawText = (overrideMessage ?? input).trim()
-    if (!rawText || isLoading || !sessionId || !userId) return
+    if (!rawText || isLoading || !sessionId || !userId || historyLoadError) return
 
     // ボタン送信はそのまま。自由入力は直近の選択肢ラベルを記号へ正規化する
     const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant')
@@ -724,7 +734,23 @@ export function MuiChat() {
           backgroundColor: '#fff',
         }}
       >
-        {messages.length === 0 && (
+        {historyLoadError && (
+          <Box sx={{ textAlign: 'center', mt: 8, px: 3 }}>
+            <Alert severity="error" sx={{ mb: 2, textAlign: 'left' }}>
+              {historyLoadError}
+            </Alert>
+            <Button
+              variant="contained"
+              onClick={handleRetryHistoryLoad}
+              disabled={historyRetrying}
+              startIcon={historyRetrying ? <CircularProgress size={16} color="inherit" /> : undefined}
+            >
+              {historyRetrying ? '再読み込み中...' : '再試行'}
+            </Button>
+          </Box>
+        )}
+
+        {messages.length === 0 && !historyLoadError && (
           <Box sx={{ textAlign: 'center', mt: 8 }}>
             <SmartToy sx={{ fontSize: 64, color: '#9e9e9e', mb: 2 }} />
             <Typography variant="h6" color="text.secondary" gutterBottom>
@@ -950,8 +976,7 @@ export function MuiChat() {
                     handleSend()
                   }
                 }}
-                disabled={isLoading}
-                variant="outlined"
+                disabled={isLoading || !!historyLoadError}
                 size="small"
                 inputRef={inputRef}
                 sx={{
@@ -963,7 +988,7 @@ export function MuiChat() {
               <IconButton
                 color="primary"
                 onClick={() => handleSend()}
-                disabled={!input.trim() || isLoading}
+                disabled={!input.trim() || isLoading || !!historyLoadError}
                 sx={{
                   bgcolor: '#1976d2',
                   color: '#fff',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -105,22 +105,18 @@ export async function sendChatMessage(request: ChatRequest): Promise<ChatRespons
 }
 
 export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> {
-    try {
-        const response = await fetch(`${API_BASE}/chat/history?session_id=${sessionId}`, {
-            headers: authService.getUserFetchHeaders(),
-        })
+    const response = await fetch(`${API_BASE}/chat/history?session_id=${sessionId}`, {
+        headers: authService.getUserFetchHeaders(),
+    })
 
-        if (!response.ok) {
-            console.warn(`History API error: ${response.status}`)
-            return []
-        }
-
-        const raw = await response.json()
-        return unwrapArray<ChatHistory>(raw)
-    } catch (error) {
-        console.warn('Failed to fetch chat history:', error)
-        return []
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => response.statusText)
+        console.error('[API] History error:', response.status, errorText)
+        throw new Error(`History API error: ${errorText || response.statusText}`)
     }
+
+    const raw = await response.json()
+    return unwrapArray<ChatHistory>(raw)
 }
 
 export async function getUserScores(sessionId: string): Promise<ChatScore[]> {


### PR DESCRIPTION
## Summary
- 履歴 API 失敗時は初回挨拶ではなくエラー UI + 再試行を表示（`mui-chat` / `job-agent-chat`）
- `getChatHistory` が失敗を握りつぶして `[]` を返していたのを throw に変更し、空履歴とエラーを区別
- 履歴 0 件（真の新規セッション）時は従来どおり挨拶 / START_SESSION

## Test plan
- [ ] 履歴 API を一時的に失敗させ、挨拶ではなくエラー + 再試行が出ること
- [ ] 再試行成功で既存履歴が復元されること
- [ ] 新規セッション（履歴 0 件）では従来どおり挨拶が出ること

Closes #569


Made with [Cursor](https://cursor.com)