### PR TITLE
feat: #561 チャットで短文でも関与度の高い回答を適切に評価する

### DIFF
--- a/Backend/internal/services/answer_evaluator.go
+++ b/Backend/internal/services/answer_evaluator.go
@@ -407,7 +407,7 @@ func (e *AnswerEvaluator) EvaluateHumanScoring(question, answer string, isChoice
 	signals := extractSignals(answer, category)
 	dimensionScores := scoreDimensions(rubric, signals, answer)
 	rawScore := scoreFromDimensions(rubric, dimensionScores)
-	score, penalties, boosts := applyPenaltiesAndBoosts(rawScore, signals)
+	score, penalties, boosts := applyPenaltiesAndBoosts(rawScore, signals, len([]rune(strings.TrimSpace(answer))))
 
 	return HumanScoreResult{
 		Action:          PrecheckScore,
@@ -418,6 +418,74 @@ func (e *AnswerEvaluator) EvaluateHumanScoring(question, answer string, isChoice
 		Penalties:       penalties,
 		Boosts:          boosts,
 	}
+}
+
+// shouldBlendLLMForHumanScore は短文または境界帯スコア時のみ LLM 合成する (#561 / #557)。
+func shouldBlendLLMForHumanScore(answer string, rule HumanScoreResult) bool {
+	if rule.Action != PrecheckScore {
+		return false
+	}
+	n := len([]rune(strings.TrimSpace(answer)))
+	if n > 0 && n <= 30 {
+		return true
+	}
+	return rule.Score >= 20 && rule.Score <= 55
+}
+
+// EvaluateHumanScoringWithContext はルール評価後、短文・境界値のみ LLM とハイブリッド合成する。
+// llmClient が nil の場合は EvaluateHumanScoring と同一。
+func (e *AnswerEvaluator) EvaluateHumanScoringWithContext(
+	ctx context.Context,
+	question, answer string,
+	isChoice, jobRoleSet bool,
+	meta *questionMeta,
+) HumanScoreResult {
+	rule := e.EvaluateHumanScoring(question, answer, isChoice, jobRoleSet, meta)
+	if e.llmClient == nil || isChoice || !shouldBlendLLMForHumanScore(answer, rule) {
+		return rule
+	}
+
+	llmResult := e.llmEvaluate(ctx, question, answer)
+	if llmResult == nil {
+		return rule
+	}
+
+	n := len([]rune(strings.TrimSpace(answer)))
+	ruleWeight := 0.55
+	if n > 0 && n <= 30 {
+		ruleWeight = 0.35 // 短文は LLM（内容品質）比重を上げる
+	}
+	blended := int(math.Round(ruleWeight*float64(rule.Score) + (1-ruleWeight)*float64(llmResult.Score)))
+	if blended < 0 {
+		blended = 0
+	}
+	if blended > 100 {
+		blended = 100
+	}
+	rule.Score = blended
+	rule.Boosts = append(rule.Boosts, "llm_hybrid")
+	if llmResult.Explanation != "" {
+		rule.Reason = llmResult.Explanation
+	}
+	return rule
+}
+
+// floorEngagedShortScore は関与のある短文が Score=0 で進捗から落ちないよう下限を設ける (#561)。
+func floorEngagedShortScore(answer string, result HumanScoreResult) HumanScoreResult {
+	if result.Action != PrecheckScore || result.Score > 0 {
+		return result
+	}
+	n := len([]rune(strings.TrimSpace(answer)))
+	if n == 0 || n > 30 {
+		return result
+	}
+	signals := extractSignals(answer, result.CategoryID)
+	if !signals.hasEngagement() {
+		return result
+	}
+	result.Score = 15
+	result.Boosts = append(result.Boosts, "engaged_short_floor")
+	return result
 }
 
 func (e *AnswerEvaluator) precheckHuman(answer string, isChoice bool, jobRoleSet bool) HumanScoreResult {
@@ -524,22 +592,43 @@ type signalSet struct {
 	hasResult            bool
 	hasReason            bool
 	hasNumbersOrTime     bool
+	hasEmotion           bool
 	hasCollaborationTerm bool
 	hasNonITTerm         bool
 	hasUxTerm            bool
 	contradiction        bool
 }
 
+// hasEngagement は関与シグナルが1つでもあるか（#561: too_generic 判定に使用）
+func (s signalSet) hasEngagement() bool {
+	return s.hasConcreteExample || s.hasAction || s.hasResult || s.hasReason ||
+		s.hasNumbersOrTime || s.hasEmotion || s.hasCollaborationTerm || s.hasUxTerm
+}
+
 func extractSignals(answer string, category string) signalSet {
 	lower := strings.ToLower(answer)
+	_ = category
 	return signalSet{
 		hasConcreteExample: containsAny(lower, []string{"例えば", "たとえば", "具体的", "実際に", "経験", "した時", "したとき"}),
-		hasAction:          containsAny(lower, []string{"取り組", "実施", "作成", "作った", "実装", "改善", "対応", "開発", "設計", "検証"}),
-		hasResult:          containsAny(lower, []string{"結果", "成果", "達成", "改善された", "向上", "成功", "失敗"}),
-		hasReason:          containsAny(lower, []string{"理由", "なぜ", "ので", "ため", "から", "だから"}),
-		hasNumbersOrTime:   regexp.MustCompile(`[0-9]`).MatchString(lower) || containsAny(lower, []string{"ヶ月", "年", "週間", "日間", "%", "人", "回"}),
+		// 凝縮表現（役割分担・リリース・出した等）も行動シグナルとして扱う (#561)
+		hasAction: containsAny(lower, []string{
+			"取り組", "実施", "作成", "作った", "実装", "改善", "対応", "開発", "設計", "検証",
+			"分担", "役割", "リリース", "出した", "進め", "仕上げ", "完了", "提出", "納品", "デプロイ",
+			"まとめた", "進めた", "対応した", "リリースした",
+		}),
+		hasResult: containsAny(lower, []string{
+			"結果", "成果", "達成", "改善された", "向上", "成功", "失敗",
+			"リリース", "出した", "出荷", "納品",
+		}),
+		hasReason: containsAny(lower, []string{"理由", "なぜ", "ので", "ため", "から", "だから"}),
+		hasNumbersOrTime: regexp.MustCompile(`[0-9]`).MatchString(lower) || containsAny(lower, []string{
+			"ヶ月", "年", "週間", "日間", "日で", "%", "人", "回",
+		}),
+		hasEmotion: containsAny(lower, []string{
+			"やりがい", "面白", "楽しい", "嬉しかっ", "充実", "役立", "人の役", "感動", "好き",
+		}),
 		hasCollaborationTerm: containsAny(lower, []string{
-			"合意", "調整", "衝突", "折衷", "意見", "まとめ",
+			"合意", "調整", "衝突", "折衷", "意見", "まとめ", "チーム", "分担",
 		}),
 		hasNonITTerm: containsAny(lower, []string{
 			"itに詳しくない", "非エンジニア", "職員", "現場", "利用者",
@@ -587,7 +676,7 @@ func scoreDimensions(rubric string, signals signalSet, answer string) map[string
 
 	if signals.hasReason && (signals.hasAction || signals.hasResult) {
 		scores["reasoning"] = 3
-	} else if signals.hasReason {
+	} else if signals.hasReason || signals.hasEmotion {
 		scores["reasoning"] = 2
 	} else if signals.hasConcreteExample {
 		scores["reasoning"] = 1
@@ -599,7 +688,7 @@ func scoreDimensions(rubric string, signals signalSet, answer string) map[string
 		scores["credibility"] = 1 // 理由・数値のない定型回答: 信頼度を落とす
 	} else if signals.hasNumbersOrTime {
 		scores["credibility"] = 3
-	} else if signals.hasConcreteExample {
+	} else if signals.hasConcreteExample || (signals.hasEmotion && signals.hasReason) {
 		scores["credibility"] = 2
 	}
 
@@ -638,12 +727,13 @@ func scoreFromDimensions(rubric string, dimensionScores map[string]int) int {
 	return int(math.Round(score))
 }
 
-func applyPenaltiesAndBoosts(score int, signals signalSet) (int, []string, []string) {
+func applyPenaltiesAndBoosts(score int, signals signalSet, answerLen int) (int, []string, []string) {
 	penalties := []string{}
 	boosts := []string{}
 	finalScore := score
 
-	if !signals.hasConcreteExample && !signals.hasAction {
+	// #561: 関与シグナルが1つでもあれば too_generic を適用しない
+	if !signals.hasEngagement() {
 		finalScore -= 5
 		penalties = append(penalties, "too_generic")
 	}
@@ -654,6 +744,11 @@ func applyPenaltiesAndBoosts(score int, signals signalSet) (int, []string, []str
 	if signals.hasNumbersOrTime {
 		finalScore += 5
 		boosts = append(boosts, "evidence")
+	}
+	// 短文でも行動・理由・感情などが凝縮されている場合はブースト (#561)
+	if answerLen > 0 && answerLen <= 30 && signals.hasEngagement() {
+		finalScore += 8
+		boosts = append(boosts, "condensed_engagement")
 	}
 
 	if finalScore < 0 {

--- a/Backend/internal/services/answer_evaluator_test.go
+++ b/Backend/internal/services/answer_evaluator_test.go
@@ -126,11 +126,11 @@ func TestScoreDimensions_shortAnswer_notTooPerfect(t *testing.T) {
 // 矛盾あり: credibility = 0（isTooPerfect より優先）
 func TestScoreDimensions_contradiction_credibilityZero(t *testing.T) {
 	signals := signalSet{
-		hasAction:       true,
-		hasResult:       true,
-		hasReason:       false,
+		hasAction:        true,
+		hasResult:        true,
+		hasReason:        false,
 		hasNumbersOrTime: false,
-		contradiction:   true,
+		contradiction:    true,
 	}
 	answer := "取り組み、成果と達成と向上を収めました。チームで実施しました。成功しました。大変良い経験でした。"
 	scores := scoreDimensions("generic_rubric", signals, answer)
@@ -195,7 +195,7 @@ func TestEvaluateHumanScoring_concreteAnswer_higherScore(t *testing.T) {
 
 func TestApplyPenaltiesAndBoosts_contradiction_penalty(t *testing.T) {
 	signals := signalSet{contradiction: true, hasConcreteExample: true, hasAction: true}
-	score, penalties, _ := applyPenaltiesAndBoosts(50, signals)
+	score, penalties, _ := applyPenaltiesAndBoosts(50, signals, 40)
 
 	if !slices.Contains(penalties, "contradiction") {
 		t.Error("contradiction シグナルがあるのに penalties に 'contradiction' が含まれていない")
@@ -207,7 +207,7 @@ func TestApplyPenaltiesAndBoosts_contradiction_penalty(t *testing.T) {
 
 func TestApplyPenaltiesAndBoosts_numbersOrTime_boost(t *testing.T) {
 	signals := signalSet{hasNumbersOrTime: true, hasConcreteExample: true, hasAction: true}
-	score, _, boosts := applyPenaltiesAndBoosts(50, signals)
+	score, _, boosts := applyPenaltiesAndBoosts(50, signals, 40)
 
 	if !slices.Contains(boosts, "evidence") {
 		t.Error("hasNumbersOrTime ありで boosts に 'evidence' が含まれていない")
@@ -219,7 +219,7 @@ func TestApplyPenaltiesAndBoosts_numbersOrTime_boost(t *testing.T) {
 
 func TestApplyPenaltiesAndBoosts_scoreFloor(t *testing.T) {
 	signals := signalSet{contradiction: true}
-	score, _, _ := applyPenaltiesAndBoosts(10, signals)
+	score, _, _ := applyPenaltiesAndBoosts(10, signals, 40)
 	if score < 0 {
 		t.Errorf("スコアがマイナスになった: %d", score)
 	}
@@ -227,8 +227,154 @@ func TestApplyPenaltiesAndBoosts_scoreFloor(t *testing.T) {
 
 func TestApplyPenaltiesAndBoosts_scoreCeiling(t *testing.T) {
 	signals := signalSet{hasNumbersOrTime: true, hasConcreteExample: true, hasAction: true}
-	score, _, _ := applyPenaltiesAndBoosts(100, signals)
+	score, _, _ := applyPenaltiesAndBoosts(100, signals, 40)
 	if score > 100 {
 		t.Errorf("スコアが100を超えた: %d", score)
+	}
+}
+
+func TestApplyPenaltiesAndBoosts_engagementSkipsTooGeneric(t *testing.T) {
+	// 理由のみでも関与あり → too_generic なし
+	signals := signalSet{hasReason: true}
+	score, penalties, _ := applyPenaltiesAndBoosts(40, signals, 40)
+	if slices.Contains(penalties, "too_generic") {
+		t.Error("関与シグナルありなのに too_generic が付与された")
+	}
+	if score != 40 {
+		t.Errorf("got=%d want=40", score)
+	}
+
+	// シグナル0 → too_generic
+	empty := signalSet{}
+	score2, penalties2, _ := applyPenaltiesAndBoosts(40, empty, 40)
+	if !slices.Contains(penalties2, "too_generic") {
+		t.Error("関与シグナル0なのに too_generic が付与されなかった")
+	}
+	if score2 != 35 {
+		t.Errorf("got=%d want=35", score2)
+	}
+}
+
+func TestApplyPenaltiesAndBoosts_condensedEngagementBoost(t *testing.T) {
+	signals := signalSet{hasAction: true, hasResult: true, hasNumbersOrTime: true}
+	score, _, boosts := applyPenaltiesAndBoosts(50, signals, 24)
+	if !slices.Contains(boosts, "condensed_engagement") {
+		t.Error("短文関与回答で condensed_engagement ブーストが無い")
+	}
+	// evidence(+5) + condensed(+8) = 63
+	if score != 63 {
+		t.Errorf("got=%d want=63", score)
+	}
+}
+
+func TestExtractSignals_condensedPatterns(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+		check  func(signalSet) bool
+	}{
+		{"release", "チームで役割分担して3日でリリースした。", func(s signalSet) bool {
+			return s.hasAction && s.hasResult && s.hasNumbersOrTime && s.hasEngagement()
+		}},
+		{"emotion_reason", "やりがいを感じた。人の役に立てたから。", func(s signalSet) bool {
+			return s.hasEmotion && s.hasReason && s.hasEngagement()
+		}},
+		{"hai", "はい", func(s signalSet) bool { return !s.hasEngagement() }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.check(extractSignals(tt.answer, "")) {
+				t.Fatalf("unexpected signals for %q", tt.answer)
+			}
+		})
+	}
+}
+
+func TestEvaluateHumanScoring_ShortHighEngagement(t *testing.T) {
+	e := NewAnswerEvaluator()
+	tests := []struct {
+		name       string
+		question   string
+		answer     string
+		wantMin    int
+		wantMax    int
+		wantSkip   bool
+		wantAction PrecheckAction
+	}{
+		{
+			name:     "thin_reason",
+			question: "なぜその職種に興味を持ちましたか？",
+			answer:   "面白そうだと思ったから。",
+			wantMin:  15,
+			wantMax:  45,
+		},
+		{
+			name:     "condensed_ship",
+			question: "これまでの経験で工夫したことを教えてください",
+			answer:   "チームで役割分担して3日でリリースした。",
+			wantMin:  50,
+			wantMax:  90,
+		},
+		{
+			name:     "emotion_reason",
+			question: "仕事でやりがいを感じた瞬間は？",
+			answer:   "やりがいを感じた。人の役に立てたから。",
+			wantMin:  45,
+			wantMax:  85,
+		},
+		{
+			name:     "hai",
+			question: "チームで働くことは好きですか？",
+			answer:   "はい",
+			wantMin:  0,
+			wantMax:  25,
+		},
+		{
+			name:       "skip",
+			question:   "これまでの経験を教えてください",
+			answer:     "わからない",
+			wantSkip:   true,
+			wantAction: PrecheckSkip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := e.EvaluateHumanScoring(tt.question, tt.answer, false, false, nil)
+			if tt.wantSkip {
+				if result.Action != tt.wantAction {
+					t.Fatalf("action=%s want=%s", result.Action, tt.wantAction)
+				}
+				return
+			}
+			if result.Action != PrecheckScore {
+				t.Fatalf("action=%s score=%d", result.Action, result.Score)
+			}
+			if result.Score < tt.wantMin || result.Score > tt.wantMax {
+				t.Fatalf("score=%d want [%d,%d] penalties=%v boosts=%v",
+					result.Score, tt.wantMin, tt.wantMax, result.Penalties, result.Boosts)
+			}
+			// 関与短文は進捗カウント対象（score>0 または floor 後）
+			floored := floorEngagedShortScore(tt.answer, result)
+			if tt.name != "hai" && floored.Score <= 0 {
+				t.Fatalf("engaged short should count for progress, score=%d", floored.Score)
+			}
+		})
+	}
+}
+
+func TestShouldBlendLLMForHumanScore(t *testing.T) {
+	short := HumanScoreResult{Action: PrecheckScore, Score: 40}
+	if !shouldBlendLLMForHumanScore("短い関与回答です。", short) {
+		t.Fatal("30文字以下は LLM blend 対象であるべき")
+	}
+	longLow := HumanScoreResult{Action: PrecheckScore, Score: 70}
+	longAnswer := "これは十分に長い回答で、境界帯以外かつ短文でもないためルール評価のみで十分と判断されるべき文章です。"
+	if shouldBlendLLMForHumanScore(longAnswer, longLow) {
+		t.Fatal("長文・高スコアは LLM blend 対象外であるべき")
+	}
+	border := HumanScoreResult{Action: PrecheckScore, Score: 40}
+	if !shouldBlendLLMForHumanScore(longAnswer, border) {
+		t.Fatal("境界帯スコアは LLM blend 対象であるべき")
 	}
 }

--- a/Backend/internal/services/chat_score_updater.go
+++ b/Backend/internal/services/chat_score_updater.go
@@ -49,7 +49,7 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 		// マッチしない自由記述（その他）は isChoice=false で文章採点する
 	}
 
-	result := s.answerEvaluator.EvaluateHumanScoring(lastQuestion, scoreAnswer, isChoice, jobCategoryID != 0, nil)
+	result := s.answerEvaluator.EvaluateHumanScoringWithContext(ctx, lastQuestion, scoreAnswer, isChoice, jobCategoryID != 0, nil)
 	if result.Action == PrecheckSkip {
 		// 「わかりません」などのスキップフレーズは進捗カウントしない
 		log.Printf("Skipping progress: skip phrase detected (%s)\n", result.Reason)
@@ -60,6 +60,7 @@ func (s *ChatService) analyzeAndUpdateWeights(ctx context.Context, userID uint, 
 		log.Printf("Skipping progress: answer ignored (%s)\n", result.Reason)
 		return false, nil
 	}
+	result = floorEngagedShortScore(scoreAnswer, result)
 	if result.Score <= 0 {
 		log.Printf("No human score applied (score=%d), not counting for progress\n", result.Score)
 		return false, nil

--- a/Backend/test/services/answer_evaluator_test.go
+++ b/Backend/test/services/answer_evaluator_test.go
@@ -49,9 +49,9 @@ var goldStandard = []EvalSample{
 		Question:      "ITに興味を持った理由を教えてください。",
 		Answer:        "面白そうだと思ったから。",
 		IsChoice:      false,
-		ExpectedMin:   10,
-		ExpectedMax:   40,
-		ExpectedScore: 25,
+		ExpectedMin:   15,
+		ExpectedMax:   50, // #561: 感情+理由の短文は低〜中（凝縮ブースト込み）
+		ExpectedScore: 35,
 	},
 	{
 		Name:          "動機_長文かつ数値あり",
@@ -97,8 +97,8 @@ var goldStandard = []EvalSample{
 		Answer:        "リリース方針で意見が対立したとき、互いの懸念点を整理して折衷案を提案しました。合意形成のために1対1でも話し合いの場を設け、最終的にチーム全員で納得した方向でリリースできました。",
 		IsChoice:      false,
 		ExpectedMin:   60,
-		ExpectedMax:   95,
-		ExpectedScore: 78,
+		ExpectedMax:   100, // #561: 凝縮シグナル強化後は上限到達しうる
+		ExpectedScore: 85,
 	},
 	{
 		Name:          "協調_曖昧な回答",
@@ -108,6 +108,25 @@ var goldStandard = []EvalSample{
 		ExpectedMin:   0,
 		ExpectedMax:   25,
 		ExpectedScore: 12,
+	},
+	// ── 短文高関与 (#561) ───────────────────────────────────────────────────
+	{
+		Name:          "短文高関与_リリース経験",
+		Question:      "これまでの経験で工夫したことを教えてください。",
+		Answer:        "チームで役割分担して3日でリリースした。",
+		IsChoice:      false,
+		ExpectedMin:   50,
+		ExpectedMax:   90,
+		ExpectedScore: 70,
+	},
+	{
+		Name:          "短文高関与_やりがい理由",
+		Question:      "仕事でやりがいを感じた瞬間は？",
+		Answer:        "やりがいを感じた。人の役に立てたから。",
+		IsChoice:      false,
+		ExpectedMin:   45,
+		ExpectedMax:   85,
+		ExpectedScore: 60,
 	},
 	// ── 非IT説明系 ────────────────────────────────────────────────────────────
 	{
@@ -268,7 +287,7 @@ func TestAnswerEvaluator_CategoryInference(t *testing.T) {
 	evaluator := services.NewAnswerEvaluator()
 
 	cases := []struct {
-		Question        string
+		Question         string
 		ExpectedCategory string
 	}{
 		{"エンジニアを目指したきっかけは？", "motivation"},


### PR DESCRIPTION
## Summary
- 凝縮表現シグナル（分担・リリース・やりがい等）を追加し、関与シグナルがある短文は \`too_generic\` を適用しない
- 30文字以下の関与短文に \`condensed_engagement\` ブースト
- 短文・境界帯のみ LLM ハイブリッド（\`EvaluateHumanScoringWithContext\`）をチャット経路に接続
- 関与短文の Score=0 に floor を設け \`valid_answers\` 進捗を落とさない
- テーブル駆動 / ゴールド標準に短文高関与ケースを追加

## Test plan
- [ ] \`go test ./internal/services/ -run 'ShortHighEngagement|condensed|too_generic'\`
- [ ] \`go test ./test/services/ -run GoldStandard\`
- [ ] 「チームで役割分担して3日でリリースした。」が中〜高スコア帯になること
- [ ] 「わからない」はスキップのまま進捗しないこと
- [ ] 「はい」は低スコアのままであること

Closes #561


Made with [Cursor](https://cursor.com)