### PR TITLE
feat: #605 管理者画面にAI/RAG運用機能を導入しLLMコスト削減に繋げる

### DIFF
--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -28,6 +28,7 @@ type CompanyInfoResult struct {
 	SourceURL     string `json:"source_url,omitempty"`
 	ModelUsed     string `json:"model_used,omitempty"`
 	Confidence    string `json:"confidence,omitempty"`
+	FromCache     bool   `json:"from_cache,omitempty"` // TTL 内の DB キャッシュ返却時 true（LLM/Search 未実行）
 }
 
 // CompanyInfoFetcher は gBizINFO を足がかりにしつつ、不足分は AI（安価 Search→Parse）で充足する。
@@ -366,6 +367,7 @@ func companyInfoFromModel(company *models.Company) *CompanyInfoResult {
 		SourceURL:     company.SourceURL,
 		ModelUsed:     company.LastModelUsed,
 		Confidence:    company.LastFetchConfidence,
+		FromCache:     true,
 	}
 }
 

--- a/Backend/test/services/company_info_fetcher_test.go
+++ b/Backend/test/services/company_info_fetcher_test.go
@@ -59,6 +59,7 @@ func TestCompanyInfoFetcher_FetchAndSave_TTLCache(t *testing.T) {
 	result, err := fetcher.FetchAndSave(context.Background(), 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, "キャッシュ済み概要", result.Description)
+	assert.True(t, result.FromCache, "TTL 内は FromCache=true で LLM/Search をスキップ")
 	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 

--- a/frontend/app/admin/ai-ops/page.tsx
+++ b/frontend/app/admin/ai-ops/page.tsx
@@ -1,0 +1,423 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  LinearProgress,
+  Stack,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { authService } from '@/lib/auth'
+
+type L1Coverage = {
+  published_total: number
+  info_fresh: number
+  has_profile: number
+  needs_warm: number
+  info_rate: number
+  profile_rate: number
+  below_target?: boolean
+  alerts?: string[]
+}
+
+type CollectionStatus = {
+  name: string
+  exists: boolean
+  count: number
+  latest_fetched_at?: string | null
+  error?: string
+}
+
+type VectorStatus = {
+  backend?: string
+  collections?: CollectionStatus[]
+  total_documents?: number
+  error?: string
+  message?: string
+}
+
+type CostSummary = {
+  current_month_cost_usd?: number
+  company_search?: {
+    month: string
+    count: number
+    limit: number
+    remaining: number
+    enforce: boolean
+    exceeded: boolean
+  }
+  realtime?: {
+    current_month_cost_usd: number
+  }
+}
+
+const COST_ALERT_THRESHOLD_USD = 40
+
+const pct = (rate: number) => `${Math.round((rate || 0) * 100)}%`
+
+export default function AdminAIOpsPage() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [coverage, setCoverage] = useState<L1Coverage | null>(null)
+  const [vector, setVector] = useState<VectorStatus | null>(null)
+  const [costs, setCosts] = useState<CostSummary | null>(null)
+  const [warming, setWarming] = useState(false)
+  const [actionMessage, setActionMessage] = useState('')
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user?.is_admin) {
+      window.location.href = '/'
+    }
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    const headers = authService.getAdminFetchHeaders()
+    try {
+      const [covRes, vecRes, costRes] = await Promise.all([
+        fetch('/api/admin/companies/l1-coverage', { headers, cache: 'no-store' }),
+        fetch('/api/admin/vector/status', { headers, cache: 'no-store' }),
+        fetch('/api/admin/costs', { headers, cache: 'no-store' }),
+      ])
+      const [covData, vecData, costData] = await Promise.all([
+        covRes.ok ? covRes.json() : null,
+        vecRes.ok ? vecRes.json() : null,
+        costRes.ok ? costRes.json() : null,
+      ])
+      if (covData) setCoverage(covData)
+      if (vecData) setVector(vecData)
+      if (costData) setCosts(costData)
+      if (!covRes.ok && !vecRes.ok && !costRes.ok) {
+        setError('要約データの取得に失敗しました')
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : '読み込みに失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleWarmL1 = async (force: boolean) => {
+    setWarming(true)
+    setActionMessage('')
+    try {
+      const res = await fetch('/api/admin/companies/warm-l1', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authService.getAdminFetchHeaders(),
+        },
+        body: JSON.stringify({
+          limit: 50,
+          dry_run: false,
+          force,
+          include_info: true,
+          include_persona: true,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setActionMessage(data?.error || 'ウォームに失敗しました')
+        return
+      }
+      setActionMessage(
+        force
+          ? `強制ウォーム完了（再調査あり）: 処理 ${data.processed ?? 0} / info ${data.info_ok ?? 0} / persona ${data.persona_ok ?? 0}`
+          : `キャッシュ優先ウォーム完了: 処理 ${data.processed ?? 0} / info ${data.info_ok ?? 0} / persona ${data.persona_ok ?? 0}`,
+      )
+      await load()
+    } finally {
+      setWarming(false)
+    }
+  }
+
+  const handleSeedL1 = async () => {
+    setWarming(true)
+    setActionMessage('')
+    try {
+      const res = await fetch('/api/admin/companies/seed-l1', {
+        method: 'POST',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setActionMessage(data?.error || 'シードに失敗しました')
+        return
+      }
+      setActionMessage(`L1 シード完了: ${JSON.stringify(data)}`)
+      await load()
+    } finally {
+      setWarming(false)
+    }
+  }
+
+  const monthCost = costs?.current_month_cost_usd ?? 0
+  const overThreshold = monthCost >= COST_ALERT_THRESHOLD_USD
+  const search = costs?.company_search
+  const collections = vector?.collections ?? []
+
+  return (
+    <Box sx={{ p: 4, maxWidth: 1100, mx: 'auto' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <IconButton component={Link} href="/admin">
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h4" fontWeight="bold" flex={1}>
+          AI / RAG 運用
+        </Typography>
+        {loading && <CircularProgress size={22} />}
+        <Button size="small" onClick={load} disabled={loading}>
+          再読み込み
+        </Button>
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        RAG・DB キャッシュを優先し、LLM / WebSearch を必要なときだけ使うための運用ハブです。
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+      {actionMessage && (
+        <Alert severity="info" sx={{ mb: 2 }} onClose={() => setActionMessage('')}>
+          {actionMessage}
+        </Alert>
+      )}
+
+      <Alert severity="info" sx={{ mb: 3 }}>
+        <Typography variant="body2" fontWeight={600} gutterBottom>
+          コスト削減の基本方針
+        </Typography>
+        <Typography variant="body2" component="div">
+          1. DB / RAG に新鮮な企業情報があれば再調査しない（安価）
+          <br />
+          2. 不足分・期限切れのみ L1 ウォームや再埋め込みで補う
+          <br />
+          3. 「強制再取得」は LLM・Search を伴うため高コスト — 明示的に実行
+        </Typography>
+      </Alert>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 3 }} flexWrap="wrap" useFlexGap>
+        <Card sx={{ flex: 1, minWidth: 220 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              今月 API コスト
+            </Typography>
+            <Typography
+              variant="h4"
+              fontWeight={700}
+              color={overThreshold ? 'error.main' : monthCost > 20 ? 'warning.main' : 'success.main'}
+            >
+              ${monthCost.toFixed(4)}
+            </Typography>
+            <Chip
+              size="small"
+              sx={{ mt: 1 }}
+              color={overThreshold ? 'error' : 'default'}
+              label={`閾値 $${COST_ALERT_THRESHOLD_USD}${overThreshold ? ' 超過' : ' 未満'}`}
+            />
+            <Typography variant="caption" display="block" color="text.secondary" sx={{ mt: 1 }}>
+              Realtime: ${(costs?.realtime?.current_month_cost_usd ?? 0).toFixed(4)}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 220 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              企業 Search（今月）
+            </Typography>
+            <Typography
+              variant="h4"
+              fontWeight={700}
+              color={search?.exceeded ? 'error.main' : 'text.primary'}
+            >
+              {(search?.count ?? 0).toLocaleString()}
+              <Typography component="span" variant="h6" color="text.secondary">
+                {' '}/ {(search?.limit ?? 0).toLocaleString()}
+              </Typography>
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              残 {search?.remaining ?? '—'}
+              {search?.enforce === false ? ' (observe)' : ''}
+            </Typography>
+            {search && (
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(100, (search.count / Math.max(1, search.limit)) * 100)}
+                sx={{ mt: 1.5, height: 8, borderRadius: 1 }}
+                color={search.exceeded ? 'error' : 'primary'}
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 220 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              L1 企業カバレッジ
+            </Typography>
+            {coverage ? (
+              <>
+                <Typography variant="h4" fontWeight={700}>
+                  {pct(coverage.info_rate)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" display="block">
+                  info 新鮮 {coverage.info_fresh}/{coverage.published_total} · profile {pct(coverage.profile_rate)}
+                </Typography>
+                <Chip
+                  size="small"
+                  sx={{ mt: 1 }}
+                  color={coverage.needs_warm > 0 ? 'warning' : 'success'}
+                  label={`要ウォーム ${coverage.needs_warm}`}
+                />
+              </>
+            ) : (
+              <Typography color="text.secondary">—</Typography>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1, minWidth: 220 }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              VectorDB ドキュメント
+            </Typography>
+            <Typography variant="h4" fontWeight={700}>
+              {(vector?.total_documents ?? 0).toLocaleString()}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              backend: {vector?.backend || '—'} · collections {collections.length}
+            </Typography>
+            {vector?.error && (
+              <Alert severity="warning" sx={{ mt: 1, py: 0 }}>
+                {vector.error}
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+      </Stack>
+
+      {coverage?.alerts && coverage.alerts.length > 0 && (
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          {coverage.alerts.join(' / ')}
+        </Alert>
+      )}
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            コスト削減アクション
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            シード・ウォームで DB キャッシュを厚くし、面接・チャットが毎回 Search しない状態を作ります。
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Button variant="contained" disabled={warming} onClick={handleSeedL1}>
+              L1 カタログシード
+            </Button>
+            <Button
+              variant="outlined"
+              color="success"
+              disabled={warming}
+              onClick={() => handleWarmL1(false)}
+              startIcon={warming ? <CircularProgress size={14} color="inherit" /> : undefined}
+            >
+              ウォーム（キャッシュ優先・安価）
+            </Button>
+            <Button
+              variant="outlined"
+              color="warning"
+              disabled={warming}
+              onClick={() => handleWarmL1(true)}
+            >
+              強制ウォーム（再調査・高価）
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 3 }}>
+        <Card sx={{ flex: 1 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              RAG コレクション
+            </Typography>
+            {collections.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                コレクション情報がありません
+              </Typography>
+            ) : (
+              <Stack spacing={1}>
+                {collections.map((c) => (
+                  <Box key={c.name}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography variant="body2" fontWeight={600}>
+                        {c.name}
+                      </Typography>
+                      <Chip size="small" label={`${c.count} docs`} />
+                      {!c.exists && <Chip size="small" color="warning" label="missing" />}
+                    </Stack>
+                    {c.latest_fetched_at && (
+                      <Typography variant="caption" color="text.secondary">
+                        latest: {new Date(c.latest_fetched_at).toLocaleString('ja-JP')}
+                      </Typography>
+                    )}
+                    {c.error && (
+                      <Typography variant="caption" color="error">
+                        {c.error}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+              </Stack>
+            )}
+            <Divider sx={{ my: 2 }} />
+            <Button variant="contained" component={Link} href="/admin/vector-db">
+              ベクトルDB管理へ
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ flex: 1 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              関連画面
+            </Typography>
+            <Stack spacing={1.5}>
+              <Button variant="outlined" component={Link} href="/admin/costs" fullWidth sx={{ justifyContent: 'flex-start' }}>
+                APIコストモニタリング
+              </Button>
+              <Button variant="outlined" component={Link} href="/admin/companies" fullWidth sx={{ justifyContent: 'flex-start' }}>
+                企業管理（シード・ウォーム・個別編集）
+              </Button>
+              <Button variant="outlined" component={Link} href="/admin/vector-db" fullWidth sx={{ justifyContent: 'flex-start' }}>
+                ベクトルDB（reembed）
+              </Button>
+            </Stack>
+            <Alert severity="success" sx={{ mt: 2 }}>
+              企業詳細の「キャッシュから読込」は TTL 内なら LLM/Search を呼びません。不足時だけ「強制再取得（高価）」を使ってください。
+            </Alert>
+          </CardContent>
+        </Card>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/app/admin/companies/[id]/info/page.tsx
+++ b/frontend/app/admin/companies/[id]/info/page.tsx
@@ -29,6 +29,7 @@ export default function AdminCompanyInfoEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
+  const [cacheLoading, setCacheLoading] = useState(false)
   const [forceLoading, setForceLoading] = useState(false)
 
   const [name, setName] = useState('')
@@ -126,6 +127,32 @@ export default function AdminCompanyInfoEditPage() {
     }
   }
 
+  const handleCacheFetch = async () => {
+    setCacheLoading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch(`/api/admin/companies/${id}/fetch-info`, {
+        method: 'POST',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || 'キャッシュ読込に失敗しました')
+        return
+      }
+      applyInfoPayload(data)
+      loadCompany()
+      if (data?.from_cache) {
+        setSuccess('DB キャッシュから読み込みました（LLM / Search 未実行）。')
+      } else {
+        setSuccess('TTL 切れのため不足分を取得して保存しました。')
+      }
+    } finally {
+      setCacheLoading(false)
+    }
+  }
+
   const handleForceFetchAndSave = async () => {
     setForceLoading(true)
     setError('')
@@ -142,7 +169,7 @@ export default function AdminCompanyInfoEditPage() {
       }
       applyInfoPayload(data)
       loadCompany()
-      setSuccess('DBへ強制再取得・保存しました。')
+      setSuccess('DBへ強制再取得・保存しました（LLM / Search を使用した可能性があります）。')
     } finally {
       setForceLoading(false)
     }
@@ -215,6 +242,15 @@ export default function AdminCompanyInfoEditPage() {
         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
           <Button
             variant="outlined"
+            color="success"
+            onClick={handleCacheFetch}
+            disabled={cacheLoading || forceLoading}
+            startIcon={cacheLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {cacheLoading ? '読込中...' : 'キャッシュから読込（安価）'}
+          </Button>
+          <Button
+            variant="outlined"
             color="secondary"
             onClick={handleAiFetch}
             disabled={!name.trim() || aiLoading}
@@ -224,14 +260,15 @@ export default function AdminCompanyInfoEditPage() {
           </Button>
           <Button
             variant="outlined"
+            color="warning"
             onClick={handleForceFetchAndSave}
-            disabled={forceLoading}
+            disabled={forceLoading || cacheLoading}
             startIcon={forceLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
-            {forceLoading ? '再取得中...' : '強制再取得して保存'}
+            {forceLoading ? '再取得中...' : '強制再取得して保存（高価）'}
           </Button>
           <Typography variant="caption" color="text.secondary">
-            gBiz不足時は AI Search Lite。壁打ち/面接はDB共有キャッシュを読む（都度Searchしない）
+            キャッシュ読込は TTL 内なら LLM/Search しません。強制再取得は都度コストが発生します。
           </Typography>
         </Stack>
 

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -208,6 +208,14 @@ export default function AdminCostsPage() {
         </Alert>
       )}
 
+      <Alert severity="info" sx={{ mb: 2 }}>
+        DB / RAG に企業情報がある場合は再調査せずコストを抑えられます。運用ハブ:{' '}
+        <Button component={Link} href="/admin/ai-ops" size="small" sx={{ verticalAlign: 'baseline', minWidth: 0, p: 0, textTransform: 'none' }}>
+          AI / RAG 運用
+        </Button>
+        。月次目安閾値 $40（超過時はアラート連携 #604）。
+      </Alert>
+
       {/* KPI Cards */}
       <Stack direction="row" spacing={2} mb={3} flexWrap="wrap">
         <Card sx={{ flex: 1, minWidth: 200 }}>

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -156,6 +156,22 @@ export default function AdminDashboardPage() {
           </Card>
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%', border: '2px solid', borderColor: 'primary.light' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                AI / RAG 運用
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                コスト要約・VectorDB・L1シード/ウォームを一箇所で。DB/RAG キャッシュ優先で LLM コストを抑えます。
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Button variant="contained" component={Link} href="/admin/ai-ops">
+                AI / RAG 運用へ
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Card sx={{ height: '100%' }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>

--- a/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
@@ -9,7 +9,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-info`, {
+  const force = request.nextUrl.searchParams.get('force')
+  const qs = force ? `?force=${encodeURIComponent(force)}` : ''
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-info${qs}`, {
     method: 'POST',
     headers: {
       'X-Admin-Email': request.headers.get('x-admin-email') || '',

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -50,8 +50,54 @@ test.describe('管理者ダッシュボードフロー', () => {
     await page.goto('/admin')
     await page.waitForLoadState('networkidle')
     await expect(page.getByRole('heading', { name: '企業データ' })).toBeVisible({ timeout: 8000 })
+    await expect(page.getByRole('heading', { name: 'AI / RAG 運用' })).toBeVisible({ timeout: 8000 })
     await expect(page.getByRole('heading', { name: 'スコアダッシュボード' })).toBeVisible({ timeout: 8000 })
     await expect(page.getByRole('heading', { name: 'スコア精度検証' })).toBeVisible({ timeout: 8000 })
+  })
+
+  test('AI / RAG 運用ページに遷移できる', async ({ page }) => {
+    await page.route('**/api/admin/companies/l1-coverage', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          published_total: 10,
+          info_fresh: 8,
+          has_profile: 7,
+          needs_warm: 2,
+          info_rate: 0.8,
+          profile_rate: 0.7,
+        }),
+      })
+    })
+    await page.route('**/api/admin/vector/status**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          backend: 'chroma',
+          total_documents: 42,
+          collections: [{ name: 'company_research', exists: true, count: 42 }],
+        }),
+      })
+    })
+    await page.route('**/api/admin/costs**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          current_month_cost_usd: 12.5,
+          company_search: { month: '2026-07', count: 100, limit: 2000, remaining: 1900, enforce: true, exceeded: false },
+          realtime: { current_month_cost_usd: 1.2 },
+        }),
+      })
+    })
+
+    await page.goto('/admin/ai-ops')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'AI / RAG 運用' })).toBeVisible({ timeout: 8000 })
+    await expect(page.getByText('コスト削減の基本方針')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByRole('button', { name: 'ウォーム（キャッシュ優先・安価）' })).toBeVisible()
   })
 
   test('スコアダッシュボードページに遷移できる', async ({ page }) => {


### PR DESCRIPTION
## Summary
- `/admin/ai-ops` ハブを新設（コスト / Search 予算 / L1 カバレッジ / VectorDB 要約とシード・ウォーム操作）
- 管理者ダッシュボードに「AI / RAG 運用」カードを追加
- 企業情報編集に「キャッシュから読込（安価）」と「強制再取得（高価）」を明示
- `fetch-info` の `force` クエリを BFF 経由で転送、TTL ヒット時は `from_cache: true`
- コスト画面に AI/RAG 運用への導線と $40 閾値メモを追加

## Test plan
- [ ] `/admin` から「AI / RAG 運用」へ遷移できる
- [ ] `/admin/ai-ops` で L1 / Vector / コスト要約が表示される
- [ ] 企業情報で「キャッシュから読込」が TTL 内で LLM を呼ばず成功する（`from_cache`）
- [ ] 「強制再取得（高価）」が従来どおり動作する
- [ ] `go test ./test/services/ -run TestCompanyInfoFetcher_FetchAndSave_TTLCache`

Closes #605


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AI・RAG運用状況を一元管理できる管理画面を追加しました。
  * コスト、検索数、カバレッジ、ベクトルDBの状態を確認できます。
  * キャッシュから企業情報を低コストで読み込む操作を追加しました。
  * 企業情報の強制再取得にも対応しました。

* **改善**
  * 管理者ダッシュボードからAI・RAG運用画面へ移動できるようになりました。
  * コスト画面に、キャッシュ利用によるコスト削減案内と目安額を追加しました。
  * キャッシュ利用時かどうかを結果で確認できるようになりました。

* **テスト**
  * AI・RAG運用画面への遷移と主要表示を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->