### PR TITLE
feat: #558 AI非依存レイヤーのシステムバグ修正（P0/P1 完了）

### DIFF
--- a/Backend/internal/models/cleanup_demo_companies.go
+++ b/Backend/internal/models/cleanup_demo_companies.go
@@ -8,6 +8,10 @@ const demoCompanySubquery = `(SELECT id FROM (SELECT id FROM companies WHERE web
 
 // CleanupDemoCompanies 過去のシードで投入されたデモ企業と関連データを削除する。
 // デモ企業が存在しない場合は何もしない（冪等）。
+//
+// company_relations は両端がデモ企業の行のみ削除する。
+// 実在企業とデモ企業の混在関係は行を残し、デモ側 FK を NULL にしてから企業を削除する
+// （片端のみデモの関係を丸ごと消すと、実在企業側の関係データが失われるため）。
 func CleanupDemoCompanies(db *gorm.DB) error {
 	// 外部キー制約に従い、子テーブルから順に削除する
 	stmts := []string{
@@ -25,10 +29,15 @@ func CleanupDemoCompanies(db *gorm.DB) error {
 		`DELETE FROM company_reviews WHERE company_id IN ` + demoCompanySubquery,
 		`DELETE FROM g_biz_company_profiles WHERE company_id IN ` + demoCompanySubquery,
 		`DELETE FROM user_application_statuses WHERE company_id IN ` + demoCompanySubquery,
-		`DELETE FROM company_relations WHERE parent_id IN ` + demoCompanySubquery +
-			` OR child_id IN ` + demoCompanySubquery +
-			` OR from_id IN ` + demoCompanySubquery +
-			` OR to_id IN ` + demoCompanySubquery,
+		// 両端ともデモ企業の関係のみ削除（資本: parent+child / ビジネス: from+to）
+		`DELETE FROM company_relations WHERE ` +
+			`(parent_id IS NOT NULL AND child_id IS NOT NULL AND parent_id IN ` + demoCompanySubquery + ` AND child_id IN ` + demoCompanySubquery + `) OR ` +
+			`(from_id IS NOT NULL AND to_id IS NOT NULL AND from_id IN ` + demoCompanySubquery + ` AND to_id IN ` + demoCompanySubquery + `)`,
+		// 混在関係はデモ側 FK を外し、実在企業側の行を残す
+		`UPDATE company_relations SET parent_id = NULL WHERE parent_id IN ` + demoCompanySubquery,
+		`UPDATE company_relations SET child_id = NULL WHERE child_id IN ` + demoCompanySubquery,
+		`UPDATE company_relations SET from_id = NULL WHERE from_id IN ` + demoCompanySubquery,
+		`UPDATE company_relations SET to_id = NULL WHERE to_id IN ` + demoCompanySubquery,
 		`DELETE FROM companies WHERE id IN ` + demoCompanySubquery,
 	}
 

--- a/Backend/test/models/cleanup_demo_companies_test.go
+++ b/Backend/test/models/cleanup_demo_companies_test.go
@@ -29,9 +29,36 @@ func TestCleanupDemoCompanies_IdempotentWhenNoDemoData(t *testing.T) {
 	db, mock := newCleanupTestDB(t)
 
 	mock.ExpectBegin()
-	for i := 0; i < 13; i++ {
+	// 子テーブル削除 11 + 両端デモ関係削除 1 + 混在FK解除 4 + 企業削除 1 = 17
+	for i := 0; i < 17; i++ {
+		mock.ExpectExec("(?i)(DELETE FROM|UPDATE)").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+	mock.ExpectCommit()
+
+	err := models.CleanupDemoCompanies(db)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCleanupDemoCompanies_RelationsRequireBothDemoEndpoints(t *testing.T) {
+	db, mock := newCleanupTestDB(t)
+
+	mock.ExpectBegin()
+	for i := 0; i < 11; i++ {
 		mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 0))
 	}
+	// 片端デモの OR 連鎖ではなく、parent+child / from+to の両端デモ条件
+	mock.ExpectExec(`DELETE FROM company_relations WHERE \(parent_id IS NOT NULL AND child_id IS NOT NULL AND parent_id IN .+ AND child_id IN .+\) OR \(from_id IS NOT NULL AND to_id IS NOT NULL AND from_id IN .+ AND to_id IN .+\)`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE company_relations SET parent_id = NULL WHERE parent_id IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE company_relations SET child_id = NULL WHERE child_id IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE company_relations SET from_id = NULL WHERE from_id IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE company_relations SET to_id = NULL WHERE to_id IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM companies").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	err := models.CleanupDemoCompanies(db)

--- a/Backend/test/repositories/company_query_repository_test.go
+++ b/Backend/test/repositories/company_query_repository_test.go
@@ -30,57 +30,71 @@ func newCompanyQueryRepoTestDB(t *testing.T) (*repositories.CompanyQueryReposito
 	return repositories.NewCompanyQueryRepository(db), mock
 }
 
-func TestGetCompaniesFiltered_DefaultOrderIsDeterministic(t *testing.T) {
-	repo, mock := newCompanyQueryRepoTestDB(t)
-
-	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\?").
-		WithArgs(true).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
-
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? ORDER BY updated_at DESC, id ASC LIMIT \\?").
-		WithArgs(true, 10).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
-			AddRow(2, "B社", true).
-			AddRow(1, "A社", true))
-
-	companies, total, err := repo.GetCompaniesFiltered(10, 0, "", "", "")
-	if err != nil {
-		t.Fatalf("GetCompaniesFiltered returned error: %v", err)
+func TestGetCompaniesFiltered_Order(t *testing.T) {
+	tests := []struct {
+		name       string
+		searchName string
+		limit      int
+		offset     int
+		setupMock  func(sqlmock.Sqlmock)
+		wantTotal  int64
+		wantCount  int
+	}{
+		{
+			name:       "デフォルトは updated_at DESC, id ASC",
+			searchName: "",
+			limit:      10,
+			offset:     0,
+			wantTotal:  2,
+			wantCount:  2,
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\?").
+					WithArgs(true).
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+				mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? ORDER BY updated_at DESC, id ASC LIMIT \\?").
+					WithArgs(true, 10).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
+						AddRow(2, "B社", true).
+						AddRow(1, "A社", true))
+			},
+		},
+		{
+			name:       "名前検索時は name ASC",
+			searchName: "テック",
+			limit:      10,
+			offset:     0,
+			wantTotal:  1,
+			wantCount:  1,
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND name LIKE \\?").
+					WithArgs(true, "%テック%").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+				mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND name LIKE \\? ORDER BY name ASC LIMIT \\?").
+					WithArgs(true, "%テック%", 10).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
+						AddRow(1, "テック株式会社", true))
+			},
+		},
 	}
-	if total != 2 {
-		t.Fatalf("expected total 2, got %d", total)
-	}
-	if len(companies) != 2 {
-		t.Fatalf("expected 2 companies, got %d", len(companies))
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations not met: %v", err)
-	}
-}
 
-func TestGetCompaniesFiltered_NameSearchOrdersByNameAsc(t *testing.T) {
-	repo, mock := newCompanyQueryRepoTestDB(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, mock := newCompanyQueryRepoTestDB(t)
+			tt.setupMock(mock)
 
-	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND name LIKE \\?").
-		WithArgs(true, "%テック%").
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND name LIKE \\? ORDER BY name ASC LIMIT \\?").
-		WithArgs(true, "%テック%", 10).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
-			AddRow(1, "テック株式会社", true))
-
-	companies, total, err := repo.GetCompaniesFiltered(10, 0, "", "テック", "")
-	if err != nil {
-		t.Fatalf("GetCompaniesFiltered returned error: %v", err)
-	}
-	if total != 1 {
-		t.Fatalf("expected total 1, got %d", total)
-	}
-	if len(companies) != 1 {
-		t.Fatalf("expected 1 company, got %d", len(companies))
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("expectations not met: %v", err)
+			companies, total, err := repo.GetCompaniesFiltered(tt.limit, tt.offset, "", tt.searchName, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, total)
+			}
+			if len(companies) != tt.wantCount {
+				t.Errorf("expected %d companies, got %d", tt.wantCount, len(companies))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("expectations not met: %v", err)
+			}
+		})
 	}
 }

--- a/Backend/test/repositories/company_query_repository_test.go
+++ b/Backend/test/repositories/company_query_repository_test.go
@@ -1,0 +1,86 @@
+package repositories_test
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"Backend/internal/repositories"
+)
+
+func newCompanyQueryRepoTestDB(t *testing.T) (*repositories.CompanyQueryRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock作成失敗: %v", err)
+	}
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm open失敗: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return repositories.NewCompanyQueryRepository(db), mock
+}
+
+func TestGetCompaniesFiltered_DefaultOrderIsDeterministic(t *testing.T) {
+	repo, mock := newCompanyQueryRepoTestDB(t)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\?").
+		WithArgs(true).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? ORDER BY updated_at DESC, id ASC LIMIT \\?").
+		WithArgs(true, 10).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
+			AddRow(2, "B社", true).
+			AddRow(1, "A社", true))
+
+	companies, total, err := repo.GetCompaniesFiltered(10, 0, "", "", "")
+	if err != nil {
+		t.Fatalf("GetCompaniesFiltered returned error: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+	if len(companies) != 2 {
+		t.Fatalf("expected 2 companies, got %d", len(companies))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations not met: %v", err)
+	}
+}
+
+func TestGetCompaniesFiltered_NameSearchOrdersByNameAsc(t *testing.T) {
+	repo, mock := newCompanyQueryRepoTestDB(t)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND name LIKE \\?").
+		WithArgs(true, "%テック%").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND name LIKE \\? ORDER BY name ASC LIMIT \\?").
+		WithArgs(true, "%テック%", 10).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "is_active"}).
+			AddRow(1, "テック株式会社", true))
+
+	companies, total, err := repo.GetCompaniesFiltered(10, 0, "", "テック", "")
+	if err != nil {
+		t.Fatalf("GetCompaniesFiltered returned error: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("expected total 1, got %d", total)
+	}
+	if len(companies) != 1 {
+		t.Fatalf("expected 1 company, got %d", len(companies))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations not met: %v", err)
+	}
+}

--- a/docs/wiki/operations.md
+++ b/docs/wiki/operations.md
@@ -171,6 +171,30 @@ docker compose --profile rag logs --tail 80 chroma rag-review
 
 ## 5. データベース管理
 
+### デモ企業データのクリーンアップ（Issue #558）
+
+旧 Seed で投入された `example.com` 系のデモ企業は、起動時の `SeedData` 内で `CleanupDemoCompanies` が冪等実行され自動削除されます。既存環境で手動実行する場合:
+
+```sh
+cd Backend && go run ./cmd/migrate
+```
+
+`cmd/migrate` はスキーマ更新後に `SeedData` を呼び出すため、デモ企業・関連子テーブルも合わせてクリーンアップされます。サーバー起動時（`go run ./cmd/server`）でも同様に実行されます。
+
+**確認クエリ:**
+
+```sql
+SELECT id, name, website_url FROM companies
+WHERE website_url LIKE '%.example.com%'
+   OR website_url = 'https://example.com'
+   OR name IN (
+     '株式会社テックイノベーション',
+     'エンタープライズシステムズ株式会社',
+     'クリエイティブラボ株式会社'
+   );
+-- 0 件であること
+```
+
 ### バックアップ
 
 ```sh

--- a/frontend/lib/company-data.ts
+++ b/frontend/lib/company-data.ts
@@ -46,48 +46,35 @@ export class CompanyDataFetchError extends Error {
   }
 }
 
-const demoCompanyNames = new Set([
-  '株式会社テックイノベーション',
-  'エンタープライズシステムズ株式会社',
-  'クリエイティブラボ株式会社',
-])
-
-function isDemoCompany(company?: Company): boolean {
-  if (!company) return true
-  const website = company.website_url || ''
-  if (website.includes('.example.com') || website === 'https://example.com') {
-    return true
-  }
-  if (demoCompanyNames.has(company.name)) {
-    return true
-  }
-  return false
-}
-
-function hasDemoEndpoint(relation: CapitalRelation): boolean {
-  if (relation.parent_id && isDemoCompany(relation.parent)) return true
-  if (relation.child_id && isDemoCompany(relation.child)) return true
-  if (relation.from_id && isDemoCompany(relation.from)) return true
-  if (relation.to_id && isDemoCompany(relation.to)) return true
-  return false
-}
-
-/** 企業関係データを Next.js プロキシ経由で取得（DB: company_relations） */
+/**
+ * 企業関係データを Next.js プロキシ経由で取得する（DB: company_relations）。
+ *
+ * 失敗時は空配列を返さず {@link CompanyDataFetchError} を throw する。
+ * 呼び出し側は try/catch で捕捉し、エラー UI を表示すること。
+ *
+ * @throws {CompanyDataFetchError} HTTP エラーまたはネットワーク失敗時
+ */
 export async function fetchCompanyRelations(): Promise<CapitalRelation[]> {
   try {
     const response = await fetch('/api/companies/relations', { cache: 'no-store' })
     if (!response.ok) {
       throw new CompanyDataFetchError('企業関係データの取得に失敗しました', response.status)
     }
-    const relations: CapitalRelation[] = await response.json()
-    return relations.filter((relation) => !hasDemoEndpoint(relation))
+    return response.json()
   } catch (error) {
     if (error instanceof CompanyDataFetchError) throw error
     throw new CompanyDataFetchError('企業関係データの取得中にエラーが発生しました')
   }
 }
 
-/** 企業市場情報を Next.js プロキシ経由で取得（DB: company_market_info） */
+/**
+ * 企業市場情報を Next.js プロキシ経由で取得する（DB: company_market_info）。
+ *
+ * 失敗時は空配列を返さず {@link CompanyDataFetchError} を throw する。
+ * 呼び出し側は try/catch で捕捉し、エラー UI を表示すること。
+ *
+ * @throws {CompanyDataFetchError} HTTP エラーまたはネットワーク失敗時
+ */
 export async function fetchCompanyMarketInfo(): Promise<CompanyMarketInfo[]> {
   try {
     const response = await fetch('/api/companies/market-info', { cache: 'no-store' })


### PR DESCRIPTION
## Summary

- **P0 デモ企業クリーンアップ改善**: `CleanupDemoCompanies` を両端デモのみ DELETE + 混在関係は FK NULL 化に変更（実在企業の関係データを保持）
- **P0 FE workaround 除去**: `isDemoCompany` / `hasDemoEndpoint` クライアントフィルタを削除（DB クリーンアップに一本化）
- **P1 テスト追加**: `GetCompaniesFiltered` の決定的ソート（`updated_at DESC, id ASC` / 名前検索時 `name ASC`）を検証
- **ドキュメント**: 既存 DB 向け `go run ./cmd/migrate` 手順を `docs/wiki/operations.md` に追記

Closes #558 の P0/P1 完了条件。P2（企業関係の scoped fetch）は別 PR で対応予定。

## Test plan

- [x] `cd Backend && go test ./test/models/... ./test/repositories/... -run 'CleanupDemo|GetCompaniesFiltered'`
- [x] `cd frontend && npm run lint`
- [ ] `go run ./cmd/migrate` 後、デモ企業が 0 件であることを SQL で確認
- [ ] 企業関係 API 障害時に diagram / results がエラー UI を表示すること


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 企業関係データで、実在企業との関係を維持しながらデモ企業のみ切り離せるようになりました。
  - 企業関係・市場情報の取得に失敗した際、空データではなくエラーとして通知されるようになりました。

- **改善**
  - デモ企業データを起動時に安全かつ繰り返し削除できるようになりました。
  - デモ企業データの手動削除方法と確認手順を運用ドキュメントに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->