### PR TITLE
feat: #604 OpenAI APIコストが月次$40超過時に Slack/Discord へアラート

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -37,6 +37,12 @@ REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200
 # REALTIME_ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
 # MATCHING_ALERT_EMAILS=ops@example.com,admin@example.com
 
+# OpenAI API 全体の月次コストアラート（api_call_logs 集計 / UTC 月境界）#604
+OPENAI_COST_ALERT_THRESHOLD_USD=40
+# OPENAI_COST_ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
+# OPENAI_COST_ALERT_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
+# ※ Slack 未設定時は REALTIME_ALERT_SLACK_WEBHOOK_URL へフォールバック
+
 # RAG Service (rag-review コンテナ)
 # ローカル: docker compose --profile rag up -d
 RAG_REVIEW_URL=http://localhost:9000

--- a/Backend/internal/services/api_cost_service.go
+++ b/Backend/internal/services/api_cost_service.go
@@ -3,25 +3,26 @@ package services
 import (
 	"Backend/internal/models"
 	"Backend/internal/repositories"
+	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
 // モデル別単価テーブル (USD per 1M tokens)
 var modelPricing = map[string][2]float64{
 	// input, output per 1M tokens
-	"gpt-4o":              {2.50, 10.00},
-	"gpt-4o-mini":         {0.15, 0.60},
-	"gpt-4-turbo":         {10.00, 30.00},
-	"gpt-4":               {30.00, 60.00},
-	"gpt-3.5-turbo":       {0.50, 1.50},
-	"gpt-5.2":             {2.50, 10.00},  // treated as gpt-4o class
-	"o1":                  {15.00, 60.00},
-	"o1-mini":             {3.00, 12.00},
-	"o3":                  {10.00, 40.00},
+	"gpt-4o":                 {2.50, 10.00},
+	"gpt-4o-mini":            {0.15, 0.60},
+	"gpt-4-turbo":            {10.00, 30.00},
+	"gpt-4":                  {30.00, 60.00},
+	"gpt-3.5-turbo":          {0.50, 1.50},
+	"gpt-5.2":                {2.50, 10.00}, // treated as gpt-4o class
+	"o1":                     {15.00, 60.00},
+	"o1-mini":                {3.00, 12.00},
+	"o3":                     {10.00, 40.00},
 	"text-embedding-3-small": {0.02, 0.02},
 	"text-embedding-3-large": {0.13, 0.13},
 }
@@ -50,18 +51,26 @@ func calculateCost(model string, promptTokens, completionTokens int) float64 {
 	return inputCost + outputCost
 }
 
-// APICostService はAPIコスト記録・集計を担当する
+// APICostService はAPIコスト記録・集計・月次閾値アラートを担当する
 type APICostService struct {
-	repo            *repositories.APICallLogRepository
-	alertThresholdUSD float64 // 月額閾値
+	repo              *repositories.APICallLogRepository
+	alertThresholdUSD float64 // 月次閾値（既定 $40）
+
+	mu               sync.Mutex
+	lastAlertMonthID string // "2006-01" UTC。同一月は1回のみ通知
+
+	// テスト用フック（nil なら本番実装を使う）
+	totalCostFn     func() (float64, error)
+	modelBreakdownFn func(since time.Time) ([]ModelCostSummary, error)
+	notifySlackFn   func(text string) error
+	notifyDiscordFn func(content string) error
 }
 
 func NewAPICostService(repo *repositories.APICallLogRepository) *APICostService {
-	threshold := 100.0
-	if v := os.Getenv("API_COST_ALERT_THRESHOLD_USD"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			threshold = f
-		}
+	// OPENAI_COST_ALERT_THRESHOLD_USD を優先、未設定時は旧 API_COST_ALERT_THRESHOLD_USD、最終既定 $40
+	threshold := getFloatEnv("OPENAI_COST_ALERT_THRESHOLD_USD", 0)
+	if threshold <= 0 {
+		threshold = getFloatEnv("API_COST_ALERT_THRESHOLD_USD", 40)
 	}
 	return &APICostService{repo: repo, alertThresholdUSD: threshold}
 }
@@ -80,20 +89,116 @@ func (s *APICostService) LogCall(model string, promptTokens, completionTokens in
 		}
 		if err := s.repo.Create(entry); err != nil {
 			log.Printf("[APICost] failed to log: %v", err)
+			return
 		}
-		s.checkThreshold()
+		s.checkAndNotifyThreshold()
 	}()
 }
 
-// checkThreshold は月額閾値を超えていたらログ警告を出す
-func (s *APICostService) checkThreshold() {
-	since := time.Now().UTC().AddDate(0, -1, 0)
-	total, err := s.repo.TotalCostSince(since)
+// checkAndNotifyThreshold は当月（UTC）累計が閾値を超えたら Slack/Discord に通知する。
+// 同一月は1回のみ。webhook 未設定時はログのみで落ちない。
+func (s *APICostService) checkAndNotifyThreshold() {
+	totalFn := s.totalCostFn
+	if totalFn == nil {
+		totalFn = s.GetCurrentMonthTotal
+	}
+	total, err := totalFn()
 	if err != nil {
 		return
 	}
-	if total > s.alertThresholdUSD {
-		log.Printf("[APICost] ALERT: Monthly API cost $%.4f exceeds threshold $%.2f", total, s.alertThresholdUSD)
+	s.NotifyIfMonthCostExceeded(total, time.Now().UTC().Format("2006-01"))
+}
+
+// NotifyIfMonthCostExceeded は閾値判定・月次デデュープ・通知送信を行う（テスト可能）。
+// 通知を送った場合 true。
+func (s *APICostService) NotifyIfMonthCostExceeded(total float64, monthID string) bool {
+	// 「超過」は閾値より大きい場合のみ（ちょうど $40 では通知しない）
+	if total <= s.alertThresholdUSD {
+		return false
+	}
+
+	s.mu.Lock()
+	if s.lastAlertMonthID == monthID {
+		s.mu.Unlock()
+		return false
+	}
+	s.lastAlertMonthID = monthID
+	s.mu.Unlock()
+
+	subject := fmt.Sprintf("[SOC AI] OpenAI API月次コスト閾値超過 (%s)", monthID)
+	body := fmt.Sprintf(
+		"OpenAI API monthly cost exceeded threshold.\nmonth=%s\ntotal_usd=%.4f\nthreshold_usd=%.2f\n",
+		monthID, total, s.alertThresholdUSD,
+	)
+	if breakdown := s.formatModelBreakdown(monthID); breakdown != "" {
+		body += "models:\n" + breakdown
+	}
+	log.Printf("[APICost] ALERT %s", strings.ReplaceAll(body, "\n", " "))
+
+	text := subject + "\n" + body
+	s.sendSlackAlert(text)
+	s.sendDiscordAlert(text)
+	return true
+}
+
+func (s *APICostService) formatModelBreakdown(monthID string) string {
+	t, err := time.ParseInLocation("2006-01", monthID, time.UTC)
+	if err != nil {
+		return ""
+	}
+	since := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	fn := s.modelBreakdownFn
+	if fn == nil {
+		fn = s.GetModelBreakdown
+	}
+	rows, err := fn(since)
+	if err != nil || len(rows) == 0 {
+		return ""
+	}
+	const maxModels = 5
+	var b strings.Builder
+	for i, r := range rows {
+		if i >= maxModels {
+			b.WriteString(fmt.Sprintf("  ... and %d more\n", len(rows)-maxModels))
+			break
+		}
+		b.WriteString(fmt.Sprintf("  - %s: $%.4f (%d calls)\n", r.Model, r.TotalCostUSD, r.CallCount))
+	}
+	return b.String()
+}
+
+func (s *APICostService) sendSlackAlert(text string) {
+	if s.notifySlackFn != nil {
+		if err := s.notifySlackFn(text); err != nil {
+			log.Printf("[APICost] slack alert failed: %v", err)
+		}
+		return
+	}
+	webhook := strings.TrimSpace(os.Getenv("OPENAI_COST_ALERT_SLACK_WEBHOOK_URL"))
+	if webhook == "" {
+		webhook = strings.TrimSpace(os.Getenv("REALTIME_ALERT_SLACK_WEBHOOK_URL"))
+	}
+	if webhook == "" {
+		return
+	}
+	if err := postSlackAlert(webhook, text); err != nil {
+		log.Printf("[APICost] slack alert failed: %v", err)
+	}
+}
+
+func (s *APICostService) sendDiscordAlert(content string) {
+	if s.notifyDiscordFn != nil {
+		if err := s.notifyDiscordFn(content); err != nil {
+			log.Printf("[APICost] discord alert failed: %v", err)
+		}
+		return
+	}
+	webhook := strings.TrimSpace(os.Getenv("OPENAI_COST_ALERT_DISCORD_WEBHOOK_URL"))
+	if webhook == "" {
+		return
+	}
+	if err := postDiscordAlert(webhook, content); err != nil {
+		log.Printf("[APICost] discord alert failed: %v", err)
 	}
 }
 
@@ -173,4 +278,23 @@ func (s *APICostService) GetCurrentMonthTotal() (float64, error) {
 	now := time.Now().UTC()
 	since := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	return s.repo.TotalCostSince(since)
+}
+
+// AlertThresholdUSD は設定済みの月次アラート閾値を返す（テスト/管理用）。
+func (s *APICostService) AlertThresholdUSD() float64 {
+	return s.alertThresholdUSD
+}
+
+// SetAlertHooksForTest は単体テスト用に通知フックと閾値を差し替える。
+func (s *APICostService) SetAlertHooksForTest(
+	threshold float64,
+	slackFn func(text string) error,
+	discordFn func(content string) error,
+) {
+	s.alertThresholdUSD = threshold
+	s.notifySlackFn = slackFn
+	s.notifyDiscordFn = discordFn
+	s.modelBreakdownFn = func(time.Time) ([]ModelCostSummary, error) {
+		return nil, nil
+	}
 }

--- a/Backend/internal/services/realtime_usage_service.go
+++ b/Backend/internal/services/realtime_usage_service.go
@@ -319,7 +319,20 @@ func (s *RealtimeUsageService) checkAndNotifyThreshold() {
 
 func postSlackAlert(webhookURL, text string) error {
 	payload := map[string]string{"text": text}
-	b, _ := json.Marshal(payload)
+	return postWebhookJSON(webhookURL, payload)
+}
+
+// postDiscordAlert は Discord Incoming Webhook に content を送信する。
+func postDiscordAlert(webhookURL, content string) error {
+	payload := map[string]string{"content": content}
+	return postWebhookJSON(webhookURL, payload)
+}
+
+func postWebhookJSON(webhookURL string, payload any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewReader(b))
 	if err != nil {
 		return err

--- a/Backend/test/services/api_cost_alert_test.go
+++ b/Backend/test/services/api_cost_alert_test.go
@@ -1,0 +1,166 @@
+package services_test
+
+// 実行: cd Backend && go test ./test/services/... -run 'TestAPICostAlert|TestNewAPICostService' -v
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"Backend/internal/services"
+)
+
+func TestAPICostAlert_ThresholdAndMonthlyDedupe(t *testing.T) {
+	tests := []struct {
+		name         string
+		threshold    float64
+		total        float64
+		monthID      string
+		priorMonthID string
+		wantNotified bool
+		wantSlack    int
+		wantDiscord  int
+	}{
+		{
+			name:         "閾値未満は通知しない",
+			threshold:    40,
+			total:        39.99,
+			monthID:      "2026-07",
+			wantNotified: false,
+		},
+		{
+			name:         "閾値ちょうどは通知しない",
+			threshold:    40,
+			total:        40.0,
+			monthID:      "2026-07",
+			wantNotified: false,
+		},
+		{
+			name:         "閾値超過で Slack/Discord に通知",
+			threshold:    40,
+			total:        40.01,
+			monthID:      "2026-07",
+			wantNotified: true,
+			wantSlack:    1,
+			wantDiscord:  1,
+		},
+		{
+			name:         "同一月の再チェックは重複通知しない",
+			threshold:    40,
+			total:        55,
+			monthID:      "2026-07",
+			priorMonthID: "2026-07",
+			wantNotified: false,
+		},
+		{
+			name:         "月が変われば再通知できる",
+			threshold:    40,
+			total:        45,
+			monthID:      "2026-08",
+			priorMonthID: "2026-07",
+			wantNotified: true,
+			wantSlack:    1,
+			wantDiscord:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu           sync.Mutex
+				slackCalls   int
+				discordCalls int
+				lastSlack    string
+			)
+
+			svc := services.NewAPICostService(nil)
+			svc.SetAlertHooksForTest(tt.threshold,
+				func(text string) error {
+					mu.Lock()
+					defer mu.Unlock()
+					slackCalls++
+					lastSlack = text
+					return nil
+				},
+				func(content string) error {
+					mu.Lock()
+					defer mu.Unlock()
+					discordCalls++
+					return nil
+				},
+			)
+
+			if tt.priorMonthID != "" {
+				_ = svc.NotifyIfMonthCostExceeded(tt.threshold+1, tt.priorMonthID)
+				mu.Lock()
+				slackCalls = 0
+				discordCalls = 0
+				mu.Unlock()
+			}
+
+			got := svc.NotifyIfMonthCostExceeded(tt.total, tt.monthID)
+			if got != tt.wantNotified {
+				t.Fatalf("notified=%v want=%v", got, tt.wantNotified)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if slackCalls != tt.wantSlack {
+				t.Fatalf("slack calls=%d want=%d", slackCalls, tt.wantSlack)
+			}
+			if discordCalls != tt.wantDiscord {
+				t.Fatalf("discord calls=%d want=%d", discordCalls, tt.wantDiscord)
+			}
+			if tt.wantNotified {
+				for _, part := range []string{tt.monthID, "total_usd", "threshold_usd"} {
+					if !strings.Contains(lastSlack, part) {
+						t.Fatalf("alert body missing %q: %q", part, lastSlack)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAPICostAlert_WebhookUnsetDoesNotPanic(t *testing.T) {
+	t.Setenv("OPENAI_COST_ALERT_SLACK_WEBHOOK_URL", "")
+	t.Setenv("OPENAI_COST_ALERT_DISCORD_WEBHOOK_URL", "")
+	t.Setenv("REALTIME_ALERT_SLACK_WEBHOOK_URL", "")
+
+	svc := services.NewAPICostService(nil)
+	svc.SetAlertHooksForTest(40, nil, nil)
+
+	if !svc.NotifyIfMonthCostExceeded(50, "2026-07") {
+		t.Fatal("expected first exceed to return true (log-only when webhooks unset)")
+	}
+	if svc.NotifyIfMonthCostExceeded(60, "2026-07") {
+		t.Fatal("expected same-month dedupe")
+	}
+}
+
+func TestNewAPICostService_DefaultThreshold40(t *testing.T) {
+	t.Setenv("OPENAI_COST_ALERT_THRESHOLD_USD", "")
+	t.Setenv("API_COST_ALERT_THRESHOLD_USD", "")
+	svc := services.NewAPICostService(nil)
+	if got := svc.AlertThresholdUSD(); got != 40 {
+		t.Fatalf("default threshold=%v want=40", got)
+	}
+}
+
+func TestNewAPICostService_OpenAIEnvOverrides(t *testing.T) {
+	t.Setenv("OPENAI_COST_ALERT_THRESHOLD_USD", "25.5")
+	t.Setenv("API_COST_ALERT_THRESHOLD_USD", "100")
+	svc := services.NewAPICostService(nil)
+	if got := svc.AlertThresholdUSD(); got != 25.5 {
+		t.Fatalf("threshold=%v want=25.5", got)
+	}
+}
+
+func TestNewAPICostService_LegacyEnvFallback(t *testing.T) {
+	t.Setenv("OPENAI_COST_ALERT_THRESHOLD_USD", "")
+	t.Setenv("API_COST_ALERT_THRESHOLD_USD", "80")
+	svc := services.NewAPICostService(nil)
+	if got := svc.AlertThresholdUSD(); got != 80 {
+		t.Fatalf("threshold=%v want=80", got)
+	}
+}

--- a/docs/wiki/operations.md
+++ b/docs/wiki/operations.md
@@ -88,8 +88,12 @@ GET /api/admin/costs/monthly   # 月別コスト
 ```
 
 **アラート設定:**
-- `REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200` を超えるとメール/Slackアラート
-- `REALTIME_ALERT_EMAILS` / `REALTIME_ALERT_SLACK_WEBHOOK_URL` で通知先設定
+- OpenAI API 全体（`api_call_logs`）: `OPENAI_COST_ALERT_THRESHOLD_USD=40`（UTC 月次）を超過すると Slack/Discord
+  - `OPENAI_COST_ALERT_SLACK_WEBHOOK_URL` / `OPENAI_COST_ALERT_DISCORD_WEBHOOK_URL`
+  - Slack 未設定時は `REALTIME_ALERT_SLACK_WEBHOOK_URL` へフォールバック
+  - 同一月は1回のみ通知
+- Realtime: `REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200` を超えるとメール/Slack
+  - `REALTIME_ALERT_EMAILS` / `REALTIME_ALERT_SLACK_WEBHOOK_URL`
 
 ### 面接セッション監視
 


### PR DESCRIPTION
## Summary
- `APICostService` の閾値チェックを **UTC 月次累計** に修正し、既定閾値を **$40**（`OPENAI_COST_ALERT_THRESHOLD_USD`）に変更
- 超過時に **Slack / Discord** Incoming Webhook へ通知（同一月は1回のみ）
- webhook 未設定時はログのみ（パニックなし）。Slack は `REALTIME_ALERT_SLACK_WEBHOOK_URL` へフォールバック可
- テーブル駆動テストで閾値判定・月次デデュープ・env 既定値を検証
- `.env.example` / `docs/wiki/operations.md` を更新

Closes #604

## Test plan
- [x] `cd Backend && go test ./test/services/... -run 'TestAPICostAlert|TestNewAPICostService' -v`
- [ ] webhook URL を設定し、ログを閾値超まで溜めたあと Slack/Discord に1通届くこと
- [ ] 同月内の再超過で追加通知が来ないこと
- [ ] webhook 未設定でもサーバーが落ちないこと


Made with [Cursor](https://cursor.com)