### PR TITLE
feat: #615 RAGサービス（FastAPI）に内部サービス認証を導入する

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -40,6 +40,10 @@ REALTIME_MONTHLY_ALERT_THRESHOLD_USD=200
 # RAG Service (rag-review コンテナ)
 # ローカル: docker compose --profile rag up -d
 RAG_REVIEW_URL=http://localhost:9000
+# Backend→RAG の内部認証トークン (#615)。両サービスで同一の値を設定する
+# 未設定の場合 RAG はヘルスチェック以外の全リクエストを拒否する（フェイルクローズ）
+# 本番は `openssl rand -hex 32` などで生成した値を設定すること
+RAG_INTERNAL_TOKEN=dev-internal-token
 # Phase 1B (#557): Read 経路の企業 Search は既定オフ。admin 温存・再埋め込み時のみ true
 RAG_ALLOW_WEB_SEARCH_FALLBACK=false
 RAG_USE_DEEP_RESEARCH=false

--- a/Backend/internal/controllers/admin_vector_controller.go
+++ b/Backend/internal/controllers/admin_vector_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"Backend/internal/ragclient"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -64,6 +65,7 @@ func (c *AdminVectorController) proxyJSON(ctx echo.Context, method, endpoint str
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	ragclient.SetAuthHeader(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/Backend/internal/controllers/es_review_controller.go
+++ b/Backend/internal/controllers/es_review_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"Backend/internal/ragclient"
 	"bytes"
 	"encoding/json"
 	"io"
@@ -58,6 +59,7 @@ func (c *ESReviewController) Review(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create RAG request")
 	}
 	ragReq.Header.Set("Content-Type", "application/json")
+	ragclient.SetAuthHeader(ragReq)
 
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Do(ragReq)

--- a/Backend/internal/ragclient/ragclient.go
+++ b/Backend/internal/ragclient/ragclient.go
@@ -1,0 +1,19 @@
+// Package ragclient は RAG サービス呼び出しの共通処理を提供する (#615)
+package ragclient
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// InternalTokenHeader は RAG サービス内部認証用のヘッダー名
+const InternalTokenHeader = "X-Internal-Token"
+
+// SetAuthHeader は RAG_INTERNAL_TOKEN が設定されていれば内部認証ヘッダーを付与する。
+// 未設定時はヘッダーを付けずに送信し、RAG 側のフェイルクローズ（503/401）に委ねる。
+func SetAuthHeader(req *http.Request) {
+	if token := strings.TrimSpace(os.Getenv("RAG_INTERNAL_TOKEN")); token != "" {
+		req.Header.Set(InternalTokenHeader, token)
+	}
+}

--- a/Backend/internal/ragclient/ragclient_test.go
+++ b/Backend/internal/ragclient/ragclient_test.go
@@ -1,0 +1,34 @@
+package ragclient
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetAuthHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		wantHeader string
+	}{
+		{name: "トークン設定時はヘッダーを付与する", token: "secret-token", wantHeader: "secret-token"},
+		{name: "空白のみのトークンは付与しない", token: "   ", wantHeader: ""},
+		{name: "未設定時は付与しない", token: "", wantHeader: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RAG_INTERNAL_TOKEN", tt.token)
+
+			req, err := http.NewRequest(http.MethodGet, "http://rag-review:9000/health", nil)
+			if err != nil {
+				t.Fatalf("リクエスト生成に失敗: %v", err)
+			}
+			SetAuthHeader(req)
+
+			if got := req.Header.Get(InternalTokenHeader); got != tt.wantHeader {
+				t.Errorf("ヘッダー = %q, want %q", got, tt.wantHeader)
+			}
+		})
+	}
+}

--- a/Backend/internal/services/job_fetch_service.go
+++ b/Backend/internal/services/job_fetch_service.go
@@ -5,6 +5,7 @@ import (
 	"Backend/internal/companyfetch"
 	"Backend/internal/models"
 	"Backend/internal/openai"
+	"Backend/internal/ragclient"
 	"Backend/internal/scraper"
 	"bytes"
 	"context"
@@ -204,6 +205,7 @@ func (s *JobFetchService) pushContextToRAG(companyName, contextType, content str
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	ragclient.SetAuthHeader(req)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	req = req.WithContext(ctx)

--- a/Backend/internal/services/resume_service.go
+++ b/Backend/internal/services/resume_service.go
@@ -4,6 +4,7 @@ import (
 	"Backend/domain/repository"
 	"Backend/internal/models"
 	"Backend/internal/openai"
+	"Backend/internal/ragclient"
 	"bufio"
 	"bytes"
 	"context"
@@ -34,7 +35,7 @@ var ErrForbidden = errors.New("forbidden")
 
 // allowedMIMETypes はアップロード可能なファイルタイプ
 var allowedMIMETypes = map[string]bool{
-	"application/pdf":  true,
+	"application/pdf":    true,
 	"application/msword": true,
 	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
 }
@@ -58,7 +59,7 @@ func validateFileUpload(fileHeader *multipart.FileHeader) error {
 
 	magicOK := bytes.HasPrefix(buf, pdfMagicBytes) ||
 		bytes.HasPrefix(buf, []byte{0x50, 0x4B, 0x03, 0x04}) || // DOCX (ZIP)
-		bytes.HasPrefix(buf, []byte{0xD0, 0xCF, 0x11, 0xE0})     // DOC (OLE2)
+		bytes.HasPrefix(buf, []byte{0xD0, 0xCF, 0x11, 0xE0}) // DOC (OLE2)
 	if magicOK {
 		return nil
 	}
@@ -824,10 +825,10 @@ type aiReviewItem struct {
 }
 
 type ragReviewRequest struct {
-	ResumeText      string `json:"resume_text"`
-	CompanyName     string `json:"company_name"`
-	JobTitle        string `json:"job_title"`
-	CompanyContext  string `json:"company_context,omitempty"`
+	ResumeText     string `json:"resume_text"`
+	CompanyName    string `json:"company_name"`
+	JobTitle       string `json:"job_title"`
+	CompanyContext string `json:"company_context,omitempty"`
 }
 
 type ragReviewResponse struct {
@@ -859,6 +860,7 @@ func (s *ResumeService) fetchRAGReport(resumeText, companyName, jobTitle string)
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	ragclient.SetAuthHeader(req)
 
 	client := &http.Client{Timeout: 45 * time.Second}
 	resp, err := client.Do(req)
@@ -912,6 +914,7 @@ func (s *ResumeService) fetchRAGReportStream(ctx context.Context, resumeText, co
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
+	ragclient.SetAuthHeader(req)
 
 	// ストリーミングのためタイムアウトなし
 	resp, err := (&http.Client{}).Do(req)

--- a/docs/wiki/rag-service.md
+++ b/docs/wiki/rag-service.md
@@ -54,6 +54,21 @@ SOC AI Agent の RAG（Retrieval-Augmented Generation）サービスは Python /
 | GET | `/vector/status` | ベクトルインデックス状況 |
 | POST | `/vector/reembed` | 企業ベクトル削除・再埋め込み |
 
+## 内部サービス認証（#615）
+
+`/health` / `/healthz` を除く全エンドポイントは、Backend からの内部認証ヘッダー `X-Internal-Token` を要求します。
+
+- トークンは環境変数 `RAG_INTERNAL_TOKEN` で設定し、**Backend と RAG で同一の値**を使う（docker compose では両サービスが `Backend/.env` を読むため1箇所の設定で足りる）
+- `RAG_INTERNAL_TOKEN` 未設定時はフェイルクローズ: ヘルスチェック以外の全リクエストを 503 で拒否する
+- トークン不一致は 401
+- 本番のトークンは `openssl rand -hex 32` などで生成する
+- Backend 側は `internal/ragclient.SetAuthHeader` がリクエストへ自動付与する（RAG 呼び出しを追加する際は必ずこれを通すこと）
+
+```bash
+# 手動でエンドポイントを叩く場合
+curl -H "X-Internal-Token: $RAG_INTERNAL_TOKEN" http://localhost:9000/vector/status
+```
+
 ### `/resume/review` リクエスト例
 
 ```json

--- a/rag/main.py
+++ b/rag/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import datetime
+import hmac
 import json
 import logging
 import math
@@ -62,6 +63,34 @@ app = FastAPI()
 # Training export endpoints (registered from training_api.py)
 import training_api
 training_api.register(app)
+
+# ── 内部サービス認証 (#615) ──────────────────────────────────────────────────
+# Backend からの呼び出しのみを許可するため X-Internal-Token を検証する。
+# ヘルスチェックのみ除外。トークン未設定時はフェイルクローズ（503）で全リクエストを拒否する。
+INTERNAL_TOKEN_HEADER = "X-Internal-Token"
+_INTERNAL_AUTH_EXEMPT_PATHS = frozenset({"/health", "/healthz"})
+
+
+@app.middleware("http")
+async def _internal_auth_middleware(request: Request, call_next: Callable) -> Any:
+    if request.url.path in _INTERNAL_AUTH_EXEMPT_PATHS:
+        return await call_next(request)
+
+    expected = os.getenv("RAG_INTERNAL_TOKEN", "").strip()
+    if not expected:
+        logger.error("RAG_INTERNAL_TOKEN が未設定のためリクエストを拒否します（フェイルクローズ）")
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "Service Unavailable: internal authentication not configured"},
+        )
+
+    provided = request.headers.get(INTERNAL_TOKEN_HEADER, "")
+    if not hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8")):
+        logger.warning("内部認証トークンが不正なリクエストを拒否しました path=%s", request.url.path)
+        return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+
+    return await call_next(request)
+
 
 @app.middleware("http")
 async def _trace_id_middleware(request: Request, call_next: Callable) -> Any:

--- a/rag/tests/conftest.py
+++ b/rag/tests/conftest.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # テストで必要な環境変数を設定（テスト用ダミーキー）
 os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault("RAG_INTERNAL_TOKEN", "test-internal-token")
 
 # crewai をスタブ化（requirements.txt から除外済みのため、ローカルで未インストール）
 _crewai_mock = types.ModuleType("crewai")
@@ -38,8 +39,11 @@ import main
 
 @pytest.fixture
 def client():
-    """TestClient を返すフィクスチャ"""
-    return TestClient(main.app)
+    """TestClient を返すフィクスチャ（内部認証トークン付き #615）"""
+    return TestClient(
+        main.app,
+        headers={"X-Internal-Token": os.environ["RAG_INTERNAL_TOKEN"]},
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/rag/tests/test_internal_auth.py
+++ b/rag/tests/test_internal_auth.py
@@ -1,0 +1,47 @@
+"""
+内部サービス認証ミドルウェアのテスト (#615)
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+@pytest.fixture
+def raw_client():
+    """認証ヘッダーなしの TestClient"""
+    return TestClient(main.app)
+
+
+class TestInternalAuth:
+    def test_トークンなしは401(self, raw_client):
+        res = raw_client.get("/vector/status")
+        assert res.status_code == 401
+
+    def test_不正なトークンは401(self, raw_client):
+        res = raw_client.get(
+            "/vector/status", headers={"X-Internal-Token": "wrong-token"}
+        )
+        assert res.status_code == 401
+
+    def test_ヘルスチェックは認証不要(self, raw_client):
+        for path in ("/health", "/healthz"):
+            res = raw_client.get(path)
+            assert res.status_code == 200, path
+
+    def test_トークン未設定時はフェイルクローズで503(self, raw_client, monkeypatch):
+        monkeypatch.delenv("RAG_INTERNAL_TOKEN", raising=False)
+        res = raw_client.get(
+            "/vector/status", headers={"X-Internal-Token": "test-internal-token"}
+        )
+        assert res.status_code == 503
+
+    def test_トークン未設定でもヘルスチェックは通る(self, raw_client, monkeypatch):
+        monkeypatch.delenv("RAG_INTERNAL_TOKEN", raising=False)
+        res = raw_client.get("/healthz")
+        assert res.status_code == 200
+
+    def test_正しいトークンは通過する(self, client):
+        # conftest の client フィクスチャは正しいトークンを付与している
+        res = client.get("/healthz")
+        assert res.status_code == 200

--- a/rag/tests/test_rag.py
+++ b/rag/tests/test_rag.py
@@ -145,10 +145,14 @@ class TestRetrieveDocs:
 
 # ── 統合テスト（FastAPI TestClient） ────────────────────────────────────────
 
+def _auth_client():
+    """内部認証トークン付きの TestClient を返す (#615)"""
+    from fastapi.testclient import TestClient
+    return TestClient(main.app, headers={"X-Internal-Token": os.environ["RAG_INTERNAL_TOKEN"]})
+
 class TestReviewEndpoint:
     def test_health(self):
-        from fastapi.testclient import TestClient
-        client = TestClient(main.app)
+        client = _auth_client()
         resp = client.get("/health")
         assert resp.status_code == 200
         body = resp.json()
@@ -158,7 +162,6 @@ class TestReviewEndpoint:
         assert "detail" in body["vector_store"]
 
     def test_review_success_web_search_path(self):
-        from fastapi.testclient import TestClient
 
         with patch("main.get_cached_context", return_value=[]), \
              patch("main.USE_DEEP_RESEARCH", False), \
@@ -167,7 +170,7 @@ class TestReviewEndpoint:
              patch("main.set_cached_context"), \
              patch("main.run_crewai", return_value="【企業別レビュー報告書】\nレポート内容"):
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/resume/review", json={
                 "resume_text": "テスト経歴書の内容です。",
                 "company_name": "テスト株式会社",
@@ -180,14 +183,13 @@ class TestReviewEndpoint:
         assert len(body["report"]) > 0
 
     def test_review_uses_cache_on_second_call(self):
-        from fastapi.testclient import TestClient
 
         cached_docs = ["企業の採用価値観: チームワーク重視"]
 
         with patch("main.get_cached_context", return_value=cached_docs), \
              patch("main.run_crewai", return_value="キャッシュヒット時のレポート") as mock_crewai:
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/resume/review", json={
                 "resume_text": "経歴テスト",
                 "company_name": "キャッシュ企業",
@@ -201,14 +203,13 @@ class TestReviewEndpoint:
 
     def test_review_no_context_fallback(self):
         """Deep Research・Web Search 両方無効時もコンテキストなしでレポートを返す。"""
-        from fastapi.testclient import TestClient
 
         with patch("main.get_cached_context", return_value=[]), \
              patch("main.USE_DEEP_RESEARCH", False), \
              patch("main.ALLOW_WEB_SEARCH_FALLBACK", False), \
              patch("main.run_crewai", return_value="外部コンテキストなしのレポート") as mock_crewai:
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/resume/review", json={
                 "resume_text": "経歴テスト",
                 "company_name": "テスト企業",
@@ -220,7 +221,6 @@ class TestReviewEndpoint:
 
     def test_review_prefers_company_context_over_web_search(self):
         """Backend brief（company_context）があるとき Search しない。"""
-        from fastapi.testclient import TestClient
 
         with patch("main.get_cached_context", return_value=[]) as mock_cache, \
              patch("main.USE_DEEP_RESEARCH", True), \
@@ -229,7 +229,7 @@ class TestReviewEndpoint:
              patch("main.set_cached_context"), \
              patch("main.run_crewai", return_value="brief利用レポート") as mock_crewai:
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/resume/review", json={
                 "resume_text": "経歴テスト",
                 "company_name": "テスト企業",
@@ -244,8 +244,7 @@ class TestReviewEndpoint:
         assert call_kwargs.kwargs.get("context_docs") == ["企業名: テスト企業\n事業: SaaS"]
 
     def test_review_missing_resume_text(self):
-        from fastapi.testclient import TestClient
-        client = TestClient(main.app)
+        client = _auth_client()
         resp = client.post("/resume/review", json={
             "resume_text": "",
             "company_name": "テスト株式会社",
@@ -253,7 +252,6 @@ class TestReviewEndpoint:
         assert resp.status_code == 422
 
     def test_hints_skips_web_search_when_fallback_disabled(self):
-        from fastapi.testclient import TestClient
 
         with patch("main.get_cached_context", return_value=[]), \
              patch("main.ALLOW_WEB_SEARCH_FALLBACK", False), \
@@ -262,7 +260,7 @@ class TestReviewEndpoint:
                  style_tags=[], top_questions=[], cached=False
              )) as mock_parse:
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/company/hints", json={
                 "company_name": "テスト企業",
                 "position": "エンジニア",
@@ -273,8 +271,7 @@ class TestReviewEndpoint:
         mock_parse.assert_called_once()
 
     def test_review_missing_company_name(self):
-        from fastapi.testclient import TestClient
-        client = TestClient(main.app)
+        client = _auth_client()
         resp = client.post("/resume/review", json={
             "resume_text": "経歴テスト",
             "company_name": "",
@@ -286,12 +283,11 @@ class TestReviewEndpoint:
 class TestFailureCases:
     def test_chromadb_connection_failure_fallback(self):
         """ChromaDB 接続で例外が出てもエンドポイントが 200 を返すことを確認する。"""
-        from fastapi.testclient import TestClient
 
         with patch("main.get_cached_context", side_effect=Exception("ChromaDB connection failed")), \
              patch("main.run_crewai", return_value="外部依存失敗時のレポート") as mock_crewai:
 
-            client = TestClient(main.app)
+            client = _auth_client()
             resp = client.post("/resume/review", json={
                 "resume_text": "経歴テスト",
                 "company_name": "接続失敗企業",


### PR DESCRIPTION
## 概要
Closes #615

RAGサービス（FastAPI）の全エンドポイントが無認証だったため、Backend からの呼び出しのみを許可する内部サービストークン認証（`X-Internal-Token`）を導入しました。誤って外部公開された場合でも、OpenAI課金を伴うエンドポイントや運用系エンドポイント（`/vector/reembed` 等）が叩かれることを防ぎます。

## 変更内容
### RAG（Python）
- `X-Internal-Token` を検証するミドルウェアを追加
  - `RAG_INTERNAL_TOKEN` 未設定時は**フェイルクローズ（503）**で全リクエスト拒否（Backend の認証方針に準拠）
  - トークン不一致は 401
  - `/health` / `/healthz` はヘルスチェック用に除外（`make rag-smoke` は影響なし）
  - 比較は `hmac.compare_digest`（タイミング攻撃対策）
  - trace ミドルウェアの内側で動作するため、拒否リクエストも構造化ログ・`X-Trace-ID` の対象

### Backend（Go）
- `internal/ragclient` パッケージを新設（`SetAuthHeader`）
- RAG 呼び出し全5箇所にヘッダー付与を適用
  - `es_review_controller`（/es/review）
  - `admin_vector_controller`（/vector/* プロキシ）
  - `resume_service`（/resume/review 同期・ストリーミング）
  - `job_fetch_service`（/company/context push）

### 設定・ドキュメント
- `Backend/.env.example` に `RAG_INTERNAL_TOKEN` を追記（docker compose では backend / rag-review の両方が `Backend/.env` を読むため1箇所の設定で両者に反映）
- `docs/wiki/rag-service.md` に内部認証の運用（トークン生成・curl例・追加時のルール）を文書化

## テスト
- RAG: 認証ミドルウェアのテスト6件を追加（トークンなし401 / 不正401 / ヘルス除外 / 未設定503 / 正常通過）、既存テスト含め **64件全パス**
- Go: `ragclient` のテーブル駆動テスト追加、`go vet` / 既存テスト全パス

## デプロイ・ローカル環境への影響
⚠️ **要対応**: 各環境の `Backend/.env` に `RAG_INTERNAL_TOKEN` の追加が必要です（未設定だと RAG がヘルスチェック以外を503で拒否します）。本番は `openssl rand -hex 32` 等で生成してください。

## 受け入れ条件
- [x] トークンなしのリクエストが401で拒否される
- [x] シークレット未設定時に fail-closed で動作する
- [x] Backend→RAG の既存機能がすべて通る（テストで担保、`/health` 系は除外済み）