### PR TITLE
fix: compose サービスに restart: unless-stopped を設定する

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,7 @@ services:
       context: ./Backend
       dockerfile: Dockerfile
     container_name: soc-ai-agent-backend
+    restart: unless-stopped
     ports:
       - "${HOST_PORT:-8080}:8080"
     volumes:
@@ -60,6 +61,7 @@ services:
   db:
     image: mysql:8.0
     container_name: soc-ai-db
+    restart: unless-stopped
     ports:
       - "${DB_HOST_BIND:-127.0.0.1}:3306:3306"
     env_file:
@@ -92,7 +94,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: soc-ai-agent-frontend
-    restart: 'always'
+    restart: unless-stopped
     volumes:
       - ./frontend:/app
       - /app/node_modules


### PR DESCRIPTION
## Summary
- ローカル開発の `compose.yml` で `app` / `db` に `restart: unless-stopped` を追加
- `frontend` も `always` から `unless-stopped` に揃え、明示的な `compose stop` 後は再起動しないようにする

## 背景
backend が「勝手に止まる」ように見えていたが、クラッシュではなく SIGTERM での停止だった。一方 `app` / `db` に restart ポリシーがなく、一度止まると自動復帰しなかった。

## Test plan
- [ ] `docker compose up -d db app frontend` で起動し、`/healthz` が OK
- [ ] `docker inspect` で各コンテナの `RestartPolicy` が `unless-stopped`
- [ ] Docker Desktop 再起動後にコンテナが自動で戻ること（環境による）
- [ ] `docker compose stop` 後は意図どおり止まったままであること


Made with [Cursor](https://cursor.com)