### PR TITLE
Resolve #653: interview/page Phase1 分割（調査書含む）

### DIFF
--- a/docs/design/refactoring-investigation.md
+++ b/docs/design/refactoring-investigation.md
@@ -29,7 +29,7 @@
 
 | 領域 | パス | 備考 |
 |------|------|------|
-| Backend | `Backend/` | Go、migrations 含む |
+| Backend | `Backend/` | Go ソースが主対象。SQL migrations は規模合計には含めず、ホットスポット表のみ別記 |
 | Frontend | `frontend/` | `node_modules` / `.next` 除外 |
 | RAG | `rag/` | `.venv` 除外 |
 
@@ -41,12 +41,13 @@
 
 ### 2.3 方法
 
-- 拡張子 `.go` / `.ts` / `.tsx` / `.py` の行数集計
+- **規模サマリー・層別 LOC** の集計対象拡張子: `.go` / `.ts` / `.tsx` / `.py` のみ
+- **SQL migrations（`.sql`）** は規模合計・ファイル数には含めない。初期スキーマなど巨大なものはホットスポット表に参考掲載する
 - 層別（services / controllers / app pages 等）の内訳
 - 800 行超ファイルの抽出と責務密度の簡易指標（メソッド数、`useState` 数など）
 - テストファイル数の比較（網羅率の精密計測ではない）
 
-> 行数は 2026-07-25 時点のローカルワークツリー計測。ブランチ差分により前後する。
+> 行数は **2026-07-25 時点・リファクタ着手前** のローカルワークツリー計測を基準値とする。以降の分割 PR により数値は変化する（例: `interview/page.tsx` は基準 1939 行 → Phase1 後は約 1409 行）。
 
 ---
 
@@ -110,9 +111,9 @@ FE ページは約 **44**。FE の `*.test.ts(x)` は約 **9** と少なく、**
 
 ### 5.1 800 行超（優先監視）
 
-| LOC | パス | 簡易指標 | 主な責務仮説 |
-|-----|------|----------|--------------|
-| 1939 | `frontend/app/interview/page.tsx` | useState≈49 / useEffect≈12 | 面接 UI・メディア・同意・レポート・状態遷移 |
+| LOC（基準日） | パス | 簡易指標 | 主な責務仮説 |
+|---------------|------|----------|--------------|
+| 1939（着手前） | `frontend/app/interview/page.tsx` | useState≈49 / useEffect≈12 | 面接 UI・メディア・同意・レポート・状態遷移。※Phase1（#653）後は約 1409 行 |
 | 1575 | `Backend/internal/services/resume_service.go` | methods≈27 | アップロード・PDF 正規化・レビュー・企業検証 |
 | 1515 | `rag/main.py` | defs≈50 | HTTP API・RAG 処理の入口集約 |
 | 1500 | `Backend/internal/services/interview_service.go` | methods≈31 | セッション・発話・ワーカー・管理一覧 |
@@ -179,10 +180,10 @@ FE ページは約 **44**。FE の `*.test.ts(x)` は約 **9** と少なく、**
 
 ## 8. 成功指標（リファクタ開始後に測る）
 
-| 指標 | 現状（概算） | 目標イメージ |
-|------|--------------|--------------|
+| 指標 | 基準値（2026-07-25・着手前） | 目標イメージ |
+|------|-------------------------------|--------------|
 | 800 行超のアプリコードファイル数 | 10（SQL 除く） | 段階的に半減 |
-| 面接 page の LOC / useState 数 | ~1939 / ~49 | 分割後 page は薄いオーケストレーションに |
+| 面接 page の LOC / useState 数 | ~1939 / ~49 | 分割後 page は薄いオーケストレーションに（Phase1 時点で ~1409 行） |
 | FE ユニットテストファイル数 | ~9 | 分割対象ドメインごとに追加 |
 | 分割 PR のレビュー可能行数 | — | 目安 400 行前後の差分を上限意識 |
 
@@ -200,12 +201,32 @@ FE ページは約 **44**。FE の `*.test.ts(x)` は約 **9** と少なく、**
 ## 10. 付録: 計測コマンド（再計測用）
 
 ```bash
-# 依存を除いた主要コードの行数再計測（例）
+# 依存を除いた主要コードの行数再計測（規模サマリーと同一条件）
+# ※ .sql は含めない（ホットスポット参考のみ）
 python3 - <<'PY'
 from pathlib import Path
-skip = {'node_modules','.next','.venv','venv','__pycache__'}
-exts = {'.go','.ts','.tsx','.py'}
-# ... Path.rglob で集計
+
+skip = {'node_modules', '.next', '.venv', 'venv', '__pycache__', 'vendor', 'dist', 'coverage'}
+exts = {'.go', '.ts', '.tsx', '.py'}
+
+def ok(path: Path) -> bool:
+    return not any(part in skip for part in path.parts)
+
+def line_count(path: Path) -> int:
+    text = path.read_text(encoding='utf-8', errors='ignore')
+    if not text:
+        return 0
+    return text.count('\n') + (0 if text.endswith('\n') else 1)
+
+for root in (Path('Backend'), Path('frontend'), Path('rag')):
+    if not root.exists():
+        continue
+    files = [
+        path for path in root.rglob('*')
+        if path.is_file() and path.suffix in exts and ok(path)
+    ]
+    loc = sum(line_count(path) for path in files)
+    print(f'{root}: {len(files)} files, {loc} LOC')
 PY
 ```
 

--- a/docs/design/refactoring-investigation.md
+++ b/docs/design/refactoring-investigation.md
@@ -1,0 +1,212 @@
+# リファクタリング事前調査書
+
+| 項目 | 内容 |
+|------|------|
+| 文書名 | SOC AI Agent コードベース規模・肥大化調査 |
+| 作成日 | 2026-07-25 |
+| 対象リポジトリ | `soc-ai-agent-mock` / `ISCProduct/soc-ai-agent` |
+| 目的 | 大規模リファクタ実施前に、現状規模・ホットスポット・リスク・分割候補を事実ベースで整理する |
+| 関連 | Issue #649（大規模リファクタ追跡） |
+
+---
+
+## 1. 結論（Executive Summary）
+
+本コードベースは **小規模プロトタイプを超え、中規模プロダクト帯** にある。
+
+- 主要コード（Backend / Frontend / RAG、依存除外）はおおよそ **9 万行 / 640 ファイル**
+- 層構造（Controller → Service → Repository）は概ね維持されている
+- 問題の中心は「全体の行数」より、**単一ファイルへの責務集中（God File）** と、**FE のテスト薄さ**
+- 全面リライトは不要。触る頻度が高い巨大ファイルから **段階的分割** が妥当
+
+**推奨スタンス:** いますぐ全域リファクタはしない。調査結果に基づき、優先度付きで「分割 PR」を切る。
+
+---
+
+## 2. 調査範囲と方法
+
+### 2.1 対象
+
+| 領域 | パス | 備考 |
+|------|------|------|
+| Backend | `Backend/` | Go、migrations 含む |
+| Frontend | `frontend/` | `node_modules` / `.next` 除外 |
+| RAG | `rag/` | `.venv` 除外 |
+
+### 2.2 非対象
+
+- `node_modules` / 仮想環境 / 生成物
+- インフラ Terraform 一式の詳細設計レビュー（別途）
+- 個別バグの根因調査
+
+### 2.3 方法
+
+- 拡張子 `.go` / `.ts` / `.tsx` / `.py` の行数集計
+- 層別（services / controllers / app pages 等）の内訳
+- 800 行超ファイルの抽出と責務密度の簡易指標（メソッド数、`useState` 数など）
+- テストファイル数の比較（網羅率の精密計測ではない）
+
+> 行数は 2026-07-25 時点のローカルワークツリー計測。ブランチ差分により前後する。
+
+---
+
+## 3. 規模サマリー
+
+### 3.1 全体
+
+| 領域 | ファイル数 | LOC（概算） | 比率 |
+|------|-----------|-------------|------|
+| Backend | 415 | 59,339 | 66% |
+| Frontend | 206 | 26,997 | 30% |
+| RAG | 17 | 3,637 | 4% |
+| **合計** | **638** | **89,973** | 100% |
+
+### 3.2 Backend 層別
+
+| 層 | ファイル数 | LOC | 所見 |
+|----|-----------|-----|------|
+| services | 107 | 24,778 | **最大の肥大層**。業務ロジックと AI/外部連携が集中 |
+| controllers | 36 | 7,179 | 一部 500 行超だがサービスほどではない |
+| repositories | 43 | 4,187 | 比較的健全（最大でも 300 行弱） |
+| models | 45 | 2,489 | seed 系が厚い |
+
+Go service 実装ファイルは約 **53**、Go テストファイルは約 **100**（Backend 全体）。Backend はテスト資産が相対的に厚い。
+
+### 3.3 Frontend 層別
+
+| 層 | ファイル数 | LOC | 所見 |
+|----|-----------|-----|------|
+| app（App Router） | 132 | 17,655 | **page.tsx に UI・状態・API 呼び出しが集中** |
+| components | 32 | 6,153 | チャット・相関図などが大きい |
+| lib | 18 | 1,741 | 薄い（分割の受け皿になりうる） |
+
+FE ページは約 **44**。FE の `*.test.ts(x)` は約 **9** と少なく、**規模に対してテストが薄い**。
+
+---
+
+## 4. アーキテクチャ上の現状評価
+
+### 4.1 良い点
+
+- Backend は DDD 風の層分けが文書化・実装の双方で継続されている
+- Repository 層は比較的小さく、DB アクセスの境界は読みやすい
+- migrations 運用方針（AutoMigrate 禁止）が明確
+- FE は App Router + 機能ページ分割の骨格がある
+
+### 4.2 懸念点
+
+1. **Service 層の神クラス化**  
+   面接・職務経歴・クロールなどが、セッション管理 / 外部 API / スコア / ファイル処理を同一ファイルに抱える。
+2. **FE page の神コンポーネント化**  
+   特に面接・結果ページは `useState` が極端に多く、画面状態機械が巨大。
+3. **RAG `main.py` の一極集中**  
+   ルーティングと処理が同居し、Backend/FE と同型の肥大パターン。
+4. **テスト非対称**  
+   Backend は厚い一方、FE 巨大ページに対する回帰テストが弱い → 分割時の安全網が不足。
+
+---
+
+## 5. ホットスポット（God File）
+
+### 5.1 800 行超（優先監視）
+
+| LOC | パス | 簡易指標 | 主な責務仮説 |
+|-----|------|----------|--------------|
+| 1939 | `frontend/app/interview/page.tsx` | useState≈49 / useEffect≈12 | 面接 UI・メディア・同意・レポート・状態遷移 |
+| 1575 | `Backend/internal/services/resume_service.go` | methods≈27 | アップロード・PDF 正規化・レビュー・企業検証 |
+| 1515 | `rag/main.py` | defs≈50 | HTTP API・RAG 処理の入口集約 |
+| 1500 | `Backend/internal/services/interview_service.go` | methods≈31 | セッション・発話・ワーカー・管理一覧 |
+| 1358 | `frontend/app/results/page.tsx` | useState≈21 | マッチング結果・応募・相関図導線 |
+| 1252 | `Backend/internal/services/crawl_service.go` | methods≈26 | ソース管理・スケジューラ・実行 |
+| 1022 | `frontend/components/mui-chat.tsx` | — | チャット UI 本体 |
+| 1020 | `Backend/migrations/000001_init_schema.up.sql` | — | 初期スキーマ（分割対象外が基本） |
+| 924 | `Backend/internal/services/github_service.go` | — | GitHub 連携 |
+| 864 | `Backend/internal/services/chat_question_generator.go` | — | 質問生成 |
+| 805 | `Backend/internal/services/answer_evaluator.go` | — | 回答評価 |
+
+### 5.2 次点（500–800 行、早期警戒）
+
+**Backend services:** `auth_service`, `chat_service`, `analysis_scoring_service`, `chat_answer_validator`, `gbizinfo_service` など。
+
+**Frontend pages:** `resume`, `profile`, `company/[id]`, `admin/score-validation`, `schedule`, `es-rewrite` など。
+
+**Frontend components:** `company-results`, `github-skills`, `job-agent-chat`, `Correlation-diagram`, `analysis-sidebar`。
+
+---
+
+## 6. リスク評価
+
+| ID | リスク | 影響 | 発生しやすさ | コメント |
+|----|--------|------|--------------|----------|
+| R1 | 巨大ファイル変更による回帰 | 高 | 高 | 面接・結果・職務経歴はユーザー導線の中核 |
+| R2 | リファクタ中の挙動差分（AI 出力・スコア） | 高 | 中 | 非決定的処理が多く、黄金出力比較が難しい |
+| R3 | FE テスト不足による分割事故 | 高 | 高 | page 分割前に最低限のテスト／スモークが必要 |
+| R4 | 一度に全域を触る PR | 高 | 中 | レビュー不能・切り戻し困難 |
+| R5 | スキーマ／API 契約まで巻き込む | 高 | 低〜中 | 調査時点では **構造分割を優先し契約変更は別トラック** が安全 |
+
+---
+
+## 7. リファクタ方針（推奨・未実施）
+
+### 7.1 原則
+
+1. **挙動変更なし**（pure refactor）を既定とする
+2. **1 PR = 1 ホットスポット（または明確に関連する小セット）**
+3. 分割前に **特徴づけるテスト or 手動チェックリスト** を用意する
+4. 公開 API / DB スキーマ変更は本トラックに混ぜない
+5. 行数目標の目安: 新規・分割後ファイルは **おおむね 400–600 行以下**（厳密な上限ではない）
+
+### 7.2 優先順位（案）
+
+| 優先度 | 対象 | 分割の方向性（案） | 理由 |
+|--------|------|-------------------|------|
+| P0 | `frontend/app/interview/page.tsx` | hooks / メディア / 同意ダイアログ / レポート送信をコンポーネント＆hooks へ | 最大・変更頻度・状態数が多い |
+| P0 | `Backend/internal/services/interview_service.go` | セッション生命周期 / 発話永続化 / worker / admin 照会をファイル分割 | FE と対になる中核ドメイン |
+| P1 | `frontend/app/results/page.tsx` | データ取得・リスト・応募アクション・ナビを分離 | マッチング価値の中核 UI |
+| P1 | `Backend/internal/services/resume_service.go` | Upload / Review / Annotated / Company validation | LOC 最大級のサービス |
+| P2 | `crawl_service.go` / `github_service.go` | スケジューラと実行、外部 API クライアント境界 | 運用系・連携系の複雑性 |
+| P2 | `rag/main.py` | router / service / store 境界の明確化 | エントリ一点集中の解消 |
+| P3 | チャット周辺（`mui-chat`, question generator, evaluator） | 生成と評価の境界整理 | 相互依存が強いため後段でも可 |
+
+### 7.3 明示的に「今はやらない」こと
+
+- フレームワーク載せ替え（Next / Echo / LangChain 等）
+- マイクロサービス分割
+- ディレクトリ全面再編を伴うビッグバン移動
+- スコア計算式やプロンプトの同時改修
+
+---
+
+## 8. 成功指標（リファクタ開始後に測る）
+
+| 指標 | 現状（概算） | 目標イメージ |
+|------|--------------|--------------|
+| 800 行超のアプリコードファイル数 | 10（SQL 除く） | 段階的に半減 |
+| 面接 page の LOC / useState 数 | ~1939 / ~49 | 分割後 page は薄いオーケストレーションに |
+| FE ユニットテストファイル数 | ~9 | 分割対象ドメインごとに追加 |
+| 分割 PR のレビュー可能行数 | — | 目安 400 行前後の差分を上限意識 |
+
+---
+
+## 9. 次アクション
+
+1. 本調査書を関係者でレビューし、P0 対象（面接 FE / 面接 Service）の合意を取る
+2. Issue #649 を親として、P0/P1 を子 Issue に分解する
+3. 各子 Issue に「分割計画・テスト計画・非ゴール」を書く
+4. **最初の PR は面接 FE か面接 Service のどちらか一方のみ** とする
+
+---
+
+## 10. 付録: 計測コマンド（再計測用）
+
+```bash
+# 依存を除いた主要コードの行数再計測（例）
+python3 - <<'PY'
+from pathlib import Path
+skip = {'node_modules','.next','.venv','venv','__pycache__'}
+exts = {'.go','.ts','.tsx','.py'}
+# ... Path.rglob で集計
+PY
+```
+
+詳細な対話用ビューは Cursor Canvas「リファクタ事前調査」も参照。

--- a/frontend/app/interview/components/ConsentDialog.tsx
+++ b/frontend/app/interview/components/ConsentDialog.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Typography,
+} from '@mui/material'
+
+export interface ConsentDialogProps {
+  open: boolean
+  consentGiven: boolean
+  onConsentChange: (checked: boolean) => void
+  onClose: () => void
+  onConfirm: () => void
+}
+
+/**
+ * 録画同意ダイアログ（LOBBY / SESSION 画面で共有）
+ */
+export default function ConsentDialog({ open, consentGiven, onConsentChange, onClose, onConfirm }: ConsentDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>面接練習を開始する前に</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          面接練習では、より良いフィードバックのために以下のデータを収集します。
+        </Typography>
+        <Typography variant="body2" component="ul" sx={{ pl: 2, mb: 2, color: 'text.secondary' }}>
+          <li>音声・動画の録画（フィードバック生成のみに使用）</li>
+          <li>会話のテキスト（評価スコア算出に使用）</li>
+        </Typography>
+        <Typography variant="body2" color="error.main" sx={{ mb: 2 }}>
+          ※ これらのデータは企業には提供されません。サービス内でのみ使用します。
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          録画データは面接セッション終了後90日で自動削除されます。
+          詳細は<Button size="small" sx={{ p: 0, minWidth: 0, textDecoration: 'underline', fontSize: 'inherit' }}
+            onClick={() => window.open('/privacy', '_blank')}>プライバシーポリシー</Button>をご確認ください。
+        </Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={consentGiven}
+              onChange={(e) => onConsentChange(e.target.checked)}
+            />
+          }
+          label="上記の内容に同意して面接練習を始める"
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose}>キャンセル</Button>
+        <Button
+          variant="contained"
+          disabled={!consentGiven}
+          onClick={onConfirm}
+        >
+          面接に参加
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/app/interview/components/SelectionScreen.tsx
+++ b/frontend/app/interview/components/SelectionScreen.tsx
@@ -123,6 +123,20 @@ export default function SelectionScreen({
     return () => window.clearTimeout(timer)
   }, [companySearch, companySourceTab, allCompanies, setInterviewCompany])
 
+  /**
+   * デバウンス待機中にロビーへ進むと resolve がキャンセルされ id:0 のまま残るため、
+   * 開始直前に登録企業解決を確定する（Bugbot: Debounced resolve skips ID lookup）。
+   */
+  const handleStartInterview = async () => {
+    const trimmed = (companySearch.trim() || interviewCompany?.name || '').trim()
+    if (interviewCompany && interviewCompany.id === 0 && trimmed) {
+      const local = allCompanies.find((c) => c.name === trimmed)
+      const resolved = local ?? await resolveCompanyByName(trimmed, interviewCompany)
+      setInterviewCompany(resolved)
+    }
+    onStartInterview()
+  }
+
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: BG_LIGHT }}>
       {/* Header */}
@@ -544,7 +558,7 @@ export default function SelectionScreen({
                 fullWidth
                 endIcon={<ArrowForwardIcon />}
                 disabled={!interviewCompany}
-                onClick={onStartInterview}
+                onClick={() => { void handleStartInterview() }}
                 sx={{
                   bgcolor: PRIMARY, '&:hover': { bgcolor: `${PRIMARY}e0` },
                   borderRadius: 2, py: 1.8, fontWeight: 700, fontSize: 16,

--- a/frontend/app/interview/components/SelectionScreen.tsx
+++ b/frontend/app/interview/components/SelectionScreen.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Dispatch, SetStateAction } from 'react'
+import { useEffect, type Dispatch, type KeyboardEvent, type SetStateAction } from 'react'
 import {
   Box,
   Button,
@@ -25,6 +25,15 @@ import { interviewLimits } from '@/lib/interview'
 import { PRIMARY, BG_LIGHT, POSITIONS } from '../constants'
 import type { InterviewCompany, Position } from '../types'
 import { resolveCompanyByName } from '../utils'
+
+const COMPANY_RESOLVE_DEBOUNCE_MS = 400
+
+function activateOnEnterOrSpace(event: KeyboardEvent, action: () => void) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    action()
+  }
+}
 
 export interface CompanyHints {
   style_tags: string[]
@@ -86,8 +95,21 @@ export default function SelectionScreen({
   questionDurationSeconds,
   onStartInterview,
 }: SelectionScreenProps) {
-  // allCompanies is already filtered by server-side search, no client-side filter needed
-  const filteredCompanies = allCompanies
+  // 入力中の企業名解決は親の一覧取得と同様にデバウンスし、1文字ごとの API 連打を避ける
+  useEffect(() => {
+    if (companySourceTab !== 'db') return
+    const trimmed = companySearch.trim()
+    if (!trimmed) return
+    if (allCompanies.some((c) => c.name === trimmed)) return
+
+    const timer = window.setTimeout(() => {
+      void resolveCompanyByName(trimmed).then((resolved) => {
+        setInterviewCompany((prev) => (prev?.name === trimmed ? resolved : prev))
+      })
+    }, COMPANY_RESOLVE_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [companySearch, companySourceTab, allCompanies, setInterviewCompany])
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: BG_LIGHT }}>
@@ -183,12 +205,8 @@ export default function SelectionScreen({
                         if (local) {
                           setInterviewCompany(local)
                         } else {
+                          // 即時は id=0 の仮選択。DB 解決は上記 useEffect でデバウンス
                           setInterviewCompany({ id: 0, name: value.trim() })
-                          void resolveCompanyByName(value.trim()).then((resolved) => {
-                            setInterviewCompany((prev) =>
-                              prev?.name === value.trim() ? resolved : prev,
-                            )
-                          })
                         }
                       }
                     }}
@@ -235,7 +253,8 @@ export default function SelectionScreen({
                       <LinearProgress sx={{ borderRadius: 1 }} />
                     ) : (
                       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
-                        {filteredCompanies.map(c => {
+                        {/* allCompanies はサーバ側検索済みのため、追加のクライアントフィルタは不要 */}
+                        {allCompanies.map(c => {
                           const isSelected = interviewCompany?.id === c.id
                           return (
                             <Button
@@ -255,7 +274,7 @@ export default function SelectionScreen({
                             </Button>
                           )
                         })}
-                        {filteredCompanies.length === 0 && !companiesLoading && !companySearch.trim() && (
+                        {allCompanies.length === 0 && !companiesLoading && !companySearch.trim() && (
                           <Typography sx={{ color: '#94a3b8', fontSize: 13 }}>登録企業が見つかりません</Typography>
                         )}
                       </Box>
@@ -272,32 +291,38 @@ export default function SelectionScreen({
                     {webSearchLoading ? (
                       <LinearProgress sx={{ borderRadius: 1 }} />
                     ) : (
-                      <Stack spacing={1}>
+                      <Stack spacing={1} role="listbox" aria-label="WEB検索結果">
                         {webSearchResults.map((result, i) => {
                           const isSelected = interviewCompany?.name === result.name
+                          const selectResult = () => {
+                            setCompanySearch(result.name)
+                            const local = allCompanies.find((c) => c.name === result.name)
+                            if (local) {
+                              setInterviewCompany({ ...local, description: result.description })
+                              return
+                            }
+                            setInterviewCompany({ id: 0, name: result.name, description: result.description })
+                            void resolveCompanyByName(result.name, { description: result.description }).then((resolved) => {
+                              setInterviewCompany((prev) =>
+                                prev?.name === result.name ? resolved : prev,
+                              )
+                            })
+                          }
                           return (
                             <Box
                               key={i}
-                              onClick={() => {
-                                setCompanySearch(result.name)
-                                const local = allCompanies.find((c) => c.name === result.name)
-                                if (local) {
-                                  setInterviewCompany({ ...local, description: result.description })
-                                  return
-                                }
-                                setInterviewCompany({ id: 0, name: result.name, description: result.description })
-                                void resolveCompanyByName(result.name, { description: result.description }).then((resolved) => {
-                                  setInterviewCompany((prev) =>
-                                    prev?.name === result.name ? resolved : prev,
-                                  )
-                                })
-                              }}
+                              role="option"
+                              aria-selected={isSelected}
+                              tabIndex={0}
+                              onClick={selectResult}
+                              onKeyDown={(e) => activateOnEnterOrSpace(e, selectResult)}
                               sx={{
                                 p: 1.5, borderRadius: 2, cursor: 'pointer',
                                 border: `2px solid ${isSelected ? PRIMARY : '#e2e8f0'}`,
                                 bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
                                 transition: 'all 0.15s',
                                 '&:hover': { borderColor: PRIMARY, bgcolor: `${PRIMARY}05` },
+                                '&:focus-visible': { outline: `2px solid ${PRIMARY}`, outlineOffset: 2 },
                               }}
                             >
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -346,7 +371,10 @@ export default function SelectionScreen({
                     size="small"
                     onClick={() => {
                       setPositionCategory('sier')
-                      if (selectedPosition.category === 'general') setSelectedPosition(POSITIONS.find(p => p.category === 'sier')!)
+                      if (selectedPosition.category === 'general') {
+                        const firstSier = POSITIONS.find((p) => p.category === 'sier')
+                        if (firstSier) setSelectedPosition(firstSier)
+                      }
                     }}
                     sx={{
                       px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
@@ -359,13 +387,21 @@ export default function SelectionScreen({
                   </Button>
                 </Box>
 
-                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1.5 }}>
+                <Box
+                  role="radiogroup"
+                  aria-label="応募職種"
+                  sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1.5 }}
+                >
                   {POSITIONS.filter(p => p.category === positionCategory).map(pos => {
                     const isSelected = selectedPosition.id === pos.id
                     return (
                       <Box
                         key={pos.id}
+                        role="radio"
+                        aria-checked={isSelected}
+                        tabIndex={0}
                         onClick={() => setSelectedPosition(pos)}
+                        onKeyDown={(e) => activateOnEnterOrSpace(e, () => setSelectedPosition(pos))}
                         sx={{
                           position: 'relative', display: 'flex', alignItems: 'center', gap: 1.5,
                           p: 2, borderRadius: 2, cursor: 'pointer',
@@ -373,6 +409,7 @@ export default function SelectionScreen({
                           bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
                           transition: 'all 0.15s',
                           '&:hover': { borderColor: isSelected ? PRIMARY : '#cbd5e1' },
+                          '&:focus-visible': { outline: `2px solid ${PRIMARY}`, outlineOffset: 2 },
                         }}
                       >
                         <Typography sx={{ fontSize: 22 }}>{pos.icon}</Typography>

--- a/frontend/app/interview/components/SelectionScreen.tsx
+++ b/frontend/app/interview/components/SelectionScreen.tsx
@@ -1,0 +1,518 @@
+'use client'
+
+import type { Dispatch, SetStateAction } from 'react'
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  LinearProgress,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import ApartmentIcon from '@mui/icons-material/Apartment'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import PsychologyIcon from '@mui/icons-material/Psychology'
+import LightbulbIcon from '@mui/icons-material/Lightbulb'
+import type { User } from '@/lib/auth'
+import { interviewLimits } from '@/lib/interview'
+import { PRIMARY, BG_LIGHT, POSITIONS } from '../constants'
+import type { InterviewCompany, Position } from '../types'
+import { resolveCompanyByName } from '../utils'
+
+export interface CompanyHints {
+  style_tags: string[]
+  top_questions: string[]
+  company_brief?: string
+}
+
+export interface SelectionScreenProps {
+  user: User
+  onBack: () => void
+  interviewCompany: InterviewCompany | null
+  setInterviewCompany: Dispatch<SetStateAction<InterviewCompany | null>>
+  companySourceTab: 'db' | 'web'
+  setCompanySourceTab: Dispatch<SetStateAction<'db' | 'web'>>
+  companySearch: string
+  setCompanySearch: Dispatch<SetStateAction<string>>
+  allCompanies: InterviewCompany[]
+  setAllCompanies: Dispatch<SetStateAction<InterviewCompany[]>>
+  companiesLoading: boolean
+  webSearchResults: { name: string; description: string }[]
+  setWebSearchResults: Dispatch<SetStateAction<{ name: string; description: string }[]>>
+  webSearchLoading: boolean
+  positionCategory: 'general' | 'sier'
+  setPositionCategory: Dispatch<SetStateAction<'general' | 'sier'>>
+  selectedPosition: Position
+  setSelectedPosition: Dispatch<SetStateAction<Position>>
+  companyHints: CompanyHints | null
+  hintsLoading: boolean
+  questionDurationSeconds: number
+  onStartInterview: () => void
+}
+
+/**
+ * SELECTION SCREEN (Step 1 of 3)
+ * 志望企業・応募職種を選ぶ画面。データ取得（useEffect）は親コンポーネント側で行い、
+ * このコンポーネントは受け取った props をそのまま描画する presentational component。
+ */
+export default function SelectionScreen({
+  user,
+  onBack,
+  interviewCompany,
+  setInterviewCompany,
+  companySourceTab,
+  setCompanySourceTab,
+  companySearch,
+  setCompanySearch,
+  allCompanies,
+  setAllCompanies,
+  companiesLoading,
+  webSearchResults,
+  setWebSearchResults,
+  webSearchLoading,
+  positionCategory,
+  setPositionCategory,
+  selectedPosition,
+  setSelectedPosition,
+  companyHints,
+  hintsLoading,
+  questionDurationSeconds,
+  onStartInterview,
+}: SelectionScreenProps) {
+  // allCompanies is already filtered by server-side search, no client-side filter needed
+  const filteredCompanies = allCompanies
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: BG_LIGHT }}>
+      {/* Header */}
+      <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, sm: 3, lg: 10 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Box sx={{ color: PRIMARY, display: 'flex', alignItems: 'center' }}>
+            <PsychologyIcon sx={{ fontSize: 32 }} />
+          </Box>
+          <Typography sx={{ fontWeight: 700, fontSize: { xs: 16, sm: 20 }, color: '#0f172a' }}>InterviewAI</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <IconButton sx={{ bgcolor: '#f1f5f9', color: '#475569' }} size="small" onClick={onBack}>
+            <ArrowBackIcon fontSize="small" />
+          </IconButton>
+          <Box sx={{ width: 40, height: 40, borderRadius: '50%', bgcolor: `${PRIMARY}30`, border: `1px solid ${PRIMARY}50`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography sx={{ fontWeight: 700, color: PRIMARY, fontSize: 14 }}>
+              {(user.name || 'U').charAt(0).toUpperCase()}
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Main */}
+      <Box component="main" sx={{ display: 'flex', justifyContent: 'center', py: { xs: 3, sm: 5 }, px: { xs: 2, sm: 3, lg: 10 } }}>
+        <Box sx={{ maxWidth: 896, width: '100%', display: 'flex', flexDirection: 'column', gap: 4 }}>
+
+          {/* Step indicator + Title */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <Typography sx={{ color: PRIMARY, fontWeight: 600, fontSize: 13, textTransform: 'uppercase', letterSpacing: 1 }}>
+                Step 1 / 3
+              </Typography>
+              <Box sx={{ height: 4, width: 96, bgcolor: '#e2e8f0', borderRadius: 9999, overflow: 'hidden' }}>
+                <Box sx={{ height: '100%', width: '33%', bgcolor: PRIMARY }} />
+              </Box>
+            </Box>
+            <Typography variant="h4" sx={{ fontWeight: 700, color: '#0f172a', fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>練習する企業・職種を選ぶ</Typography>
+            <Typography sx={{ color: '#64748b', fontSize: 15 }}>
+              志望企業と職種を選択して、AIが面接内容をカスタマイズします。
+            </Typography>
+          </Box>
+
+          {/* 3-col grid */}
+          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '2fr 1fr' }, gap: 4, alignItems: 'start' }}>
+
+            {/* Left: Company + Position */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+
+              {/* Company section */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0' }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2 }}>志望企業</Typography>
+
+                {/* Source tab toggle */}
+                <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+                  <Button
+                    size="small"
+                    onClick={() => { setCompanySourceTab('db'); setWebSearchResults([]) }}
+                    sx={{
+                      px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
+                      bgcolor: companySourceTab === 'db' ? PRIMARY : '#f1f5f9',
+                      color: companySourceTab === 'db' ? '#fff' : '#475569',
+                      '&:hover': { bgcolor: companySourceTab === 'db' ? `${PRIMARY}e0` : '#e2e8f0' },
+                    }}
+                  >
+                    🏢 企業管理から選択
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={() => { setCompanySourceTab('web'); setAllCompanies([]) }}
+                    sx={{
+                      px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
+                      bgcolor: companySourceTab === 'web' ? PRIMARY : '#f1f5f9',
+                      color: companySourceTab === 'web' ? '#fff' : '#475569',
+                      '&:hover': { bgcolor: companySourceTab === 'web' ? `${PRIMARY}e0` : '#e2e8f0' },
+                    }}
+                  >
+                    🔍 WEB検索
+                  </Button>
+                </Box>
+
+                {/* Search / direct input */}
+                <Box sx={{ position: 'relative', mb: 2 }}>
+                  <SearchIcon sx={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', color: '#94a3b8', fontSize: 20 }} />
+                  <Box
+                    component="input"
+                    value={companySearch}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const value = e.target.value
+                      setCompanySearch(value)
+                      if (companySourceTab === 'db' && value.trim()) {
+                        const local = allCompanies.find((c) => c.name === value.trim())
+                        if (local) {
+                          setInterviewCompany(local)
+                        } else {
+                          setInterviewCompany({ id: 0, name: value.trim() })
+                          void resolveCompanyByName(value.trim()).then((resolved) => {
+                            setInterviewCompany((prev) =>
+                              prev?.name === value.trim() ? resolved : prev,
+                            )
+                          })
+                        }
+                      }
+                    }}
+                    placeholder={companySourceTab === 'web' ? '企業名を入力してWEB検索' : '企業名を入力、または下のリストから選択'}
+                    sx={{
+                      width: '100%', pl: '40px', pr: 2, py: 1.5,
+                      bgcolor: '#f8fafc', border: '1px solid #e2e8f0',
+                      borderRadius: 2, fontSize: 14, color: '#0f172a',
+                      outline: 'none', boxSizing: 'border-box',
+                      '&:focus': { borderColor: PRIMARY, boxShadow: `0 0 0 2px ${PRIMARY}20` },
+                      fontFamily: 'inherit',
+                    }}
+                  />
+                </Box>
+
+                {/* Manual entry / unresolved company warning (#567) */}
+                {interviewCompany && interviewCompany.id === 0 && interviewCompany.name.trim() && (
+                  <Box sx={{ mb: 2, p: 1.5, borderRadius: 2, bgcolor: '#fff8e1', border: '1px solid #ffe082', display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                    <WarningAmberIcon sx={{ color: '#f9a825', fontSize: 18, mt: 0.2, flexShrink: 0 }} />
+                    <Box>
+                      <Typography sx={{ fontSize: 13, color: '#f57f17', fontWeight: 600 }}>
+                        「{interviewCompany.name}」は企業管理に未登録です
+                      </Typography>
+                      <Typography sx={{ fontSize: 12, color: '#795548', mt: 0.5, lineHeight: 1.5 }}>
+                        カスタム質問・深掘り追質問は、企業管理に登録された企業を選択した場合のみ利用できます。一般的な面接練習は可能です。
+                      </Typography>
+                    </Box>
+                  </Box>
+                )}
+                {interviewCompany && interviewCompany.id > 0 && companySourceTab !== 'db' && (
+                  <Box sx={{ mb: 2, p: 1.5, borderRadius: 2, bgcolor: `${PRIMARY}08`, border: `1px solid ${PRIMARY}30`, display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 18 }} />
+                    <Typography sx={{ fontSize: 13, color: PRIMARY, fontWeight: 600 }}>
+                      企業管理の「{interviewCompany.name}」と一致しました（カスタム質問・深掘りが有効）
+                    </Typography>
+                  </Box>
+                )}
+
+                {/* DB mode: Company chips from DB */}
+                {companySourceTab === 'db' && (
+                  <>
+                    <Typography sx={{ fontSize: 12, color: '#94a3b8', mb: 1 }}>登録企業から選択</Typography>
+                    {companiesLoading ? (
+                      <LinearProgress sx={{ borderRadius: 1 }} />
+                    ) : (
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
+                        {filteredCompanies.map(c => {
+                          const isSelected = interviewCompany?.id === c.id
+                          return (
+                            <Button
+                              key={c.id}
+                              size="small"
+                              onClick={() => { setInterviewCompany(c); setCompanySearch(c.name) }}
+                              startIcon={isSelected ? <CheckCircleIcon sx={{ fontSize: '16px !important' }} /> : undefined}
+                              sx={{
+                                px: 2, py: 0.8, borderRadius: 2, fontWeight: 500, fontSize: 13,
+                                textTransform: 'none',
+                                bgcolor: isSelected ? PRIMARY : '#f1f5f9',
+                                color: isSelected ? '#fff' : '#475569',
+                                '&:hover': { bgcolor: isSelected ? `${PRIMARY}e0` : '#e2e8f0' },
+                              }}
+                            >
+                              {c.name}
+                            </Button>
+                          )
+                        })}
+                        {filteredCompanies.length === 0 && !companiesLoading && !companySearch.trim() && (
+                          <Typography sx={{ color: '#94a3b8', fontSize: 13 }}>登録企業が見つかりません</Typography>
+                        )}
+                      </Box>
+                    )}
+                  </>
+                )}
+
+                {/* WEB mode: web search results */}
+                {companySourceTab === 'web' && (
+                  <>
+                    <Typography sx={{ fontSize: 12, color: '#94a3b8', mb: 1 }}>
+                      {companySearch.trim() ? 'WEB検索結果' : 'キーワードを入力してください'}
+                    </Typography>
+                    {webSearchLoading ? (
+                      <LinearProgress sx={{ borderRadius: 1 }} />
+                    ) : (
+                      <Stack spacing={1}>
+                        {webSearchResults.map((result, i) => {
+                          const isSelected = interviewCompany?.name === result.name
+                          return (
+                            <Box
+                              key={i}
+                              onClick={() => {
+                                setCompanySearch(result.name)
+                                const local = allCompanies.find((c) => c.name === result.name)
+                                if (local) {
+                                  setInterviewCompany({ ...local, description: result.description })
+                                  return
+                                }
+                                setInterviewCompany({ id: 0, name: result.name, description: result.description })
+                                void resolveCompanyByName(result.name, { description: result.description }).then((resolved) => {
+                                  setInterviewCompany((prev) =>
+                                    prev?.name === result.name ? resolved : prev,
+                                  )
+                                })
+                              }}
+                              sx={{
+                                p: 1.5, borderRadius: 2, cursor: 'pointer',
+                                border: `2px solid ${isSelected ? PRIMARY : '#e2e8f0'}`,
+                                bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
+                                transition: 'all 0.15s',
+                                '&:hover': { borderColor: PRIMARY, bgcolor: `${PRIMARY}05` },
+                              }}
+                            >
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                {isSelected && <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 16, flexShrink: 0 }} />}
+                                <Typography sx={{ fontWeight: 600, fontSize: 14, color: '#0f172a' }}>{result.name}</Typography>
+                              </Box>
+                              {result.description && (
+                                <Typography sx={{ fontSize: 12, color: '#64748b', mt: 0.5, lineHeight: 1.5 }}>
+                                  {result.description.slice(0, 100)}{result.description.length > 100 ? '...' : ''}
+                                </Typography>
+                              )}
+                            </Box>
+                          )
+                        })}
+                        {webSearchResults.length === 0 && companySearch.trim() && !webSearchLoading && (
+                          <Typography sx={{ color: '#94a3b8', fontSize: 13 }}>検索結果が見つかりません</Typography>
+                        )}
+                      </Stack>
+                    )}
+                  </>
+                )}
+              </Paper>
+
+              {/* Position section */}
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0' }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2 }}>応募職種</Typography>
+
+                {/* Category tab */}
+                <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      setPositionCategory('general')
+                      if (selectedPosition.category === 'sier') setSelectedPosition(POSITIONS[0])
+                    }}
+                    sx={{
+                      px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
+                      bgcolor: positionCategory === 'general' ? PRIMARY : '#f1f5f9',
+                      color: positionCategory === 'general' ? '#fff' : '#475569',
+                      '&:hover': { bgcolor: positionCategory === 'general' ? `${PRIMARY}e0` : '#e2e8f0' },
+                    }}
+                  >
+                    💼 一般・IT職種
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      setPositionCategory('sier')
+                      if (selectedPosition.category === 'general') setSelectedPosition(POSITIONS.find(p => p.category === 'sier')!)
+                    }}
+                    sx={{
+                      px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
+                      bgcolor: positionCategory === 'sier' ? PRIMARY : '#f1f5f9',
+                      color: positionCategory === 'sier' ? '#fff' : '#475569',
+                      '&:hover': { bgcolor: positionCategory === 'sier' ? `${PRIMARY}e0` : '#e2e8f0' },
+                    }}
+                  >
+                    🏗️ SIer職種
+                  </Button>
+                </Box>
+
+                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1.5 }}>
+                  {POSITIONS.filter(p => p.category === positionCategory).map(pos => {
+                    const isSelected = selectedPosition.id === pos.id
+                    return (
+                      <Box
+                        key={pos.id}
+                        onClick={() => setSelectedPosition(pos)}
+                        sx={{
+                          position: 'relative', display: 'flex', alignItems: 'center', gap: 1.5,
+                          p: 2, borderRadius: 2, cursor: 'pointer',
+                          border: `2px solid ${isSelected ? PRIMARY : 'transparent'}`,
+                          bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
+                          transition: 'all 0.15s',
+                          '&:hover': { borderColor: isSelected ? PRIMARY : '#cbd5e1' },
+                        }}
+                      >
+                        <Typography sx={{ fontSize: 22 }}>{pos.icon}</Typography>
+                        <Box sx={{ flex: 1 }}>
+                          <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#0f172a' }}>{pos.title}</Typography>
+                          <Typography sx={{ fontSize: 12, color: '#94a3b8' }}>{pos.department}</Typography>
+                        </Box>
+                        <Box sx={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
+                          {isSelected
+                            ? <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 20 }} />
+                            : <Box sx={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid #cbd5e1' }} />
+                          }
+                        </Box>
+                      </Box>
+                    )
+                  })}
+                </Box>
+              </Paper>
+            </Box>
+
+            {/* Right: Summary + CTA */}
+            <Box sx={{ position: { md: 'sticky' }, top: 32, display: 'flex', flexDirection: 'column', gap: 3 }}>
+              <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: `1px solid ${PRIMARY}30`, bgcolor: `${PRIMARY}05` }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 3 }}>
+                  <Box sx={{ width: 48, height: 48, borderRadius: 2, bgcolor: '#fff', border: '1px solid #e2e8f0', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <ApartmentIcon sx={{ color: PRIMARY }} />
+                  </Box>
+                  <Box>
+                    <Typography sx={{ fontWeight: 700, fontSize: 15 }}>{interviewCompany?.name || '企業未選択'}</Typography>
+                    <Typography sx={{ fontSize: 13, color: '#64748b' }}>{interviewCompany?.industry || '業種未設定'}</Typography>
+                  </Box>
+                </Box>
+
+                <Stack spacing={2.5}>
+                  <Box>
+                    <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: 1, mb: 0.5 }}>応募ポジション</Typography>
+                    <Typography sx={{ fontWeight: 600, fontSize: 15 }}>{selectedPosition.title}</Typography>
+                  </Box>
+                  <Box>
+                    <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: 1, mb: 0.5 }}>企業概要</Typography>
+                    <Typography sx={{ fontSize: 13, color: '#64748b', lineHeight: 1.7 }}>
+                      {interviewCompany?.description
+                        ? interviewCompany.description.slice(0, 120) + (interviewCompany.description.length > 120 ? '...' : '')
+                        : '企業を選択すると詳細が表示されます。'}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ pt: 2, borderTop: `1px solid ${PRIMARY}15` }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                      <Typography sx={{ fontSize: 14 }}>⏱</Typography>
+                      <Typography sx={{ fontSize: 13, color: '#475569' }}>所要時間: {interviewLimits.maxMinutes}分</Typography>
+                    </Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Typography sx={{ fontSize: 14 }}>❓</Typography>
+                      <Typography sx={{ fontSize: 13, color: '#475569' }}>
+                        {selectedPosition.questions}問（1問あたり約{Math.round(questionDurationSeconds / 60)}分）
+                      </Typography>
+                    </Box>
+                  </Box>
+                </Stack>
+              </Paper>
+
+              {/* 企業別面接傾向ヒント */}
+              {interviewCompany && (
+                <Paper elevation={0} sx={{ p: 2.5, borderRadius: 2, border: '1px solid #fcd34d', bgcolor: '#fffbeb' }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+                    <LightbulbIcon sx={{ fontSize: 18, color: '#d97706' }} />
+                    <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#92400e' }}>
+                      {interviewCompany.name} の面接傾向
+                    </Typography>
+                  </Box>
+                  {hintsLoading ? (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <CircularProgress size={14} sx={{ color: '#d97706' }} />
+                      <Typography sx={{ fontSize: 12, color: '#92400e' }}>共有キャッシュから読み込み中...</Typography>
+                    </Box>
+                  ) : companyHints && (companyHints.style_tags.length > 0 || companyHints.top_questions.length > 0 || companyHints.company_brief) ? (
+                    <Stack spacing={1.5}>
+                      {companyHints.company_brief ? (
+                        <Box>
+                          <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>企業スナップショット（DB）</Typography>
+                          <Typography sx={{ fontSize: 12, color: '#78350f', whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
+                            {companyHints.company_brief}
+                          </Typography>
+                        </Box>
+                      ) : null}
+                      {companyHints.style_tags.length > 0 && (
+                        <Box>
+                          <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>面接スタイル</Typography>
+                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                            {companyHints.style_tags.map((tag, i) => (
+                              <Chip key={i} label={tag} size="small" sx={{ bgcolor: '#fef3c7', color: '#92400e', fontWeight: 600, fontSize: 11, border: '1px solid #fcd34d' }} />
+                            ))}
+                          </Box>
+                        </Box>
+                      )}
+                      {companyHints.top_questions.length > 0 && (
+                        <Box>
+                          <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>よく聞かれる質問</Typography>
+                          <Stack spacing={0.5}>
+                            {companyHints.top_questions.map((q, i) => (
+                              <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                                <Typography sx={{ fontSize: 11, fontWeight: 700, color: PRIMARY, minWidth: 16 }}>{i + 1}.</Typography>
+                                <Typography sx={{ fontSize: 12, color: '#78350f', lineHeight: 1.5 }}>{q}</Typography>
+                              </Box>
+                            ))}
+                          </Stack>
+                        </Box>
+                      )}
+                    </Stack>
+                  ) : (
+                    <Typography sx={{ fontSize: 12, color: '#92400e' }}>
+                      共有キャッシュに企業情報があるとスナップショットを表示します（都度Web検索はしません）。
+                    </Typography>
+                  )}
+                </Paper>
+              )}
+
+              <Button
+                variant="contained"
+                fullWidth
+                endIcon={<ArrowForwardIcon />}
+                disabled={!interviewCompany}
+                onClick={onStartInterview}
+                sx={{
+                  bgcolor: PRIMARY, '&:hover': { bgcolor: `${PRIMARY}e0` },
+                  borderRadius: 2, py: 1.8, fontWeight: 700, fontSize: 16,
+                  textTransform: 'none',
+                  boxShadow: `0 8px 24px ${PRIMARY}30`,
+                  '&:disabled': { bgcolor: '#e2e8f0', color: '#94a3b8', boxShadow: 'none' },
+                }}
+              >
+                面接を開始する
+              </Button>
+              <Typography sx={{ fontSize: 12, textAlign: 'center', color: '#94a3b8' }}>
+                開始すると<Box component="a" href="#" sx={{ textDecoration: 'underline', color: 'inherit' }}>利用規約</Box>に同意したことになります
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/app/interview/components/SelectionScreen.tsx
+++ b/frontend/app/interview/components/SelectionScreen.tsx
@@ -24,7 +24,7 @@ import type { User } from '@/lib/auth'
 import { interviewLimits } from '@/lib/interview'
 import { PRIMARY, BG_LIGHT, POSITIONS } from '../constants'
 import type { InterviewCompany, Position } from '../types'
-import { resolveCompanyByName } from '../utils'
+import { resolveCompanyByName, mergeResolvedCompany } from '../utils'
 
 const COMPANY_RESOLVE_DEBOUNCE_MS = 400
 
@@ -116,7 +116,7 @@ export default function SelectionScreen({
 
     const timer = window.setTimeout(() => {
       void resolveCompanyByName(trimmed).then((resolved) => {
-        setInterviewCompany((prev) => (prev?.name === trimmed ? resolved : prev))
+        setInterviewCompany((prev) => mergeResolvedCompany(prev, trimmed, resolved))
       })
     }, COMPANY_RESOLVE_DEBOUNCE_MS)
 
@@ -125,14 +125,15 @@ export default function SelectionScreen({
 
   /**
    * デバウンス待機中にロビーへ進むと resolve がキャンセルされ id:0 のまま残るため、
-   * 開始直前に登録企業解決を確定する（Bugbot: Debounced resolve skips ID lookup）。
+   * 開始直前に登録企業解決を確定する。
+   * await 中に選択が変わった場合は stale な結果で上書きしない。
    */
   const handleStartInterview = async () => {
     const trimmed = (companySearch.trim() || interviewCompany?.name || '').trim()
     if (interviewCompany && interviewCompany.id === 0 && trimmed) {
       const local = allCompanies.find((c) => c.name === trimmed)
       const resolved = local ?? await resolveCompanyByName(trimmed, interviewCompany)
-      setInterviewCompany(resolved)
+      setInterviewCompany((prev) => mergeResolvedCompany(prev, trimmed, resolved))
     }
     onStartInterview()
   }
@@ -330,7 +331,7 @@ export default function SelectionScreen({
                             setInterviewCompany({ id: 0, name: result.name, description: result.description })
                             void resolveCompanyByName(result.name, { description: result.description }).then((resolved) => {
                               setInterviewCompany((prev) =>
-                                prev?.name === result.name ? resolved : prev,
+                                mergeResolvedCompany(prev, result.name, resolved),
                               )
                             })
                           }

--- a/frontend/app/interview/components/SelectionScreen.tsx
+++ b/frontend/app/interview/components/SelectionScreen.tsx
@@ -95,12 +95,24 @@ export default function SelectionScreen({
   questionDurationSeconds,
   onStartInterview,
 }: SelectionScreenProps) {
-  // 入力中の企業名解決は親の一覧取得と同様にデバウンスし、1文字ごとの API 連打を避ける
+  // 入力中の企業名解決は親の一覧取得と同様にデバウンスし、1文字ごとの API 連打を避ける。
+  // allCompanies に名前一致がある場合は API を呼ばず、id:0 の仮選択を登録企業へ昇格させる。
   useEffect(() => {
     if (companySourceTab !== 'db') return
     const trimmed = companySearch.trim()
     if (!trimmed) return
-    if (allCompanies.some((c) => c.name === trimmed)) return
+
+    const local = allCompanies.find((c) => c.name === trimmed)
+    if (local) {
+      setInterviewCompany((prev) => {
+        if (prev?.id === local.id && prev.name === local.name) return prev
+        if (!prev || prev.name !== trimmed || prev.id === 0 || prev.id !== local.id) {
+          return local
+        }
+        return prev
+      })
+      return
+    }
 
     const timer = window.setTimeout(() => {
       void resolveCompanyByName(trimmed).then((resolved) => {

--- a/frontend/app/interview/constants.ts
+++ b/frontend/app/interview/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared constants for the interview feature.
+ */
+import type { Position } from './types'
+
+export const PRIMARY = '#ec5b13'
+export const BG_LIGHT = '#f8f6f6'
+export const BG_DARK = '#221610'
+
+export const POSITIONS: Position[] = [
+  { id: 'engineer', title: 'ソフトウェアエンジニア', department: 'Engineering', icon: '💻', questions: 8, category: 'general' },
+  { id: 'designer', title: 'プロダクトデザイナー', department: 'Design', icon: '🎨', questions: 7, category: 'general' },
+  { id: 'sales', title: '営業職', department: 'Sales', icon: '📈', questions: 7, category: 'general' },
+  { id: 'marketing', title: 'マーケティング', department: 'Growth', icon: '📣', questions: 6, category: 'general' },
+  { id: 'pm', title: 'プロダクトマネージャー', department: 'Product', icon: '🧭', questions: 9, category: 'general' },
+  { id: 'data', title: 'データアナリスト', department: 'Data', icon: '📊', questions: 7, category: 'general' },
+  { id: 'se', title: 'システムエンジニア（SE）', department: 'SIer / Development', icon: '🖥️', questions: 8, category: 'sier' },
+  { id: 'infra', title: 'インフラエンジニア', department: 'SIer / Infrastructure', icon: '🔧', questions: 7, category: 'sier' },
+  { id: 'it_consultant', title: 'ITコンサルタント', department: 'SIer / Consulting', icon: '📋', questions: 8, category: 'sier' },
+  { id: 'pmo', title: 'PMO（プロジェクト管理）', department: 'SIer / PMO', icon: '📅', questions: 7, category: 'sier' },
+  { id: 'network', title: 'ネットワークエンジニア', department: 'SIer / Network', icon: '🌐', questions: 7, category: 'sier' },
+  { id: 'qa', title: 'テスト・品質保証（QA）', department: 'SIer / QA', icon: '✅', questions: 6, category: 'sier' },
+]

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -7,15 +7,7 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Drawer,
-  FormControlLabel,
-  Checkbox,
   IconButton,
-  InputBase,
   LinearProgress,
   Paper,
   Stack,
@@ -27,107 +19,31 @@ import MicOffIcon from '@mui/icons-material/MicOff'
 import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
-import CallEndIcon from '@mui/icons-material/CallEnd'
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption'
 import PsychologyIcon from '@mui/icons-material/Psychology'
-import LightbulbIcon from '@mui/icons-material/Lightbulb'
-import SendIcon from '@mui/icons-material/Send'
-import SearchIcon from '@mui/icons-material/Search'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import ApartmentIcon from '@mui/icons-material/Apartment'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { BACKEND_URL } from '@/lib/backend-url'
 import { authService, User } from '@/lib/auth'
 import { interviewApi, interviewLimits, InterviewReport, InterviewSession } from '@/lib/interview'
 import { formatSeconds, parseJsonSafe, parseMediaError, parseMultipartResponse } from '@/lib/interview-utils'
 import ThreeAvatar from './components/ThreeAvatar'
 import InterviewSummary from './components/InterviewSummary'
+import ConsentDialog from './components/ConsentDialog'
+import SelectionScreen from './components/SelectionScreen'
 import ScoreUpdateBanner, { WeightScore } from '@/components/ScoreUpdateBanner'
 import { PageLoading } from '@/components/common/PageLoading'
-
-const PRIMARY = '#ec5b13'
-const BG_LIGHT = '#f8f6f6'
-const BG_DARK = '#221610'
-
-type Utterance = {
-  role: 'user' | 'ai'
-  text: string
-}
-
-type InterviewCompany = {
-  id: number
-  name: string
-  name_reading?: string
-  description?: string
-  main_business?: string
-  industry?: string
-  location?: string
-  employee_count?: number
-  culture?: string
-  work_style?: string
-  welfare_details?: string
-}
-
-type Position = {
-  id: string
-  title: string
-  department: string
-  icon: string
-  questions: number
-  category: 'general' | 'sier'
-}
-
-const POSITIONS: Position[] = [
-  { id: 'engineer', title: 'ソフトウェアエンジニア', department: 'Engineering', icon: '💻', questions: 8, category: 'general' },
-  { id: 'designer', title: 'プロダクトデザイナー', department: 'Design', icon: '🎨', questions: 7, category: 'general' },
-  { id: 'sales', title: '営業職', department: 'Sales', icon: '📈', questions: 7, category: 'general' },
-  { id: 'marketing', title: 'マーケティング', department: 'Growth', icon: '📣', questions: 6, category: 'general' },
-  { id: 'pm', title: 'プロダクトマネージャー', department: 'Product', icon: '🧭', questions: 9, category: 'general' },
-  { id: 'data', title: 'データアナリスト', department: 'Data', icon: '📊', questions: 7, category: 'general' },
-  { id: 'se', title: 'システムエンジニア（SE）', department: 'SIer / Development', icon: '🖥️', questions: 8, category: 'sier' },
-  { id: 'infra', title: 'インフラエンジニア', department: 'SIer / Infrastructure', icon: '🔧', questions: 7, category: 'sier' },
-  { id: 'it_consultant', title: 'ITコンサルタント', department: 'SIer / Consulting', icon: '📋', questions: 8, category: 'sier' },
-  { id: 'pmo', title: 'PMO（プロジェクト管理）', department: 'SIer / PMO', icon: '📅', questions: 7, category: 'sier' },
-  { id: 'network', title: 'ネットワークエンジニア', department: 'SIer / Network', icon: '🌐', questions: 7, category: 'sier' },
-  { id: 'qa', title: 'テスト・品質保証（QA）', department: 'SIer / QA', icon: '✅', questions: 6, category: 'sier' },
-]
-
-/** DB 登録企業と企業名が一致すれば id を解決。未登録なら id=0 のまま返す (#567) */
-async function resolveCompanyByName(
-  name: string,
-  fallback?: Partial<InterviewCompany>,
-): Promise<InterviewCompany> {
-  const trimmed = name.trim()
-  if (!trimmed) {
-    return { id: 0, name: '', ...fallback }
-  }
-  try {
-    const params = new URLSearchParams({ limit: '20', offset: '0', name: trimmed })
-    const res = await fetch(`/api/companies?${params}`, { cache: 'no-store' })
-    if (res.ok) {
-      const data = await res.json()
-      const list: InterviewCompany[] = Array.isArray(data?.companies) ? data.companies : []
-      const exact = list.find((c) => c.name === trimmed)
-      if (exact) {
-        return { ...exact, ...fallback, id: exact.id, name: exact.name }
-      }
-    }
-  } catch {
-    // ignore — 解決失敗時は id=0
-  }
-  return { id: 0, name: trimmed, ...fallback }
-}
+import { PRIMARY, BG_LIGHT, BG_DARK, POSITIONS } from './constants'
+import type { Utterance, InterviewCompany, Position, InterviewStatus } from './types'
+import { resolveCompanyByName, getNextAvatarGender } from './utils'
 
 function InterviewContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
-  const [status, setStatus] = useState<'selection' | 'lobby' | 'connecting' | 'connected' | 'error' | 'finished'>('selection')
+  const [status, setStatus] = useState<InterviewStatus>('selection')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [utterances, setUtterances] = useState<Utterance[]>([])
   const [partialUser, setPartialUser] = useState('')
@@ -811,484 +727,50 @@ function InterviewContent() {
     '', `【勤務地・人数】 ${interviewCompany?.location || '未設定'} / ${interviewCompany?.employee_count ? interviewCompany.employee_count + '名' : '非公開'}`,
   ].join('\n')
 
-  // allCompanies is already filtered by server-side search, no client-side filter needed
-  const filteredCompanies = allCompanies
-
   // ─────────────────────────────────────────────
   // SELECTION SCREEN  (Step 1 of 3)
   // ─────────────────────────────────────────────
   if (status === 'selection') {
     return (
-      <Box sx={{ minHeight: '100vh', bgcolor: BG_LIGHT }}>
-        {/* Header */}
-        <Box component="header" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: { xs: 2, sm: 3, lg: 10 }, py: 2, bgcolor: '#fff', borderBottom: '1px solid #e2e8f0' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <Box sx={{ color: PRIMARY, display: 'flex', alignItems: 'center' }}>
-              <PsychologyIcon sx={{ fontSize: 32 }} />
-            </Box>
-            <Typography sx={{ fontWeight: 700, fontSize: { xs: 16, sm: 20 }, color: '#0f172a' }}>InterviewAI</Typography>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <IconButton sx={{ bgcolor: '#f1f5f9', color: '#475569' }} size="small" onClick={() => router.push('/')}>
-              <ArrowBackIcon fontSize="small" />
-            </IconButton>
-            <Box sx={{ width: 40, height: 40, borderRadius: '50%', bgcolor: `${PRIMARY}30`, border: `1px solid ${PRIMARY}50`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Typography sx={{ fontWeight: 700, color: PRIMARY, fontSize: 14 }}>
-                {(user.name || 'U').charAt(0).toUpperCase()}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-
-        {/* Main */}
-        <Box component="main" sx={{ display: 'flex', justifyContent: 'center', py: { xs: 3, sm: 5 }, px: { xs: 2, sm: 3, lg: 10 } }}>
-          <Box sx={{ maxWidth: 896, width: '100%', display: 'flex', flexDirection: 'column', gap: 4 }}>
-
-            {/* Step indicator + Title */}
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                <Typography sx={{ color: PRIMARY, fontWeight: 600, fontSize: 13, textTransform: 'uppercase', letterSpacing: 1 }}>
-                  Step 1 / 3
-                </Typography>
-                <Box sx={{ height: 4, width: 96, bgcolor: '#e2e8f0', borderRadius: 9999, overflow: 'hidden' }}>
-                  <Box sx={{ height: '100%', width: '33%', bgcolor: PRIMARY }} />
-                </Box>
-              </Box>
-              <Typography variant="h4" sx={{ fontWeight: 700, color: '#0f172a', fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>練習する企業・職種を選ぶ</Typography>
-              <Typography sx={{ color: '#64748b', fontSize: 15 }}>
-                志望企業と職種を選択して、AIが面接内容をカスタマイズします。
-              </Typography>
-            </Box>
-
-            {/* 3-col grid */}
-            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '2fr 1fr' }, gap: 4, alignItems: 'start' }}>
-
-              {/* Left: Company + Position */}
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-
-                {/* Company section */}
-                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0' }}>
-                  <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2 }}>志望企業</Typography>
-
-                  {/* Source tab toggle */}
-                  <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
-                    <Button
-                      size="small"
-                      onClick={() => { setCompanySourceTab('db'); setWebSearchResults([]) }}
-                      sx={{
-                        px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
-                        bgcolor: companySourceTab === 'db' ? PRIMARY : '#f1f5f9',
-                        color: companySourceTab === 'db' ? '#fff' : '#475569',
-                        '&:hover': { bgcolor: companySourceTab === 'db' ? `${PRIMARY}e0` : '#e2e8f0' },
-                      }}
-                    >
-                      🏢 企業管理から選択
-                    </Button>
-                    <Button
-                      size="small"
-                      onClick={() => { setCompanySourceTab('web'); setAllCompanies([]) }}
-                      sx={{
-                        px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
-                        bgcolor: companySourceTab === 'web' ? PRIMARY : '#f1f5f9',
-                        color: companySourceTab === 'web' ? '#fff' : '#475569',
-                        '&:hover': { bgcolor: companySourceTab === 'web' ? `${PRIMARY}e0` : '#e2e8f0' },
-                      }}
-                    >
-                      🔍 WEB検索
-                    </Button>
-                  </Box>
-
-                  {/* Search / direct input */}
-                  <Box sx={{ position: 'relative', mb: 2 }}>
-                    <SearchIcon sx={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', color: '#94a3b8', fontSize: 20 }} />
-                    <Box
-                      component="input"
-                      value={companySearch}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        const value = e.target.value
-                        setCompanySearch(value)
-                        if (companySourceTab === 'db' && value.trim()) {
-                          const local = allCompanies.find((c) => c.name === value.trim())
-                          if (local) {
-                            setInterviewCompany(local)
-                          } else {
-                            setInterviewCompany({ id: 0, name: value.trim() })
-                            void resolveCompanyByName(value.trim()).then((resolved) => {
-                              setInterviewCompany((prev) =>
-                                prev?.name === value.trim() ? resolved : prev,
-                              )
-                            })
-                          }
-                        }
-                      }}
-                      placeholder={companySourceTab === 'web' ? '企業名を入力してWEB検索' : '企業名を入力、または下のリストから選択'}
-                      sx={{
-                        width: '100%', pl: '40px', pr: 2, py: 1.5,
-                        bgcolor: '#f8fafc', border: '1px solid #e2e8f0',
-                        borderRadius: 2, fontSize: 14, color: '#0f172a',
-                        outline: 'none', boxSizing: 'border-box',
-                        '&:focus': { borderColor: PRIMARY, boxShadow: `0 0 0 2px ${PRIMARY}20` },
-                        fontFamily: 'inherit',
-                      }}
-                    />
-                  </Box>
-
-                  {/* Manual entry / unresolved company warning (#567) */}
-                  {interviewCompany && interviewCompany.id === 0 && interviewCompany.name.trim() && (
-                    <Box sx={{ mb: 2, p: 1.5, borderRadius: 2, bgcolor: '#fff8e1', border: '1px solid #ffe082', display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                      <WarningAmberIcon sx={{ color: '#f9a825', fontSize: 18, mt: 0.2, flexShrink: 0 }} />
-                      <Box>
-                        <Typography sx={{ fontSize: 13, color: '#f57f17', fontWeight: 600 }}>
-                          「{interviewCompany.name}」は企業管理に未登録です
-                        </Typography>
-                        <Typography sx={{ fontSize: 12, color: '#795548', mt: 0.5, lineHeight: 1.5 }}>
-                          カスタム質問・深掘り追質問は、企業管理に登録された企業を選択した場合のみ利用できます。一般的な面接練習は可能です。
-                        </Typography>
-                      </Box>
-                    </Box>
-                  )}
-                  {interviewCompany && interviewCompany.id > 0 && companySourceTab !== 'db' && (
-                    <Box sx={{ mb: 2, p: 1.5, borderRadius: 2, bgcolor: `${PRIMARY}08`, border: `1px solid ${PRIMARY}30`, display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 18 }} />
-                      <Typography sx={{ fontSize: 13, color: PRIMARY, fontWeight: 600 }}>
-                        企業管理の「{interviewCompany.name}」と一致しました（カスタム質問・深掘りが有効）
-                      </Typography>
-                    </Box>
-                  )}
-
-                  {/* DB mode: Company chips from DB */}
-                  {companySourceTab === 'db' && (
-                    <>
-                      <Typography sx={{ fontSize: 12, color: '#94a3b8', mb: 1 }}>登録企業から選択</Typography>
-                      {companiesLoading ? (
-                        <LinearProgress sx={{ borderRadius: 1 }} />
-                      ) : (
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
-                          {filteredCompanies.map(c => {
-                            const isSelected = interviewCompany?.id === c.id
-                            return (
-                              <Button
-                                key={c.id}
-                                size="small"
-                                onClick={() => { setInterviewCompany(c); setCompanySearch(c.name) }}
-                                startIcon={isSelected ? <CheckCircleIcon sx={{ fontSize: '16px !important' }} /> : undefined}
-                                sx={{
-                                  px: 2, py: 0.8, borderRadius: 2, fontWeight: 500, fontSize: 13,
-                                  textTransform: 'none',
-                                  bgcolor: isSelected ? PRIMARY : '#f1f5f9',
-                                  color: isSelected ? '#fff' : '#475569',
-                                  '&:hover': { bgcolor: isSelected ? `${PRIMARY}e0` : '#e2e8f0' },
-                                }}
-                              >
-                                {c.name}
-                              </Button>
-                            )
-                          })}
-                          {filteredCompanies.length === 0 && !companiesLoading && !companySearch.trim() && (
-                            <Typography sx={{ color: '#94a3b8', fontSize: 13 }}>登録企業が見つかりません</Typography>
-                          )}
-                        </Box>
-                      )}
-                    </>
-                  )}
-
-                  {/* WEB mode: web search results */}
-                  {companySourceTab === 'web' && (
-                    <>
-                      <Typography sx={{ fontSize: 12, color: '#94a3b8', mb: 1 }}>
-                        {companySearch.trim() ? 'WEB検索結果' : 'キーワードを入力してください'}
-                      </Typography>
-                      {webSearchLoading ? (
-                        <LinearProgress sx={{ borderRadius: 1 }} />
-                      ) : (
-                        <Stack spacing={1}>
-                          {webSearchResults.map((result, i) => {
-                            const isSelected = interviewCompany?.name === result.name
-                            return (
-                              <Box
-                                key={i}
-                                onClick={() => {
-                                  setCompanySearch(result.name)
-                                  const local = allCompanies.find((c) => c.name === result.name)
-                                  if (local) {
-                                    setInterviewCompany({ ...local, description: result.description })
-                                    return
-                                  }
-                                  setInterviewCompany({ id: 0, name: result.name, description: result.description })
-                                  void resolveCompanyByName(result.name, { description: result.description }).then((resolved) => {
-                                    setInterviewCompany((prev) =>
-                                      prev?.name === result.name ? resolved : prev,
-                                    )
-                                  })
-                                }}
-                                sx={{
-                                  p: 1.5, borderRadius: 2, cursor: 'pointer',
-                                  border: `2px solid ${isSelected ? PRIMARY : '#e2e8f0'}`,
-                                  bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
-                                  transition: 'all 0.15s',
-                                  '&:hover': { borderColor: PRIMARY, bgcolor: `${PRIMARY}05` },
-                                }}
-                              >
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                  {isSelected && <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 16, flexShrink: 0 }} />}
-                                  <Typography sx={{ fontWeight: 600, fontSize: 14, color: '#0f172a' }}>{result.name}</Typography>
-                                </Box>
-                                {result.description && (
-                                  <Typography sx={{ fontSize: 12, color: '#64748b', mt: 0.5, lineHeight: 1.5 }}>
-                                    {result.description.slice(0, 100)}{result.description.length > 100 ? '...' : ''}
-                                  </Typography>
-                                )}
-                              </Box>
-                            )
-                          })}
-                          {webSearchResults.length === 0 && companySearch.trim() && !webSearchLoading && (
-                            <Typography sx={{ color: '#94a3b8', fontSize: 13 }}>検索結果が見つかりません</Typography>
-                          )}
-                        </Stack>
-                      )}
-                    </>
-                  )}
-                </Paper>
-
-                {/* Position section */}
-                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: '1px solid #e2e8f0' }}>
-                  <Typography sx={{ fontWeight: 700, fontSize: 17, mb: 2 }}>応募職種</Typography>
-
-                  {/* Category tab */}
-                  <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
-                    <Button
-                      size="small"
-                      onClick={() => {
-                        setPositionCategory('general')
-                        if (selectedPosition.category === 'sier') setSelectedPosition(POSITIONS[0])
-                      }}
-                      sx={{
-                        px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
-                        bgcolor: positionCategory === 'general' ? PRIMARY : '#f1f5f9',
-                        color: positionCategory === 'general' ? '#fff' : '#475569',
-                        '&:hover': { bgcolor: positionCategory === 'general' ? `${PRIMARY}e0` : '#e2e8f0' },
-                      }}
-                    >
-                      💼 一般・IT職種
-                    </Button>
-                    <Button
-                      size="small"
-                      onClick={() => {
-                        setPositionCategory('sier')
-                        if (selectedPosition.category === 'general') setSelectedPosition(POSITIONS.find(p => p.category === 'sier')!)
-                      }}
-                      sx={{
-                        px: 2, py: 0.6, borderRadius: 2, textTransform: 'none', fontWeight: 600, fontSize: 13,
-                        bgcolor: positionCategory === 'sier' ? PRIMARY : '#f1f5f9',
-                        color: positionCategory === 'sier' ? '#fff' : '#475569',
-                        '&:hover': { bgcolor: positionCategory === 'sier' ? `${PRIMARY}e0` : '#e2e8f0' },
-                      }}
-                    >
-                      🏗️ SIer職種
-                    </Button>
-                  </Box>
-
-                  <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 1.5 }}>
-                    {POSITIONS.filter(p => p.category === positionCategory).map(pos => {
-                      const isSelected = selectedPosition.id === pos.id
-                      return (
-                        <Box
-                          key={pos.id}
-                          onClick={() => setSelectedPosition(pos)}
-                          sx={{
-                            position: 'relative', display: 'flex', alignItems: 'center', gap: 1.5,
-                            p: 2, borderRadius: 2, cursor: 'pointer',
-                            border: `2px solid ${isSelected ? PRIMARY : 'transparent'}`,
-                            bgcolor: isSelected ? `${PRIMARY}08` : '#f8fafc',
-                            transition: 'all 0.15s',
-                            '&:hover': { borderColor: isSelected ? PRIMARY : '#cbd5e1' },
-                          }}
-                        >
-                          <Typography sx={{ fontSize: 22 }}>{pos.icon}</Typography>
-                          <Box sx={{ flex: 1 }}>
-                            <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#0f172a' }}>{pos.title}</Typography>
-                            <Typography sx={{ fontSize: 12, color: '#94a3b8' }}>{pos.department}</Typography>
-                          </Box>
-                          <Box sx={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)' }}>
-                            {isSelected
-                              ? <CheckCircleIcon sx={{ color: PRIMARY, fontSize: 20 }} />
-                              : <Box sx={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid #cbd5e1' }} />
-                            }
-                          </Box>
-                        </Box>
-                      )
-                    })}
-                  </Box>
-                </Paper>
-              </Box>
-
-              {/* Right: Summary + CTA */}
-              <Box sx={{ position: { md: 'sticky' }, top: 32, display: 'flex', flexDirection: 'column', gap: 3 }}>
-                <Paper elevation={0} sx={{ p: 3, borderRadius: 2, border: `1px solid ${PRIMARY}30`, bgcolor: `${PRIMARY}05` }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 3 }}>
-                    <Box sx={{ width: 48, height: 48, borderRadius: 2, bgcolor: '#fff', border: '1px solid #e2e8f0', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                      <ApartmentIcon sx={{ color: PRIMARY }} />
-                    </Box>
-                    <Box>
-                      <Typography sx={{ fontWeight: 700, fontSize: 15 }}>{interviewCompany?.name || '企業未選択'}</Typography>
-                      <Typography sx={{ fontSize: 13, color: '#64748b' }}>{interviewCompany?.industry || '業種未設定'}</Typography>
-                    </Box>
-                  </Box>
-
-                  <Stack spacing={2.5}>
-                    <Box>
-                      <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: 1, mb: 0.5 }}>応募ポジション</Typography>
-                      <Typography sx={{ fontWeight: 600, fontSize: 15 }}>{selectedPosition.title}</Typography>
-                    </Box>
-                    <Box>
-                      <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: 1, mb: 0.5 }}>企業概要</Typography>
-                      <Typography sx={{ fontSize: 13, color: '#64748b', lineHeight: 1.7 }}>
-                        {interviewCompany?.description
-                          ? interviewCompany.description.slice(0, 120) + (interviewCompany.description.length > 120 ? '...' : '')
-                          : '企業を選択すると詳細が表示されます。'}
-                      </Typography>
-                    </Box>
-                    <Box sx={{ pt: 2, borderTop: `1px solid ${PRIMARY}15` }}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <Typography sx={{ fontSize: 14 }}>⏱</Typography>
-                        <Typography sx={{ fontSize: 13, color: '#475569' }}>所要時間: {interviewLimits.maxMinutes}分</Typography>
-                      </Box>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography sx={{ fontSize: 14 }}>❓</Typography>
-                        <Typography sx={{ fontSize: 13, color: '#475569' }}>
-                          {selectedPosition.questions}問（1問あたり約{Math.round(questionDurationSeconds / 60)}分）
-                        </Typography>
-                      </Box>
-                    </Box>
-                  </Stack>
-                </Paper>
-
-                {/* 企業別面接傾向ヒント */}
-                {interviewCompany && (
-                  <Paper elevation={0} sx={{ p: 2.5, borderRadius: 2, border: '1px solid #fcd34d', bgcolor: '#fffbeb' }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-                      <LightbulbIcon sx={{ fontSize: 18, color: '#d97706' }} />
-                      <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#92400e' }}>
-                        {interviewCompany.name} の面接傾向
-                      </Typography>
-                    </Box>
-                    {hintsLoading ? (
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <CircularProgress size={14} sx={{ color: '#d97706' }} />
-                        <Typography sx={{ fontSize: 12, color: '#92400e' }}>共有キャッシュから読み込み中...</Typography>
-                      </Box>
-                    ) : companyHints && (companyHints.style_tags.length > 0 || companyHints.top_questions.length > 0 || companyHints.company_brief) ? (
-                      <Stack spacing={1.5}>
-                        {companyHints.company_brief ? (
-                          <Box>
-                            <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>企業スナップショット（DB）</Typography>
-                            <Typography sx={{ fontSize: 12, color: '#78350f', whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
-                              {companyHints.company_brief}
-                            </Typography>
-                          </Box>
-                        ) : null}
-                        {companyHints.style_tags.length > 0 && (
-                          <Box>
-                            <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>面接スタイル</Typography>
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                              {companyHints.style_tags.map((tag, i) => (
-                                <Chip key={i} label={tag} size="small" sx={{ bgcolor: '#fef3c7', color: '#92400e', fontWeight: 600, fontSize: 11, border: '1px solid #fcd34d' }} />
-                              ))}
-                            </Box>
-                          </Box>
-                        )}
-                        {companyHints.top_questions.length > 0 && (
-                          <Box>
-                            <Typography sx={{ fontSize: 11, fontWeight: 700, color: '#b45309', mb: 0.5 }}>よく聞かれる質問</Typography>
-                            <Stack spacing={0.5}>
-                              {companyHints.top_questions.map((q, i) => (
-                                <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                                  <Typography sx={{ fontSize: 11, fontWeight: 700, color: PRIMARY, minWidth: 16 }}>{i + 1}.</Typography>
-                                  <Typography sx={{ fontSize: 12, color: '#78350f', lineHeight: 1.5 }}>{q}</Typography>
-                                </Box>
-                              ))}
-                            </Stack>
-                          </Box>
-                        )}
-                      </Stack>
-                    ) : (
-                      <Typography sx={{ fontSize: 12, color: '#92400e' }}>
-                        共有キャッシュに企業情報があるとスナップショットを表示します（都度Web検索はしません）。
-                      </Typography>
-                    )}
-                  </Paper>
-                )}
-
-                <Button
-                  variant="contained"
-                  fullWidth
-                  endIcon={<ArrowForwardIcon />}
-                  disabled={!interviewCompany}
-                  onClick={() => setStatus('lobby')}
-                  sx={{
-                    bgcolor: PRIMARY, '&:hover': { bgcolor: `${PRIMARY}e0` },
-                    borderRadius: 2, py: 1.8, fontWeight: 700, fontSize: 16,
-                    textTransform: 'none',
-                    boxShadow: `0 8px 24px ${PRIMARY}30`,
-                    '&:disabled': { bgcolor: '#e2e8f0', color: '#94a3b8', boxShadow: 'none' },
-                  }}
-                >
-                  面接を開始する
-                </Button>
-                <Typography sx={{ fontSize: 12, textAlign: 'center', color: '#94a3b8' }}>
-                  開始すると<Box component="a" href="#" sx={{ textDecoration: 'underline', color: 'inherit' }}>利用規約</Box>に同意したことになります
-                </Typography>
-              </Box>
-            </Box>
-          </Box>
-        </Box>
-      </Box>
+      <SelectionScreen
+        user={user}
+        onBack={() => router.push('/')}
+        interviewCompany={interviewCompany}
+        setInterviewCompany={setInterviewCompany}
+        companySourceTab={companySourceTab}
+        setCompanySourceTab={setCompanySourceTab}
+        companySearch={companySearch}
+        setCompanySearch={setCompanySearch}
+        allCompanies={allCompanies}
+        setAllCompanies={setAllCompanies}
+        companiesLoading={companiesLoading}
+        webSearchResults={webSearchResults}
+        setWebSearchResults={setWebSearchResults}
+        webSearchLoading={webSearchLoading}
+        positionCategory={positionCategory}
+        setPositionCategory={setPositionCategory}
+        selectedPosition={selectedPosition}
+        setSelectedPosition={setSelectedPosition}
+        companyHints={companyHints}
+        hintsLoading={hintsLoading}
+        questionDurationSeconds={questionDurationSeconds}
+        onStartInterview={() => setStatus('lobby')}
+      />
     )
   }
+
 
   // ─────────────────────────────────────────────
   // 録画同意ダイアログ（LOBBY / SESSION 画面で共有）
   // ─────────────────────────────────────────────
   const consentDialog = (
-    <Dialog open={consentDialogOpen} onClose={() => setConsentDialogOpen(false)} maxWidth="sm" fullWidth>
-      <DialogTitle>面接練習を開始する前に</DialogTitle>
-      <DialogContent>
-        <Typography variant="body2" sx={{ mb: 2 }}>
-          面接練習では、より良いフィードバックのために以下のデータを収集します。
-        </Typography>
-        <Typography variant="body2" component="ul" sx={{ pl: 2, mb: 2, color: 'text.secondary' }}>
-          <li>音声・動画の録画（フィードバック生成のみに使用）</li>
-          <li>会話のテキスト（評価スコア算出に使用）</li>
-        </Typography>
-        <Typography variant="body2" color="error.main" sx={{ mb: 2 }}>
-          ※ これらのデータは企業には提供されません。サービス内でのみ使用します。
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 2 }}>
-          録画データは面接セッション終了後90日で自動削除されます。
-          詳細は<Button size="small" sx={{ p: 0, minWidth: 0, textDecoration: 'underline', fontSize: 'inherit' }}
-            onClick={() => window.open('/privacy', '_blank')}>プライバシーポリシー</Button>をご確認ください。
-        </Typography>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={consentGiven}
-              onChange={(e) => setConsentGiven(e.target.checked)}
-            />
-          }
-          label="上記の内容に同意して面接練習を始める"
-        />
-      </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={() => setConsentDialogOpen(false)}>キャンセル</Button>
-        <Button
-          variant="contained"
-          disabled={!consentGiven}
-          onClick={() => { setConsentDialogOpen(false); handleJoin() }}
-        >
-          面接に参加
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <ConsentDialog
+      open={consentDialogOpen}
+      consentGiven={consentGiven}
+      onConsentChange={setConsentGiven}
+      onClose={() => setConsentDialogOpen(false)}
+      onConfirm={() => { setConsentDialogOpen(false); handleJoin() }}
+    />
   )
 
   // ─────────────────────────────────────────────
@@ -1916,18 +1398,6 @@ function InterviewContent() {
       {consentDialog}
     </Box>
   )
-}
-
-function getNextAvatarGender(): 'male' | 'female' {
-  try {
-    const key = 'interview_avatar_index'
-    const current = Number(localStorage.getItem(key) || '0')
-    const next = current + 1
-    localStorage.setItem(key, String(next))
-    return next % 2 === 0 ? 'female' : 'male'
-  } catch {
-    return 'male'
-  }
 }
 
 export default function InterviewPage() {

--- a/frontend/app/interview/types.ts
+++ b/frontend/app/interview/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared types for the interview feature.
+ */
+
+export type Utterance = {
+  role: 'user' | 'ai'
+  text: string
+}
+
+export type InterviewCompany = {
+  id: number
+  name: string
+  name_reading?: string
+  description?: string
+  main_business?: string
+  industry?: string
+  location?: string
+  employee_count?: number
+  culture?: string
+  work_style?: string
+  welfare_details?: string
+}
+
+export type Position = {
+  id: string
+  title: string
+  department: string
+  icon: string
+  questions: number
+  category: 'general' | 'sier'
+}
+
+export type InterviewStatus = 'selection' | 'lobby' | 'connecting' | 'connected' | 'error' | 'finished'

--- a/frontend/app/interview/utils.ts
+++ b/frontend/app/interview/utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure/side-effectful helper functions for the interview feature that are
+ * independent of React state — safe to unit test in isolation.
+ */
+import type { InterviewCompany } from './types'
+
+/** DB 登録企業と企業名が一致すれば id を解決。未登録なら id=0 のまま返す (#567) */
+export async function resolveCompanyByName(
+  name: string,
+  fallback?: Partial<InterviewCompany>,
+): Promise<InterviewCompany> {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    return { id: 0, name: '', ...fallback }
+  }
+  try {
+    const params = new URLSearchParams({ limit: '20', offset: '0', name: trimmed })
+    const res = await fetch(`/api/companies?${params}`, { cache: 'no-store' })
+    if (res.ok) {
+      const data = await res.json()
+      const list: InterviewCompany[] = Array.isArray(data?.companies) ? data.companies : []
+      const exact = list.find((c) => c.name === trimmed)
+      if (exact) {
+        return { ...exact, ...fallback, id: exact.id, name: exact.name }
+      }
+    }
+  } catch {
+    // ignore — 解決失敗時は id=0
+  }
+  return { id: 0, name: trimmed, ...fallback }
+}
+
+export function getNextAvatarGender(): 'male' | 'female' {
+  try {
+    const key = 'interview_avatar_index'
+    const current = Number(localStorage.getItem(key) || '0')
+    const next = current + 1
+    localStorage.setItem(key, String(next))
+    return next % 2 === 0 ? 'female' : 'male'
+  } catch {
+    return 'male'
+  }
+}

--- a/frontend/app/interview/utils.ts
+++ b/frontend/app/interview/utils.ts
@@ -33,6 +33,21 @@ export async function resolveCompanyByName(
 }
 
 /**
+ * 非同期の企業名解決結果を既存選択へ安全にマージする。
+ * - 選択名が変わっている（stale）→ 無視
+ * - 既に正の id があるのに resolved が id:0 → 正の id を潰さない
+ */
+export function mergeResolvedCompany(
+  prev: InterviewCompany | null,
+  expectedName: string,
+  resolved: InterviewCompany,
+): InterviewCompany | null {
+  if (!prev || prev.name !== expectedName) return prev
+  if (prev.id > 0 && resolved.id === 0) return prev
+  return resolved
+}
+
+/**
  * 面接アバターの性別を交互に切り替える。
  * localStorage のカウンタを進め、偶数目は female / 奇数目は male。
  */

--- a/frontend/app/interview/utils.ts
+++ b/frontend/app/interview/utils.ts
@@ -1,10 +1,12 @@
 /**
- * Pure/side-effectful helper functions for the interview feature that are
- * independent of React state — safe to unit test in isolation.
+ * 面接機能向けのヘルパー（React state 非依存。単体テストしやすい境界）。
  */
 import type { InterviewCompany } from './types'
 
-/** DB 登録企業と企業名が一致すれば id を解決。未登録なら id=0 のまま返す (#567) */
+/**
+ * DB 登録企業と企業名が一致すれば id を解決する。
+ * 未登録・検索失敗時は `id=0` のまま名前だけ返す（#567）。
+ */
 export async function resolveCompanyByName(
   name: string,
   fallback?: Partial<InterviewCompany>,
@@ -30,6 +32,10 @@ export async function resolveCompanyByName(
   return { id: 0, name: trimmed, ...fallback }
 }
 
+/**
+ * 面接アバターの性別を交互に切り替える。
+ * localStorage のカウンタを進め、偶数目は female / 奇数目は male。
+ */
 export function getNextAvatarGender(): 'male' | 'female' {
   try {
     const key = 'interview_avatar_index'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -947,37 +947,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -1028,24 +997,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1054,19 +1005,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -4921,16 +4859,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5209,13 +5147,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5798,24 +5729,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -5837,19 +5750,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -6254,39 +6154,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -9271,24 +9138,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9309,19 +9158,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/three": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,8 @@
   },
   "overrides": {
     "sharp": "^0.35.3",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "brace-expansion": "^5.0.8",
+    "minimatch": "^10.2.5"
   }
 }

--- a/frontend/tests/app/interview/SelectionScreen.test.tsx
+++ b/frontend/tests/app/interview/SelectionScreen.test.tsx
@@ -62,4 +62,26 @@ describe('SelectionScreen', () => {
     fireEvent.keyDown(radios[1], { key: 'Enter' })
     expect(setSelectedPosition).toHaveBeenCalled()
   })
+
+  it('DB一覧に名前一致があるとき id:0 の仮選択を登録企業へ昇格する', () => {
+    const setInterviewCompany = jest.fn((updater) => {
+      if (typeof updater === 'function') {
+        return updater({ id: 0, name: '登録株式会社' })
+      }
+      return updater
+    })
+    const registered = { id: 42, name: '登録株式会社', industry: 'IT' }
+
+    renderScreen({
+      companySearch: '登録株式会社',
+      interviewCompany: { id: 0, name: '登録株式会社' },
+      allCompanies: [registered],
+      setInterviewCompany,
+    })
+
+    expect(setInterviewCompany).toHaveBeenCalled()
+    const updater = setInterviewCompany.mock.calls[0][0]
+    expect(typeof updater).toBe('function')
+    expect(updater({ id: 0, name: '登録株式会社' })).toEqual(registered)
+  })
 })

--- a/frontend/tests/app/interview/SelectionScreen.test.tsx
+++ b/frontend/tests/app/interview/SelectionScreen.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import SelectionScreen from '@/app/interview/components/SelectionScreen'
+import { POSITIONS } from '@/app/interview/constants'
+import type { User } from '@/lib/auth'
+
+describe('SelectionScreen', () => {
+  const user: User = { user_id: 1, name: 'テストユーザー' } as User
+
+  const noop = () => {}
+
+  it('最小限の props でステップタイトルと企業名を表示する', () => {
+    render(
+      <SelectionScreen
+        user={user}
+        onBack={noop}
+        interviewCompany={null}
+        setInterviewCompany={noop}
+        companySourceTab="db"
+        setCompanySourceTab={noop}
+        companySearch=""
+        setCompanySearch={noop}
+        allCompanies={[]}
+        setAllCompanies={noop}
+        companiesLoading={false}
+        webSearchResults={[]}
+        setWebSearchResults={noop}
+        webSearchLoading={false}
+        positionCategory="general"
+        setPositionCategory={noop}
+        selectedPosition={POSITIONS[0]}
+        setSelectedPosition={noop}
+        companyHints={null}
+        hintsLoading={false}
+        questionDurationSeconds={180}
+        onStartInterview={noop}
+      />
+    )
+
+    expect(screen.getByText('InterviewAI')).toBeInTheDocument()
+    expect(screen.getByText('練習する企業・職種を選ぶ')).toBeInTheDocument()
+    expect(screen.getByText('企業未選択')).toBeInTheDocument()
+    expect(screen.getAllByText(POSITIONS[0].title).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/tests/app/interview/SelectionScreen.test.tsx
+++ b/frontend/tests/app/interview/SelectionScreen.test.tsx
@@ -1,13 +1,18 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import SelectionScreen from '@/app/interview/components/SelectionScreen'
 import { POSITIONS } from '@/app/interview/constants'
 import type { User } from '@/lib/auth'
 
 describe('SelectionScreen', () => {
   const user: User = { user_id: 1, name: 'テストユーザー' } as User
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
 
   const noop = () => {}
 
@@ -87,7 +92,12 @@ describe('SelectionScreen', () => {
 
   it('開始ボタン押下時に id:0 なら企業解決を確定してから進む', async () => {
     const onStartInterview = jest.fn()
-    const setInterviewCompany = jest.fn()
+    const setInterviewCompany = jest.fn((updater) => {
+      if (typeof updater === 'function') {
+        return updater({ id: 0, name: '開始前解決株式会社' })
+      }
+      return updater
+    })
     const registered = { id: 7, name: '開始前解決株式会社' }
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -105,13 +115,16 @@ describe('SelectionScreen', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '面接を開始する' }))
 
-    await screen.findByRole('button', { name: '面接を開始する' })
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(setInterviewCompany).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 7, name: '開始前解決株式会社' }),
-    )
-    expect(onStartInterview).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(setInterviewCompany).toHaveBeenCalled()
+      const updater = setInterviewCompany.mock.calls.find(
+        (call) => typeof call[0] === 'function',
+      )?.[0]
+      expect(updater).toEqual(expect.any(Function))
+      expect(updater({ id: 0, name: '開始前解決株式会社' })).toEqual(
+        expect.objectContaining({ id: 7, name: '開始前解決株式会社' }),
+      )
+      expect(onStartInterview).toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/tests/app/interview/SelectionScreen.test.tsx
+++ b/frontend/tests/app/interview/SelectionScreen.test.tsx
@@ -84,4 +84,34 @@ describe('SelectionScreen', () => {
     expect(typeof updater).toBe('function')
     expect(updater({ id: 0, name: '登録株式会社' })).toEqual(registered)
   })
+
+  it('開始ボタン押下時に id:0 なら企業解決を確定してから進む', async () => {
+    const onStartInterview = jest.fn()
+    const setInterviewCompany = jest.fn()
+    const registered = { id: 7, name: '開始前解決株式会社' }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ companies: [registered] }),
+    }) as unknown as typeof fetch
+
+    renderScreen({
+      companySearch: '開始前解決株式会社',
+      interviewCompany: { id: 0, name: '開始前解決株式会社' },
+      allCompanies: [],
+      setInterviewCompany,
+      onStartInterview,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '面接を開始する' }))
+
+    await screen.findByRole('button', { name: '面接を開始する' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(setInterviewCompany).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7, name: '開始前解決株式会社' }),
+    )
+    expect(onStartInterview).toHaveBeenCalled()
+  })
 })

--- a/frontend/tests/app/interview/SelectionScreen.test.tsx
+++ b/frontend/tests/app/interview/SelectionScreen.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import SelectionScreen from '@/app/interview/components/SelectionScreen'
 import { POSITIONS } from '@/app/interview/constants'
 import type { User } from '@/lib/auth'
@@ -11,7 +11,10 @@ describe('SelectionScreen', () => {
 
   const noop = () => {}
 
-  it('最小限の props でステップタイトルと企業名を表示する', () => {
+  function renderScreen(
+    overrides: Partial<React.ComponentProps<typeof SelectionScreen>> = {},
+  ) {
+    const setSelectedPosition = jest.fn()
     render(
       <SelectionScreen
         user={user}
@@ -31,17 +34,32 @@ describe('SelectionScreen', () => {
         positionCategory="general"
         setPositionCategory={noop}
         selectedPosition={POSITIONS[0]}
-        setSelectedPosition={noop}
+        setSelectedPosition={setSelectedPosition}
         companyHints={null}
         hintsLoading={false}
         questionDurationSeconds={180}
         onStartInterview={noop}
+        {...overrides}
       />
     )
+    return { setSelectedPosition }
+  }
+
+  it('最小限の props でステップタイトルと企業名を表示する', () => {
+    renderScreen()
 
     expect(screen.getByText('InterviewAI')).toBeInTheDocument()
     expect(screen.getByText('練習する企業・職種を選ぶ')).toBeInTheDocument()
     expect(screen.getByText('企業未選択')).toBeInTheDocument()
     expect(screen.getAllByText(POSITIONS[0].title).length).toBeGreaterThan(0)
+  })
+
+  it('職種カードをキーボード（Enter）で選択できる', () => {
+    const { setSelectedPosition } = renderScreen()
+    const radios = screen.getAllByRole('radio')
+    expect(radios.length).toBeGreaterThan(1)
+
+    fireEvent.keyDown(radios[1], { key: 'Enter' })
+    expect(setSelectedPosition).toHaveBeenCalled()
   })
 })

--- a/frontend/tests/app/interview/utils.test.ts
+++ b/frontend/tests/app/interview/utils.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { resolveCompanyByName, getNextAvatarGender } from '@/app/interview/utils'
+import { resolveCompanyByName, getNextAvatarGender, mergeResolvedCompany } from '@/app/interview/utils'
 
 describe('resolveCompanyByName', () => {
   const originalFetch = global.fetch
@@ -73,6 +73,31 @@ describe('resolveCompanyByName', () => {
     const result = await resolveCompanyByName('失敗企業')
 
     expect(result).toEqual({ id: 0, name: '失敗企業' })
+  })
+})
+
+describe('mergeResolvedCompany', () => {
+  it('選択名が変わっている場合は prev を維持する', () => {
+    // await 中にユーザーが別企業へ切り替えたケース
+    expect(
+      mergeResolvedCompany({ id: 0, name: 'B社' }, 'A社', { id: 2, name: 'A社' }),
+    ).toEqual({ id: 0, name: 'B社' })
+  })
+
+  it('正の id を id:0 の失敗結果で上書きしない', () => {
+    const prev = { id: 99, name: '登録株式会社' }
+    const resolved = { id: 0, name: '登録株式会社' }
+    expect(mergeResolvedCompany(prev, '登録株式会社', resolved)).toEqual(prev)
+  })
+
+  it('名前が一致し resolved が正の id なら更新する', () => {
+    const prev = { id: 0, name: '登録株式会社' }
+    const resolved = { id: 42, name: '登録株式会社', industry: 'IT' }
+    expect(mergeResolvedCompany(prev, '登録株式会社', resolved)).toEqual(resolved)
+  })
+
+  it('prev が null なら null のまま', () => {
+    expect(mergeResolvedCompany(null, 'X', { id: 1, name: 'X' })).toBeNull()
   })
 })
 

--- a/frontend/tests/app/interview/utils.test.ts
+++ b/frontend/tests/app/interview/utils.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import { resolveCompanyByName, getNextAvatarGender } from '@/app/interview/utils'
+
+describe('resolveCompanyByName', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  it('空文字の場合は id=0 の空エントリを返す', async () => {
+    const result = await resolveCompanyByName('  ')
+    expect(result).toEqual({ id: 0, name: '' })
+  })
+
+  it('DB に完全一致する企業が見つかれば id を解決する', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        companies: [
+          { id: 42, name: '株式会社テスト', industry: 'IT' },
+        ],
+      }),
+    }) as unknown as typeof fetch
+
+    const result = await resolveCompanyByName('株式会社テスト')
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/companies?'),
+      expect.objectContaining({ cache: 'no-store' }),
+    )
+    expect(result).toEqual({ id: 42, name: '株式会社テスト', industry: 'IT' })
+  })
+
+  it('fallback は解決済みデータより優先されない基本フィールド以外を補完する', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        companies: [{ id: 7, name: '未来株式会社' }],
+      }),
+    }) as unknown as typeof fetch
+
+    const result = await resolveCompanyByName('未来株式会社', { industry: '製造業' })
+
+    expect(result).toEqual({ id: 7, name: '未来株式会社', industry: '製造業' })
+  })
+
+  it('一致する企業が見つからない場合は id=0 で fallback を保持する', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ companies: [] }),
+    }) as unknown as typeof fetch
+
+    const result = await resolveCompanyByName('未登録企業', { description: '説明' })
+
+    expect(result).toEqual({ id: 0, name: '未登録企業', description: '説明' })
+  })
+
+  it('fetch が失敗した場合も id=0 のフォールバックを返す', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch
+
+    const result = await resolveCompanyByName('エラー企業')
+
+    expect(result).toEqual({ id: 0, name: 'エラー企業' })
+  })
+
+  it('レスポンスが ok でない場合も id=0 のフォールバックを返す', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch
+
+    const result = await resolveCompanyByName('失敗企業')
+
+    expect(result).toEqual({ id: 0, name: '失敗企業' })
+  })
+})
+
+describe('getNextAvatarGender', () => {
+  const KEY = 'interview_avatar_index'
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('呼び出しごとに male / female を交互に返す', () => {
+    expect(getNextAvatarGender()).toBe('male')
+    expect(getNextAvatarGender()).toBe('female')
+    expect(getNextAvatarGender()).toBe('male')
+  })
+
+  it('localStorage にインデックスを永続化する', () => {
+    getNextAvatarGender()
+    expect(localStorage.getItem(KEY)).toBe('1')
+    getNextAvatarGender()
+    expect(localStorage.getItem(KEY)).toBe('2')
+  })
+
+  it('localStorage が使用できない場合は male を返す', () => {
+    const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('unavailable')
+    })
+    expect(getNextAvatarGender()).toBe('male')
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
Closes #653
Closes #652

親: #649

## 変更内容
- リファクタ事前調査書を `docs/design/refactoring-investigation.md` に追加
- `interview/page.tsx` から types / constants / utils を抽出
- `SelectionScreen` / `ConsentDialog` をプレゼンテーショナルコンポーネントとして分離
- page は ~1939 → ~1409 行（メディア・VAD・ロビー/セッションは未移動）
- utils / SelectionScreen のユニットテストを追加

## やらないこと（後続 Issue）
- #654 Lobby/Report
- #655 Session プレゼンテーション
- #656 media/session hooks

## Test plan
- [ ] `/interview` で企業・職種選択 → ロビーへ遷移できる
- [ ] 企業管理 / WEB検索タブが従来どおり動く
- [ ] `cd frontend && npm test -- --testPathPatterns=interview` が通る


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 面接練習前に、録画・会話テキスト収集への同意を確認するダイアログを追加。
  - 企業や職種を選択し、企業情報・面接概要を確認できる選択画面を追加。
  - 未登録企業の検索や企業情報の自動補完に対応。
  - 面接中に使用するアバターを切り替え可能にしました。

- **ドキュメント**
  - リファクタリング調査、リスク、段階的な進め方、評価指標を整理した資料を追加。

- **テスト**
  - 面接選択画面と企業検索・アバター切り替え機能のテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->