### PR TITLE
fix: チャット履歴ロード時の 401 でログイン画面へリダイレクトする

### DIFF
--- a/frontend/components/job-agent-chat.tsx
+++ b/frontend/components/job-agent-chat.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect } from "react"
+import { useRouter } from "next/navigation"
 import styles from "./job-agent-chat.module.css"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -10,7 +11,8 @@ import { Progress } from "@/components/ui/progress"
 import { Send, Bot, User } from "lucide-react"
 import { CompanyResults } from "@/components/company-results"
 import { AnalysisLoading } from "@/components/analysis-loading"
-import { sendChatMessage, getChatHistory, getUserScores, type ChatResponse, type ChatScore } from "@/lib/api"
+import { sendChatMessage, getChatHistory, getUserScores, ApiError, type ChatResponse, type ChatScore } from "@/lib/api"
+import { authService } from "@/lib/auth"
 
 type Message = {
   id: string
@@ -54,6 +56,8 @@ function extractChoices(content: string): { choices: ChoiceOption[], mainText: s
 }
 
 export function JobAgentChat() {
+  const router = useRouter()
+
   // セッションIDを最初に初期化（他のstateより先に）
   const [sessionId, setSessionId] = useState<string>(() => {
     if (typeof window !== 'undefined') {
@@ -194,6 +198,11 @@ export function JobAgentChat() {
         history = await getChatHistory(sessionId)
       } catch (error) {
         console.error("Failed to load chat history:", error)
+        if (error instanceof ApiError && error.httpStatus === 401) {
+          authService.logout()
+          router.replace('/login')
+          return
+        }
         // #569: 履歴取得失敗時は挨拶ではなくエラー UI
         setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
         setMessages([])
@@ -220,6 +229,11 @@ export function JobAgentChat() {
         history = await getChatHistory(sessionId)
       } catch (error) {
         console.error("Failed to load history (retry):", error)
+        if (error instanceof ApiError && error.httpStatus === 401) {
+          authService.logout()
+          router.replace('/login')
+          return
+        }
         setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
         setMessages([])
         return

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -21,7 +21,7 @@ import {
   DialogActions,
 } from '@mui/material'
 import { Send, SmartToy, Person, Refresh, Business, LocationOn, People, TrendingUp as TrendingUpIcon } from '@mui/icons-material'
-import { sendChatMessage, getChatHistory, getUserScores, ChatRequest, ChatResponse } from '@/lib/api'
+import { sendChatMessage, getChatHistory, getUserScores, ChatRequest, ChatResponse, ApiError } from '@/lib/api'
 import { authService } from '@/lib/auth'
 import { buildResultsPath, getResultsSessionContext } from '@/lib/results-navigation'
 import { resolveChatOutgoingMessage } from '@/lib/chat-choices'
@@ -223,6 +223,11 @@ export function MuiChat() {
       await loadChatHistory(sessionId)
     } catch (error) {
       console.error('[MUI Chat] Failed to load history (retry):', error)
+      if (error instanceof ApiError && error.httpStatus === 401) {
+        authService.logout()
+        router.replace('/login')
+        return
+      }
       setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
       setMessages([])
     } finally {
@@ -269,6 +274,11 @@ export function MuiChat() {
         await loadChatHistory(storedSessionId)
       } catch (error) {
         console.error('[MUI Chat] Failed to load history:', error)
+        if (error instanceof ApiError && error.httpStatus === 401) {
+          authService.logout()
+          router.replace('/login')
+          return
+        }
         // #569: 失敗時は挨拶ではなくエラー UI（再試行で復元）
         setHistoryLoadError('履歴の読み込みに失敗しました。通信状況を確認して、もう一度お試しください。')
         setMessages([])

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -104,6 +104,13 @@ export async function sendChatMessage(request: ChatRequest): Promise<ChatRespons
     }
 }
 
+export class ApiError extends Error {
+    constructor(message: string, public readonly httpStatus: number) {
+        super(message)
+        this.name = 'ApiError'
+    }
+}
+
 export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> {
     const response = await fetch(`${API_BASE}/chat/history?session_id=${sessionId}`, {
         headers: authService.getUserFetchHeaders(),
@@ -112,7 +119,7 @@ export async function getChatHistory(sessionId: string): Promise<ChatHistory[]> 
     if (!response.ok) {
         const errorText = await response.text().catch(() => response.statusText)
         console.error('[API] History error:', response.status, errorText)
-        throw new Error(`History API error: ${errorText || response.statusText}`)
+        throw new ApiError(`History API error: ${errorText || response.statusText}`, response.status)
     }
 
     const raw = await response.json()


### PR DESCRIPTION
## 概要

JWT アクセストークン（有効期限 1 時間）が失効した状態でチャット履歴を読み込むと、バックエンドが 401 を返すにもかかわらず「通信状況を確認して、もう一度お試しください。」という誤ったエラーメッセージが表示されていた問題を修正します。

## 変更内容

- **`frontend/lib/api.ts`**
  - `ApiError` クラスを追加し、HTTP ステータスコードをエラーオブジェクトに保持できるように変更
  - `getChatHistory` が非 200 応答を受け取った際に `ApiError` をスロー

- **`frontend/components/mui-chat.tsx`**
  - 初回ロードおよびリトライ時の catch ブロックで `ApiError` の `httpStatus === 401` を検出
  - 401 の場合は `authService.logout()` → `/login` へリダイレクト

- **`frontend/components/job-agent-chat.tsx`**
  - 同様に `useRouter` / `authService` / `ApiError` を追加
  - 401 時はログイン画面へリダイレクト

## 動作

| 状況 | 修正前 | 修正後 |
|---|---|---|
| JWT 失効（401） | 「通信エラー」表示で止まる | ログアウト後 `/login` へ自動遷移 |
| バックエンド障害（500） | 「通信エラー」表示 | 変わらず「通信エラー」表示 |

## テスト確認手順

1. ログイン後、セッションストレージの `user_token` を無効な値に書き換えるか、1 時間以上経過させる
2. トップページへアクセス
3. ログイン画面に自動リダイレクトされることを確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized auth UX change on history fetch only; no backend or token validation logic changes.
> 
> **Overview**
> **Expired JWT on chat history load** no longer shows a generic “check your connection” error. `getChatHistory` now throws an **`ApiError`** that carries the HTTP status, and both **`job-agent-chat`** and **`mui-chat`** treat **401** on initial load and retry by calling **`authService.logout()`** and navigating to **`/login`**.
> 
> Other failures (e.g. 500) still use the existing history error UI and retry flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f437a857b3c01ca6bca27ee3f3a272a54bd6233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->