### PR TITLE
Resolve #693: resume/page.tsx を hooks/components 分割

### DIFF
--- a/frontend/app/resume/components/ResumePageHeader.tsx
+++ b/frontend/app/resume/components/ResumePageHeader.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Box, IconButton, Typography } from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+
+type ResumePageHeaderProps = {
+  router: AppRouterInstance
+  prefilledCompany: string
+  prefilledIndustry: string
+}
+
+export function ResumePageHeader({ router, prefilledCompany, prefilledIndustry }: ResumePageHeaderProps) {
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <IconButton
+          onClick={() => router.back()}
+          size="small"
+          aria-label="前のページに戻る"
+          sx={{ bgcolor: '#f1f5f9', color: '#475569' }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h4" fontWeight="bold" sx={{ fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>
+          履歴書・エントリシート レビュー
+        </Typography>
+      </Box>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: prefilledCompany ? 1.5 : 3 }}>
+        PDF/DOCX/Google Docsをアップロードして、注釈付きPDFを生成します。
+      </Typography>
+      {prefilledCompany && (
+        <Box sx={{ mb: 3, px: 2, py: 1.5, bgcolor: '#e8f5e9', borderRadius: 1, border: '1px solid #a5d6a7' }}>
+          <Typography sx={{ fontSize: 14, color: '#2e7d32', fontWeight: 600 }}>
+            {prefilledCompany}{prefilledIndustry ? `（${prefilledIndustry}）` : ''}向けに最適化されたフィードバックを提供します
+          </Typography>
+          <Typography sx={{ fontSize: 12, color: '#388e3c', mt: 0.5 }}>
+            企業の求める人材像を踏まえたアドバイスが反映されます
+          </Typography>
+        </Box>
+      )}
+    </>
+  )
+}

--- a/frontend/app/resume/components/ResumePageHeader.tsx
+++ b/frontend/app/resume/components/ResumePageHeader.tsx
@@ -2,15 +2,16 @@
 
 import { Box, IconButton, Typography } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { useRouter } from 'next/navigation'
 
 type ResumePageHeaderProps = {
-  router: AppRouterInstance
   prefilledCompany: string
   prefilledIndustry: string
 }
 
-export function ResumePageHeader({ router, prefilledCompany, prefilledIndustry }: ResumePageHeaderProps) {
+export function ResumePageHeader({ prefilledCompany, prefilledIndustry }: ResumePageHeaderProps) {
+  const router = useRouter()
+
   return (
     <>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>

--- a/frontend/app/resume/components/ResumeRagReport.tsx
+++ b/frontend/app/resume/components/ResumeRagReport.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { Box, Paper, Typography } from '@mui/material'
+
+type ResumeRagReportProps = {
+  ragReport: string
+  reviewLoading: boolean
+}
+
+export function ResumeRagReport({ ragReport, reviewLoading }: ResumeRagReportProps) {
+  if (!ragReport) return null
+
+  return (
+    <Paper sx={{ p: 3, mt: 4 }} elevation={2}>
+      <Typography variant="h5" fontWeight="bold" gutterBottom>
+        企業別レビューレポート
+        {reviewLoading && (
+          <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+            生成中...
+          </Typography>
+        )}
+      </Typography>
+      <Box
+        sx={{
+          whiteSpace: 'pre-wrap',
+          fontFamily: 'inherit',
+          fontSize: '0.95rem',
+          lineHeight: 1.8,
+          color: 'text.primary',
+        }}
+      >
+        {ragReport}
+      </Box>
+    </Paper>
+  )
+}

--- a/frontend/app/resume/components/ResumeReviewForm.tsx
+++ b/frontend/app/resume/components/ResumeReviewForm.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import type { CompanyCandidate } from '../types'
+
+type ResumeReviewFormProps = {
+  companyQuery: string
+  onCompanyQueryChange: (value: string) => void
+  companyName: string
+  companyValidated: boolean
+  companySearchLoading: boolean
+  companySearchError: string
+  selectedCompanyMeta: CompanyCandidate | null
+  companyCandidates: CompanyCandidate[]
+  onSearchCompanies: (includeWebSearch: boolean) => void
+  onSelectCompany: (candidate: CompanyCandidate) => void
+  onClearSelectedCompany: () => void
+  jobTitle: string
+  onJobTitleChange: (value: string) => void
+  candidateType: string
+  onCandidateTypeChange: (value: string) => void
+  documentId: number | null
+  reviewLoading: boolean
+  ragReport: string
+  reviewError: string
+  reviewCompleted: boolean
+  onReview: () => void
+}
+
+export function ResumeReviewForm({
+  companyQuery,
+  onCompanyQueryChange,
+  companyName,
+  companyValidated,
+  companySearchLoading,
+  companySearchError,
+  selectedCompanyMeta,
+  companyCandidates,
+  onSearchCompanies,
+  onSelectCompany,
+  onClearSelectedCompany,
+  jobTitle,
+  onJobTitleChange,
+  candidateType,
+  onCandidateTypeChange,
+  documentId,
+  reviewLoading,
+  ragReport,
+  reviewError,
+  reviewCompleted,
+  onReview,
+}: ResumeReviewFormProps) {
+  return (
+    <Paper sx={{ p: 3 }} elevation={2}>
+      <Stack spacing={2}>
+        <Typography variant="h6">レビュー実行</Typography>
+        <Typography variant="body2" color="text.secondary">
+          企業を指定する場合は、DB検索またはWEB実在確認で候補を選択してください（自由入力のみではレビューできません）。
+          企業なしで職種のみの一般レビューも可能です。
+        </Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'flex-start' }}>
+          <TextField
+            label="応募企業名を検索"
+            value={companyQuery}
+            onChange={(e) => onCompanyQueryChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void onSearchCompanies(false)
+              }
+            }}
+            fullWidth
+            helperText={companyValidated ? `選択済み: ${companyName}` : '未選択（職種のみレビュー可）'}
+          />
+          <Button
+            variant="outlined"
+            onClick={() => onSearchCompanies(false)}
+            disabled={companySearchLoading || !companyQuery.trim()}
+            sx={{ whiteSpace: 'nowrap', minWidth: 100 }}
+          >
+            DB検索
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => onSearchCompanies(true)}
+            disabled={companySearchLoading || !companyQuery.trim()}
+            sx={{ whiteSpace: 'nowrap', minWidth: 140 }}
+          >
+            WEBで実在確認
+          </Button>
+        </Stack>
+        {companySearchLoading && <LinearProgress />}
+        {companySearchError && <Alert severity="warning">{companySearchError}</Alert>}
+        {selectedCompanyMeta && (
+          <Alert
+            severity="success"
+            action={
+              <Button color="inherit" size="small" onClick={onClearSelectedCompany}>
+                クリア
+              </Button>
+            }
+          >
+            確定: {selectedCompanyMeta.name}
+            {selectedCompanyMeta.source ? `（${selectedCompanyMeta.source}）` : ''}
+            {selectedCompanyMeta.evidence_urls?.[0] ? ` / ${selectedCompanyMeta.evidence_urls[0]}` : ''}
+          </Alert>
+        )}
+        {companyCandidates.length > 0 && (
+          <Stack spacing={1}>
+            <Typography variant="subtitle2">候補から選択</Typography>
+            {companyCandidates.map((c) => (
+              <Card
+                key={`${c.source}-${c.company_id ?? c.name}`}
+                variant="outlined"
+                sx={{ cursor: 'pointer', '&:hover': { borderColor: 'primary.main' } }}
+                onClick={() => onSelectCompany(c)}
+              >
+                <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                  <Typography fontWeight="bold">{c.name}</Typography>
+                  {c.description && (
+                    <Typography variant="body2" color="text.secondary">
+                      {c.description}
+                    </Typography>
+                  )}
+                  <Chip size="small" label={c.source} sx={{ mt: 0.5 }} />
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        )}
+        <TextField
+          label={companyName.trim() ? '応募職種 (任意)' : '応募職種 (企業名未選択の場合は必須)'}
+          value={jobTitle}
+          onChange={(e) => onJobTitleChange(e.target.value)}
+          fullWidth
+          required={!companyName.trim()}
+          error={!companyName.trim() && !jobTitle.trim()}
+          helperText={!companyName.trim() ? '企業未選択の場合は職種を入力すると一般レビューが実行されます' : ''}
+        />
+        <TextField
+          select
+          label="候補者区分"
+          value={candidateType}
+          onChange={(e) => onCandidateTypeChange(e.target.value)}
+          fullWidth
+        >
+          <MenuItem value="new_grad">新卒</MenuItem>
+          <MenuItem value="mid_career">中途</MenuItem>
+        </TextField>
+        <Button variant="contained" onClick={onReview} disabled={reviewLoading || !documentId}>
+          レビューを生成
+        </Button>
+        {reviewLoading && (
+          <Box>
+            <LinearProgress />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              {ragReport ? '企業別レビューレポートを生成中...' : 'PDFを解析中...（通常30〜60秒かかります）'}
+            </Typography>
+          </Box>
+        )}
+        {reviewError && (
+          <Alert severity="error">{reviewError}</Alert>
+        )}
+        {reviewCompleted && !reviewLoading && (
+          <Alert severity="success">レビューが完了しました。下の指摘事項をご確認ください。</Alert>
+        )}
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/app/resume/components/ResumeReviewForm.tsx
+++ b/frontend/app/resume/components/ResumeReviewForm.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Card,
+  CardActionArea,
   CardContent,
   Chip,
   LinearProgress,
@@ -25,7 +26,7 @@ type ResumeReviewFormProps = {
   companySearchError: string
   selectedCompanyMeta: CompanyCandidate | null
   companyCandidates: CompanyCandidate[]
-  onSearchCompanies: (includeWebSearch: boolean) => void
+  onSearchCompanies: (includeWebSearch: boolean) => void | Promise<void>
   onSelectCompany: (candidate: CompanyCandidate) => void
   onClearSelectedCompany: () => void
   jobTitle: string
@@ -125,18 +126,19 @@ export function ResumeReviewForm({
               <Card
                 key={`${c.source}-${c.company_id ?? c.name}`}
                 variant="outlined"
-                sx={{ cursor: 'pointer', '&:hover': { borderColor: 'primary.main' } }}
-                onClick={() => onSelectCompany(c)}
+                sx={{ '&:hover': { borderColor: 'primary.main' } }}
               >
-                <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-                  <Typography fontWeight="bold">{c.name}</Typography>
-                  {c.description && (
-                    <Typography variant="body2" color="text.secondary">
-                      {c.description}
-                    </Typography>
-                  )}
-                  <Chip size="small" label={c.source} sx={{ mt: 0.5 }} />
-                </CardContent>
+                <CardActionArea onClick={() => onSelectCompany(c)}>
+                  <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                    <Typography fontWeight="bold">{c.name}</Typography>
+                    {c.description && (
+                      <Typography variant="body2" color="text.secondary">
+                        {c.description}
+                      </Typography>
+                    )}
+                    <Chip size="small" label={c.source} sx={{ mt: 0.5 }} />
+                  </CardContent>
+                </CardActionArea>
               </Card>
             ))}
           </Stack>

--- a/frontend/app/resume/components/ResumeReviewResults.tsx
+++ b/frontend/app/resume/components/ResumeReviewResults.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material'
+import ScoreUpdateBanner, { type WeightScore } from '@/components/ScoreUpdateBanner'
+import type { ReviewResult } from '../types'
+import { getSeverityConfig } from '../utils'
+
+type ResumeReviewResultsProps = {
+  review: ReviewResult | null
+  scoresBefore: WeightScore[] | null
+  scoresAfter: WeightScore[] | null
+  annotateError: string
+  onDownload: () => void
+}
+
+export function ResumeReviewResults({
+  review,
+  scoresBefore,
+  scoresAfter,
+  annotateError,
+  onDownload,
+}: ResumeReviewResultsProps) {
+  if (!review) return null
+
+  return (
+    <>
+      {scoresAfter && (
+        <Box mt={4}>
+          <ScoreUpdateBanner
+            beforeScores={scoresBefore}
+            afterScores={scoresAfter}
+            title="職務経歴書レビュー結果がプロフィールスコアに反映されました"
+          />
+        </Box>
+      )}
+
+      <Paper sx={{ p: 3, mt: 4 }} elevation={2}>
+        <Typography variant="h5" fontWeight="bold" gutterBottom>
+          指摘事項
+        </Typography>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            総合スコア: {review.review.score} / 100
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            {review.review.summary}
+          </Typography>
+        </Box>
+        <Divider sx={{ mb: 3 }} />
+        <Stack spacing={2}>
+          {review.items.map((item) => {
+            const config = getSeverityConfig(item.severity)
+            return (
+              <Card
+                key={item.id}
+                variant="outlined"
+                sx={{ borderLeft: 4, borderLeftColor: config.borderColor }}
+              >
+                <CardContent>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Chip label={config.label} color={config.color} size="small" />
+                    <Typography variant="caption" color="text.secondary">
+                      ページ {item.page_number}
+                    </Typography>
+                  </Box>
+                  <Typography variant="body1" fontWeight="medium">
+                    {item.message}
+                  </Typography>
+                  {item.suggestion && (
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                      改善案: {item.suggestion}
+                    </Typography>
+                  )}
+                </CardContent>
+              </Card>
+            )
+          })}
+        </Stack>
+        <Box sx={{ mt: 3 }}>
+          {annotateError && (
+            <Alert severity="warning" sx={{ mb: 2 }}>{annotateError}</Alert>
+          )}
+          {review.annotated_available && (
+            <Button variant="outlined" onClick={onDownload}>
+              注釈PDFをダウンロード
+            </Button>
+          )}
+        </Box>
+      </Paper>
+    </>
+  )
+}

--- a/frontend/app/resume/components/ResumeReviewResults.tsx
+++ b/frontend/app/resume/components/ResumeReviewResults.tsx
@@ -59,7 +59,7 @@ export function ResumeReviewResults({
         </Box>
         <Divider sx={{ mb: 3 }} />
         <Stack spacing={2}>
-          {review.items.map((item) => {
+          {(review.items ?? []).map((item) => {
             const config = getSeverityConfig(item.severity)
             return (
               <Card

--- a/frontend/app/resume/components/ResumeUploadForm.tsx
+++ b/frontend/app/resume/components/ResumeUploadForm.tsx
@@ -86,7 +86,7 @@ export function ResumeUploadForm({
         {uploadError && (
           <Alert severity="error">{uploadError}</Alert>
         )}
-        {documentId && (
+        {documentId !== null && (
           <Alert severity="success">
             アップロード完了！下のフォームでレビューを実行してください。
           </Alert>

--- a/frontend/app/resume/components/ResumeUploadForm.tsx
+++ b/frontend/app/resume/components/ResumeUploadForm.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import {
+  Alert,
+  Box,
+  Button,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+
+type ResumeUploadFormProps = {
+  sourceType: string
+  onSourceTypeChange: (value: string) => void
+  sourceUrl: string
+  onSourceUrlChange: (value: string) => void
+  file: File | null
+  onFileChange: (file: File | null) => void
+  loading: boolean
+  uploadError: string
+  documentId: number | null
+  onUpload: () => void
+}
+
+export function ResumeUploadForm({
+  sourceType,
+  onSourceTypeChange,
+  sourceUrl,
+  onSourceUrlChange,
+  file,
+  onFileChange,
+  loading,
+  uploadError,
+  documentId,
+  onUpload,
+}: ResumeUploadFormProps) {
+  return (
+    <Paper sx={{ p: 3, mb: 3 }} elevation={2}>
+      <Stack spacing={2}>
+        <TextField
+          select
+          label="提出形式"
+          value={sourceType}
+          onChange={(e) => onSourceTypeChange(e.target.value)}
+          fullWidth
+        >
+          <MenuItem value="pdf">PDF</MenuItem>
+          <MenuItem value="docx">DOCX</MenuItem>
+          <MenuItem value="google_docs">Google Docs</MenuItem>
+        </TextField>
+        <TextField
+          label="Google Docs / URL (任意)"
+          value={sourceUrl}
+          onChange={(e) => onSourceUrlChange(e.target.value)}
+          placeholder="https://... (PDFエクスポートURL)"
+          fullWidth
+        />
+        <Button variant="outlined" component="label">
+          ファイルを選択
+          <input
+            type="file"
+            hidden
+            accept=".pdf,.docx"
+            onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+          />
+        </Button>
+        {file && (
+          <Typography variant="body2" color="text.secondary">
+            選択ファイル: {file.name}
+          </Typography>
+        )}
+        <Button variant="contained" onClick={onUpload} disabled={loading}>
+          アップロード
+        </Button>
+        {loading && (
+          <Box>
+            <LinearProgress />
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              アップロード中...
+            </Typography>
+          </Box>
+        )}
+        {uploadError && (
+          <Alert severity="error">{uploadError}</Alert>
+        )}
+        {documentId && (
+          <Alert severity="success">
+            アップロード完了！下のフォームでレビューを実行してください。
+          </Alert>
+        )}
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/app/resume/hooks/useResumePage.ts
+++ b/frontend/app/resume/hooks/useResumePage.ts
@@ -1,0 +1,351 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { authService } from '@/lib/auth'
+import type { WeightScore } from '@/components/ScoreUpdateBanner'
+import type { CompanyCandidate, ReviewResult } from '../types'
+import {
+  isAnnotatedPdfResponse,
+  mapDbCompanyResults,
+  mapWebSearchResults,
+  parseApiErrorMessage,
+} from '../utils'
+
+/**
+ * 履歴書レビューページの state・副作用・イベントハンドラ。
+ */
+export function useResumePage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [userId, setUserId] = useState('')
+  const [sessionId, setSessionId] = useState('')
+  const [sourceType, setSourceType] = useState('pdf')
+  const [sourceUrl, setSourceUrl] = useState('')
+  const [companyName, setCompanyName] = useState('')
+  const [companyQuery, setCompanyQuery] = useState('')
+  const [companyCandidates, setCompanyCandidates] = useState<CompanyCandidate[]>([])
+  const [companyValidated, setCompanyValidated] = useState(false)
+  const [companySearchLoading, setCompanySearchLoading] = useState(false)
+  const [companySearchError, setCompanySearchError] = useState('')
+  const [selectedCompanyMeta, setSelectedCompanyMeta] = useState<CompanyCandidate | null>(null)
+  const [jobTitle, setJobTitle] = useState('')
+  const [candidateType, setCandidateType] = useState('new_grad')
+  const [file, setFile] = useState<File | null>(null)
+  const [documentId, setDocumentId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [reviewLoading, setReviewLoading] = useState(false)
+  const [uploadError, setUploadError] = useState('')
+  const [reviewError, setReviewError] = useState('')
+  const [annotateError, setAnnotateError] = useState('')
+  const [review, setReview] = useState<ReviewResult | null>(null)
+  const [ragReport, setRagReport] = useState('')
+  const [scoresBefore, setScoresBefore] = useState<WeightScore[] | null>(null)
+  const [scoresAfter, setScoresAfter] = useState<WeightScore[] | null>(null)
+
+  const prefilledCompany = searchParams.get('company_name') || ''
+  const prefilledIndustry = searchParams.get('industry') || ''
+
+  const checkAnnotatedPdfAvailable = async (id: number) => {
+    try {
+      const response = await fetch(`/api/resume/annotated?document_id=${id}`, {
+        headers: { Range: 'bytes=0-0', ...authService.getUserFetchHeaders() },
+      })
+      if (!response.ok) return false
+      return isAnnotatedPdfResponse(
+        response.headers.get('content-type') || '',
+        response.headers.get('content-disposition') || '',
+        response.status,
+      )
+    } catch {
+      return false
+    }
+  }
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (user?.user_id) {
+      setUserId(String(user.user_id))
+    }
+    if (typeof window !== 'undefined') {
+      const storedSession =
+        sessionStorage.getItem('chatSessionId') ||
+        localStorage.getItem('currentSessionId') ||
+        ''
+      setSessionId(storedSession)
+    }
+    if (prefilledCompany) {
+      setCompanyName(prefilledCompany)
+      setCompanyQuery(prefilledCompany)
+      setCompanyValidated(false)
+      setSelectedCompanyMeta(null)
+    }
+  }, [prefilledCompany])
+
+  const selectCompany = (candidate: CompanyCandidate) => {
+    setCompanyName(candidate.name)
+    setCompanyQuery(candidate.name)
+    setCompanyValidated(true)
+    setSelectedCompanyMeta(candidate)
+    setCompanyCandidates([])
+    setCompanySearchError('')
+  }
+
+  const clearSelectedCompany = () => {
+    setCompanyName('')
+    setCompanyQuery('')
+    setCompanyValidated(false)
+    setSelectedCompanyMeta(null)
+    setCompanyCandidates([])
+    setCompanySearchError('')
+  }
+
+  const handleCompanyQueryChange = (value: string) => {
+    setCompanyQuery(value)
+    setCompanyValidated(false)
+    setSelectedCompanyMeta(null)
+    setCompanyName('')
+  }
+
+  const handleSearchCompanies = async (includeWebSearch: boolean) => {
+    const q = companyQuery.trim()
+    if (!q) {
+      setCompanySearchError('企業名を入力してください')
+      return
+    }
+    setCompanySearchLoading(true)
+    setCompanySearchError('')
+    setCompanyCandidates([])
+    try {
+      if (!includeWebSearch) {
+        const res = await fetch(`/api/companies?name=${encodeURIComponent(q)}&limit=5`, { cache: 'no-store' })
+        if (!res.ok) {
+          const errText = await res.text()
+          throw new Error(parseApiErrorMessage(errText, 'DB検索に失敗しました'))
+        }
+        const data = await res.json()
+        const list = mapDbCompanyResults(data)
+        setCompanyCandidates(list)
+        if (list.length === 0) {
+          setCompanySearchError('DBに該当企業がありません。「WEBで実在確認」を試してください')
+        }
+        return
+      }
+
+      // WEB: 候補一覧 API（DB優先 + WEB補完）。単体 validate より候補選択しやすい
+      const res = await fetch(`/api/companies/web-search?q=${encodeURIComponent(q)}`, { cache: 'no-store' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(parseApiErrorMessage(JSON.stringify(data), 'WEB検索に失敗しました'))
+      }
+      const list = mapWebSearchResults(data)
+      setCompanyCandidates(list)
+      if (list.length === 0) {
+        setCompanyValidated(false)
+        setSelectedCompanyMeta(null)
+        setCompanyName('')
+        setCompanySearchError('候補が見つかりませんでした。企業名を変えて再検索するか、職種のみでレビューしてください')
+      }
+    } catch (err) {
+      setCompanySearchError(err instanceof Error ? err.message : '企業検索に失敗しました')
+    } finally {
+      setCompanySearchLoading(false)
+    }
+  }
+
+  const handleUpload = async () => {
+    setUploadError('')
+    setReview(null)
+    setLoading(true)
+    try {
+      if (!userId) {
+        throw new Error('user_id が取得できません。ログインしてください。')
+      }
+      const formData = new FormData()
+      formData.append('user_id', userId)
+      if (sessionId) {
+        formData.append('session_id', sessionId)
+      }
+      formData.append('source_type', sourceType)
+      if (sourceUrl) {
+        formData.append('source_url', sourceUrl)
+      }
+      if (file) {
+        formData.append('file', file)
+      }
+
+      const response = await fetch('/api/resume/upload', {
+        method: 'POST',
+        headers: authService.getUserFetchHeaders(),
+        body: formData,
+      })
+      if (!response.ok) {
+        const errText = await response.text()
+        throw new Error(parseApiErrorMessage(errText, 'Upload failed'))
+      }
+      const data = await response.json()
+      setDocumentId(data?.document?.id ?? null)
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleReview = async () => {
+    if (!documentId) {
+      setReviewError('document_id が未設定です')
+      return
+    }
+    if (!companyName.trim() && !jobTitle.trim()) {
+      setReviewError('企業名が未入力の場合は応募職種を入力してください')
+      return
+    }
+    if (companyName.trim() && !companyValidated) {
+      setReviewError('企業を検索して候補から選択するか、「WEBで実在確認」を実行してください')
+      return
+    }
+    setReviewError('')
+    setAnnotateError('')
+    setReview(null)
+    setRagReport('')
+    setScoresAfter(null)
+    setReviewLoading(true)
+
+    if (userId && sessionId) {
+      try {
+        const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
+        const data = await res.json()
+        setScoresBefore(data.weight_scores ?? null)
+      } catch { /* ignore */ }
+    }
+
+    try {
+      const response = await fetch(`/api/resume/review/stream?document_id=${documentId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
+        body: JSON.stringify({
+          company_name: companyName,
+          job_title: jobTitle,
+          candidate_type: candidateType,
+        }),
+      })
+
+      if (!response.ok || !response.body) {
+        const errText = await response.text()
+        throw new Error(errText || 'Review failed')
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const data = JSON.parse(line.slice(6))
+            if (data.type === 'chunk') {
+              setRagReport((prev) => prev + data.text)
+            } else if (data.type === 'complete') {
+              const backendAnnotated = data.annotated_available === true
+              const annotatedAvailable = backendAnnotated || (documentId ? await checkAnnotatedPdfAvailable(documentId) : false)
+              setReview({ review: data.review, items: data.items, annotated_available: annotatedAvailable })
+              if (userId && sessionId) {
+                try {
+                  const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
+                  const scoreData = await res.json()
+                  setScoresAfter(scoreData.weight_scores ?? null)
+                } catch { /* ignore */ }
+              }
+            } else if (data.type === 'annotate_error') {
+              setAnnotateError(data.message)
+            } else if (data.type === 'error') {
+              throw new Error(data.message)
+            }
+          } catch (parseErr) {
+            if (parseErr instanceof Error && parseErr.message !== 'Unexpected token') {
+              throw parseErr
+            }
+          }
+        }
+      }
+    } catch (err) {
+      setReviewError(err instanceof Error ? err.message : 'Review failed')
+    } finally {
+      setReviewLoading(false)
+    }
+  }
+
+  const handleDownload = () => {
+    if (!documentId) {
+      setReviewError('document_id が未設定です')
+      return
+    }
+    void (async () => {
+      try {
+        setReviewError('')
+        const response = await fetch(`/api/resume/annotated?document_id=${documentId}`, {
+          headers: authService.getUserFetchHeaders(),
+        })
+        if (!response.ok) {
+          const errText = await response.text()
+          throw new Error(errText || 'Download failed')
+        }
+        const blob = await response.blob()
+        const url = URL.createObjectURL(blob)
+        window.open(url, '_blank')
+        setTimeout(() => URL.revokeObjectURL(url), 60_000)
+      } catch (err) {
+        setReviewError(err instanceof Error ? err.message : 'Download failed')
+      }
+    })()
+  }
+
+  return {
+    router,
+    prefilledCompany,
+    prefilledIndustry,
+    sourceType,
+    setSourceType,
+    sourceUrl,
+    setSourceUrl,
+    file,
+    setFile,
+    loading,
+    uploadError,
+    documentId,
+    handleUpload,
+    companyQuery,
+    handleCompanyQueryChange,
+    companyName,
+    companyValidated,
+    companySearchLoading,
+    companySearchError,
+    selectedCompanyMeta,
+    companyCandidates,
+    selectCompany,
+    clearSelectedCompany,
+    handleSearchCompanies,
+    jobTitle,
+    setJobTitle,
+    candidateType,
+    setCandidateType,
+    reviewLoading,
+    reviewError,
+    review,
+    ragReport,
+    handleReview,
+    scoresBefore,
+    scoresAfter,
+    annotateError,
+    handleDownload,
+  }
+}

--- a/frontend/app/resume/hooks/useResumePage.ts
+++ b/frontend/app/resume/hooks/useResumePage.ts
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { authService } from '@/lib/auth'
 import type { WeightScore } from '@/components/ScoreUpdateBanner'
 import type { CompanyCandidate, ReviewResult } from '../types'
@@ -16,7 +16,6 @@ import {
  * 履歴書レビューページの state・副作用・イベントハンドラ。
  */
 export function useResumePage() {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const [userId, setUserId] = useState('')
   const [sessionId, setSessionId] = useState('')
@@ -42,6 +41,7 @@ export function useResumePage() {
   const [ragReport, setRagReport] = useState('')
   const [scoresBefore, setScoresBefore] = useState<WeightScore[] | null>(null)
   const [scoresAfter, setScoresAfter] = useState<WeightScore[] | null>(null)
+  const reviewAbortRef = useRef<AbortController | null>(null)
 
   const prefilledCompany = searchParams.get('company_name') || ''
   const prefilledIndustry = searchParams.get('industry') || ''
@@ -56,6 +56,8 @@ export function useResumePage() {
         response.headers.get('content-type') || '',
         response.headers.get('content-disposition') || '',
         response.status,
+        response.headers.get('content-length'),
+        response.headers.get('content-range'),
       )
     } catch {
       return false
@@ -81,6 +83,12 @@ export function useResumePage() {
       setSelectedCompanyMeta(null)
     }
   }, [prefilledCompany])
+
+  useEffect(() => {
+    return () => {
+      reviewAbortRef.current?.abort()
+    }
+  }, [])
 
   const selectCompany = (candidate: CompanyCandidate) => {
     setCompanyName(candidate.name)
@@ -205,6 +213,11 @@ export function useResumePage() {
       setReviewError('企業を検索して候補から選択するか、「WEBで実在確認」を実行してください')
       return
     }
+
+    reviewAbortRef.current?.abort()
+    const abortController = new AbortController()
+    reviewAbortRef.current = abortController
+
     setReviewError('')
     setAnnotateError('')
     setReview(null)
@@ -214,10 +227,18 @@ export function useResumePage() {
 
     if (userId && sessionId) {
       try {
-        const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
+        const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`, {
+          signal: abortController.signal,
+        })
         const data = await res.json()
         setScoresBefore(data.weight_scores ?? null)
-      } catch { /* ignore */ }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          setReviewLoading(false)
+          return
+        }
+        /* ignore */
+      }
     }
 
     try {
@@ -229,6 +250,7 @@ export function useResumePage() {
           job_title: jobTitle,
           candidate_type: candidateType,
         }),
+        signal: abortController.signal,
       })
 
       if (!response.ok || !response.body) {
@@ -241,6 +263,11 @@ export function useResumePage() {
       let buffer = ''
 
       while (true) {
+        if (abortController.signal.aborted) {
+          await reader.cancel().catch(() => undefined)
+          break
+        }
+
         const { done, value } = await reader.read()
         if (done) break
 
@@ -250,37 +277,63 @@ export function useResumePage() {
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue
+
+          let data: {
+            type?: string
+            text?: string
+            review?: ReviewResult['review']
+            items?: ReviewResult['items']
+            annotated_available?: boolean
+            message?: string
+          }
           try {
-            const data = JSON.parse(line.slice(6))
-            if (data.type === 'chunk') {
-              setRagReport((prev) => prev + data.text)
-            } else if (data.type === 'complete') {
-              const backendAnnotated = data.annotated_available === true
-              const annotatedAvailable = backendAnnotated || (documentId ? await checkAnnotatedPdfAvailable(documentId) : false)
-              setReview({ review: data.review, items: data.items, annotated_available: annotatedAvailable })
-              if (userId && sessionId) {
-                try {
-                  const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
-                  const scoreData = await res.json()
+            data = JSON.parse(line.slice(6))
+          } catch {
+            // 不完全・不正な行はスキップ
+            continue
+          }
+
+          if (data.type === 'chunk') {
+            setRagReport((prev) => prev + (data.text ?? ''))
+          } else if (data.type === 'complete') {
+            const backendAnnotated = data.annotated_available === true
+            const annotatedAvailable = backendAnnotated || (documentId ? await checkAnnotatedPdfAvailable(documentId) : false)
+            if (abortController.signal.aborted) return
+            setReview({
+              review: data.review as ReviewResult['review'],
+              items: data.items ?? [],
+              annotated_available: annotatedAvailable,
+            })
+            if (userId && sessionId) {
+              try {
+                const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`, {
+                  signal: abortController.signal,
+                })
+                const scoreData = await res.json()
+                if (!abortController.signal.aborted) {
                   setScoresAfter(scoreData.weight_scores ?? null)
-                } catch { /* ignore */ }
+                }
+              } catch (err) {
+                if (err instanceof DOMException && err.name === 'AbortError') return
+                /* ignore */
               }
-            } else if (data.type === 'annotate_error') {
-              setAnnotateError(data.message)
-            } else if (data.type === 'error') {
-              throw new Error(data.message)
             }
-          } catch (parseErr) {
-            if (parseErr instanceof Error && parseErr.message !== 'Unexpected token') {
-              throw parseErr
-            }
+          } else if (data.type === 'annotate_error') {
+            setAnnotateError(String(data.message ?? ''))
+          } else if (data.type === 'error') {
+            throw new Error(String(data.message ?? 'Review failed'))
           }
         }
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return
+      }
       setReviewError(err instanceof Error ? err.message : 'Review failed')
     } finally {
-      setReviewLoading(false)
+      if (!abortController.signal.aborted) {
+        setReviewLoading(false)
+      }
     }
   }
 
@@ -310,7 +363,6 @@ export function useResumePage() {
   }
 
   return {
-    router,
     prefilledCompany,
     prefilledIndustry,
     sourceType,

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -16,7 +16,6 @@ import { ResumeReviewResults } from './components/ResumeReviewResults'
  */
 function ResumeContent() {
   const {
-    router,
     prefilledCompany,
     prefilledIndustry,
     sourceType,
@@ -58,7 +57,6 @@ function ResumeContent() {
   return (
     <Box sx={{ p: { xs: 2, sm: 4 }, maxWidth: 900, mx: 'auto' }}>
       <ResumePageHeader
-        router={router}
         prefilledCompany={prefilledCompany}
         prefilledIndustry={prefilledIndustry}
       />

--- a/frontend/app/resume/page.tsx
+++ b/frontend/app/resume/page.tsx
@@ -1,690 +1,114 @@
 'use client'
 
-import { useEffect, useState, Suspense } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import {
-  Box,
-  Button,
-  TextField,
-  Typography,
-  Paper,
-  Stack,
-  MenuItem,
-  LinearProgress,
-  Alert,
-  Divider,
-  Card,
-  CardContent,
-  Chip,
-  IconButton,
-} from '@mui/material'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { authService } from '@/lib/auth'
+import { Suspense } from 'react'
+import { Box } from '@mui/material'
 import { PageLoading } from '@/components/common/PageLoading'
-import ScoreUpdateBanner, { WeightScore } from '@/components/ScoreUpdateBanner'
+import { useResumePage } from './hooks/useResumePage'
+import { ResumePageHeader } from './components/ResumePageHeader'
+import { ResumeUploadForm } from './components/ResumeUploadForm'
+import { ResumeReviewForm } from './components/ResumeReviewForm'
+import { ResumeRagReport } from './components/ResumeRagReport'
+import { ResumeReviewResults } from './components/ResumeReviewResults'
 
-type ReviewItem = {
-  id: number
-  page_number: number
-  severity: string
-  message: string
-  suggestion?: string
-}
-
-type ReviewResult = {
-  review: {
-    id: number
-    score: number
-    summary: string
-  }
-  items: ReviewItem[]
-  annotated_available: boolean
-}
-
-type CompanyCandidate = {
-  name: string
-  description?: string
-  source: string
-  exists?: boolean
-  confidence?: string
-  company_id?: number
-  evidence_urls?: string[]
-}
-
-const severityConfig: Record<string, { color: 'error' | 'warning' | 'info'; label: string; borderColor: string }> = {
-  critical: { color: 'error', label: '重大', borderColor: '#d32f2f' },
-  warning: { color: 'warning', label: '注意', borderColor: '#ed6c02' },
-  info: { color: 'info', label: '情報', borderColor: '#0288d1' },
-}
-
+/**
+ * 履歴書レビューページのオーケストレーション。
+ * データ取得・操作は useResumePage、表示は各コンポーネントに委譲する。
+ */
 function ResumeContent() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [userId, setUserId] = useState('')
-  const [sessionId, setSessionId] = useState('')
-  const [sourceType, setSourceType] = useState('pdf')
-  const [sourceUrl, setSourceUrl] = useState('')
-  const [companyName, setCompanyName] = useState('')
-  const [companyQuery, setCompanyQuery] = useState('')
-  const [companyCandidates, setCompanyCandidates] = useState<CompanyCandidate[]>([])
-  const [companyValidated, setCompanyValidated] = useState(false)
-  const [companySearchLoading, setCompanySearchLoading] = useState(false)
-  const [companySearchError, setCompanySearchError] = useState('')
-  const [selectedCompanyMeta, setSelectedCompanyMeta] = useState<CompanyCandidate | null>(null)
-  const [jobTitle, setJobTitle] = useState('')
-  const [candidateType, setCandidateType] = useState('new_grad')
-  const [file, setFile] = useState<File | null>(null)
-  const [documentId, setDocumentId] = useState<number | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [reviewLoading, setReviewLoading] = useState(false)
-  const [uploadError, setUploadError] = useState('')
-  const [reviewError, setReviewError] = useState('')
-  const [annotateError, setAnnotateError] = useState('')
-  const [review, setReview] = useState<ReviewResult | null>(null)
-  const [ragReport, setRagReport] = useState('')
-  const [scoresBefore, setScoresBefore] = useState<WeightScore[] | null>(null)
-  const [scoresAfter, setScoresAfter] = useState<WeightScore[] | null>(null)
-
-  const checkAnnotatedPdfAvailable = async (id: number) => {
-    try {
-      const response = await fetch(`/api/resume/annotated?document_id=${id}`, {
-        headers: { Range: 'bytes=0-0', ...authService.getUserFetchHeaders() },
-      })
-      if (!response.ok) return false
-      const contentType = (response.headers.get('content-type') || '').toLowerCase()
-      if (contentType.includes('application/pdf')) return true
-
-      const contentDisposition = (response.headers.get('content-disposition') || '').toLowerCase()
-      if (contentDisposition.includes('.pdf')) return true
-
-      // Content-Type が application/octet-stream でも、Range リクエスト成功なら実体ありとみなす。
-      return response.status === 206 || response.status === 200
-    } catch {
-      return false
-    }
-  }
-
-  const prefilledCompany = searchParams.get('company_name') || ''
-  const prefilledIndustry = searchParams.get('industry') || ''
-
-  useEffect(() => {
-    const user = authService.getStoredUser()
-    if (user?.user_id) {
-      setUserId(String(user.user_id))
-    }
-    if (typeof window !== 'undefined') {
-      const storedSession =
-        sessionStorage.getItem('chatSessionId') ||
-        localStorage.getItem('currentSessionId') ||
-        ''
-      setSessionId(storedSession)
-    }
-    if (prefilledCompany) {
-      setCompanyName(prefilledCompany)
-      setCompanyQuery(prefilledCompany)
-      setCompanyValidated(false)
-      setSelectedCompanyMeta(null)
-    }
-  }, [prefilledCompany])
-
-  const selectCompany = (candidate: CompanyCandidate) => {
-    setCompanyName(candidate.name)
-    setCompanyQuery(candidate.name)
-    setCompanyValidated(true)
-    setSelectedCompanyMeta(candidate)
-    setCompanyCandidates([])
-    setCompanySearchError('')
-  }
-
-  const clearSelectedCompany = () => {
-    setCompanyName('')
-    setCompanyQuery('')
-    setCompanyValidated(false)
-    setSelectedCompanyMeta(null)
-    setCompanyCandidates([])
-    setCompanySearchError('')
-  }
-
-  const handleSearchCompanies = async (includeWebSearch: boolean) => {
-    const q = companyQuery.trim()
-    if (!q) {
-      setCompanySearchError('企業名を入力してください')
-      return
-    }
-    setCompanySearchLoading(true)
-    setCompanySearchError('')
-    setCompanyCandidates([])
-    try {
-      if (!includeWebSearch) {
-        const res = await fetch(`/api/companies?name=${encodeURIComponent(q)}&limit=5`, { cache: 'no-store' })
-        if (!res.ok) {
-          const errText = await res.text()
-          let message = 'DB検索に失敗しました'
-          try {
-            const parsed = JSON.parse(errText)
-            message = parsed?.message || parsed?.error || message
-          } catch {
-            /* keep default */
-          }
-          throw new Error(message)
-        }
-        const data = await res.json()
-        const companies = (data.companies || data || []) as { id?: number; name?: string; description?: string }[]
-        const list = (Array.isArray(companies) ? companies : [])
-          .filter((c) => c?.name)
-          .map((c) => ({
-            name: c.name as string,
-            description: c.description || '',
-            source: 'db',
-            exists: true,
-            confidence: 'high',
-            company_id: c.id,
-          }))
-        setCompanyCandidates(list)
-        if (list.length === 0) {
-          setCompanySearchError('DBに該当企業がありません。「WEBで実在確認」を試してください')
-        }
-        return
-      }
-
-      // WEB: 候補一覧 API（DB優先 + WEB補完）。単体 validate より候補選択しやすい
-      const res = await fetch(`/api/companies/web-search?q=${encodeURIComponent(q)}`, { cache: 'no-store' })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        throw new Error(data?.message || data?.error || 'WEB検索に失敗しました')
-      }
-      const results = (data.results || []) as {
-        name?: string
-        description?: string
-        source?: string
-        exists?: boolean
-        confidence?: string
-        company_id?: number
-        evidence_urls?: string[]
-      }[]
-      const list = (Array.isArray(results) ? results : [])
-        .filter((c) => c?.name && c.exists !== false)
-        .map((c) => ({
-          name: c.name as string,
-          description: c.description || '',
-          source: c.source || 'web_search',
-          exists: true,
-          confidence: c.confidence,
-          company_id: c.company_id,
-          evidence_urls: c.evidence_urls || [],
-        }))
-      setCompanyCandidates(list)
-      if (list.length === 0) {
-        setCompanyValidated(false)
-        setSelectedCompanyMeta(null)
-        setCompanyName('')
-        setCompanySearchError('候補が見つかりませんでした。企業名を変えて再検索するか、職種のみでレビューしてください')
-      }
-    } catch (err) {
-      setCompanySearchError(err instanceof Error ? err.message : '企業検索に失敗しました')
-    } finally {
-      setCompanySearchLoading(false)
-    }
-  }
-
-  const handleUpload = async () => {
-    setUploadError('')
-    setReview(null)
-    setLoading(true)
-    try {
-      if (!userId) {
-        throw new Error('user_id が取得できません。ログインしてください。')
-      }
-      const formData = new FormData()
-      formData.append('user_id', userId)
-      if (sessionId) {
-        formData.append('session_id', sessionId)
-      }
-      formData.append('source_type', sourceType)
-      if (sourceUrl) {
-        formData.append('source_url', sourceUrl)
-      }
-      if (file) {
-        formData.append('file', file)
-      }
-
-      const response = await fetch('/api/resume/upload', {
-        method: 'POST',
-        headers: authService.getUserFetchHeaders(),
-        body: formData,
-      })
-      if (!response.ok) {
-        const errText = await response.text()
-        let message = errText
-        try {
-          const parsed = JSON.parse(errText)
-          message = parsed?.error || parsed?.message || errText
-        } catch {
-          message = errText || 'Upload failed'
-        }
-        throw new Error(message)
-      }
-      const data = await response.json()
-      setDocumentId(data?.document?.id ?? null)
-    } catch (err) {
-      setUploadError(err instanceof Error ? err.message : 'Upload failed')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleReview = async () => {
-    if (!documentId) {
-      setReviewError('document_id が未設定です')
-      return
-    }
-    if (!companyName.trim() && !jobTitle.trim()) {
-      setReviewError('企業名が未入力の場合は応募職種を入力してください')
-      return
-    }
-    if (companyName.trim() && !companyValidated) {
-      setReviewError('企業を検索して候補から選択するか、「WEBで実在確認」を実行してください')
-      return
-    }
-    setReviewError('')
-    setAnnotateError('')
-    setReview(null)
-    setRagReport('')
-    setScoresAfter(null)
-    setReviewLoading(true)
-
-    if (userId && sessionId) {
-      try {
-        const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
-        const data = await res.json()
-        setScoresBefore(data.weight_scores ?? null)
-      } catch { /* ignore */ }
-    }
-
-    try {
-      const response = await fetch(`/api/resume/review/stream?document_id=${documentId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authService.getUserFetchHeaders() },
-        body: JSON.stringify({
-          company_name: companyName,
-          job_title: jobTitle,
-          candidate_type: candidateType,
-        }),
-      })
-
-      if (!response.ok || !response.body) {
-        const errText = await response.text()
-        throw new Error(errText || 'Review failed')
-      }
-
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() ?? ''
-
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue
-          try {
-            const data = JSON.parse(line.slice(6))
-            if (data.type === 'chunk') {
-              setRagReport((prev) => prev + data.text)
-            } else if (data.type === 'complete') {
-              const backendAnnotated = data.annotated_available === true
-              const annotatedAvailable = backendAnnotated || (documentId ? await checkAnnotatedPdfAvailable(documentId) : false)
-              setReview({ review: data.review, items: data.items, annotated_available: annotatedAvailable })
-              if (userId && sessionId) {
-                try {
-                  const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(sessionId)}`)
-                  const scoreData = await res.json()
-                  setScoresAfter(scoreData.weight_scores ?? null)
-                } catch { /* ignore */ }
-              }
-            } else if (data.type === 'annotate_error') {
-              setAnnotateError(data.message)
-            } else if (data.type === 'error') {
-              throw new Error(data.message)
-            }
-          } catch (parseErr) {
-            if (parseErr instanceof Error && parseErr.message !== 'Unexpected token') {
-              throw parseErr
-            }
-          }
-        }
-      }
-    } catch (err) {
-      setReviewError(err instanceof Error ? err.message : 'Review failed')
-    } finally {
-      setReviewLoading(false)
-    }
-  }
-
-  const handleDownload = () => {
-    if (!documentId) {
-      setReviewError('document_id が未設定です')
-      return
-    }
-    void (async () => {
-      try {
-        setReviewError('')
-        const response = await fetch(`/api/resume/annotated?document_id=${documentId}`, {
-          headers: authService.getUserFetchHeaders(),
-        })
-        if (!response.ok) {
-          const errText = await response.text()
-          throw new Error(errText || 'Download failed')
-        }
-        const blob = await response.blob()
-        const url = URL.createObjectURL(blob)
-        window.open(url, '_blank')
-        setTimeout(() => URL.revokeObjectURL(url), 60_000)
-      } catch (err) {
-        setReviewError(err instanceof Error ? err.message : 'Download failed')
-      }
-    })()
-  }
+  const {
+    router,
+    prefilledCompany,
+    prefilledIndustry,
+    sourceType,
+    setSourceType,
+    sourceUrl,
+    setSourceUrl,
+    file,
+    setFile,
+    loading,
+    uploadError,
+    documentId,
+    handleUpload,
+    companyQuery,
+    handleCompanyQueryChange,
+    companyName,
+    companyValidated,
+    companySearchLoading,
+    companySearchError,
+    selectedCompanyMeta,
+    companyCandidates,
+    selectCompany,
+    clearSelectedCompany,
+    handleSearchCompanies,
+    jobTitle,
+    setJobTitle,
+    candidateType,
+    setCandidateType,
+    reviewLoading,
+    reviewError,
+    review,
+    ragReport,
+    handleReview,
+    scoresBefore,
+    scoresAfter,
+    annotateError,
+    handleDownload,
+  } = useResumePage()
 
   return (
     <Box sx={{ p: { xs: 2, sm: 4 }, maxWidth: 900, mx: 'auto' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-        <IconButton
-          onClick={() => router.back()}
-          size="small"
-          aria-label="前のページに戻る"
-          sx={{ bgcolor: '#f1f5f9', color: '#475569' }}
-        >
-          <ArrowBackIcon />
-        </IconButton>
-        <Typography variant="h4" fontWeight="bold" sx={{ fontSize: { xs: '1.4rem', sm: '2.125rem' } }}>
-          履歴書・エントリシート レビュー
-        </Typography>
-      </Box>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: prefilledCompany ? 1.5 : 3 }}>
-        PDF/DOCX/Google Docsをアップロードして、注釈付きPDFを生成します。
-      </Typography>
-      {prefilledCompany && (
-        <Box sx={{ mb: 3, px: 2, py: 1.5, bgcolor: '#e8f5e9', borderRadius: 1, border: '1px solid #a5d6a7' }}>
-          <Typography sx={{ fontSize: 14, color: '#2e7d32', fontWeight: 600 }}>
-            {prefilledCompany}{prefilledIndustry ? `（${prefilledIndustry}）` : ''}向けに最適化されたフィードバックを提供します
-          </Typography>
-          <Typography sx={{ fontSize: 12, color: '#388e3c', mt: 0.5 }}>
-            企業の求める人材像を踏まえたアドバイスが反映されます
-          </Typography>
-        </Box>
-      )}
+      <ResumePageHeader
+        router={router}
+        prefilledCompany={prefilledCompany}
+        prefilledIndustry={prefilledIndustry}
+      />
 
-      <Paper sx={{ p: 3, mb: 3 }} elevation={2}>
-        <Stack spacing={2}>
-          <TextField
-            select
-            label="提出形式"
-            value={sourceType}
-            onChange={(e) => setSourceType(e.target.value)}
-            fullWidth
-          >
-            <MenuItem value="pdf">PDF</MenuItem>
-            <MenuItem value="docx">DOCX</MenuItem>
-            <MenuItem value="google_docs">Google Docs</MenuItem>
-          </TextField>
-          <TextField
-            label="Google Docs / URL (任意)"
-            value={sourceUrl}
-            onChange={(e) => setSourceUrl(e.target.value)}
-            placeholder="https://... (PDFエクスポートURL)"
-            fullWidth
-          />
-          <Button variant="outlined" component="label">
-            ファイルを選択
-            <input
-              type="file"
-              hidden
-              accept=".pdf,.docx"
-              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            />
-          </Button>
-          {file && (
-            <Typography variant="body2" color="text.secondary">
-              選択ファイル: {file.name}
-            </Typography>
-          )}
-          <Button variant="contained" onClick={handleUpload} disabled={loading}>
-            アップロード
-          </Button>
-          {loading && (
-            <Box>
-              <LinearProgress />
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                アップロード中...
-              </Typography>
-            </Box>
-          )}
-          {uploadError && (
-            <Alert severity="error">{uploadError}</Alert>
-          )}
-          {documentId && (
-            <Alert severity="success">
-              アップロード完了！下のフォームでレビューを実行してください。
-            </Alert>
-          )}
-        </Stack>
-      </Paper>
+      <ResumeUploadForm
+        sourceType={sourceType}
+        onSourceTypeChange={setSourceType}
+        sourceUrl={sourceUrl}
+        onSourceUrlChange={setSourceUrl}
+        file={file}
+        onFileChange={setFile}
+        loading={loading}
+        uploadError={uploadError}
+        documentId={documentId}
+        onUpload={handleUpload}
+      />
 
-      <Paper sx={{ p: 3 }} elevation={2}>
-        <Stack spacing={2}>
-          <Typography variant="h6">レビュー実行</Typography>
-          <Typography variant="body2" color="text.secondary">
-            企業を指定する場合は、DB検索またはWEB実在確認で候補を選択してください（自由入力のみではレビューできません）。
-            企業なしで職種のみの一般レビューも可能です。
-          </Typography>
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'flex-start' }}>
-            <TextField
-              label="応募企業名を検索"
-              value={companyQuery}
-              onChange={(e) => {
-                setCompanyQuery(e.target.value)
-                setCompanyValidated(false)
-                setSelectedCompanyMeta(null)
-                setCompanyName('')
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  void handleSearchCompanies(false)
-                }
-              }}
-              fullWidth
-              helperText={companyValidated ? `選択済み: ${companyName}` : '未選択（職種のみレビュー可）'}
-            />
-            <Button
-              variant="outlined"
-              onClick={() => handleSearchCompanies(false)}
-              disabled={companySearchLoading || !companyQuery.trim()}
-              sx={{ whiteSpace: 'nowrap', minWidth: 100 }}
-            >
-              DB検索
-            </Button>
-            <Button
-              variant="contained"
-              onClick={() => handleSearchCompanies(true)}
-              disabled={companySearchLoading || !companyQuery.trim()}
-              sx={{ whiteSpace: 'nowrap', minWidth: 140 }}
-            >
-              WEBで実在確認
-            </Button>
-          </Stack>
-          {companySearchLoading && <LinearProgress />}
-          {companySearchError && <Alert severity="warning">{companySearchError}</Alert>}
-          {selectedCompanyMeta && (
-            <Alert
-              severity="success"
-              action={
-                <Button color="inherit" size="small" onClick={clearSelectedCompany}>
-                  クリア
-                </Button>
-              }
-            >
-              確定: {selectedCompanyMeta.name}
-              {selectedCompanyMeta.source ? `（${selectedCompanyMeta.source}）` : ''}
-              {selectedCompanyMeta.evidence_urls?.[0] ? ` / ${selectedCompanyMeta.evidence_urls[0]}` : ''}
-            </Alert>
-          )}
-          {companyCandidates.length > 0 && (
-            <Stack spacing={1}>
-              <Typography variant="subtitle2">候補から選択</Typography>
-              {companyCandidates.map((c) => (
-                <Card
-                  key={`${c.source}-${c.company_id ?? c.name}`}
-                  variant="outlined"
-                  sx={{ cursor: 'pointer', '&:hover': { borderColor: 'primary.main' } }}
-                  onClick={() => selectCompany(c)}
-                >
-                  <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-                    <Typography fontWeight="bold">{c.name}</Typography>
-                    {c.description && (
-                      <Typography variant="body2" color="text.secondary">
-                        {c.description}
-                      </Typography>
-                    )}
-                    <Chip size="small" label={c.source} sx={{ mt: 0.5 }} />
-                  </CardContent>
-                </Card>
-              ))}
-            </Stack>
-          )}
-          <TextField
-            label={companyName.trim() ? '応募職種 (任意)' : '応募職種 (企業名未選択の場合は必須)'}
-            value={jobTitle}
-            onChange={(e) => setJobTitle(e.target.value)}
-            fullWidth
-            required={!companyName.trim()}
-            error={!companyName.trim() && !jobTitle.trim()}
-            helperText={!companyName.trim() ? '企業未選択の場合は職種を入力すると一般レビューが実行されます' : ''}
-          />
-          <TextField
-            select
-            label="候補者区分"
-            value={candidateType}
-            onChange={(e) => setCandidateType(e.target.value)}
-            fullWidth
-          >
-            <MenuItem value="new_grad">新卒</MenuItem>
-            <MenuItem value="mid_career">中途</MenuItem>
-          </TextField>
-          <Button variant="contained" onClick={handleReview} disabled={reviewLoading || !documentId}>
-            レビューを生成
-          </Button>
-          {reviewLoading && (
-            <Box>
-              <LinearProgress />
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                {ragReport ? '企業別レビューレポートを生成中...' : 'PDFを解析中...（通常30〜60秒かかります）'}
-              </Typography>
-            </Box>
-          )}
-          {reviewError && (
-            <Alert severity="error">{reviewError}</Alert>
-          )}
-          {review && !reviewLoading && (
-            <Alert severity="success">レビューが完了しました。下の指摘事項をご確認ください。</Alert>
-          )}
-        </Stack>
-      </Paper>
+      <ResumeReviewForm
+        companyQuery={companyQuery}
+        onCompanyQueryChange={handleCompanyQueryChange}
+        companyName={companyName}
+        companyValidated={companyValidated}
+        companySearchLoading={companySearchLoading}
+        companySearchError={companySearchError}
+        selectedCompanyMeta={selectedCompanyMeta}
+        companyCandidates={companyCandidates}
+        onSearchCompanies={handleSearchCompanies}
+        onSelectCompany={selectCompany}
+        onClearSelectedCompany={clearSelectedCompany}
+        jobTitle={jobTitle}
+        onJobTitleChange={setJobTitle}
+        candidateType={candidateType}
+        onCandidateTypeChange={setCandidateType}
+        documentId={documentId}
+        reviewLoading={reviewLoading}
+        ragReport={ragReport}
+        reviewError={reviewError}
+        reviewCompleted={!!review}
+        onReview={handleReview}
+      />
 
-      {ragReport && (
-        <Paper sx={{ p: 3, mt: 4 }} elevation={2}>
-          <Typography variant="h5" fontWeight="bold" gutterBottom>
-            企業別レビューレポート
-            {reviewLoading && (
-              <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
-                生成中...
-              </Typography>
-            )}
-          </Typography>
-          <Box
-            sx={{
-              whiteSpace: 'pre-wrap',
-              fontFamily: 'inherit',
-              fontSize: '0.95rem',
-              lineHeight: 1.8,
-              color: 'text.primary',
-            }}
-          >
-            {ragReport}
-          </Box>
-        </Paper>
-      )}
+      <ResumeRagReport ragReport={ragReport} reviewLoading={reviewLoading} />
 
-      {review && scoresAfter && (
-        <Box mt={4}>
-          <ScoreUpdateBanner
-            beforeScores={scoresBefore}
-            afterScores={scoresAfter}
-            title="職務経歴書レビュー結果がプロフィールスコアに反映されました"
-          />
-        </Box>
-      )}
-
-      {review && (
-        <Paper sx={{ p: 3, mt: 4 }} elevation={2}>
-          <Typography variant="h5" fontWeight="bold" gutterBottom>
-            指摘事項
-          </Typography>
-          <Box sx={{ mb: 2 }}>
-            <Typography variant="h6" gutterBottom>
-              総合スコア: {review.review.score} / 100
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              {review.review.summary}
-            </Typography>
-          </Box>
-          <Divider sx={{ mb: 3 }} />
-          <Stack spacing={2}>
-            {review.items.map((item) => {
-              const config = severityConfig[item.severity] ?? { color: 'default' as const, label: item.severity, borderColor: '#9e9e9e' }
-              return (
-                <Card
-                  key={item.id}
-                  variant="outlined"
-                  sx={{ borderLeft: 4, borderLeftColor: config.borderColor }}
-                >
-                  <CardContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                      <Chip label={config.label} color={config.color} size="small" />
-                      <Typography variant="caption" color="text.secondary">
-                        ページ {item.page_number}
-                      </Typography>
-                    </Box>
-                    <Typography variant="body1" fontWeight="medium">
-                      {item.message}
-                    </Typography>
-                    {item.suggestion && (
-                      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                        改善案: {item.suggestion}
-                      </Typography>
-                    )}
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </Stack>
-          <Box sx={{ mt: 3 }}>
-            {annotateError && (
-              <Alert severity="warning" sx={{ mb: 2 }}>{annotateError}</Alert>
-            )}
-            {review.annotated_available && (
-              <Button variant="outlined" onClick={handleDownload}>
-                注釈PDFをダウンロード
-              </Button>
-            )}
-          </Box>
-        </Paper>
-      )}
+      <ResumeReviewResults
+        review={review}
+        scoresBefore={scoresBefore}
+        scoresAfter={scoresAfter}
+        annotateError={annotateError}
+        onDownload={handleDownload}
+      />
     </Box>
   )
 }

--- a/frontend/app/resume/types.ts
+++ b/frontend/app/resume/types.ts
@@ -1,0 +1,39 @@
+/**
+ * 履歴書レビューページ向けの共有型。
+ */
+
+export type ReviewItem = {
+  id: number
+  page_number: number
+  severity: string
+  message: string
+  suggestion?: string
+}
+
+export type ReviewResult = {
+  review: {
+    id: number
+    score: number
+    summary: string
+  }
+  items: ReviewItem[]
+  annotated_available: boolean
+}
+
+export type CompanyCandidate = {
+  name: string
+  description?: string
+  source: string
+  exists?: boolean
+  confidence?: string
+  company_id?: number
+  evidence_urls?: string[]
+}
+
+export type SeverityChipColor = 'error' | 'warning' | 'info' | 'default'
+
+export type SeverityConfig = {
+  color: SeverityChipColor
+  label: string
+  borderColor: string
+}

--- a/frontend/app/resume/utils.ts
+++ b/frontend/app/resume/utils.ts
@@ -1,0 +1,93 @@
+/**
+ * 履歴書レビューページ向けの純粋ヘルパー（React state 非依存）。
+ */
+import type { CompanyCandidate, SeverityConfig } from './types'
+
+/** 指摘事項の重要度表示設定 */
+export const severityConfig: Record<string, Omit<SeverityConfig, 'color'> & { color: 'error' | 'warning' | 'info' }> = {
+  critical: { color: 'error', label: '重大', borderColor: '#d32f2f' },
+  warning: { color: 'warning', label: '注意', borderColor: '#ed6c02' },
+  info: { color: 'info', label: '情報', borderColor: '#0288d1' },
+}
+
+/** 未知の severity にはデフォルト表示を返す */
+export function getSeverityConfig(severity: string): SeverityConfig {
+  return severityConfig[severity] ?? { color: 'default', label: severity, borderColor: '#9e9e9e' }
+}
+
+/** API エラーテキストからユーザー向けメッセージを抽出する */
+export function parseApiErrorMessage(errText: string, defaultMessage: string): string {
+  if (!errText) return defaultMessage
+  try {
+    const parsed = JSON.parse(errText) as { error?: string; message?: string }
+    return parsed?.error || parsed?.message || errText
+  } catch {
+    return errText || defaultMessage
+  }
+}
+
+/** DB 企業検索 API のレスポンスを候補一覧に変換する */
+export function mapDbCompanyResults(data: unknown): CompanyCandidate[] {
+  const payload = data as { companies?: unknown } | unknown[]
+  const companies = (Array.isArray(payload)
+    ? payload
+    : (payload as { companies?: unknown }).companies || payload || []) as {
+    id?: number
+    name?: string
+    description?: string
+  }[]
+
+  return (Array.isArray(companies) ? companies : [])
+    .filter((c) => c?.name)
+    .map((c) => ({
+      name: c.name as string,
+      description: c.description || '',
+      source: 'db',
+      exists: true,
+      confidence: 'high',
+      company_id: c.id,
+    }))
+}
+
+/** WEB 企業検索 API のレスポンスを候補一覧に変換する */
+export function mapWebSearchResults(data: unknown): CompanyCandidate[] {
+  const results = (data as { results?: unknown }).results as {
+    name?: string
+    description?: string
+    source?: string
+    exists?: boolean
+    confidence?: string
+    company_id?: number
+    evidence_urls?: string[]
+  }[] | undefined
+
+  return (Array.isArray(results) ? results : [])
+    .filter((c) => c?.name && c.exists !== false)
+    .map((c) => ({
+      name: c.name as string,
+      description: c.description || '',
+      source: c.source || 'web_search',
+      exists: true,
+      confidence: c.confidence,
+      company_id: c.company_id,
+      evidence_urls: c.evidence_urls || [],
+    }))
+}
+
+/**
+ * 注釈 PDF レスポンスかどうかをヘッダーとステータスから判定する。
+ * Content-Type が application/octet-stream でも Range 成功なら実体ありとみなす。
+ */
+export function isAnnotatedPdfResponse(
+  contentType: string,
+  contentDisposition: string,
+  status: number,
+): boolean {
+  const normalizedType = contentType.toLowerCase()
+  if (normalizedType.includes('application/pdf')) return true
+
+  const normalizedDisposition = contentDisposition.toLowerCase()
+  if (normalizedDisposition.includes('.pdf')) return true
+
+  return status === 206 || status === 200
+}

--- a/frontend/app/resume/utils.ts
+++ b/frontend/app/resume/utils.ts
@@ -28,6 +28,8 @@ export function parseApiErrorMessage(errText: string, defaultMessage: string): s
 
 /** DB 企業検索 API のレスポンスを候補一覧に変換する */
 export function mapDbCompanyResults(data: unknown): CompanyCandidate[] {
+  if (!data || typeof data !== 'object') return []
+
   const payload = data as { companies?: unknown } | unknown[]
   const companies = (Array.isArray(payload)
     ? payload
@@ -51,6 +53,8 @@ export function mapDbCompanyResults(data: unknown): CompanyCandidate[] {
 
 /** WEB 企業検索 API のレスポンスを候補一覧に変換する */
 export function mapWebSearchResults(data: unknown): CompanyCandidate[] {
+  if (!data || typeof data !== 'object') return []
+
   const results = (data as { results?: unknown }).results as {
     name?: string
     description?: string
@@ -77,11 +81,14 @@ export function mapWebSearchResults(data: unknown): CompanyCandidate[] {
 /**
  * 注釈 PDF レスポンスかどうかをヘッダーとステータスから判定する。
  * Content-Type が application/octet-stream でも Range 成功なら実体ありとみなす。
+ * status 200 のみの場合は content-length / content-range の存在を要求する。
  */
 export function isAnnotatedPdfResponse(
   contentType: string,
   contentDisposition: string,
   status: number,
+  contentLength?: string | null,
+  contentRange?: string | null,
 ): boolean {
   const normalizedType = contentType.toLowerCase()
   if (normalizedType.includes('application/pdf')) return true
@@ -89,5 +96,9 @@ export function isAnnotatedPdfResponse(
   const normalizedDisposition = contentDisposition.toLowerCase()
   if (normalizedDisposition.includes('.pdf')) return true
 
-  return status === 206 || status === 200
+  if (status === 206) return true
+  if (status === 200) {
+    return Boolean(contentLength || contentRange)
+  }
+  return false
 }

--- a/frontend/tests/app/resume/utils.test.ts
+++ b/frontend/tests/app/resume/utils.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { CompanyCandidate } from '@/app/resume/types'
+import {
+  getSeverityConfig,
+  isAnnotatedPdfResponse,
+  mapDbCompanyResults,
+  mapWebSearchResults,
+  parseApiErrorMessage,
+  severityConfig,
+} from '@/app/resume/utils'
+
+describe('severityConfig / getSeverityConfig', () => {
+  it('既知の severity に設定を返す', () => {
+    expect(severityConfig.critical).toEqual({
+      color: 'error',
+      label: '重大',
+      borderColor: '#d32f2f',
+    })
+    expect(severityConfig.warning.label).toBe('注意')
+    expect(severityConfig.info.color).toBe('info')
+  })
+
+  it('未知の severity にはデフォルト表示を返す', () => {
+    expect(getSeverityConfig('unknown')).toEqual({
+      color: 'default',
+      label: 'unknown',
+      borderColor: '#9e9e9e',
+    })
+  })
+
+  it('既知の severity は getSeverityConfig でも同じ値', () => {
+    expect(getSeverityConfig('critical')).toEqual(severityConfig.critical)
+  })
+})
+
+describe('parseApiErrorMessage', () => {
+  it('JSON の error フィールドを優先する', () => {
+    expect(parseApiErrorMessage('{"error":"詳細エラー"}', 'デフォルト')).toBe('詳細エラー')
+  })
+
+  it('JSON の message フィールドをフォールバックする', () => {
+    expect(parseApiErrorMessage('{"message":"メッセージ"}', 'デフォルト')).toBe('メッセージ')
+  })
+
+  it('JSON でない場合は生テキストを返す', () => {
+    expect(parseApiErrorMessage('plain error', 'デフォルト')).toBe('plain error')
+  })
+
+  it('空文字の場合はデフォルトを返す', () => {
+    expect(parseApiErrorMessage('', 'デフォルト')).toBe('デフォルト')
+  })
+})
+
+describe('mapDbCompanyResults', () => {
+  it('companies 配列を候補に変換する', () => {
+    const list = mapDbCompanyResults({
+      companies: [
+        { id: 1, name: '株式会社A', description: '説明A' },
+        { id: 2, name: '株式会社B' },
+      ],
+    })
+
+    expect(list).toEqual<CompanyCandidate[]>([
+      {
+        name: '株式会社A',
+        description: '説明A',
+        source: 'db',
+        exists: true,
+        confidence: 'high',
+        company_id: 1,
+      },
+      {
+        name: '株式会社B',
+        description: '',
+        source: 'db',
+        exists: true,
+        confidence: 'high',
+        company_id: 2,
+      },
+    ])
+  })
+
+  it('name がないエントリは除外する', () => {
+    expect(mapDbCompanyResults({ companies: [{ id: 1 }, { name: '有効' }] })).toHaveLength(1)
+  })
+
+  it('配列を直接渡しても変換できる', () => {
+    expect(mapDbCompanyResults([{ name: '直接' }])).toEqual([
+      expect.objectContaining({ name: '直接', source: 'db' }),
+    ])
+  })
+})
+
+describe('mapWebSearchResults', () => {
+  it('results を候補に変換する', () => {
+    const list = mapWebSearchResults({
+      results: [
+        {
+          name: 'WEB企業',
+          description: 'WEB説明',
+          source: 'web',
+          confidence: 'medium',
+          company_id: 10,
+          evidence_urls: ['https://example.com'],
+        },
+      ],
+    })
+
+    expect(list).toEqual([
+      {
+        name: 'WEB企業',
+        description: 'WEB説明',
+        source: 'web',
+        exists: true,
+        confidence: 'medium',
+        company_id: 10,
+        evidence_urls: ['https://example.com'],
+      },
+    ])
+  })
+
+  it('exists: false の候補は除外する', () => {
+    expect(mapWebSearchResults({
+      results: [{ name: '除外', exists: false }, { name: '残る' }],
+    })).toHaveLength(1)
+  })
+
+  it('source 省略時は web_search を使う', () => {
+    expect(mapWebSearchResults({ results: [{ name: 'A' }] })[0].source).toBe('web_search')
+  })
+})
+
+describe('isAnnotatedPdfResponse', () => {
+  it('application/pdf の Content-Type を PDF と判定する', () => {
+    expect(isAnnotatedPdfResponse('application/pdf', '', 200)).toBe(true)
+  })
+
+  it('Content-Disposition に .pdf があれば PDF と判定する', () => {
+    expect(isAnnotatedPdfResponse('application/octet-stream', 'attachment; filename="a.pdf"', 200)).toBe(true)
+  })
+
+  it('206/200 ステータスでも PDF ありと判定する', () => {
+    expect(isAnnotatedPdfResponse('application/octet-stream', '', 206)).toBe(true)
+    expect(isAnnotatedPdfResponse('application/octet-stream', '', 200)).toBe(true)
+  })
+
+  it('PDF でない応答は false', () => {
+    expect(isAnnotatedPdfResponse('application/json', '', 404)).toBe(false)
+  })
+})

--- a/frontend/tests/app/resume/utils.test.ts
+++ b/frontend/tests/app/resume/utils.test.ts
@@ -130,6 +130,12 @@ describe('mapWebSearchResults', () => {
   it('source 省略時は web_search を使う', () => {
     expect(mapWebSearchResults({ results: [{ name: 'A' }] })[0].source).toBe('web_search')
   })
+  it('null / 非オブジェクトは空配列', () => {
+    expect(mapDbCompanyResults(null)).toEqual([])
+    expect(mapDbCompanyResults('x')).toEqual([])
+    expect(mapWebSearchResults(null)).toEqual([])
+    expect(mapWebSearchResults(undefined)).toEqual([])
+  })
 })
 
 describe('isAnnotatedPdfResponse', () => {
@@ -141,9 +147,11 @@ describe('isAnnotatedPdfResponse', () => {
     expect(isAnnotatedPdfResponse('application/octet-stream', 'attachment; filename="a.pdf"', 200)).toBe(true)
   })
 
-  it('206/200 ステータスでも PDF ありと判定する', () => {
+  it('206 または content-length/range 付き 200 を PDF ありと判定する', () => {
     expect(isAnnotatedPdfResponse('application/octet-stream', '', 206)).toBe(true)
-    expect(isAnnotatedPdfResponse('application/octet-stream', '', 200)).toBe(true)
+    expect(isAnnotatedPdfResponse('application/octet-stream', '', 200, '1', null)).toBe(true)
+    expect(isAnnotatedPdfResponse('application/octet-stream', '', 200, null, 'bytes 0-0/10')).toBe(true)
+    expect(isAnnotatedPdfResponse('application/octet-stream', '', 200)).toBe(false)
   })
 
   it('PDF でない応答は false', () => {


### PR DESCRIPTION
Closes #693

親: #692 / 第3波 / 推奨順 1/4

## 変更内容
- \`page.tsx\`: ~698 → **~122** 行
- \`hooks/useResumePage.ts\` — 状態・ハンドラ
- \`components/\` — Header / Upload / ReviewForm / Results / RagReport
- \`types.ts\` / \`utils.ts\` + ユニットテスト

## Test plan
- [x] \`npm test -- --testPathPatterns=app/resume\`
- [x] \`npx tsc --noEmit\`
- [ ] 職務経歴アップロード〜レビューの手動スモーク


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * PDF、DOCX、Google Docsの履歴書をアップロードし、レビューを実行できるようになりました。
  * 企業検索、職種・候補者区分の指定に対応しました。
  * 指摘事項、重要度、改善案、総合スコアを確認できます。
  * 生成中の企業別レポートや、注釈付きPDFのダウンロードに対応しました。
* **改善**
  * レビュー画面の構成とエラー・進捗表示を整理しました。
  * 企業情報やレビュー結果の表示精度を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->