### PR TITLE
Resolve #639: 面接レポート生成ポーリングにタイムアウトと再試行を追加

### DIFF
--- a/frontend/app/interview/components/ReportScreen.tsx
+++ b/frontend/app/interview/components/ReportScreen.tsx
@@ -14,11 +14,12 @@ import { InterviewReport, InterviewSession } from '@/lib/interview'
 import InterviewSummary from './InterviewSummary'
 import ScoreUpdateBanner, { WeightScore } from '@/components/ScoreUpdateBanner'
 import { PRIMARY, BG_DARK } from '../constants'
+import type { ReportStatus } from '../hooks/useInterviewSession'
 
 export interface ReportScreenProps {
   onBack: () => void
   errorMessage: string | null
-  reportStatus: 'idle' | 'pending' | 'ready' | 'error'
+  reportStatus: ReportStatus
   report: InterviewReport | null
   scoresBefore: WeightScore[] | null
   scoresAfter: WeightScore[] | null
@@ -28,6 +29,8 @@ export interface ReportScreenProps {
   emailSending: boolean
   emailSent: boolean
   onSendEmail: () => void
+  /** タイムアウト / エラー時の再ポーリング */
+  onRetryReport?: () => void
   /** ゲストユーザーはメール送信不可 */
   isGuest: boolean
   videoUploadStatus: 'idle' | 'uploading' | 'done' | 'error'
@@ -52,6 +55,7 @@ export default function ReportScreen({
   emailSending,
   emailSent,
   onSendEmail,
+  onRetryReport,
   isGuest,
   videoUploadStatus,
   videoUploadProgress,
@@ -100,9 +104,22 @@ export default function ReportScreen({
           </Stack>
         )}
 
-        {reportStatus === 'error' && (
+        {(reportStatus === 'error' || reportStatus === 'timeout') && (
           <Paper sx={{ bgcolor: '#2d2e31', border: '1px solid rgba(234,67,53,0.3)', p: 3, borderRadius: 2 }}>
-            <Typography variant="body2" sx={{ color: '#f28b82' }}>レポート生成に失敗しました。</Typography>
+            <Typography variant="body2" sx={{ color: '#f28b82', mb: onRetryReport ? 2 : 0 }}>
+              {reportStatus === 'timeout'
+                ? 'レポート生成がタイムアウトしました。時間をおいて再試行してください。'
+                : 'レポート生成に失敗しました。'}
+            </Typography>
+            {onRetryReport && (
+              <Button
+                variant="contained"
+                onClick={onRetryReport}
+                sx={{ bgcolor: PRIMARY, '&:hover': { bgcolor: '#d14f10' } }}
+              >
+                再試行
+              </Button>
+            )}
           </Paper>
         )}
 

--- a/frontend/app/interview/hooks/useInterviewSession.ts
+++ b/frontend/app/interview/hooks/useInterviewSession.ts
@@ -9,7 +9,14 @@ import { WeightScore } from '@/components/ScoreUpdateBanner'
 import type { InterviewMedia } from './useInterviewMedia'
 import { useHandsFreeVad } from './useHandsFreeVad'
 import { buildCompanyInfo, getNextAvatarGender } from '../utils'
+import {
+  evaluateReportPollTick,
+  REPORT_POLL_INTERVAL_MS,
+  REPORT_POLL_TIMEOUT_MS,
+} from '../reportPolling'
 import type { Utterance, InterviewCompany, Position, InterviewStatus } from '../types'
+
+export type ReportStatus = 'idle' | 'pending' | 'ready' | 'error' | 'timeout'
 
 type UseInterviewSessionArgs = {
   user: User | null
@@ -45,7 +52,7 @@ export function useInterviewSession({
   const [sessionWarningShown, setSessionWarningShown] = useState(false)
   const [session, setSession] = useState<InterviewSession | null>(null)
   const [report, setReport] = useState<InterviewReport | null>(null)
-  const [reportStatus, setReportStatus] = useState<'idle' | 'pending' | 'ready' | 'error'>('idle')
+  const [reportStatus, setReportStatus] = useState<ReportStatus>('idle')
   const [emailSending, setEmailSending] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
   const [aiLevel, setAiLevel] = useState(0)
@@ -71,6 +78,10 @@ export function useInterviewSession({
   const aiLevelRafRef = useRef<number | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollStartedAtRef = useRef<number | null>(null)
+  const pollSessionRef = useRef<{ sessionId: number; userId: number } | null>(null)
+  /** 再試行時に古い tick の結果を破棄するための世代カウンタ */
+  const pollGenerationRef = useRef(0)
   const sessionStartRef = useRef<number | null>(null)
   const transcriptEndRef = useRef<HTMLDivElement | null>(null)
   const isRecordingRef = useRef(false)
@@ -329,23 +340,89 @@ export function useInterviewSession({
     }
   }
 
+  const stopReportPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }
+
+  const loadScoresAfter = async (userId: number) => {
+    const scoreSessionId = `interview-${userId}`
+    try {
+      const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(scoreSessionId)}`)
+      const data = await res.json()
+      setScoresAfter(data.weight_scores ?? null)
+    } catch { /* ignore */ }
+  }
+
   const startReportPolling = (sessionId: number, userId: number) => {
-    if (pollRef.current) clearInterval(pollRef.current)
-    pollRef.current = setInterval(async () => {
+    stopReportPolling()
+    const generation = ++pollGenerationRef.current
+    pollSessionRef.current = { sessionId, userId }
+    pollStartedAtRef.current = Date.now()
+    setReportStatus('pending')
+
+    const tick = async () => {
+      if (generation !== pollGenerationRef.current) return
+
+      const startedAt = pollStartedAtRef.current ?? Date.now()
+      let hasReport = false
+      let fetchFailed = false
+      let reportPayload: InterviewReport | null = null
+
       try {
         const detail = await interviewApi.getDetail(sessionId, userId)
         if (detail.report) {
-          setReport(detail.report); setReportStatus('ready')
-          clearInterval(pollRef.current!); pollRef.current = null
-          const scoreSessionId = `interview-${userId}`
-          try {
-            const res = await fetch(`/api/user/weight-scores?user_id=${userId}&session_id=${encodeURIComponent(scoreSessionId)}`)
-            const data = await res.json()
-            setScoresAfter(data.weight_scores ?? null)
-          } catch { /* ignore */ }
+          hasReport = true
+          reportPayload = detail.report
         }
-      } catch { setReportStatus('error') }
-    }, 3000)
+      } catch {
+        fetchFailed = true
+      }
+
+      if (generation !== pollGenerationRef.current) return
+
+      const outcome = evaluateReportPollTick({
+        startedAtMs: startedAt,
+        nowMs: Date.now(),
+        timeoutMs: REPORT_POLL_TIMEOUT_MS,
+        hasReport,
+        fetchFailed,
+      })
+
+      if (outcome === 'ready' && reportPayload) {
+        setReport(reportPayload)
+        setReportStatus('ready')
+        stopReportPolling()
+        await loadScoresAfter(userId)
+        return
+      }
+      if (outcome === 'error') {
+        setReportStatus('error')
+        stopReportPolling()
+        return
+      }
+      if (outcome === 'timeout') {
+        setReportStatus('timeout')
+        stopReportPolling()
+      }
+    }
+
+    // 初回は即時、以降は interval
+    void tick()
+    pollRef.current = setInterval(() => { void tick() }, REPORT_POLL_INTERVAL_MS)
+  }
+
+  const retryReportPolling = () => {
+    const target = pollSessionRef.current
+    if (!target) {
+      if (session && user) {
+        startReportPolling(session.id, user.user_id)
+      }
+      return
+    }
+    startReportPolling(target.sessionId, target.userId)
   }
 
   const startRecording = () => {
@@ -450,6 +527,7 @@ export function useInterviewSession({
     session,
     report,
     reportStatus,
+    retryReportPolling,
     emailSending,
     emailSent,
     aiLevel,

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -244,6 +244,7 @@ function InterviewContent() {
         emailSent={session.emailSent}
         isGuest={!user || user.is_guest}
         onSendEmail={session.sendReportEmail}
+        onRetryReport={session.retryReportPolling}
         videoUploadStatus={session.videoUploadStatus}
         videoUploadProgress={session.videoUploadProgress}
         videoSizeWarning={session.videoSizeWarning}

--- a/frontend/app/interview/reportPolling.ts
+++ b/frontend/app/interview/reportPolling.ts
@@ -1,0 +1,31 @@
+/**
+ * 面接レポート生成ポーリングの定数と判定ロジック。
+ * UI / hook から分離し、タイムアウト判定を単体テスト可能にする。
+ */
+
+export const REPORT_POLL_INTERVAL_MS = 3000
+/** レポート未到着の最大待ち時間（3分） */
+export const REPORT_POLL_TIMEOUT_MS = 3 * 60 * 1000
+
+export type ReportPollTickResult = 'ready' | 'continue' | 'timeout' | 'error'
+
+/**
+ * 1回のポーリング結果を評価する。
+ * - fetch 失敗 → error
+ * - report あり → ready
+ * - 開始から timeoutMs 経過 → timeout
+ * - それ以外 → continue（次のポーリングへ）
+ */
+export function evaluateReportPollTick(args: {
+  startedAtMs: number
+  nowMs: number
+  timeoutMs?: number
+  hasReport: boolean
+  fetchFailed: boolean
+}): ReportPollTickResult {
+  if (args.fetchFailed) return 'error'
+  if (args.hasReport) return 'ready'
+  const timeoutMs = args.timeoutMs ?? REPORT_POLL_TIMEOUT_MS
+  if (args.nowMs - args.startedAtMs >= timeoutMs) return 'timeout'
+  return 'continue'
+}

--- a/frontend/tests/app/interview/ReportScreen.test.tsx
+++ b/frontend/tests/app/interview/ReportScreen.test.tsx
@@ -43,4 +43,29 @@ describe('ReportScreen', () => {
 
     expect(screen.getByText('レポートを生成中です...')).toBeInTheDocument()
   })
+
+  it('timeout の場合はタイムアウト文言と再試行ボタンを表示する', () => {
+    const onRetryReport = jest.fn()
+    renderScreen({ reportStatus: 'timeout', onRetryReport })
+
+    expect(
+      screen.getByText('レポート生成がタイムアウトしました。時間をおいて再試行してください。'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '再試行' })).toBeInTheDocument()
+  })
+
+  it('error の場合は失敗文言と再試行ボタンを表示する', () => {
+    renderScreen({ reportStatus: 'error', onRetryReport: jest.fn() })
+
+    expect(screen.getByText('レポート生成に失敗しました。')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '再試行' })).toBeInTheDocument()
+  })
+
+  it('再試行ボタン押下で onRetryReport が呼ばれる', () => {
+    const onRetryReport = jest.fn()
+    renderScreen({ reportStatus: 'timeout', onRetryReport })
+
+    screen.getByRole('button', { name: '再試行' }).click()
+    expect(onRetryReport).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/tests/app/interview/reportPolling.test.ts
+++ b/frontend/tests/app/interview/reportPolling.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  evaluateReportPollTick,
+  REPORT_POLL_INTERVAL_MS,
+  REPORT_POLL_TIMEOUT_MS,
+} from '@/app/interview/reportPolling'
+
+describe('reportPolling', () => {
+  it('定数は 3 秒間隔・3 分タイムアウトである', () => {
+    expect(REPORT_POLL_INTERVAL_MS).toBe(3000)
+    expect(REPORT_POLL_TIMEOUT_MS).toBe(3 * 60 * 1000)
+  })
+
+  it('fetch 失敗時は error を返す', () => {
+    expect(
+      evaluateReportPollTick({
+        startedAtMs: 0,
+        nowMs: 1000,
+        hasReport: false,
+        fetchFailed: true,
+      }),
+    ).toBe('error')
+  })
+
+  it('report がある場合は ready を返す（タイムアウト前でも）', () => {
+    expect(
+      evaluateReportPollTick({
+        startedAtMs: 0,
+        nowMs: REPORT_POLL_TIMEOUT_MS + 1,
+        hasReport: true,
+        fetchFailed: false,
+      }),
+    ).toBe('ready')
+  })
+
+  it('未到着かつ制限時間未満なら continue', () => {
+    expect(
+      evaluateReportPollTick({
+        startedAtMs: 0,
+        nowMs: REPORT_POLL_TIMEOUT_MS - 1,
+        hasReport: false,
+        fetchFailed: false,
+      }),
+    ).toBe('continue')
+  })
+
+  it('未到着かつ制限時間以上なら timeout', () => {
+    expect(
+      evaluateReportPollTick({
+        startedAtMs: 0,
+        nowMs: REPORT_POLL_TIMEOUT_MS,
+        hasReport: false,
+        fetchFailed: false,
+      }),
+    ).toBe('timeout')
+  })
+
+  it('fetchFailed は hasReport より優先される', () => {
+    expect(
+      evaluateReportPollTick({
+        startedAtMs: 0,
+        nowMs: 0,
+        hasReport: true,
+        fetchFailed: true,
+      }),
+    ).toBe('error')
+  })
+})


### PR DESCRIPTION
## Summary
- 面接終了後のレポートポーリングに最大待ち時間（3分）を追加し、超過時は `timeout` UI を表示
- API 失敗時はポーリングを止め、タイムアウト/エラー時に「再試行」で再開可能に
- 判定ロジックを `reportPolling.ts` に分離し単体テストを追加

## Test plan
- [ ] 面接終了後、通常どおりレポートが表示されること
- [ ] レポート未生成が続く場合、約3分後にタイムアウト文言と再試行ボタンが出ること
- [ ] 再試行でポーリングが再開し、生成済みならレポートが表示されること
- [ ] ページ離脱時にポーリングが止まること（無限待ちにならないこと）

Closes #639

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 面接レポートの生成がタイムアウトした場合も、状況に応じた案内を表示できるようになりました。
  - レポート生成に失敗した場合やタイムアウトした場合、「再試行」ボタンから再取得できるようになりました。
  - レポート生成状況の確認処理を改善し、完了したレポートをより適切に表示できるようになりました。

- **テスト**
  - エラー、タイムアウト、再試行操作などの動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->