### PR TITLE
Resolve #641: チャット終了時のセッションキャッシュ削除バグ

### DIFF
--- a/frontend/components/mui-chat/hooks/useMuiChat.ts
+++ b/frontend/components/mui-chat/hooks/useMuiChat.ts
@@ -11,6 +11,7 @@ import {
   makeMessageId,
   INITIAL_GREETING,
   RESET_GREETING,
+  clearChatSessionOnEnd,
 } from '../utils'
 import type { Message, PhaseProgress, ProgressTotals, ChoiceOption } from '../types'
 
@@ -433,17 +434,7 @@ export function useMuiChat() {
   }
 
   const handleConfirmEndChat = () => {
-    // セッションとキャッシュを完全にクリア
-    sessionStorage.removeItem('chatSessionId')
-    sessionStorage.removeItem('chatMessages')
-    localStorage.removeItem('chatMessages')
-
-    // チャット履歴のキャッシュも削除
-    const currentSessionId = sessionStorage.getItem('chatSessionId')
-    if (currentSessionId) {
-      localStorage.removeItem(`chat_cache_${currentSessionId}`)
-    }
-    localStorage.removeItem('chat_session_id')
+    clearChatSessionOnEnd({ sessionStorage, localStorage })
 
     // ページをリロードして新しいセッションを開始
     window.location.reload()

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -43,3 +43,21 @@ export const JOB_QUICK_OPTIONS = [
   '両方に興味がある',
   'まだ決めていない',
 ] as const
+
+/**
+ * チャット終了時にセッション ID とメッセージ／キャッシュを削除する。
+ * sessionId は remove 前に取得する（先に消すと chat_cache_ が残る）。
+ */
+export function clearChatSessionOnEnd(storage: {
+  sessionStorage: Pick<Storage, 'getItem' | 'removeItem'>
+  localStorage: Pick<Storage, 'removeItem'>
+}): void {
+  const currentSessionId = storage.sessionStorage.getItem('chatSessionId')
+  if (currentSessionId) {
+    storage.localStorage.removeItem(`chat_cache_${currentSessionId}`)
+  }
+  storage.sessionStorage.removeItem('chatSessionId')
+  storage.sessionStorage.removeItem('chatMessages')
+  storage.localStorage.removeItem('chatMessages')
+  storage.localStorage.removeItem('chat_session_id')
+}

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -1,4 +1,9 @@
-import { extractChoices, makeMessageId, INITIAL_GREETING } from '@/components/mui-chat/utils'
+import {
+  extractChoices,
+  makeMessageId,
+  INITIAL_GREETING,
+  clearChatSessionOnEnd,
+} from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
   it('A) 形式の選択肢を抽出する', () => {
@@ -70,5 +75,51 @@ describe('makeMessageId / INITIAL_GREETING', () => {
 
   it('INITIAL_GREETING は挨拶文を含む', () => {
     expect(INITIAL_GREETING).toContain('キャリアエージェント')
+  })
+})
+
+describe('clearChatSessionOnEnd', () => {
+  function createMemoryStorage(initial: Record<string, string> = {}) {
+    const store = { ...initial }
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      removeItem: (key: string) => {
+        delete store[key]
+      },
+      _store: store,
+    }
+  }
+
+  it('sessionId 削除前に chat_cache_ を消す', () => {
+    const sessionStorage = createMemoryStorage({
+      chatSessionId: 'sess-42',
+      chatMessages: '[]',
+    })
+    const localStorage = createMemoryStorage({
+      'chat_cache_sess-42': 'cached',
+      chatMessages: '[]',
+      chat_session_id: 'sess-42',
+    })
+
+    clearChatSessionOnEnd({ sessionStorage, localStorage })
+
+    expect(localStorage._store['chat_cache_sess-42']).toBeUndefined()
+    expect(sessionStorage._store.chatSessionId).toBeUndefined()
+    expect(sessionStorage._store.chatMessages).toBeUndefined()
+    expect(localStorage._store.chatMessages).toBeUndefined()
+    expect(localStorage._store.chat_session_id).toBeUndefined()
+  })
+
+  it('sessionId が無い場合も他キーは削除する', () => {
+    const sessionStorage = createMemoryStorage({ chatMessages: '[]' })
+    const localStorage = createMemoryStorage({
+      chatMessages: '[]',
+      chat_session_id: 'x',
+    })
+
+    clearChatSessionOnEnd({ sessionStorage, localStorage })
+
+    expect(sessionStorage._store.chatMessages).toBeUndefined()
+    expect(localStorage._store.chat_session_id).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- チャット終了時に `chatSessionId` を先に削除していたため `chat_cache_*` が残るバグを修正
- 削除ロジックを `clearChatSessionOnEnd` に切り出し、削除順を単体テストで固定

## Test plan
- [ ] チャット終了確認後、該当セッションの `localStorage.chat_cache_<sessionId>` が消えること
- [ ] 終了後にリロードされ、新規セッションとして開始できること

Closes #641

Made with [Cursor](https://cursor.com)