### PR TITLE
Resolve #642: 結果ページの内部診断情報をユーザー向けメッセージに変更

### DIFF
--- a/frontend/app/results/utils.ts
+++ b/frontend/app/results/utils.ts
@@ -67,6 +67,7 @@ export function normalizeCategoryScores(
 
 /**
  * 推薦が空のときのユーザー向けメッセージを組み立てる。
+ * diagnostics は開発向けログのみ（本番 UI には出さない）。
  */
 export function buildEmptyRecommendationsMessage(
   reason?: string,
@@ -78,11 +79,8 @@ export function buildEmptyRecommendationsMessage(
   } else if (reason === 'insufficient_company_data') {
     message = '現在、公開済みの企業データがありません。管理者が企業情報を公開するまでお待ちください。'
   }
-  if (diagnostics) {
-    const scoreCount = diagnostics.user_score_count ?? '-'
-    const companyCount = diagnostics.active_company_count ?? '-'
-    const profileCount = diagnostics.weight_profile_count ?? '-'
-    message += `\n\nスコア数: ${scoreCount}, 企業数: ${companyCount}, プロファイル数: ${profileCount}`
+  if (diagnostics && typeof console !== 'undefined' && typeof console.debug === 'function') {
+    console.debug('[recommendations empty]', { reason, diagnostics })
   }
   return message
 }

--- a/frontend/tests/app/results/utils.test.ts
+++ b/frontend/tests/app/results/utils.test.ts
@@ -94,25 +94,35 @@ describe('buildEmptyRecommendationsMessage', () => {
     expect(buildEmptyRecommendationsMessage('insufficient_company_data')).toContain('公開済みの企業データがありません')
   })
 
-  it('diagnostics を末尾に付与する', () => {
-    const message = buildEmptyRecommendationsMessage('matching_results_empty', {
+  it('diagnostics はユーザー向けメッセージに含めず debug ログに出す', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    const diagnostics = {
       user_score_count: 1,
       active_company_count: 2,
       weight_profile_count: 3,
+    }
+    const message = buildEmptyRecommendationsMessage('matching_results_empty', diagnostics)
+
+    expect(message).not.toContain('スコア数')
+    expect(message).not.toContain('企業数')
+    expect(message).not.toContain('プロファイル数')
+    expect(message).toContain('データがありません')
+    expect(debugSpy).toHaveBeenCalledWith('[recommendations empty]', {
+      reason: 'matching_results_empty',
+      diagnostics,
     })
-    expect(message).toContain('スコア数: 1')
-    expect(message).toContain('企業数: 2')
-    expect(message).toContain('プロファイル数: 3')
+    debugSpy.mockRestore()
   })
 
-  it('diagnostics 欠損フィールドは - で表示する', () => {
+  it('diagnostics 欠損時もメッセージは日本語のみ', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
     const message = buildEmptyRecommendationsMessage('matching_results_empty', {
       user_score_count: 1,
     })
-    expect(message).toContain('スコア数: 1')
-    expect(message).toContain('企業数: -')
-    expect(message).toContain('プロファイル数: -')
+    expect(message).not.toContain('スコア数')
     expect(message).not.toContain('undefined')
+    expect(debugSpy).toHaveBeenCalled()
+    debugSpy.mockRestore()
   })
 })
 


### PR DESCRIPTION
## Summary
- マッチング結果が空のときのエラー文言からスコア数・企業数などの内部診断値を削除
- diagnostics は `console.debug` のみに出力し、本番 UI は reason ベースの日本語メッセージに統一

## Test plan
- [ ] 推薦結果が空のとき、画面に「スコア数」「企業数」などが表示されないこと
- [ ] reason ごとの日本語メッセージは従来どおり出ること
- [ ] 開発者ツールの debug ログに diagnostics が出ること

Closes #642

Made with [Cursor](https://cursor.com)