### PR TITLE
Resolve #643: 相関図・チャット履歴のエラー/空状態UIを改善

### DIFF
--- a/frontend/app/chat-history/page.tsx
+++ b/frontend/app/chat-history/page.tsx
@@ -1,60 +1,56 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Box, Container, Typography, Paper, List, ListItem, ListItemButton, ListItemText, Divider, CircularProgress, Button } from '@mui/material'
+import { useState, useEffect, useCallback } from 'react'
+import { Box, Container, Typography, Paper, List, ListItem, ListItemButton, ListItemText, Divider, CircularProgress, Button, Stack } from '@mui/material'
 import { useRouter } from 'next/navigation'
 import { authService } from '@/lib/auth'
 import ChatIcon from '@mui/icons-material/Chat'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-
-interface ChatSession {
-  session_id: string
-  user_id: number
-  started_at: string
-  last_message_at: string
-  message_count: number
-}
+import { parseChatSessionsResponse, type ChatSessionSummary } from './parseSessions'
 
 export default function ChatHistoryPage() {
-  const [sessions, setSessions] = useState<ChatSession[]>([])
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [authError, setAuthError] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const router = useRouter()
 
-  useEffect(() => {
-    const user = authService.getStoredUser()
-    if (!user) {
-      router.push('/')
-      return
-    }
-    fetchSessions()
-  }, [router])
-
-  const fetchSessions = async () => {
+  const fetchSessions = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    setAuthError(false)
     try {
       const response = await fetch('/api/chat/sessions', {
         headers: authService.getUserFetchHeaders(),
       })
       if (response.status === 401 || response.status === 403) {
         setAuthError(true)
+        setSessions([])
         return
       }
       if (!response.ok) {
-        console.error('Failed to fetch sessions:', response.status)
+        setLoadError('チャット履歴の取得に失敗しました。')
         setSessions([])
         return
       }
       const raw = await response.json()
-      // buildProxyJsonResponse は配列を { data: [...] } にラップするため両形式に対応
-      const data: ChatSession[] = Array.isArray(raw) ? raw : Array.isArray(raw?.data) ? raw.data : []
-      setSessions(data)
-    } catch (error) {
-      console.error('Error fetching sessions:', error)
+      setSessions(parseChatSessionsResponse(raw))
+    } catch {
+      setLoadError('チャット履歴の取得に失敗しました。')
       setSessions([])
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    const user = authService.getStoredUser()
+    if (!user) {
+      router.push('/login')
+      return
+    }
+    void fetchSessions()
+  }, [router, fetchSessions])
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr)
@@ -91,7 +87,7 @@ export default function ChatHistoryPage() {
           <Typography color="text.secondary" sx={{ mb: 2 }}>
             セッションが期限切れです。再度ログインしてください。
           </Typography>
-          <Button variant="contained" onClick={() => { authService.logout(); router.push('/') }}>
+          <Button variant="contained" onClick={() => { authService.logout(); router.push('/login') }}>
             ログインページへ
           </Button>
         </Paper>
@@ -113,7 +109,19 @@ export default function ChatHistoryPage() {
         チャット履歴
       </Typography>
 
-      {sessions.length === 0 ? (
+      {loadError ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Stack spacing={2} alignItems="center">
+            <Typography color="error">{loadError}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              空の履歴ではなく、読み込みエラーです。時間をおいて再試行してください。
+            </Typography>
+            <Button variant="contained" onClick={() => { void fetchSessions() }}>
+              再試行
+            </Button>
+          </Stack>
+        </Paper>
+      ) : sessions.length === 0 ? (
         <Paper sx={{ p: 4, textAlign: 'center' }}>
           <Typography color="text.secondary">
             チャット履歴がありません

--- a/frontend/app/chat-history/parseSessions.ts
+++ b/frontend/app/chat-history/parseSessions.ts
@@ -1,0 +1,21 @@
+export type ChatSessionSummary = {
+  session_id: string
+  user_id: number
+  started_at: string
+  last_message_at: string
+  message_count: number
+}
+
+/**
+ * チャット履歴 API レスポンスを正規化する。
+ * buildProxyJsonResponse は配列を { data: [...] } にラップするため両形式に対応する。
+ */
+export function parseChatSessionsResponse(raw: unknown): ChatSessionSummary[] {
+  if (Array.isArray(raw)) {
+    return raw as ChatSessionSummary[]
+  }
+  if (raw && typeof raw === 'object' && Array.isArray((raw as { data?: unknown }).data)) {
+    return (raw as { data: ChatSessionSummary[] }).data
+  }
+  return []
+}

--- a/frontend/components/Correlation-diagram.tsx
+++ b/frontend/components/Correlation-diagram.tsx
@@ -14,7 +14,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { Card, CardContent } from '@/components/ui/card';
-import { Box, Typography, ToggleButtonGroup, ToggleButton, Chip, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
+import { Box, Typography, ToggleButtonGroup, ToggleButton, Chip, Select, MenuItem, FormControl, InputLabel, Button, Stack } from '@mui/material';
 import {
     fetchCompanyRelations,
     fetchCompanyMarketInfo,
@@ -108,6 +108,7 @@ export default function CorrelationDiagram({ initialCompanyId = null }: Correlat
     const [marketInfo, setMarketInfo] = useState<CompanyMarketInfo[]>([]);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
+    const [reloadToken, setReloadToken] = useState(0);
 
     useEffect(() => {
         async function loadData() {
@@ -129,7 +130,7 @@ export default function CorrelationDiagram({ initialCompanyId = null }: Correlat
             }
         }
         void loadData();
-    }, []);
+    }, [reloadToken]);
 
     const uniqueCompanies = useMemo(() => {
         const companyMap = new Map();
@@ -381,8 +382,32 @@ export default function CorrelationDiagram({ initialCompanyId = null }: Correlat
 
     if (loadError) {
         return (
-            <Box sx={{ width: '100%', height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <Typography color="error">{loadError}</Typography>
+            <Box sx={{ width: '100%', height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 3 }}>
+                <Stack spacing={2} alignItems="center" sx={{ maxWidth: 480, textAlign: 'center' }}>
+                    <Typography color="error">企業相関データの取得に失敗しました。</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        ネットワーク接続を確認のうえ、再試行してください。
+                    </Typography>
+                    <Button variant="contained" onClick={() => setReloadToken((n) => n + 1)}>
+                        再試行
+                    </Button>
+                </Stack>
+            </Box>
+        );
+    }
+
+    if (relations.length === 0) {
+        return (
+            <Box sx={{ width: '100%', height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', p: 3 }}>
+                <Stack spacing={2} alignItems="center" sx={{ maxWidth: 480, textAlign: 'center' }}>
+                    <Typography>表示できる企業の関連データがまだありません。</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        データが準備され次第、ここに相関図が表示されます。しばらくしてから再度お試しください。
+                    </Typography>
+                    <Button variant="outlined" onClick={() => setReloadToken((n) => n + 1)}>
+                        再読み込み
+                    </Button>
+                </Stack>
             </Box>
         );
     }

--- a/frontend/tests/app/chat-history/parseSessions.test.ts
+++ b/frontend/tests/app/chat-history/parseSessions.test.ts
@@ -1,0 +1,25 @@
+import { parseChatSessionsResponse } from '@/app/chat-history/parseSessions'
+
+describe('parseChatSessionsResponse', () => {
+  const sample = {
+    session_id: 'abc-123',
+    user_id: 1,
+    started_at: '2026-01-01T00:00:00Z',
+    last_message_at: '2026-01-01T01:00:00Z',
+    message_count: 3,
+  }
+
+  it('配列レスポンスをそのまま返す', () => {
+    expect(parseChatSessionsResponse([sample])).toEqual([sample])
+  })
+
+  it('{ data: [...] } 形式を展開する', () => {
+    expect(parseChatSessionsResponse({ data: [sample] })).toEqual([sample])
+  })
+
+  it('不正な形式は空配列を返す', () => {
+    expect(parseChatSessionsResponse(null)).toEqual([])
+    expect(parseChatSessionsResponse({})).toEqual([])
+    expect(parseChatSessionsResponse({ data: 'x' })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- 相関図: 取得失敗時に再試行、データなし時は一般ユーザー向け文言 + 再読み込みを表示
- チャット履歴: API 失敗を空履歴と区別し、エラー UI + 再試行を追加
- 認証切れ時の「ログインページへ」遷移先を `/login` に修正

## Test plan
- [ ] 相関図で API 失敗時に再試行ボタンが出ること
- [ ] 関連データ 0 件時に管理者向け文言ではなくユーザー向け文言が出ること
- [ ] チャット履歴 API 失敗時に「履歴がありません」ではなくエラー + 再試行が出ること
- [ ] 認証エラー時のボタンが `/login` に遷移すること

Closes #643

Made with [Cursor](https://cursor.com)