### PR TITLE
Resolve #705: フロント画面遷移の高速化

### DIFF
--- a/frontend/app/Correlation-diagram/loading.tsx
+++ b/frontend/app/Correlation-diagram/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="企業相関図を読み込み中..." />
+}

--- a/frontend/app/Correlation-diagram/page.tsx
+++ b/frontend/app/Correlation-diagram/page.tsx
@@ -3,7 +3,13 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Button, Box } from '@mui/material';
 import { Suspense } from 'react';
-import CorrelationDiagram from '@/components/Correlation-diagram';
+import dynamic from 'next/dynamic';
+import { PageLoading } from '@/components/common/PageLoading';
+
+const CorrelationDiagram = dynamic(() => import('@/components/Correlation-diagram'), {
+    ssr: false,
+    loading: () => <PageLoading message="企業相関図を準備しています..." />,
+});
 
 function CorrelationDiagramContent() {
     const router = useRouter();
@@ -24,7 +30,7 @@ function CorrelationDiagramContent() {
 
 export default function Page() {
     return (
-        <Suspense fallback={null}>
+        <Suspense fallback={<PageLoading message="企業相関図を読み込み中..." />}>
             <CorrelationDiagramContent />
         </Suspense>
     );

--- a/frontend/app/company/[id]/page.tsx
+++ b/frontend/app/company/[id]/page.tsx
@@ -11,7 +11,16 @@ import {
   DollarSign, Star, Clock, Target, GitBranch, Network
 } from "lucide-react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import CompanyDiagram from "@/components/company-diagram"
+import dynamic from "next/dynamic"
+
+const CompanyDiagram = dynamic(() => import("@/components/company-diagram"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ padding: 24, textAlign: "center", color: "#64748b" }}>
+      相関図を読み込み中...
+    </div>
+  ),
+})
 
 type Company = {
   id: number

--- a/frontend/app/interview/components/SessionScreen.tsx
+++ b/frontend/app/interview/components/SessionScreen.tsx
@@ -17,10 +17,19 @@ import VideocamIcon from '@mui/icons-material/Videocam'
 import VideocamOffIcon from '@mui/icons-material/VideocamOff'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption'
-import ThreeAvatar from './ThreeAvatar'
+import dynamic from 'next/dynamic'
 import { PRIMARY } from '../constants'
 import { formatSeconds } from '@/lib/interview-utils'
 import type { Utterance } from '../types'
+
+const ThreeAvatar = dynamic(() => import('./ThreeAvatar'), {
+  ssr: false,
+  loading: () => (
+    <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <CircularProgress size={36} sx={{ color: PRIMARY }} />
+    </Box>
+  ),
+})
 
 const waveHeights = [5, 8, 13, 18, 25, 34, 42, 48, 44, 36, 28, 20, 14, 9, 6, 7, 11, 18, 27, 36, 44, 48, 42, 34, 26, 18, 12, 8, 5, 7, 10, 14]
 

--- a/frontend/app/interview/history/InterviewTrendChart.tsx
+++ b/frontend/app/interview/history/InterviewTrendChart.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { InterviewTrendPoint } from '@/lib/interview'
+
+const PRIMARY = '#ec5b13'
+
+type InterviewTrendChartProps = {
+  points: InterviewTrendPoint[]
+}
+
+/** recharts 依存を履歴ページ本体から切り離すためのチャート表示。 */
+export default function InterviewTrendChart({ points }: InterviewTrendChartProps) {
+  const data = points.map((p, i) => ({
+    ...p,
+    label: `#${p.session_id}`,
+    index: i + 1,
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
+        <XAxis dataKey="label" tick={{ fontSize: 12, fill: '#64748b' }} />
+        <YAxis domain={[0, 10]} tick={{ fontSize: 12, fill: '#64748b' }} width={28} />
+        <Tooltip formatter={(v: number) => v?.toFixed(1)} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Line type="monotone" dataKey="logic" name="論理性" stroke={PRIMARY} dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+        <Line type="monotone" dataKey="specificity" name="具体性" stroke="#3b82f6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+        <Line type="monotone" dataKey="ownership" name="主体性" stroke="#10b981" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+        <Line type="monotone" dataKey="communication" name="コミュニケーション" stroke="#8b5cf6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+        <Line type="monotone" dataKey="enthusiasm" name="熱意" stroke="#f59e0b" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/app/interview/history/page.tsx
+++ b/frontend/app/interview/history/page.tsx
@@ -16,22 +16,22 @@ import {
 } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import PsychologyIcon from '@mui/icons-material/Psychology'
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-} from 'recharts'
+import dynamic from 'next/dynamic'
 import { authService, User } from '@/lib/auth'
 import { interviewApi, InterviewDetail, InterviewSession, InterviewTrendPoint, TeacherReport } from '@/lib/interview'
 import InterviewSummary from '../components/InterviewSummary'
 import { parseJsonSafe } from '@/lib/interview-utils'
 
 const PRIMARY = '#ec5b13'
+
+const InterviewTrendChart = dynamic(() => import('./InterviewTrendChart'), {
+  ssr: false,
+  loading: () => (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+      <CircularProgress size={28} sx={{ color: PRIMARY }} />
+    </Box>
+  ),
+})
 
 const statusLabel = (s: string) => {
   if (s === 'finished') return <Chip label="完了" color="success" size="small" />
@@ -135,24 +135,7 @@ export default function InterviewHistoryPage() {
             </Typography>
           ) : (
             <Box sx={{ height: { xs: 180, md: 240 } }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={trendPoints.map((p, i) => ({
-                ...p,
-                label: `#${p.session_id}`,
-                index: i + 1,
-              }))}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" />
-                <XAxis dataKey="label" tick={{ fontSize: 12, fill: '#64748b' }} />
-                <YAxis domain={[0, 10]} tick={{ fontSize: 12, fill: '#64748b' }} width={28} />
-                <Tooltip formatter={(v: number) => v?.toFixed(1)} />
-                <Legend wrapperStyle={{ fontSize: 12 }} />
-                <Line type="monotone" dataKey="logic" name="論理性" stroke="#ec5b13" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
-                <Line type="monotone" dataKey="specificity" name="具体性" stroke="#3b82f6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
-                <Line type="monotone" dataKey="ownership" name="主体性" stroke="#10b981" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
-                <Line type="monotone" dataKey="communication" name="コミュニケーション" stroke="#8b5cf6" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
-                <Line type="monotone" dataKey="enthusiasm" name="熱意" stroke="#f59e0b" dot={{ r: 3 }} activeDot={{ r: 5 }} connectNulls />
-              </LineChart>
-            </ResponsiveContainer>
+              <InterviewTrendChart points={trendPoints} />
             </Box>
           )}
         </Paper>

--- a/frontend/app/interview/hooks/mediaPreviewGate.ts
+++ b/frontend/app/interview/hooks/mediaPreviewGate.ts
@@ -1,0 +1,13 @@
+import type { InterviewStatus } from '../types'
+
+/**
+ * 面接遷移直後の getUserMedia 起動判定。
+ * selection ではカメラ許可ダイアログを出さない。
+ */
+export function shouldStartInterviewMediaPreview(args: {
+  loading: boolean
+  status: InterviewStatus
+}): boolean {
+  if (args.loading) return false
+  return args.status === 'lobby' || args.status === 'connecting' || args.status === 'connected'
+}

--- a/frontend/app/interview/hooks/useInterviewMedia.ts
+++ b/frontend/app/interview/hooks/useInterviewMedia.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { InterviewStatus } from '../types'
+import { shouldStartInterviewMediaPreview } from './mediaPreviewGate'
 
 /** getUserMedia 共通制約（ロビープレビュー / ensureStream で共有） */
 export const MEDIA_CONSTRAINTS: MediaStreamConstraints = {
@@ -39,9 +40,9 @@ export function useInterviewMedia({ loading, status }: UseInterviewMediaArgs) {
   const videoRecorderRef = useRef<MediaRecorder | null>(null)
   const videoChunksRef = useRef<Blob[]>([])
 
-  // Lobby camera preview
+  // Lobby camera preview — 選択画面では getUserMedia しない（遷移直後の遅延を避ける）
   useEffect(() => {
-    if (loading) return
+    if (!shouldStartInterviewMediaPreview({ loading, status })) return
     let stream: MediaStream | null = null
     const startPreview = async () => {
       try {
@@ -70,7 +71,7 @@ export function useInterviewMedia({ loading, status }: UseInterviewMediaArgs) {
     return () => {
       // stream is kept in streamRef for reuse during interview
     }
-  }, [loading])
+  }, [loading, status])
 
   // Attach stream to session video when connected
   useEffect(() => {

--- a/frontend/app/interview/loading.tsx
+++ b/frontend/app/interview/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="面接ページを読み込み中..." />
+}

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, Suspense } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { interviewLimits } from '@/lib/interview'
 import { authService, User } from '@/lib/auth'
@@ -8,13 +9,18 @@ import ConsentDialog from './components/ConsentDialog'
 import SelectionScreen from './components/SelectionScreen'
 import LobbyScreen from './components/LobbyScreen'
 import ReportScreen from './components/ReportScreen'
-import SessionScreen from './components/SessionScreen'
 import { PageLoading } from '@/components/common/PageLoading'
 import { POSITIONS } from './constants'
 import type { InterviewCompany, Position, InterviewStatus } from './types'
 import { resolveCompanyByName } from './utils'
 import { useInterviewMedia } from './hooks/useInterviewMedia'
 import { useInterviewSession } from './hooks/useInterviewSession'
+
+/** three.js 依存の SessionScreen は選択/ロビーでは不要のため遅延ロード */
+const SessionScreen = dynamic(() => import('./components/SessionScreen'), {
+  ssr: false,
+  loading: () => <PageLoading message="面接セッションを準備しています..." />,
+})
 
 function InterviewContent() {
   const router = useRouter()

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="ページを読み込み中..." />
+}

--- a/frontend/app/profile/loading.tsx
+++ b/frontend/app/profile/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="プロフィールを読み込み中..." />
+}

--- a/frontend/app/results/components/CompanyDetailView.tsx
+++ b/frontend/app/results/components/CompanyDetailView.tsx
@@ -11,11 +11,21 @@ import {
   Chip,
   Tabs,
   Tab,
+  CircularProgress,
 } from '@mui/material'
 import { ArrowBack, LocationOn, People, TrendingUp as TrendingUpIcon } from '@mui/icons-material'
+import dynamic from 'next/dynamic'
 import type { CapitalRelation, CompanyMarketInfo } from '@/lib/company-data'
 import type { Company } from '../types'
-import CompanyRelationDiagram from './CompanyRelationDiagram'
+
+const CompanyRelationDiagram = dynamic(() => import('./CompanyRelationDiagram'), {
+  ssr: false,
+  loading: () => (
+    <Box sx={{ height: 360, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <CircularProgress size={32} />
+    </Box>
+  ),
+})
 
 export interface CompanyDetailViewProps {
   company: Company

--- a/frontend/app/results/loading.tsx
+++ b/frontend/app/results/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="マッチング結果を読み込み中..." />
+}

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Suspense } from 'react'
+import dynamic from 'next/dynamic'
 import { Box, CircularProgress } from '@mui/material'
 import { PageLoading } from '@/components/common/PageLoading'
 import { useResultsData } from './hooks/useResultsData'
@@ -9,8 +10,17 @@ import {
   ResultsErrorView,
   ResultsNoMatchView,
 } from './components/ResultsStatusViews'
-import CompanyDetailView from './components/CompanyDetailView'
 import ResultsListView from './components/ResultsListView'
+
+/** ReactFlow 依存の詳細ビューは一覧表示では不要のため遅延ロード */
+const CompanyDetailView = dynamic(() => import('./components/CompanyDetailView'), {
+  ssr: false,
+  loading: () => (
+    <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <CircularProgress />
+    </Box>
+  ),
+})
 
 /**
  * マッチング結果ページのオーケストレーション。

--- a/frontend/app/resume/loading.tsx
+++ b/frontend/app/resume/loading.tsx
@@ -1,0 +1,5 @@
+import RouteLoading from '@/components/common/RouteLoading'
+
+export default function Loading() {
+  return <RouteLoading message="履歴書レビューを読み込み中..." />
+}

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, {useState, useEffect} from 'react'
+import Link from 'next/link'
 import styles from './analysis-sidebar.module.css'
 import
 {
@@ -39,9 +40,19 @@ import {
     CalendarMonth,
 } from '@mui/icons-material'
 import {authService, User} from '@/lib/auth'
-import {useRouter} from 'next/navigation'
+import {SIDEBAR_ADMIN_NAV, SIDEBAR_NAV_ITEMS} from '@/lib/sidebar-nav'
 
 const DRAWER_WIDTH = 280
+
+const NAV_ICONS: Record<(typeof SIDEBAR_NAV_ITEMS)[number]['href'], React.ReactNode> = {
+    '/Correlation-diagram': <BorderAll color="primary"/>,
+    '/chat-history': <History color="primary"/>,
+    '/resume': <Description color="primary"/>,
+    '/interview': <RecordVoiceOver color="primary"/>,
+    '/es-rewrite': <EditNote color="primary"/>,
+    '/schedule': <CalendarMonth color="primary"/>,
+    '/profile': <ManageAccounts color="primary"/>,
+}
 
 interface AnalysisStep {
     id: string
@@ -75,7 +86,6 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
     const [totalQuestions, setTotalQuestions] = useState(15)
     const [phases, setPhases] = useState<PhaseProgress[] | null>(null)
     const [isAdmin, setIsAdmin] = useState(!!user.is_admin)
-    const router = useRouter()
     const theme = useTheme()
     const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
@@ -328,152 +338,41 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
 
 
                 <Divider sx={{my: 2}}/>
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/Correlation-diagram')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <BorderAll color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="企業相関図"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <Divider sx={{my: 2}}/>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/chat-history')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <History color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="チャット履歴"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/resume')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <Description color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="履歴書レビュー"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/interview')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <RecordVoiceOver color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="面接練習"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/es-rewrite')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <EditNote color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="ESリライト・添削"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/schedule')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <CalendarMonth color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="選考スケジュール"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
-
-                <ListItem disablePadding>
-                    <ListItemButton
-                        onClick={() => router.push('/profile')}
-                        sx={{
-                            borderRadius: 1,
-                        }}
-                    >
-                        <ListItemIcon sx={{minWidth: 36}}>
-                            <ManageAccounts color="primary"/>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary="プロフィール設定"
-                            primaryTypographyProps={{
-                                fontSize: '0.875rem',
-                                fontWeight: 500,
-                            }}
-                        />
-                    </ListItemButton>
-                </ListItem>
+                {SIDEBAR_NAV_ITEMS.map((item, index) => (
+                    <React.Fragment key={item.href}>
+                        {index === 1 && <Divider sx={{my: 2}}/>}
+                        <ListItem disablePadding>
+                            <ListItemButton
+                                component={Link}
+                                href={item.href}
+                                prefetch
+                                onClick={onMobileClose}
+                                sx={{
+                                    borderRadius: 1,
+                                }}
+                            >
+                                <ListItemIcon sx={{minWidth: 36}}>
+                                    {NAV_ICONS[item.href]}
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={item.label}
+                                    primaryTypographyProps={{
+                                        fontSize: '0.875rem',
+                                        fontWeight: 500,
+                                    }}
+                                />
+                            </ListItemButton>
+                        </ListItem>
+                    </React.Fragment>
+                ))}
 
                 {isAdmin && (
                     <ListItem disablePadding>
                         <ListItemButton
-                            onClick={() => router.push('/admin')}
+                            component={Link}
+                            href={SIDEBAR_ADMIN_NAV.href}
+                            prefetch
+                            onClick={onMobileClose}
                             sx={{
                                 borderRadius: 1,
                             }}
@@ -482,7 +381,7 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                                 <AdminPanelSettings color="primary"/>
                             </ListItemIcon>
                             <ListItemText
-                                primary="管理者機能"
+                                primary={SIDEBAR_ADMIN_NAV.label}
                                 primaryTypographyProps={{
                                     fontSize: '0.875rem',
                                     fontWeight: 600,

--- a/frontend/components/common/RouteLoading.tsx
+++ b/frontend/components/common/RouteLoading.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { PageLoading } from '@/components/common/PageLoading'
+
+/** App Router の loading.tsx 用。遷移先チャンク取得中に即時表示する。 */
+export default function RouteLoading({ message = '読み込み中...' }: { message?: string }) {
+  return <PageLoading message={message} />
+}

--- a/frontend/lib/sidebar-nav.ts
+++ b/frontend/lib/sidebar-nav.ts
@@ -1,0 +1,18 @@
+/**
+ * 分析サイドバーの固定ナビ項目。
+ * next/link で prefetch するため href を一元管理する。
+ */
+export const SIDEBAR_NAV_ITEMS = [
+  { href: '/Correlation-diagram', label: '企業相関図' },
+  { href: '/chat-history', label: 'チャット履歴' },
+  { href: '/resume', label: '履歴書レビュー' },
+  { href: '/interview', label: '面接練習' },
+  { href: '/es-rewrite', label: 'ESリライト・添削' },
+  { href: '/schedule', label: '選考スケジュール' },
+  { href: '/profile', label: 'プロフィール設定' },
+] as const
+
+export const SIDEBAR_ADMIN_NAV = {
+  href: '/admin',
+  label: '管理者機能',
+} as const

--- a/frontend/tests/app/interview/mediaPreviewGate.test.ts
+++ b/frontend/tests/app/interview/mediaPreviewGate.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import { shouldStartInterviewMediaPreview } from '@/app/interview/hooks/mediaPreviewGate'
+
+describe('shouldStartInterviewMediaPreview', () => {
+  it('auth loading 中は開始しない', () => {
+    expect(shouldStartInterviewMediaPreview({ loading: true, status: 'lobby' })).toBe(false)
+  })
+
+  it('selection / finished では開始しない', () => {
+    expect(shouldStartInterviewMediaPreview({ loading: false, status: 'selection' })).toBe(false)
+    expect(shouldStartInterviewMediaPreview({ loading: false, status: 'finished' })).toBe(false)
+  })
+
+  it('lobby / connecting / connected では開始する', () => {
+    expect(shouldStartInterviewMediaPreview({ loading: false, status: 'lobby' })).toBe(true)
+    expect(shouldStartInterviewMediaPreview({ loading: false, status: 'connecting' })).toBe(true)
+    expect(shouldStartInterviewMediaPreview({ loading: false, status: 'connected' })).toBe(true)
+  })
+})

--- a/frontend/tests/lib/sidebar-nav.test.ts
+++ b/frontend/tests/lib/sidebar-nav.test.ts
@@ -1,0 +1,22 @@
+import { SIDEBAR_ADMIN_NAV, SIDEBAR_NAV_ITEMS } from '@/lib/sidebar-nav'
+
+describe('sidebar-nav', () => {
+  it('主要ナビは絶対パスで定義されている', () => {
+    expect(SIDEBAR_NAV_ITEMS.length).toBeGreaterThanOrEqual(5)
+    for (const item of SIDEBAR_NAV_ITEMS) {
+      expect(item.href.startsWith('/')).toBe(true)
+      expect(item.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('面接・相関図・プロフィールへのリンクを含む', () => {
+    const hrefs = SIDEBAR_NAV_ITEMS.map((i) => i.href)
+    expect(hrefs).toContain('/interview')
+    expect(hrefs).toContain('/Correlation-diagram')
+    expect(hrefs).toContain('/profile')
+  })
+
+  it('管理者ナビは /admin', () => {
+    expect(SIDEBAR_ADMIN_NAV.href).toBe('/admin')
+  })
+})


### PR DESCRIPTION
## Summary
- サイドバーを `next/link` + prefetch に変更（`router.push` 廃止）
- three.js / ReactFlow / recharts を `next/dynamic` で遅延ロード
- 主要ルートに `loading.tsx` を追加しチャンク取得中も即時フィードバック
- 面接の `getUserMedia` を selection では起動せず、ロビー以降に遅延

## Test plan
- [ ] サイドバー各リンクにホバーすると Network で遷移先チャンクが prefetch される
- [ ] `/interview` 遷移直後は選択画面が早く出る（three.js はセッション開始まで遅延）
- [ ] `/results` 一覧では ReactFlow を読み込まず、詳細を開いたときに読み込む
- [ ] `/Correlation-diagram` で loading UI のあと相関図が表示される
- [ ] 面接選択画面ではカメラ許可ダイアログが出ない（ロビーで出る）

Closes #705

Made with [Cursor](https://cursor.com)