### PR TITLE
fix: 企業詳細ページ(/company/[id])のデザイン崩れを修正

### DIFF
--- a/frontend/app/company/[id]/companyDetailUtils.ts
+++ b/frontend/app/company/[id]/companyDetailUtils.ts
@@ -1,0 +1,94 @@
+/**
+ * 企業詳細ページ用のユーティリティ。
+ */
+
+export function parseJsonArray(s?: string): string[] {
+  if (!s) return []
+  try {
+    const parsed: unknown = JSON.parse(s)
+    return Array.isArray(parsed) ? parsed.map(String) : []
+  } catch {
+    return s.split(',').map((x) => x.trim()).filter(Boolean)
+  }
+}
+
+/** API / プロキシ応答から企業オブジェクトを取り出す */
+export function unwrapCompanyRecord(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object') return null
+  if (Array.isArray(raw)) return null
+  const obj = raw as Record<string, unknown>
+  if (obj.data && typeof obj.data === 'object' && !Array.isArray(obj.data)) {
+    return obj.data as Record<string, unknown>
+  }
+  return obj
+}
+
+export type CompanyDetailViewModel = {
+  id: number
+  name: string
+  industry: string
+  location: string
+  employees: string
+  description: string
+  matchScore: number
+  tags: string[]
+  tech_stack?: string
+  techStack: string[]
+  infra_stack?: string
+  cicd_tools?: string
+  development_style?: string
+  projectTypes: string[]
+  salary: string
+  benefits: string[]
+  culture: string[]
+  founded: string
+  website: string
+  size: string
+  parentCompany?: string
+  subsidiaries?: string[]
+  partnerships?: string[]
+}
+
+export function mapCompanyApiToViewModel(raw: unknown): CompanyDetailViewModel | null {
+  const data = unwrapCompanyRecord(raw)
+  if (!data) return null
+
+  const id = typeof data.id === 'number' ? data.id : Number(data.id)
+  if (!Number.isFinite(id)) return null
+
+  const cultureRaw = data.culture
+  const culture = Array.isArray(cultureRaw)
+    ? cultureRaw.map(String)
+    : typeof cultureRaw === 'string' && cultureRaw
+      ? [cultureRaw]
+      : []
+
+  const employeeCount = typeof data.employee_count === 'number' ? data.employee_count : undefined
+  const foundedYear = typeof data.founded_year === 'number' ? data.founded_year : undefined
+
+  return {
+    id,
+    name: typeof data.name === 'string' ? data.name : `企業 ${id}`,
+    industry: typeof data.industry === 'string' ? data.industry : '',
+    location: typeof data.location === 'string' ? data.location : '',
+    description: typeof data.description === 'string' ? data.description : '',
+    tech_stack: typeof data.tech_stack === 'string' ? data.tech_stack : undefined,
+    infra_stack: typeof data.infra_stack === 'string' ? data.infra_stack : undefined,
+    cicd_tools: typeof data.cicd_tools === 'string' ? data.cicd_tools : undefined,
+    development_style: typeof data.development_style === 'string' ? data.development_style : undefined,
+    techStack: parseJsonArray(typeof data.tech_stack === 'string' ? data.tech_stack : undefined),
+    matchScore: typeof data.matchScore === 'number' ? data.matchScore : 0,
+    tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
+    projectTypes: Array.isArray(data.projectTypes) ? data.projectTypes.map(String) : [],
+    salary: typeof data.salary === 'string' ? data.salary : '',
+    benefits: Array.isArray(data.benefits) ? data.benefits.map(String) : [],
+    culture,
+    founded: foundedYear ? `${foundedYear}年` : '',
+    website: typeof data.website_url === 'string' ? data.website_url : '',
+    employees: employeeCount ? `${employeeCount}名` : '',
+    size: employeeCount ? `${employeeCount}名規模` : '',
+    parentCompany: typeof data.parentCompany === 'string' ? data.parentCompany : undefined,
+    subsidiaries: Array.isArray(data.subsidiaries) ? data.subsidiaries.map(String) : undefined,
+    partnerships: Array.isArray(data.partnerships) ? data.partnerships.map(String) : undefined,
+  }
+}

--- a/frontend/app/company/[id]/page.tsx
+++ b/frontend/app/company/[id]/page.tsx
@@ -1,102 +1,79 @@
-"use client"
+'use client'
 
-import { useParams, useRouter } from "next/navigation"
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { 
-  ArrowLeft, Building2, MapPin, Users, Calendar, Globe, 
-  TrendingUp, Award, Code, Briefcase, Heart, ExternalLink,
-  DollarSign, Star, Clock, Target, GitBranch, Network
-} from "lucide-react"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import dynamic from "next/dynamic"
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import BusinessIcon from '@mui/icons-material/Business'
+import PlaceIcon from '@mui/icons-material/Place'
+import PeopleIcon from '@mui/icons-material/People'
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
+import LanguageIcon from '@mui/icons-material/Language'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import StarIcon from '@mui/icons-material/Star'
+import CodeIcon from '@mui/icons-material/Code'
+import WorkIcon from '@mui/icons-material/Work'
+import FavoriteIcon from '@mui/icons-material/Favorite'
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+import AccountTreeIcon from '@mui/icons-material/AccountTree'
+import HubIcon from '@mui/icons-material/Hub'
+import {
+  mapCompanyApiToViewModel,
+  parseJsonArray,
+  type CompanyDetailViewModel,
+} from './companyDetailUtils'
 
-const CompanyDiagram = dynamic(() => import("@/components/company-diagram"), {
+const CompanyDiagram = dynamic(() => import('@/components/company-diagram'), {
   ssr: false,
   loading: () => (
-    <div style={{ padding: 24, textAlign: "center", color: "#64748b" }}>
+    <Box sx={{ py: 4, textAlign: 'center', color: 'text.secondary' }}>
       相関図を読み込み中...
-    </div>
+    </Box>
   ),
 })
 
-type Company = {
+type JobPosition = {
   id: number
-  name: string
-  industry: string
-  location: string
-  employee_count?: number
-  employees: string
-  description: string
-  matchScore: number
-  tags: string[]
-  tech_stack?: string
-  techStack: string[]
-  infra_stack?: string
-  cicd_tools?: string
-  development_style?: string
-  projectTypes: string[]
-  salary: string
-  benefits: string[]
-  culture: string[]
-  founded_year?: number
-  founded: string
-  website_url?: string
-  website: string
-  size: string
-  parentCompany?: string
-  subsidiaries?: string[]
-  partnerships?: string[]
-  capitalStructure?: {
-    shareholders: { name: string; percentage: number }[]
-  }
-}
-
-function parseJsonArray(s?: string): string[] {
-  if (!s) return []
-  try {
-    const parsed = JSON.parse(s)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return s.split(',').map((x) => x.trim()).filter(Boolean)
-  }
+  title: string
+  employment_type?: string
+  work_location?: string
+  description?: string
+  job_category?: { name: string }
 }
 
 export default function CompanyDetailPage() {
   const params = useParams()
   const router = useRouter()
-  const [company, setCompany] = useState<Company | null>(null)
+  const [company, setCompany] = useState<CompanyDetailViewModel | null>(null)
   const [loading, setLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState('capital')
-  const [jobPositions, setJobPositions] = useState<{ id: number; title: string; employment_type?: string; work_location?: string; description?: string; job_category?: { name: string } }[]>([])
+  const [activeTab, setActiveTab] = useState<'capital' | 'business'>('capital')
+  const [jobPositions, setJobPositions] = useState<JobPosition[]>([])
 
   useEffect(() => {
+    const companyId = String(params.id)
+
     const fetchCompanyDetail = async () => {
       try {
-        // バックエンドから企業詳細を取得
-        const response = await fetch(`/api/companies/${params.id}`)
-
-        if (response.ok) {
-          const data = await response.json()
-          // DB形式のフィールドをUI向けに補完
-          data.techStack = parseJsonArray(data.tech_stack)
-          data.matchScore = data.matchScore ?? 0
-          data.tags = data.tags ?? []
-          data.projectTypes = data.projectTypes ?? []
-          data.salary = data.salary ?? ''
-          data.benefits = data.benefits ?? []
-          data.culture = data.culture ? (Array.isArray(data.culture) ? data.culture : [data.culture]) : []
-          data.founded = data.founded_year ? `${data.founded_year}年` : ''
-          data.website = data.website_url ?? ''
-          data.employees = data.employee_count ? `${data.employee_count}名` : ''
-          data.size = data.employee_count ? `${data.employee_count}名規模` : ''
-          setCompany(data)
-        } else {
-          console.error('Failed to fetch company details:', response.statusText)
+        const response = await fetch(`/api/companies/${companyId}`)
+        if (!response.ok) {
           setCompany(null)
+          return
         }
+        const raw: unknown = await response.json()
+        setCompany(mapCompanyApiToViewModel(raw))
       } catch (error) {
         console.error('Failed to fetch company details:', error)
         setCompany(null)
@@ -107,400 +84,390 @@ export default function CompanyDetailPage() {
 
     const fetchJobPositions = async () => {
       try {
-        const res = await fetch(`/api/companies/${params.id}/job-positions`)
-        if (res.ok) {
-          const data = await res.json()
-          setJobPositions(data.positions || [])
-        }
+        const res = await fetch(`/api/companies/${companyId}/job-positions`)
+        if (!res.ok) return
+        const raw: unknown = await res.json()
+        const payload =
+          raw && typeof raw === 'object' && !Array.isArray(raw)
+            ? (raw as { data?: unknown; positions?: JobPosition[] })
+            : null
+        const positions = Array.isArray(payload?.positions)
+          ? payload.positions
+          : payload?.data && typeof payload.data === 'object' && !Array.isArray(payload.data)
+            ? (payload.data as { positions?: JobPosition[] }).positions
+            : undefined
+        if (Array.isArray(positions)) setJobPositions(positions)
       } catch {
         // job positions are optional
       }
     }
 
-    fetchCompanyDetail()
-    fetchJobPositions()
+    void fetchCompanyDetail()
+    void fetchJobPositions()
   }, [params.id])
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">読み込み中...</p>
-        </div>
-      </div>
+      <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Stack spacing={2} alignItems="center">
+          <CircularProgress />
+          <Typography color="text.secondary">読み込み中...</Typography>
+        </Stack>
+      </Box>
     )
   }
 
   if (!company) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-4">企業が見つかりません</h1>
-          <Button onClick={() => router.back()}>
-            <ArrowLeft className="w-4 h-4 mr-2" />
+      <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Stack spacing={2} alignItems="center">
+          <Typography variant="h5" fontWeight={700}>企業が見つかりません</Typography>
+          <Button startIcon={<ArrowBackIcon />} variant="contained" onClick={() => router.back()}>
             戻る
           </Button>
-        </div>
-      </div>
+        </Stack>
+      </Box>
     )
   }
 
+  const infra = parseJsonArray(company.infra_stack)
+  const cicd = parseJsonArray(company.cicd_tools)
+
   return (
-    <div className="min-h-screen bg-background">
-      {/* ヘッダー */}
-      <div className="border-b bg-muted/50">
-        <div className="container mx-auto px-4 py-4">
-          <Button variant="ghost" onClick={() => router.back()}>
-            <ArrowLeft className="w-4 h-4 mr-2" />
+    <Box sx={{ minHeight: '100vh', bgcolor: '#f5f7fa' }}>
+      <Box sx={{ borderBottom: '1px solid', borderColor: 'divider', bgcolor: 'background.paper' }}>
+        <Box sx={{ maxWidth: 1000, mx: 'auto', px: 2, py: 1.5 }}>
+          <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()}>
             一覧に戻る
           </Button>
-        </div>
-      </div>
+        </Box>
+      </Box>
 
-      <div className="container mx-auto px-4 py-8 max-w-5xl">
-        {/* 企業ヘッダー */}
-        <Card className="mb-6">
-          <CardHeader>
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <div className="flex items-center gap-3 mb-2">
-                  <Building2 className="w-8 h-8 text-primary" />
-                  <CardTitle className="text-3xl">{company.name}</CardTitle>
-                </div>
-                <p className="text-muted-foreground">{company.industry}</p>
-              </div>
-              <div className="text-right">
-                <div className="flex items-center gap-2 mb-2">
-                  <Star className="w-5 h-5 text-yellow-500 fill-yellow-500" />
-                  <span className="text-2xl font-bold text-primary">{company.matchScore}%</span>
-                </div>
-                <p className="text-sm text-muted-foreground">マッチ度</p>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-              <div className="flex items-center gap-2">
-                <MapPin className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm">{company.location}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Users className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm">{company.employees}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Calendar className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm">設立: {company.founded}</span>
-              </div>
-            </div>
+      <Box sx={{ maxWidth: 1000, mx: 'auto', px: 2, py: 4 }}>
+        <Card sx={{ mb: 3, borderRadius: 2 }}>
+          <CardContent sx={{ p: { xs: 2.5, md: 3 } }}>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              justifyContent="space-between"
+              alignItems={{ xs: 'flex-start', sm: 'flex-start' }}
+              spacing={2}
+              sx={{ mb: 2 }}
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 0.5 }}>
+                  <BusinessIcon color="primary" sx={{ fontSize: 36 }} />
+                  <Typography variant="h4" fontWeight={700} sx={{ wordBreak: 'break-word' }}>
+                    {company.name}
+                  </Typography>
+                </Stack>
+                <Typography color="text.secondary">{company.industry || '業種未登録'}</Typography>
+              </Box>
+              <Box sx={{ textAlign: { xs: 'left', sm: 'right' } }}>
+                <Stack direction="row" spacing={0.75} alignItems="center" justifyContent={{ sm: 'flex-end' }}>
+                  <StarIcon sx={{ color: '#f59e0b' }} />
+                  <Typography variant="h5" fontWeight={700} color="primary.main">
+                    {company.matchScore}%
+                  </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary">マッチ度</Typography>
+              </Box>
+            </Stack>
 
-            {/* タグ */}
-            <div className="flex flex-wrap gap-2 mb-4">
-              {company.tags.map((tag, index) => (
-                <Badge key={index} variant="secondary">{tag}</Badge>
-              ))}
-            </div>
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 2.5 }}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <PlaceIcon fontSize="small" color="action" />
+                <Typography variant="body2">{company.location || '—'}</Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <PeopleIcon fontSize="small" color="action" />
+                <Typography variant="body2">{company.employees || '—'}</Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <CalendarMonthIcon fontSize="small" color="action" />
+                <Typography variant="body2">設立: {company.founded || '—'}</Typography>
+              </Stack>
+            </Stack>
 
-            {/* ウェブサイト */}
-            <div className="flex flex-wrap gap-2">
-              <Button variant="outline" asChild>
-                <a href={company.website} target="_blank" rel="noopener noreferrer">
-                  <Globe className="w-4 h-4 mr-2" />
+            {company.tags.length > 0 && (
+              <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: 2 }}>
+                {company.tags.map((tag) => (
+                  <Chip key={tag} label={tag} size="small" />
+                ))}
+              </Stack>
+            )}
+
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+              {company.website ? (
+                <Button
+                  variant="outlined"
+                  href={company.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  startIcon={<LanguageIcon />}
+                  endIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                >
                   公式サイトを見る
-                  <ExternalLink className="w-3 h-3 ml-2" />
-                </a>
-              </Button>
-              <Button onClick={() => router.push(`/interview?company_id=${company.id}`)}>
-                <Briefcase className="w-4 h-4 mr-2" />
+                </Button>
+              ) : null}
+              <Button
+                variant="contained"
+                startIcon={<WorkIcon />}
+                onClick={() => router.push(`/interview?company_id=${company.id}`)}
+              >
                 この企業で面接練習
               </Button>
-            </div>
+            </Stack>
           </CardContent>
         </Card>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* 企業概要 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Building2 className="w-5 h-5" />
-                企業概要
-              </CardTitle>
-            </CardHeader>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+            gap: 2.5,
+          }}
+        >
+          <Card sx={{ borderRadius: 2 }}>
             <CardContent>
-              <p className="text-sm leading-relaxed">{company.description}</p>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <BusinessIcon fontSize="small" />
+                <Typography fontWeight={700}>企業概要</Typography>
+              </Stack>
+              <Typography variant="body2" sx={{ lineHeight: 1.8, whiteSpace: 'pre-wrap' }}>
+                {company.description || '概要未登録'}
+              </Typography>
             </CardContent>
           </Card>
 
-          {/* 技術スタック */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Code className="w-5 h-5" />
-                技術スタック
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {company.techStack.length > 0 && (
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">言語・フレームワーク</p>
-                  <div className="flex flex-wrap gap-2">
-                    {company.techStack.map((tech, index) => (
-                      <Badge key={index} variant="outline">{tech}</Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {parseJsonArray(company.infra_stack).length > 0 && (
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">インフラ</p>
-                  <div className="flex flex-wrap gap-2">
-                    {parseJsonArray(company.infra_stack).map((item, index) => (
-                      <Badge key={index} variant="secondary">{item}</Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {parseJsonArray(company.cicd_tools).length > 0 && (
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">CI/CD</p>
-                  <div className="flex flex-wrap gap-2">
-                    {parseJsonArray(company.cicd_tools).map((item, index) => (
-                      <Badge key={index} variant="secondary">{item}</Badge>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {company.development_style && (
-                <div>
-                  <p className="text-xs text-muted-foreground mb-1">開発手法</p>
-                  <Badge>{company.development_style}</Badge>
-                </div>
-              )}
-              {company.techStack.length === 0 && !company.infra_stack && !company.cicd_tools && (
-                <p className="text-sm text-muted-foreground">技術情報未登録</p>
+          <Card sx={{ borderRadius: 2 }}>
+            <CardContent>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <CodeIcon fontSize="small" />
+                <Typography fontWeight={700}>技術スタック</Typography>
+              </Stack>
+              <Stack spacing={1.5}>
+                {company.techStack.length > 0 && (
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">言語・フレームワーク</Typography>
+                    <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mt: 0.5 }}>
+                      {company.techStack.map((tech) => (
+                        <Chip key={tech} label={tech} size="small" variant="outlined" />
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+                {infra.length > 0 && (
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">インフラ</Typography>
+                    <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mt: 0.5 }}>
+                      {infra.map((item) => (
+                        <Chip key={item} label={item} size="small" />
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+                {cicd.length > 0 && (
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">CI/CD</Typography>
+                    <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mt: 0.5 }}>
+                      {cicd.map((item) => (
+                        <Chip key={item} label={item} size="small" />
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+                {company.development_style && (
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">開発手法</Typography>
+                    <Box sx={{ mt: 0.5 }}>
+                      <Chip label={company.development_style} size="small" color="primary" />
+                    </Box>
+                  </Box>
+                )}
+                {company.techStack.length === 0 && infra.length === 0 && cicd.length === 0 && !company.development_style && (
+                  <Typography variant="body2" color="text.secondary">技術情報未登録</Typography>
+                )}
+              </Stack>
+            </CardContent>
+          </Card>
+
+          <Card sx={{ borderRadius: 2 }}>
+            <CardContent>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <HubIcon fontSize="small" />
+                <Typography fontWeight={700}>プロジェクトタイプ</Typography>
+              </Stack>
+              {company.projectTypes.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">未登録</Typography>
+              ) : (
+                <Stack spacing={1}>
+                  {company.projectTypes.map((type) => (
+                    <Typography key={type} variant="body2">• {type}</Typography>
+                  ))}
+                </Stack>
               )}
             </CardContent>
           </Card>
 
-          {/* プロジェクトタイプ */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Target className="w-5 h-5" />
-                プロジェクトタイプ
-              </CardTitle>
-            </CardHeader>
+          <Card sx={{ borderRadius: 2 }}>
             <CardContent>
-              <ul className="space-y-2">
-                {company.projectTypes.map((type, index) => (
-                  <li key={index} className="flex items-center gap-2 text-sm">
-                    <div className="w-1.5 h-1.5 rounded-full bg-primary" />
-                    {type}
-                  </li>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <TrendingUpIcon fontSize="small" />
+                <Typography fontWeight={700}>給与・待遇</Typography>
+              </Stack>
+              <Typography fontWeight={600} sx={{ mb: 1 }}>
+                {company.salary || '給与情報未登録'}
+              </Typography>
+              <Stack spacing={0.75}>
+                {company.benefits.map((benefit) => (
+                  <Stack key={benefit} direction="row" spacing={1} alignItems="center">
+                    <FavoriteIcon sx={{ fontSize: 14, color: 'primary.main' }} />
+                    <Typography variant="body2">{benefit}</Typography>
+                  </Stack>
                 ))}
-              </ul>
+              </Stack>
             </CardContent>
           </Card>
 
-          {/* 給与・待遇 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <DollarSign className="w-5 h-5" />
-                給与・待遇
-              </CardTitle>
-            </CardHeader>
+          <Card sx={{ borderRadius: 2 }}>
             <CardContent>
-              <p className="text-lg font-semibold mb-3">{company.salary}</p>
-              <div className="space-y-1">
-                {company.benefits.map((benefit, index) => (
-                  <div key={index} className="flex items-center gap-2 text-sm">
-                    <Heart className="w-3 h-3 text-primary" />
-                    {benefit}
-                  </div>
-                ))}
-              </div>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <EmojiEventsIcon fontSize="small" />
+                <Typography fontWeight={700}>企業文化・働き方</Typography>
+              </Stack>
+              {company.culture.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">未登録</Typography>
+              ) : (
+                <Stack spacing={1}>
+                  {company.culture.map((item) => (
+                    <Typography key={item} variant="body2">• {item}</Typography>
+                  ))}
+                </Stack>
+              )}
             </CardContent>
           </Card>
 
-          {/* 企業文化 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Award className="w-5 h-5" />
-                企業文化・働き方
-              </CardTitle>
-            </CardHeader>
+          <Card sx={{ borderRadius: 2 }}>
             <CardContent>
-              <ul className="space-y-2">
-                {company.culture.map((item, index) => (
-                  <li key={index} className="flex items-center gap-2 text-sm">
-                    <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* 企業規模 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <TrendingUp className="w-5 h-5" />
-                企業規模・関連情報
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div>
-                <p className="text-sm font-semibold mb-1">企業規模</p>
-                <p className="text-sm text-muted-foreground">{company.size}</p>
-              </div>
-              
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+                <TrendingUpIcon fontSize="small" />
+                <Typography fontWeight={700}>企業規模・関連情報</Typography>
+              </Stack>
+              <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>企業規模</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                {company.size || '—'}
+              </Typography>
               {company.parentCompany && (
-                <div>
-                  <p className="text-sm font-semibold mb-1">親会社</p>
-                  <p className="text-sm text-muted-foreground">{company.parentCompany}</p>
-                </div>
+                <Box sx={{ mb: 1.5 }}>
+                  <Typography variant="body2" fontWeight={600}>親会社</Typography>
+                  <Typography variant="body2" color="text.secondary">{company.parentCompany}</Typography>
+                </Box>
               )}
-
               {company.subsidiaries && company.subsidiaries.length > 0 && (
-                <div>
-                  <p className="text-sm font-semibold mb-1">子会社</p>
-                  <ul className="text-sm text-muted-foreground space-y-1">
-                    {company.subsidiaries.map((sub, index) => (
-                      <li key={index}>• {sub}</li>
-                    ))}
-                  </ul>
-                </div>
+                <Box sx={{ mb: 1.5 }}>
+                  <Typography variant="body2" fontWeight={600}>子会社</Typography>
+                  {company.subsidiaries.map((sub) => (
+                    <Typography key={sub} variant="body2" color="text.secondary">• {sub}</Typography>
+                  ))}
+                </Box>
               )}
-
               {company.partnerships && company.partnerships.length > 0 && (
-                <div>
-                  <p className="text-sm font-semibold mb-1">主要パートナー</p>
-                  <ul className="text-sm text-muted-foreground space-y-1">
-                    {company.partnerships.map((partner, index) => (
-                      <li key={index}>• {partner}</li>
-                    ))}
-                  </ul>
-                </div>
+                <Box>
+                  <Typography variant="body2" fontWeight={600}>主要パートナー</Typography>
+                  {company.partnerships.map((partner) => (
+                    <Typography key={partner} variant="body2" color="text.secondary">• {partner}</Typography>
+                  ))}
+                </Box>
               )}
             </CardContent>
           </Card>
-        </div>
+        </Box>
 
-        {/* 公開求人情報 */}
         {jobPositions.length > 0 && (
-          <Card className="mt-6">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Briefcase className="w-5 h-5" />
-                募集職種
-              </CardTitle>
-            </CardHeader>
+          <Card sx={{ mt: 3, borderRadius: 2 }}>
             <CardContent>
-              <div className="space-y-3">
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+                <WorkIcon fontSize="small" />
+                <Typography fontWeight={700}>募集職種</Typography>
+              </Stack>
+              <Stack spacing={1.5}>
                 {jobPositions.map((pos) => (
-                  <div key={pos.id} className="border rounded-lg p-4">
-                    <div className="flex items-start justify-between gap-2">
-                      <div>
-                        <p className="font-semibold">{pos.title}</p>
-                        <p className="text-sm text-muted-foreground mt-1">
-                          {[pos.job_category?.name, pos.employment_type, pos.work_location].filter(Boolean).join(' / ')}
-                        </p>
-                        {pos.description && (
-                          <p className="text-sm mt-2 text-muted-foreground line-clamp-2">{pos.description}</p>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                  <Box key={pos.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 2 }}>
+                    <Typography fontWeight={600}>{pos.title}</Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                      {[pos.job_category?.name, pos.employment_type, pos.work_location].filter(Boolean).join(' / ')}
+                    </Typography>
+                    {pos.description && (
+                      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                        {pos.description}
+                      </Typography>
+                    )}
+                  </Box>
                 ))}
-              </div>
+              </Stack>
             </CardContent>
           </Card>
         )}
 
-        {/* 企業関連図 */}
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Network className="w-5 h-5" />
-              企業関連図
-            </CardTitle>
-          </CardHeader>
+        <Card sx={{ mt: 3, borderRadius: 2 }}>
           <CardContent>
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className="grid w-full max-w-md grid-cols-2">
-                <TabsTrigger value="capital" className="flex items-center gap-2">
-                  <GitBranch className="w-4 h-4" />
-                  資本関連図
-                </TabsTrigger>
-                <TabsTrigger value="business" className="flex items-center gap-2">
-                  <Network className="w-4 h-4" />
-                  ビジネス関連図
-                </TabsTrigger>
-              </TabsList>
-              
-              <TabsContent value="capital" className="mt-4">
-                <div className="mb-3 text-sm text-muted-foreground space-y-1">
-                  <p>• 黄色でハイライトされた企業が現在表示中の企業です</p>
-                  <p>• 実線：子会社（出資比率50%以上）、破線：関連会社（出資比率50%未満）</p>
-                  <div className="flex gap-4 mt-2">
-                    <span className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#4169E1' }}></span>
-                      プライム
-                    </span>
-                    <span className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#32CD32' }}></span>
-                      スタンダード
-                    </span>
-                    <span className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#FF6347' }}></span>
-                      グロース
-                    </span>
-                    <span className="flex items-center gap-2">
-                      <span className="w-3 h-3 rounded-full" style={{ backgroundColor: '#9E9E9E' }}></span>
-                      非上場
-                    </span>
-                  </div>
-                </div>
-                <CompanyDiagram 
-                  companyId={company.id} 
-                  diagramType="capital" 
-                />
-              </TabsContent>
-              
-              <TabsContent value="business" className="mt-4">
-                <div className="mb-3 text-sm text-muted-foreground space-y-1">
-                  <p>• 黄色でハイライトされた企業が現在表示中の企業です</p>
-                  <p>• 青い矢印：ビジネス取引関係、灰色の点線：資本関係（親会社）</p>
-                </div>
-                <CompanyDiagram 
-                  companyId={company.id} 
-                  diagramType="business" 
-                />
-              </TabsContent>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+              <AccountTreeIcon fontSize="small" />
+              <Typography fontWeight={700}>企業関連図</Typography>
+            </Stack>
+
+            <Tabs
+              value={activeTab}
+              onChange={(_, v: 'capital' | 'business') => setActiveTab(v)}
+              sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
+            >
+              <Tab value="capital" icon={<AccountTreeIcon />} iconPosition="start" label="資本関連図" />
+              <Tab value="business" icon={<HubIcon />} iconPosition="start" label="ビジネス関連図" />
             </Tabs>
+
+            {activeTab === 'capital' ? (
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  • 黄色でハイライトされた企業が現在表示中の企業です
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  • 実線：子会社（出資比率50%以上）、破線：関連会社（出資比率50%未満）
+                </Typography>
+                <CompanyDiagram companyId={company.id} diagramType="capital" />
+              </Box>
+            ) : (
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  • 黄色でハイライトされた企業が現在表示中の企業です
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  • 青い矢印：ビジネス取引関係、灰色の点線：資本関係（親会社）
+                </Typography>
+                <CompanyDiagram companyId={company.id} diagramType="business" />
+              </Box>
+            )}
           </CardContent>
         </Card>
 
-        {/* アクションボタン */}
-        <div className="mt-8 flex gap-4 justify-center">
-          <Button size="lg" onClick={() => router.back()}>
-            <ArrowLeft className="w-4 h-4 mr-2" />
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} justifyContent="center" sx={{ mt: 4 }}>
+          <Button size="large" variant="contained" startIcon={<ArrowBackIcon />} onClick={() => router.back()}>
             一覧に戻る
           </Button>
-          <Button size="lg" variant="outline" asChild>
-            <a href={company.website} target="_blank" rel="noopener noreferrer">
-              <Globe className="w-4 h-4 mr-2" />
+          {company.website ? (
+            <Button
+              size="large"
+              variant="outlined"
+              href={company.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              startIcon={<LanguageIcon />}
+              endIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+            >
               公式サイトへ
-              <ExternalLink className="w-3 h-3 ml-2" />
-            </a>
-          </Button>
-        </div>
-      </div>
-    </div>
+            </Button>
+          ) : null}
+        </Stack>
+      </Box>
+    </Box>
   )
 }

--- a/frontend/app/company/[id]/page.tsx
+++ b/frontend/app/company/[id]/page.tsx
@@ -9,7 +9,6 @@ import {
   Card,
   CardContent,
   Chip,
-  CircularProgress,
   Stack,
   Tab,
   Tabs,
@@ -108,11 +107,8 @@ export default function CompanyDetailPage() {
 
   if (loading) {
     return (
-      <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <Stack spacing={2} alignItems="center">
-          <CircularProgress />
-          <Typography color="text.secondary">読み込み中...</Typography>
-        </Stack>
+      <Box sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: '#f5f7fa' }}>
+        <Typography color="text.secondary">読み込み中...</Typography>
       </Box>
     )
   }

--- a/frontend/tests/app/company/companyDetailUtils.test.ts
+++ b/frontend/tests/app/company/companyDetailUtils.test.ts
@@ -1,0 +1,70 @@
+import {
+  mapCompanyApiToViewModel,
+  parseJsonArray,
+  unwrapCompanyRecord,
+} from '@/app/company/[id]/companyDetailUtils'
+
+describe('parseJsonArray', () => {
+  it('JSON 配列文字列をパースする', () => {
+    expect(parseJsonArray('["Go","TypeScript"]')).toEqual(['Go', 'TypeScript'])
+  })
+
+  it('カンマ区切りを配列にする', () => {
+    expect(parseJsonArray('Go, TypeScript')).toEqual(['Go', 'TypeScript'])
+  })
+
+  it('空・undefined は空配列', () => {
+    expect(parseJsonArray()).toEqual([])
+    expect(parseJsonArray('')).toEqual([])
+  })
+})
+
+describe('unwrapCompanyRecord', () => {
+  it('生オブジェクトをそのまま返す', () => {
+    expect(unwrapCompanyRecord({ id: 1, name: 'A' })).toEqual({ id: 1, name: 'A' })
+  })
+
+  it('{ data: {...} } を展開する', () => {
+    expect(unwrapCompanyRecord({ data: { id: 2, name: 'B' } })).toEqual({ id: 2, name: 'B' })
+  })
+
+  it('不正値は null', () => {
+    expect(unwrapCompanyRecord(null)).toBeNull()
+    expect(unwrapCompanyRecord([])).toBeNull()
+  })
+})
+
+describe('mapCompanyApiToViewModel', () => {
+  it('API フィールドを UI 向けに補完する', () => {
+    const vm = mapCompanyApiToViewModel({
+      id: 40045,
+      name: 'テスト株式会社',
+      industry: 'IT',
+      location: '東京',
+      description: '説明',
+      employee_count: 100,
+      founded_year: 2000,
+      website_url: 'https://example.com',
+      tech_stack: '["Go"]',
+      culture: '風通しが良い',
+    })
+
+    expect(vm).toMatchObject({
+      id: 40045,
+      name: 'テスト株式会社',
+      employees: '100名',
+      size: '100名規模',
+      founded: '2000年',
+      website: 'https://example.com',
+      techStack: ['Go'],
+      culture: ['風通しが良い'],
+    })
+  })
+
+  it('ラップされたレスポンスも扱える', () => {
+    const vm = mapCompanyApiToViewModel({
+      data: { id: 1, name: 'Wrapped' },
+    })
+    expect(vm?.name).toBe('Wrapped')
+  })
+})


### PR DESCRIPTION
## Summary
- `/company/[id]` が Tailwind クラス依存のまま Tailwind 未導入だったためスタイルが一切当たらず崩れていた
- 他画面と同様に MUI で再実装し、カード／グリッド／タブが正しく表示されるようにした
- 壊れていた Tabs（両タブ常時描画）を MUI Tabs に置換
- API レスポンス正規化ユーティリティと単体テストを追加

## Test plan
- [ ] http://localhost:3000/company/40045 でカード・2カラム・ボタンが整列して表示される
- [ ] 資本/ビジネス関連図タブ切替で片方だけ表示される
- [ ] 公式サイト・面接練習ボタンが動作する
- [ ] 狭い画面でもヘッダーが折り返されて読める


Made with [Cursor](https://cursor.com)