### PR TITLE
Resolve #711: チャット画面UIの使いやすさ改善

### DIFF
--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -12,14 +12,19 @@
 
 .mainContent {
     flex-grow: 1;
-    height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
     display: flex;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;
     overflow: hidden;
 }
 
 .chatWrapper {
-    flex-grow: 1;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
   }
 
   return (
-    <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+    <Box sx={{ display: 'flex', height: '100dvh', maxHeight: '100dvh', overflow: 'hidden' }}>
       <AnalysisSidebar
         user={user}
         onLogout={handleLogout}

--- a/frontend/components/mui-chat.module.css
+++ b/frontend/components/mui-chat.module.css
@@ -1,6 +1,7 @@
-/* チャット全体コンテナ */
+/* チャット全体コンテナ — 親の flex 高さを埋め、モバイルでも入力欄を確保 */
 .chatContainer {
-    height: calc(100vh - 48px); /* モバイルヘッダー(48px)分を引く */
+    height: 100%;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     background-color: #fff;
@@ -8,12 +9,14 @@
 
 /* ヘッダー */
 .chatHeader {
-    padding: 12px 12px; /* 1.5 * 8px */
+    padding: 10px 12px;
     border-bottom: 1px solid #e0e0e0;
     background-color: #fff;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-shrink: 0;
+    gap: 8px;
 }
 
 /* デスクトップタイトル: モバイルでは非表示 */
@@ -30,41 +33,38 @@
 
 /* 終了ボタン */
 .endButton {
-    min-width: 80px !important;
+    min-width: 64px !important;
     font-size: 0.75rem !important;
 }
 
 /* メッセージエリア */
 .messagesArea {
-    padding: 16px; /* 2 * 8px */
+    padding: 12px 12px 16px;
 }
 
 /* メッセージバブル */
 .messageBubble {
-    padding: 12px !important; /* 1.5 * 8px */
-    max-width: 90% !important;
+    padding: 10px 12px !important;
+    max-width: 88% !important;
+    border-radius: 12px !important;
 }
 
 /* 選択肢ボタン */
 .choiceButton {
     font-size: 0.75rem !important;
-    padding-top: 6px !important;    /* 0.75 * 8px */
+    padding-top: 6px !important;
     padding-bottom: 6px !important;
 }
 
 /* デスクトップ(md: 900px以上) */
 @media (min-width: 900px) {
-    .chatContainer {
-        height: 100vh;
-    }
-
     .chatHeader {
-        padding: 16px; /* 2 * 8px */
+        padding: 16px;
     }
 
     .chatTitle {
         display: block;
-        font-size: 1.5rem;
+        font-size: 1.35rem;
     }
 
     .chatProgress {
@@ -72,16 +72,16 @@
     }
 
     .endButton {
-        min-width: 120px !important;
+        min-width: 96px !important;
         font-size: 0.875rem !important;
     }
 
     .messagesArea {
-        padding: 24px; /* 3 * 8px */
+        padding: 24px;
     }
 
     .messageBubble {
-        padding: 16px !important; /* 2 * 8px */
+        padding: 14px 16px !important;
         max-width: 70% !important;
     }
 

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -49,8 +49,11 @@ export function MuiChat() {
           historyLoadError={chat.historyLoadError}
           historyRetrying={chat.historyRetrying}
           messagesEndRef={chat.messagesEndRef}
+          messagesAreaRef={chat.messagesAreaRef}
           onRetryHistoryLoad={chat.handleRetryHistoryLoad}
-          onQuickSelect={chat.setInput}
+          onQuickSelect={(option) => {
+            void chat.handleSend(option)
+          }}
         />
 
         <ChatInputBar

--- a/frontend/components/mui-chat/components/ChatHeader.tsx
+++ b/frontend/components/mui-chat/components/ChatHeader.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, LinearProgress, Typography } from '@mui/material'
 import styles from '../../mui-chat.module.css'
+import { CHAT_BRAND } from '../utils'
 import type { ProgressTotals } from '../types'
 
 type ChatHeaderProps = {
@@ -19,26 +20,37 @@ export function ChatHeader({
   onEndChat,
 }: ChatHeaderProps) {
   const valid = progressTotals?.valid ?? questionCount
-  const required = progressTotals?.required ?? totalQuestions
+  const required = progressTotals?.required ?? Math.max(1, totalQuestions)
   const percent =
-    progressTotals?.percent ?? Math.round((questionCount / totalQuestions) * 100)
+    progressTotals?.percent ?? Math.min(100, Math.round((questionCount / required) * 100))
 
   return (
     <Box className={styles.chatHeader}>
-      <Box sx={{ minWidth: 0 }}>
+      <Box sx={{ minWidth: 0, flex: 1, pr: 1 }}>
         <Typography variant="h5" className={styles.chatTitle}>
           IT業界キャリアエージェント
         </Typography>
         <Typography variant="body2" color="text.secondary" className={styles.chatProgress}>
-          AI適性診断 - {valid}/{required} 問完了
-          {valid > 0 && ` (${percent}%)`}
+          AI適性診断 — {valid}/{required} 問完了（想定{required}問・{percent}%）
         </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={percent}
+          sx={{
+            mt: 1,
+            height: 6,
+            borderRadius: 3,
+            bgcolor: 'rgba(236,91,19,0.12)',
+            '& .MuiLinearProgress-bar': { bgcolor: CHAT_BRAND },
+          }}
+        />
       </Box>
       <Button
         variant="outlined"
         size="small"
         onClick={onEndChat}
         className={styles.endButton}
+        sx={{ borderColor: CHAT_BRAND, color: CHAT_BRAND, flexShrink: 0 }}
       >
         終了
       </Button>

--- a/frontend/components/mui-chat/components/ChatInputBar.tsx
+++ b/frontend/components/mui-chat/components/ChatInputBar.tsx
@@ -13,6 +13,7 @@ import {
 import { Send } from '@mui/icons-material'
 import styles from '../../mui-chat.module.css'
 import type { ChoiceOption } from '../types'
+import { CHAT_BRAND, CHAT_BRAND_HOVER } from '../utils'
 
 type ChatInputBarProps = {
   analysisComplete: boolean
@@ -66,6 +67,8 @@ export function ChatInputBar({
               px: 4,
               fontSize: '1.1rem',
               fontWeight: 'bold',
+              bgcolor: CHAT_BRAND,
+              '&:hover': { bgcolor: CHAT_BRAND_HOVER },
             }}
           >
             🎉 分析完了！結果を見る
@@ -142,10 +145,10 @@ export function ChatInputBar({
               onClick={() => onSend()}
               disabled={!input.trim() || isLoading || !!historyLoadError}
               sx={{
-                bgcolor: '#1976d2',
+                bgcolor: CHAT_BRAND,
                 color: '#fff',
                 '&:hover': {
-                  bgcolor: '#1565c0',
+                  bgcolor: CHAT_BRAND_HOVER,
                 },
                 '&.Mui-disabled': {
                   bgcolor: '#e0e0e0',

--- a/frontend/components/mui-chat/components/ChatMessageList.tsx
+++ b/frontend/components/mui-chat/components/ChatMessageList.tsx
@@ -15,7 +15,12 @@ import {
 import { Person, SmartToy } from '@mui/icons-material'
 import styles from '../../mui-chat.module.css'
 import { TypingIndicator } from './TypingIndicator'
-import { JOB_QUICK_OPTIONS } from '../utils'
+import {
+  CHAT_BRAND,
+  extractChoices,
+  JOB_QUICK_OPTIONS,
+  stripChoiceLines,
+} from '../utils'
 import type { Message } from '../types'
 
 type ChatMessageListProps = {
@@ -24,6 +29,7 @@ type ChatMessageListProps = {
   historyLoadError: string | null
   historyRetrying: boolean
   messagesEndRef: React.RefObject<HTMLDivElement | null>
+  messagesAreaRef: React.RefObject<HTMLDivElement | null>
   onRetryHistoryLoad: () => void
   onQuickSelect: (option: string) => void
 }
@@ -35,20 +41,26 @@ export function ChatMessageList({
   historyLoadError,
   historyRetrying,
   messagesEndRef,
+  messagesAreaRef,
   onRetryHistoryLoad,
   onQuickSelect,
 }: ChatMessageListProps) {
+  const hasUserMessage = messages.some((m) => m.role === 'user')
+  const showQuickSelect = !historyLoadError && !hasUserMessage && messages.length > 0
+
   return (
     <Box
+      ref={messagesAreaRef}
       className={styles.messagesArea}
       sx={{
         flexGrow: 1,
+        minHeight: 0,
         overflowY: 'auto',
         backgroundColor: '#fff',
       }}
     >
       {historyLoadError && (
-        <Box sx={{ textAlign: 'center', mt: 8, px: 3 }}>
+        <Box sx={{ textAlign: 'center', mt: 4, px: 2 }}>
           <Alert severity="error" sx={{ mb: 2, textAlign: 'left' }}>
             {historyLoadError}
           </Alert>
@@ -57,23 +69,10 @@ export function ChatMessageList({
             onClick={onRetryHistoryLoad}
             disabled={historyRetrying}
             startIcon={historyRetrying ? <CircularProgress size={16} color="inherit" /> : undefined}
+            sx={{ bgcolor: CHAT_BRAND, '&:hover': { bgcolor: '#d14f10' } }}
           >
             {historyRetrying ? '再読み込み中...' : '再試行'}
           </Button>
-        </Box>
-      )}
-
-      {messages.length === 0 && !historyLoadError && (
-        <Box sx={{ textAlign: 'center', mt: 8 }}>
-          <SmartToy sx={{ fontSize: 64, color: '#9e9e9e', mb: 2 }} />
-          <Typography variant="h6" color="text.secondary" gutterBottom>
-            こんにちは！IT業界専門のキャリアエージェントです。
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            4万社余りのIT企業の中から、あなたに最適な企業を選定いたします。
-            <br />
-            まず、どのような職種を希望されますか？
-          </Typography>
         </Box>
       )}
 
@@ -88,12 +87,17 @@ export function ChatMessageList({
           message.role === 'assistant' &&
           message.content.includes('チャットを終了させていただきます')
 
+        const choices =
+          message.role === 'assistant' ? extractChoices(message.content) : []
+        const displayContent =
+          choices.length > 0 ? stripChoiceLines(message.content) : message.content
+
         return (
           <Box
             key={message.id}
             sx={{
               display: 'flex',
-              mb: 3,
+              mb: { xs: 2, md: 2.5 },
               justifyContent: message.role === 'user' ? 'flex-end' : 'flex-start',
             }}
           >
@@ -104,98 +108,100 @@ export function ChatMessageList({
                     ? '#d32f2f'
                     : isValidationError
                       ? '#f57c00'
-                      : '#1976d2',
-                  width: 36,
-                  height: 36,
-                  mr: 2,
+                      : CHAT_BRAND,
+                  width: 32,
+                  height: 32,
+                  mr: 1.5,
+                  flexShrink: 0,
                 }}
               >
-                <SmartToy sx={{ fontSize: 20 }} />
+                <SmartToy sx={{ fontSize: 18 }} />
               </Avatar>
             )}
             <Paper
-              elevation={1}
+              elevation={0}
               className={styles.messageBubble}
               sx={{
                 backgroundColor:
                   message.role === 'user'
-                    ? '#1976d2'
+                    ? CHAT_BRAND
                     : isTerminationMessage
                       ? '#ffebee'
                       : isValidationError
                         ? '#fff3e0'
                         : '#f5f5f5',
-                color: message.role === 'user' ? '#fff' : '#000',
+                color: message.role === 'user' ? '#fff' : '#1a1a1a',
                 border: isTerminationMessage
                   ? '2px solid #d32f2f'
                   : isValidationError
                     ? '2px solid #f57c00'
-                    : 'none',
+                    : message.role === 'assistant'
+                      ? '1px solid #ebebeb'
+                      : 'none',
               }}
             >
-              <Typography variant="body1">{message.content}</Typography>
+              <Typography
+                variant="body1"
+                sx={{ whiteSpace: 'pre-line', lineHeight: 1.65, fontSize: { xs: '0.9375rem', md: '1rem' } }}
+              >
+                {displayContent}
+              </Typography>
             </Paper>
             {message.role === 'user' && (
               <Avatar
                 sx={{
                   bgcolor: '#757575',
-                  width: 36,
-                  height: 36,
-                  ml: 2,
+                  width: 32,
+                  height: 32,
+                  ml: 1.5,
+                  flexShrink: 0,
                 }}
               >
-                <Person sx={{ fontSize: 20 }} />
+                <Person sx={{ fontSize: 18 }} />
               </Avatar>
             )}
           </Box>
         )
       })}
 
-      {/* ローディングインジケーター */}
       {isLoading && (
-        <Box
-          sx={{
-            display: 'flex',
-            mb: 3,
-            justifyContent: 'flex-start',
-          }}
-        >
+        <Box sx={{ display: 'flex', mb: 2, justifyContent: 'flex-start' }}>
           <Avatar
             sx={{
-              bgcolor: '#1976d2',
-              width: 36,
-              height: 36,
-              mr: 2,
+              bgcolor: CHAT_BRAND,
+              width: 32,
+              height: 32,
+              mr: 1.5,
+              flexShrink: 0,
             }}
           >
-            <SmartToy sx={{ fontSize: 20 }} />
+            <SmartToy sx={{ fontSize: 18 }} />
           </Avatar>
           <Paper
-            elevation={1}
+            elevation={0}
             className={styles.messageBubble}
-            sx={{
-              backgroundColor: '#f5f5f5',
-            }}
+            sx={{ backgroundColor: '#f5f5f5', border: '1px solid #ebebeb' }}
           >
             <TypingIndicator />
           </Paper>
         </Box>
       )}
 
-      {messages.length === 0 && (
-        <Box sx={{ mt: 4 }}>
+      {showQuickSelect && (
+        <Box sx={{ mt: 1, mb: 2, px: 1 }}>
           <Typography
             variant="body2"
             color="text.secondary"
-            sx={{ mb: 2, textAlign: 'center' }}
+            sx={{ mb: 1.5, textAlign: 'center' }}
           >
-            クイック選択：
+            クイック選択（タップで送信）
           </Typography>
           <Stack
             direction="row"
             spacing={1}
             justifyContent="center"
             flexWrap="wrap"
+            useFlexGap
             gap={1}
           >
             {JOB_QUICK_OPTIONS.map((option) => (
@@ -203,7 +209,13 @@ export function ChatMessageList({
                 key={option}
                 label={option}
                 onClick={() => onQuickSelect(option)}
-                sx={{ cursor: 'pointer' }}
+                clickable
+                sx={{
+                  cursor: 'pointer',
+                  borderColor: CHAT_BRAND,
+                  '&:hover': { bgcolor: 'rgba(236,91,19,0.08)' },
+                }}
+                variant="outlined"
               />
             ))}
           </Stack>

--- a/frontend/components/mui-chat/hooks/useMuiChat.ts
+++ b/frontend/components/mui-chat/hooks/useMuiChat.ts
@@ -12,6 +12,8 @@ import {
   INITIAL_GREETING,
   RESET_GREETING,
   clearChatSessionOnEnd,
+  computeProgressTotals,
+  shouldAutoScrollToBottom,
 } from '../utils'
 import type { Message, PhaseProgress, ProgressTotals, ChoiceOption } from '../types'
 
@@ -39,30 +41,30 @@ export function useMuiChat() {
   const [historyLoadError, setHistoryLoadError] = useState<string | null>(null)
   const [historyRetrying, setHistoryRetrying] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesAreaRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const progressTotals: ProgressTotals | null = (() => {
-    if (!phaseProgresses || phaseProgresses.length === 0) return null
-    let valid = 0
-    let asked = 0
-    for (const phase of phaseProgresses) {
-      asked += phase.questions_asked || 0
-      valid += phase.valid_answers || 0
-    }
-    if (asked <= 0) return null
-    return {
-      valid,
-      required: asked,
-      percent: Math.round((valid / asked) * 100),
-    }
-  })()
+  const progressTotals: ProgressTotals = computeProgressTotals({
+    phases: phaseProgresses,
+    questionCount,
+    totalQuestions,
+  })
 
-  const scrollToBottom = () => {
+  const scrollToBottomIfNeeded = () => {
+    const area = messagesAreaRef.current
+    if (area) {
+      const allow = shouldAutoScrollToBottom({
+        scrollHeight: area.scrollHeight,
+        scrollTop: area.scrollTop,
+        clientHeight: area.clientHeight,
+      })
+      if (!allow) return
+    }
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   useEffect(() => {
-    scrollToBottom()
+    scrollToBottomIfNeeded()
   }, [messages, isLoading])
 
   const applyHistoryOrGreeting = useCallback((history: Awaited<ReturnType<typeof getChatHistory>>) => {
@@ -516,6 +518,7 @@ export function useMuiChat() {
     historyLoadError,
     historyRetrying,
     messagesEndRef,
+    messagesAreaRef,
     inputRef,
     progressTotals,
     choiceOptions,

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -44,6 +44,74 @@ export const JOB_QUICK_OPTIONS = [
   'まだ決めていない',
 ] as const
 
+/** チャット画面のブランドアクセント（サイドバーと揃える） */
+export const CHAT_BRAND = '#ec5b13'
+export const CHAT_BRAND_HOVER = '#d14f10'
+
+/**
+ * 選択肢行（A) / 1. など）を本文から除き、バブルとボタンの二重表示を防ぐ。
+ */
+export function stripChoiceLines(content: string): string {
+  const kept = content.split('\n').filter((line) => {
+    const trimmed = line.trim()
+    if (!trimmed) return true
+    if (/^([A-E])\)\s*.+$/.test(trimmed)) return false
+    if (/^([A-E])[：、.．]\s*.+$/.test(trimmed)) return false
+    if (/^(\d+)[\.\)．]\s*.+$/.test(trimmed)) return false
+    return true
+  })
+  return kept.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+/**
+ * ヘッダー進捗をサイドバーと同じ「想定総質問数」ベースで計算する。
+ * asked ベースだと途中で 100% に見える問題を避ける。
+ */
+export function computeProgressTotals(args: {
+  phases: { questions_asked?: number; valid_answers?: number; min_questions?: number; max_questions?: number }[] | null
+  questionCount: number
+  totalQuestions: number
+}): { valid: number; required: number; percent: number } {
+  const totalFallback = Math.max(1, args.totalQuestions || 15)
+  if (args.phases && args.phases.length > 0) {
+    let valid = 0
+    let required = 0
+    for (const phase of args.phases) {
+      valid += phase.valid_answers || 0
+      const need =
+        (phase.max_questions && phase.max_questions > 0
+          ? phase.max_questions
+          : phase.min_questions) || 0
+      required += need
+    }
+    if (required <= 0) required = totalFallback
+    return {
+      valid,
+      required,
+      percent: Math.min(100, Math.round((valid / required) * 100)),
+    }
+  }
+  return {
+    valid: args.questionCount,
+    required: totalFallback,
+    percent: Math.min(100, Math.round((args.questionCount / totalFallback) * 100)),
+  }
+}
+
+/**
+ * メッセージ一覧の自動スクロールを「下部付近にいるときだけ」許可する。
+ */
+export function shouldAutoScrollToBottom(args: {
+  scrollHeight: number
+  scrollTop: number
+  clientHeight: number
+  thresholdPx?: number
+}): boolean {
+  const threshold = args.thresholdPx ?? 120
+  const distanceFromBottom = args.scrollHeight - args.scrollTop - args.clientHeight
+  return distanceFromBottom <= threshold
+}
+
 /**
  * チャット終了時にセッション ID とメッセージ／キャッシュを削除する。
  * sessionId は remove 前に取得する（先に消すと chat_cache_ が残る）。

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -3,6 +3,10 @@ import {
   makeMessageId,
   INITIAL_GREETING,
   clearChatSessionOnEnd,
+  stripChoiceLines,
+  computeProgressTotals,
+  shouldAutoScrollToBottom,
+  CHAT_BRAND,
 } from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
@@ -121,5 +125,70 @@ describe('clearChatSessionOnEnd', () => {
 
     expect(sessionStorage._store.chatMessages).toBeUndefined()
     expect(localStorage._store.chat_session_id).toBeUndefined()
+  })
+})
+
+describe('stripChoiceLines', () => {
+  it('選択肢行を除去して質問文を残す', () => {
+    const content = [
+      'どの働き方が好みですか？',
+      '',
+      'A) リモート中心',
+      'B) オフィス中心',
+      '補足です',
+    ].join('\n')
+    expect(stripChoiceLines(content)).toBe('どの働き方が好みですか？\n\n補足です')
+  })
+})
+
+describe('computeProgressTotals', () => {
+  it('フェーズの想定総数を required に使う（asked ではない）', () => {
+    const totals = computeProgressTotals({
+      phases: [
+        { valid_answers: 2, questions_asked: 2, min_questions: 3, max_questions: 5 },
+        { valid_answers: 0, questions_asked: 0, min_questions: 2, max_questions: 4 },
+      ],
+      questionCount: 2,
+      totalQuestions: 15,
+    })
+    expect(totals.required).toBe(9)
+    expect(totals.valid).toBe(2)
+    expect(totals.percent).toBe(Math.round((2 / 9) * 100))
+  })
+
+  it('フェーズ無しなら totalQuestions ベース', () => {
+    expect(
+      computeProgressTotals({ phases: null, questionCount: 3, totalQuestions: 15 }),
+    ).toEqual({ valid: 3, required: 15, percent: 20 })
+  })
+})
+
+describe('shouldAutoScrollToBottom', () => {
+  it('下部付近なら true', () => {
+    expect(
+      shouldAutoScrollToBottom({
+        scrollHeight: 1000,
+        scrollTop: 900,
+        clientHeight: 100,
+        thresholdPx: 120,
+      }),
+    ).toBe(true)
+  })
+
+  it('上部を見ているときは false', () => {
+    expect(
+      shouldAutoScrollToBottom({
+        scrollHeight: 1000,
+        scrollTop: 0,
+        clientHeight: 100,
+        thresholdPx: 120,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('CHAT_BRAND', () => {
+  it('ブランドオレンジである', () => {
+    expect(CHAT_BRAND).toBe('#ec5b13')
   })
 })


### PR DESCRIPTION
## Summary
- メッセージ改行を保持し、選択肢行はバブルから除去（ボタンのみ）
- 初回の職種クイック選択を復活し、タップで送信
- ヘッダー進捗を想定総質問数ベースに統一しプログレスバーを追加
- `100dvh` / flex `minHeight:0` と「下部付近のみ」自動スクロール
- ユーザーバブル・送信・主要アクセントを `#ec5b13` に統一

## Test plan
- [ ] 新規チャットで挨拶の改行が見える
- [ ] 選択肢付き質問で本文に A) 行が重複しない
- [ ] 初回にクイック選択が出て、タップで送信される
- [ ] ヘッダーが途中で常時 100% にならない（サイドバーと大きく食い違わない）
- [ ] モバイルで上にスクロールしたあと、入力中にすぐ最下部へ飛ばない
- [ ] バブル／送信ボタンがオレンジ系

Closes #711

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - チャット画面に質問数と回答進捗を表示。
  - 選択肢をクリックすると、そのまま送信できるよう改善。
  - チャットのブランドカラーを各種ボタンや表示に統一。

- **改善**
  - メッセージ内の選択肢重複表示を解消。
  - 履歴エラー時の再試行表示を調整。
  - ユーザーが閲覧位置を保っている場合のみ自動スクロールするよう変更。
  - モバイル端末を含む画面高さやチャット領域のレイアウトを改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->