### PR TITLE
Resolve #713: チャット職種ID消失修正と送信キー・改行入力

### DIFF
--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -534,15 +534,43 @@ func isJobSelectionQuestionText(text string) bool {
 	if strings.TrimSpace(text) == "" {
 		return false
 	}
-	keywords := []string{
-		"職種", "どの職種", "IT職種",
+	// 職種・興味の明示。これだけで職種選択とみなしてよい。
+	primary := []string{
+		"職種", "IT職種", "どの職種",
 		"興味がありますか", "興味の方向", "どれに興味",
-		"選んでください", "まだ決めていない", "番号で答えても",
-		"どれが近い", "近いですか",
+		"まだ決めていない", "番号で答えても",
 		"好きな作業", "どんな作業", "作業が好き",
 	}
-	for _, keyword := range keywords {
+	for _, keyword := range primary {
 		if strings.Contains(text, keyword) {
+			return true
+		}
+	}
+
+	// 「選んでください」「近いですか」は通常の面接MCQにも出るため、
+	// 職種・役割の文脈があるときだけ職種選択とみなす。
+	selectionCue := strings.Contains(text, "選んでください") ||
+		strings.Contains(text, "どれが近い") ||
+		strings.Contains(text, "近いですか") ||
+		strings.Contains(text, "一番近い")
+	if !selectionCue {
+		return false
+	}
+	return containsJobSelectionContext(text)
+}
+
+// containsJobSelectionContext: 職種clarification系の選択質問かどうかを文脈語で判定する。
+// 「開発」「データ」など経験談MCQにも出る語は入れない（誤って職種判定に再突入するのを防ぐ）。
+func containsJobSelectionContext(text string) bool {
+	cues := []string{
+		"職種", "興味", "まだ決めていない",
+		"エンジニア", "営業", "マーケ", "人事", "デザイナー",
+		"作業が好き", "好きな作業", "どんな作業",
+		"どの分野", "どの領域", "キャリアの方向", "仕事の向き",
+		"役割", "ポジション",
+	}
+	for _, cue := range cues {
+		if strings.Contains(text, cue) {
 			return true
 		}
 	}

--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -517,8 +517,11 @@ func isJobSelectionQuestionText(text string) bool {
 		return false
 	}
 	keywords := []string{
-		"職種", "どの職種", "IT職種", "興味がありますか", "選んでください",
-		"まだ決めていない", "番号で答えても",
+		"職種", "どの職種", "IT職種",
+		"興味がありますか", "興味の方向", "どれに興味",
+		"選んでください", "まだ決めていない", "番号で答えても",
+		"どれが近い", "近いですか",
+		"好きな作業", "どんな作業", "作業が好き",
 	}
 	for _, keyword := range keywords {
 		if strings.Contains(text, keyword) {

--- a/Backend/internal/services/chat_answer_validator.go
+++ b/Backend/internal/services/chat_answer_validator.go
@@ -12,32 +12,45 @@ import (
 	"unicode"
 )
 
+// isValidationFeedbackMessage: 無効回答の警告・強制終了メッセージか。
+// これらを「直近の質問」と誤認すると、再回答が職種選択扱いなどになり連鎖で無効になる。
+func isValidationFeedbackMessage(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return false
+	}
+	return strings.Contains(trimmed, "書かれた内容にはお答えできません") ||
+		strings.Contains(trimmed, "質問と関係のない内容が3回続いた")
+}
+
+// findLastAssistantQuestion: 警告・終了メッセージを飛ばし、履歴上の直近の質問文を返す。
+// 見つからない場合は空文字（呼び出し側で初回職種選択フォールバック）。
+func findLastAssistantQuestion(history []models.ChatMessage) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role != "assistant" {
+			continue
+		}
+		content := history[i].Content
+		if isValidationFeedbackMessage(content) {
+			continue
+		}
+		if isQuestion(content) {
+			return content
+		}
+	}
+	return ""
+}
+
 // checkAnswerValidity: 直近の assistant メッセージが質問かを判定し、ユーザー入力がその質問に対する有効な回答かを判定する。
 // 無効な場合はアシスタントの「書かれた内容にはお答えできません」メッセージを保存して true を返す。
 // 3回連続で無効な場合はセッションを強制終了する。
 // 戻り値: handled(bool) - true の場合は処理を終了してよい、response(string) - 保存したアシスタント応答（ある場合）、error
 func (s *ChatService) checkAnswerValidity(ctx context.Context, history []models.ChatMessage, userMessage string, userID uint, sessionID string) (bool, string, error) {
-	// 直近の assistant メッセージを探す
-	var lastAssistant *models.ChatMessage
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Role == "assistant" {
-			lastAssistant = &history[i]
-			break
-		}
-	}
-
-	// アシスタントメッセージがない場合、またはそれが質問でない場合
-	// → これは初回や説明メッセージの直後なので、職種に関する回答を期待する
-	var questionText string
-	if lastAssistant == nil {
-		// 履歴がない場合は、初回の職種選択を期待
+	// 警告メッセージを飛ばして実質の質問を特定する（1回ミス後の再回答が別質問扱いになるのを防ぐ）
+	questionText := findLastAssistantQuestion(history)
+	if questionText == "" {
+		// 履歴に質問が無い初回などは職種選択を期待
 		questionText = "どのようなIT職種に興味がありますか？"
-	} else if !isQuestion(lastAssistant.Content) {
-		// 質問ではない場合（説明文など）も、職種に関する回答を期待
-		questionText = "IT業界のどのような職種に興味がありますか？"
-	} else {
-		// 通常の質問の場合
-		questionText = lastAssistant.Content
 	}
 
 	// ユーザー回答が質問に対する答えかどうか判定
@@ -134,6 +147,11 @@ func (s *ChatService) validateAnswerRelevance(ctx context.Context, question, ans
 
 			// 閾値は運用で調整。0.30 を採用（緩めに設定して誤検知を抑える）
 			if cos >= 0.30 {
+				return true, nil
+			}
+			// 埋め込み不一致でも実質的な回答なら受理（誤字修正の再送・観点ズレを過剰に落とさない）
+			if isLikelyAnswer(answer, question) {
+				log.Printf("[Validation] Embedding below threshold but fallback accepted\n")
 				return true, nil
 			}
 			return false, nil

--- a/Backend/internal/services/chat_answer_validator_test.go
+++ b/Backend/internal/services/chat_answer_validator_test.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"testing"
+)
+
+func TestIsValidationFeedbackMessage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "warning", content: "書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）", want: true},
+		{name: "terminate", content: "申し訳ございませんが、質問と関係のない内容が3回続いたため、チャットを終了させていただきます。", want: true},
+		{name: "normal question", content: "チームでの経験について具体的に教えてください。", want: false},
+		{name: "empty", content: "", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isValidationFeedbackMessage(tc.content); got != tc.want {
+				t.Fatalf("isValidationFeedbackMessage(%q)=%v want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindLastAssistantQuestion_SkipsValidationFeedback(t *testing.T) {
+	t.Parallel()
+	realQuestion := "その経験について、具体的なエピソードを教えてください。"
+	history := []models.ChatMessage{
+		{Role: "assistant", Content: realQuestion},
+		{Role: "user", Content: "その経験は少ないですが、やはりIT弱者の職員が使いやすいUIwo"},
+		{Role: "assistant", Content: "書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）"},
+	}
+
+	got := findLastAssistantQuestion(history)
+	if got != realQuestion {
+		t.Fatalf("findLastAssistantQuestion()=%q want %q", got, realQuestion)
+	}
+}
+
+func TestFindLastAssistantQuestion_EmptyWhenOnlyFeedback(t *testing.T) {
+	t.Parallel()
+	history := []models.ChatMessage{
+		{Role: "assistant", Content: "書かれた内容にはお答えできません。質問に回答してください。（2/3回目の警告）"},
+	}
+	if got := findLastAssistantQuestion(history); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}
+
+func TestIsLikelyAnswer_AcceptsEpisodeAboutUI(t *testing.T) {
+	t.Parallel()
+	question := "これまでの経験で印象に残っていることを具体的に教えてください。"
+	answer := "その経験は少ないですが児童養護施設の案件をやっていて思ったのはIT弱者の職員が使いやすいUIを作成することがいい経験になると思います"
+	if !isLikelyAnswer(answer, question) {
+		t.Fatalf("expected valid answer for substantial episode text")
+	}
+}

--- a/Backend/internal/services/chat_critical_regression_test.go
+++ b/Backend/internal/services/chat_critical_regression_test.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"testing"
+)
+
+// チャット主要機能の回帰ケース（職種誤判定・無効回答連鎖）。
+// 本番で致命傷になる経路を重点的に固定する。
+
+func TestIsJobSelectionQuestion_RegressionInterviewMCQ(t *testing.T) {
+	t.Parallel()
+	s := &ChatService{}
+
+	interviewQ := "児童養護施設向けに「ITに不慣れな職員でも使いやすいUI」を考えたのは素敵だと思います。" +
+		"正直に聞きたいのですが、その方向性で作るときに一番モヤっとした／妥協せざるを得なかったのはどれですか？" +
+		"（一番近いものを選んでください）\n" +
+		"A) 要件が曖昧でスコープが膨らむ\n" +
+		"B) 技術制約でやりたいUIが出せない\n" +
+		"C) ステークホルダー調整が難しい"
+
+	if s.isJobSelectionQuestion(interviewQ) {
+		t.Fatal("面接の経験談MCQを職種選択と誤判定してはいけない")
+	}
+}
+
+func TestShouldValidateJobCategory_RegressionChoiceANotJob(t *testing.T) {
+	t.Parallel()
+	s := &ChatService{}
+	history := []models.ChatMessage{
+		{Role: "assistant", Content: "これまでの経験を具体的に教えてください。"},
+		{Role: "user", Content: "児童養護施設向けのUIを作りました"},
+		{
+			Role: "assistant",
+			Content: "一番モヤっとしたのはどれですか？（一番近いものを選んでください）\n" +
+				"A) 要件が曖昧\nB) 技術制約\nC) 調整が難しい",
+		},
+		{Role: "user", Content: "A"},
+	}
+	if s.shouldValidateJobCategory(history) {
+		t.Fatal("経験談MCQへの「A」回答で職種判定へ再突入してはいけない")
+	}
+}
+
+func TestShouldValidateJobCategory_TrueForRealJobQuestion(t *testing.T) {
+	t.Parallel()
+	s := &ChatService{}
+	history := []models.ChatMessage{
+		{Role: "assistant", Content: "どの職種に興味がありますか？\n1. エンジニア\n2. 営業\n3. まだ決めていない"},
+		{Role: "user", Content: "1"},
+	}
+	if !s.shouldValidateJobCategory(history) {
+		t.Fatal("本物の職種質問では職種判定が必要")
+	}
+}
+
+func TestFindLastAssistantQuestion_AfterTwoWarnings(t *testing.T) {
+	t.Parallel()
+	q := "チームでの役割について具体的に教えてください。"
+	history := []models.ChatMessage{
+		{Role: "assistant", Content: q},
+		{Role: "user", Content: "あ"},
+		{Role: "assistant", Content: "書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）"},
+		{Role: "user", Content: "あああ"},
+		{Role: "assistant", Content: "書かれた内容にはお答えできません。質問に回答してください。（2/3回目の警告）"},
+	}
+	if got := findLastAssistantQuestion(history); got != q {
+		t.Fatalf("got %q want %q", got, q)
+	}
+}
+
+func TestIsLikelyAnswer_RejectsGarbageAcceptsRetry(t *testing.T) {
+	t.Parallel()
+	q := "これまでの経験で印象に残っていることを具体的に教えてください。"
+
+	if isLikelyAnswer("あ", q) {
+		t.Fatal("極短入力は無効であるべき")
+	}
+	if isLikelyAnswer("あああああ", q) {
+		t.Fatal("連続同一文字は無効であるべき")
+	}
+
+	retry := "その経験は少ないですが児童養護施設の案件をやっていて思ったのはIT弱者の職員が使いやすいUIを作成することがいい経験になると思います"
+	if !isLikelyAnswer(retry, q) {
+		t.Fatal("十分な再回答は有効であるべき")
+	}
+}
+
+func TestIsJobSelectionQuestion_SelectionCueNeedsContext(t *testing.T) {
+	t.Parallel()
+	s := &ChatService{}
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"一番近いものを選んでください", false},
+		{"以下から選んでください", false},
+		{"どれが近いですか？", false},
+		{"以下の職種から選んでください", true},
+		{"どれが近いですか？\n1. エンジニア\n2. 営業", true},
+		{"まだ決めていない場合、どんな作業が好きですか？", true},
+	}
+	for _, tc := range cases {
+		if got := s.isJobSelectionQuestion(tc.text); got != tc.want {
+			t.Fatalf("%q: got %v want %v", tc.text, got, tc.want)
+		}
+	}
+}

--- a/Backend/internal/services/chat_process_job.go
+++ b/Backend/internal/services/chat_process_job.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/internal/models"
 	"context"
+	"fmt"
 	"log"
 )
 
@@ -20,15 +21,20 @@ func (s *ChatService) resolveJobCategoryForChat(ctx context.Context, req ChatReq
 	if s.conversationContextRepo != nil {
 		if id, err := s.conversationContextRepo.GetJobCategoryID(req.SessionID); err == nil {
 			storedJobCategoryID = id
+		} else {
+			log.Printf("[JobValidation] failed to load stored job category: %v\n", err)
 		}
 	}
+	// リクエスト未指定時はセッション保存値を優先
 	if jobCategoryID == 0 {
 		jobCategoryID = storedJobCategoryID
 	}
+	// クライアント側で保持している ID をセッションへ同期
 	if jobCategoryID != 0 && s.conversationContextRepo != nil && storedJobCategoryID != jobCategoryID {
 		if err := s.conversationContextRepo.SetJobCategoryID(req.UserID, req.SessionID, jobCategoryID); err != nil {
-			log.Printf("Warning: failed to store job category: %v\n", err)
+			return nil, fmt.Errorf("failed to store job category: %w", err)
 		}
+		storedJobCategoryID = jobCategoryID
 	}
 
 	if jobCategoryID == 0 && s.shouldValidateJobCategory(history) {
@@ -36,20 +42,18 @@ func (s *ChatService) resolveJobCategoryForChat(ctx context.Context, req ChatReq
 		jobValidation, err := s.jobValidator.ValidateJobCategory(ctx, req.Message)
 		if err != nil {
 			log.Printf("[JobValidation] Error: %v\n", err)
-			// エラーでも続行
+			// 判定エラーでも会話は続行（職種未設定のまま）
 		} else if jobValidation != nil {
 			if jobValidation.IsValid && len(jobValidation.MatchedCategories) > 0 {
-				// 明確に職種が特定できた場合
 				log.Printf("[JobValidation] Valid job category matched: %d categories\n", len(jobValidation.MatchedCategories))
 				jobCategoryID = jobValidation.MatchedCategories[0].ID
 				result.jobJustResolved = true
 				if s.conversationContextRepo != nil {
 					if err := s.conversationContextRepo.SetJobCategoryID(req.UserID, req.SessionID, jobCategoryID); err != nil {
-						log.Printf("Warning: failed to store job category: %v\n", err)
+						return nil, fmt.Errorf("failed to store resolved job category: %w", err)
 					}
 				}
 			} else if jobValidation.NeedsClarification && jobValidation.SuggestedQuestion != "" {
-				// 職種が曖昧な場合は選択肢を提示
 				log.Printf("[JobValidation] Needs clarification, presenting options\n")
 
 				assistantMsg := &models.ChatMessage{
@@ -67,6 +71,7 @@ func (s *ChatService) resolveJobCategoryForChat(ctx context.Context, req ChatReq
 					IsComplete:        false,
 					TotalQuestions:    15,
 					AnsweredQuestions: 0,
+					JobCategoryID:     0,
 				}
 				return result, nil
 			}

--- a/Backend/internal/services/chat_process_question.go
+++ b/Backend/internal/services/chat_process_question.go
@@ -276,6 +276,7 @@ func (s *ChatService) processAnswerAndNextQuestion(ctx context.Context, input pr
 		EvaluatedCategories: len(evaluatedCategories),
 		TotalCategories:     10,
 		Summary:             sessionSummary,
+		JobCategoryID:       jobCategoryID,
 	}, nil
 }
 

--- a/Backend/internal/services/chat_process_question.go
+++ b/Backend/internal/services/chat_process_question.go
@@ -33,13 +33,7 @@ func (s *ChatService) processAnswerAndNextQuestion(ctx context.Context, input pr
 	// 3. ユーザーの回答から重み係数を判定・更新し、回答品質に応じてフェーズ進捗を更新
 	// isQualityAnswer: スキップフレーズ・極短回答・スコア0でなければ true（進捗カウント対象）
 	trimmedAnswer := strings.TrimSpace(req.Message)
-	lastAssistantQuestion := ""
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Role == "assistant" {
-			lastAssistantQuestion = history[i].Content
-			break
-		}
-	}
+	lastAssistantQuestion := findLastAssistantQuestion(history)
 	resolved := ResolveChoiceAnswer(lastAssistantQuestion, trimmedAnswer)
 	log.Printf("[ProcessChat] Checking answer: raw=%q resolved_choice=%v letter=%q free_text=%v\n",
 		trimmedAnswer, resolved.IsChoice, resolved.Letter, resolved.IsFreeText)

--- a/Backend/internal/services/chat_question_generator_test.go
+++ b/Backend/internal/services/chat_question_generator_test.go
@@ -15,11 +15,14 @@ func TestIsJobSelectionQuestion(t *testing.T) {
 		{"empty", "", false},
 		{"whitespace", "   ", false},
 		{"job keyword", "どの職種に興味がありますか？", true},
-		{"select keyword", "以下から選んでください", true},
+		{"select with job context", "以下の職種から選んでください", true},
+		{"select without job context", "以下から選んでください", false},
 		{"number hint", "番号で答えても職種名でも構いません", true},
 		{"undecided", "まだ決めていない場合も教えてください", true},
 		{"preference clarification", "どんな作業が好きですか？", true},
-		{"closest option", "どれが近いですか？", true},
+		{"closest with job options", "どれが近いですか？\n1. エンジニア\n2. 営業", true},
+		{"closest without job context", "どれが近いですか？", false},
+		{"interview mcq closest", "その方向性で作るときに一番モヤっとしたのはどれですか？（一番近いものを選んでください）", false},
 		{"unrelated", "最近頑張ったことを教えてください", false},
 	}
 	for _, tc := range cases {
@@ -56,6 +59,16 @@ func TestShouldValidateJobCategory(t *testing.T) {
 			history: []models.ChatMessage{
 				{Role: "assistant", Content: "最近頑張ったことを教えてください"},
 				{Role: "user", Content: "ハッカソンに参加しました"},
+			},
+			want: false,
+		},
+		{
+			name: "interview choice after experience must not re-enter job validation",
+			history: []models.ChatMessage{
+				{Role: "assistant", Content: "経験について具体的に教えてください。"},
+				{Role: "user", Content: "児童養護施設向けのUIを作りました"},
+				{Role: "assistant", Content: "一番モヤっとしたのはどれですか？（一番近いものを選んでください）\nA) 要件が曖昧\nB) 技術制約\nC) ステークホルダー調整"},
+				{Role: "user", Content: "A"},
 			},
 			want: false,
 		},

--- a/Backend/internal/services/chat_question_generator_test.go
+++ b/Backend/internal/services/chat_question_generator_test.go
@@ -18,6 +18,8 @@ func TestIsJobSelectionQuestion(t *testing.T) {
 		{"select keyword", "以下から選んでください", true},
 		{"number hint", "番号で答えても職種名でも構いません", true},
 		{"undecided", "まだ決めていない場合も教えてください", true},
+		{"preference clarification", "どんな作業が好きですか？", true},
+		{"closest option", "どれが近いですか？", true},
 		{"unrelated", "最近頑張ったことを教えてください", false},
 	}
 	for _, tc := range cases {

--- a/Backend/internal/services/chat_question_predefined.go
+++ b/Backend/internal/services/chat_question_predefined.go
@@ -59,9 +59,14 @@ func (s *ChatService) isJobSelectionQuestion(text string) bool {
 }
 
 func (s *ChatService) shouldValidateJobCategory(history []models.ChatMessage) bool {
-	lastAssistant := s.getLastAssistantMessage(history)
+	// 警告メッセージを飛ばし、実質の直前質問で判定する
+	lastAssistant := findLastAssistantQuestion(history)
 	if strings.TrimSpace(lastAssistant) == "" {
-		return true
+		// 質問がまだ無い初回のみ職種判定へ
+		if s.getLastAssistantMessage(history) == "" {
+			return true
+		}
+		return false
 	}
 	return s.isJobSelectionQuestion(lastAssistant)
 }

--- a/Backend/internal/services/chat_question_predefined.go
+++ b/Backend/internal/services/chat_question_predefined.go
@@ -55,19 +55,7 @@ func (s *ChatService) tryGetPredefinedQuestion(userID uint, sessionID string, pr
 }
 
 func (s *ChatService) isJobSelectionQuestion(text string) bool {
-	if strings.TrimSpace(text) == "" {
-		return false
-	}
-	keywords := []string{
-		"職種", "どの職種", "IT職種", "興味がありますか", "選んでください",
-		"まだ決めていない", "番号で答えても",
-	}
-	for _, keyword := range keywords {
-		if strings.Contains(text, keyword) {
-			return true
-		}
-	}
-	return false
+	return isJobSelectionQuestionText(text)
 }
 
 func (s *ChatService) shouldValidateJobCategory(history []models.ChatMessage) bool {

--- a/Backend/internal/services/chat_service.go
+++ b/Backend/internal/services/chat_service.go
@@ -89,6 +89,7 @@ type ChatResponse struct {
 	EvaluatedCategories int                      `json:"evaluated_categories"`
 	TotalCategories     int                      `json:"total_categories"`
 	Summary             *SessionSummary          `json:"summary,omitempty"`
+	JobCategoryID       uint                     `json:"job_category_id,omitempty"`
 }
 
 // PhaseProgress フェーズ進捗情報

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -12,14 +12,19 @@
 
 .mainContent {
     flex-grow: 1;
-    height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
     display: flex;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;
     overflow: hidden;
 }
 
 .chatWrapper {
-    flex-grow: 1;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
   }
 
   return (
-    <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+    <Box sx={{ display: 'flex', height: '100dvh', maxHeight: '100dvh', overflow: 'hidden' }}>
       <AnalysisSidebar
         user={user}
         onLogout={handleLogout}

--- a/frontend/components/mui-chat.module.css
+++ b/frontend/components/mui-chat.module.css
@@ -1,6 +1,7 @@
-/* チャット全体コンテナ */
+/* チャット全体コンテナ — 親の flex 高さを埋め、モバイルでも入力欄を確保 */
 .chatContainer {
-    height: calc(100vh - 48px); /* モバイルヘッダー(48px)分を引く */
+    height: 100%;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     background-color: #fff;
@@ -8,12 +9,14 @@
 
 /* ヘッダー */
 .chatHeader {
-    padding: 12px 12px; /* 1.5 * 8px */
+    padding: 10px 12px;
     border-bottom: 1px solid #e0e0e0;
     background-color: #fff;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-shrink: 0;
+    gap: 8px;
 }
 
 /* デスクトップタイトル: モバイルでは非表示 */
@@ -30,41 +33,38 @@
 
 /* 終了ボタン */
 .endButton {
-    min-width: 80px !important;
+    min-width: 64px !important;
     font-size: 0.75rem !important;
 }
 
 /* メッセージエリア */
 .messagesArea {
-    padding: 16px; /* 2 * 8px */
+    padding: 12px 12px 16px;
 }
 
 /* メッセージバブル */
 .messageBubble {
-    padding: 12px !important; /* 1.5 * 8px */
-    max-width: 90% !important;
+    padding: 10px 12px !important;
+    max-width: 88% !important;
+    border-radius: 12px !important;
 }
 
 /* 選択肢ボタン */
 .choiceButton {
     font-size: 0.75rem !important;
-    padding-top: 6px !important;    /* 0.75 * 8px */
+    padding-top: 6px !important;
     padding-bottom: 6px !important;
 }
 
 /* デスクトップ(md: 900px以上) */
 @media (min-width: 900px) {
-    .chatContainer {
-        height: 100vh;
-    }
-
     .chatHeader {
-        padding: 16px; /* 2 * 8px */
+        padding: 16px;
     }
 
     .chatTitle {
         display: block;
-        font-size: 1.5rem;
+        font-size: 1.35rem;
     }
 
     .chatProgress {
@@ -72,16 +72,16 @@
     }
 
     .endButton {
-        min-width: 120px !important;
+        min-width: 96px !important;
         font-size: 0.875rem !important;
     }
 
     .messagesArea {
-        padding: 24px; /* 3 * 8px */
+        padding: 24px;
     }
 
     .messageBubble {
-        padding: 16px !important; /* 2 * 8px */
+        padding: 14px 16px !important;
         max-width: 70% !important;
     }
 

--- a/frontend/components/mui-chat.tsx
+++ b/frontend/components/mui-chat.tsx
@@ -49,8 +49,11 @@ export function MuiChat() {
           historyLoadError={chat.historyLoadError}
           historyRetrying={chat.historyRetrying}
           messagesEndRef={chat.messagesEndRef}
+          messagesAreaRef={chat.messagesAreaRef}
           onRetryHistoryLoad={chat.handleRetryHistoryLoad}
-          onQuickSelect={chat.setInput}
+          onQuickSelect={(option) => {
+            void chat.handleSend(option)
+          }}
         />
 
         <ChatInputBar

--- a/frontend/components/mui-chat/components/ChatHeader.tsx
+++ b/frontend/components/mui-chat/components/ChatHeader.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, LinearProgress, Typography } from '@mui/material'
 import styles from '../../mui-chat.module.css'
+import { CHAT_BRAND } from '../utils'
 import type { ProgressTotals } from '../types'
 
 type ChatHeaderProps = {
@@ -19,26 +20,37 @@ export function ChatHeader({
   onEndChat,
 }: ChatHeaderProps) {
   const valid = progressTotals?.valid ?? questionCount
-  const required = progressTotals?.required ?? totalQuestions
+  const required = progressTotals?.required ?? Math.max(1, totalQuestions)
   const percent =
-    progressTotals?.percent ?? Math.round((questionCount / totalQuestions) * 100)
+    progressTotals?.percent ?? Math.min(100, Math.round((questionCount / required) * 100))
 
   return (
     <Box className={styles.chatHeader}>
-      <Box sx={{ minWidth: 0 }}>
+      <Box sx={{ minWidth: 0, flex: 1, pr: 1 }}>
         <Typography variant="h5" className={styles.chatTitle}>
           IT業界キャリアエージェント
         </Typography>
         <Typography variant="body2" color="text.secondary" className={styles.chatProgress}>
-          AI適性診断 - {valid}/{required} 問完了
-          {valid > 0 && ` (${percent}%)`}
+          AI適性診断 — {valid}/{required} 問完了（想定{required}問・{percent}%）
         </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={percent}
+          sx={{
+            mt: 1,
+            height: 6,
+            borderRadius: 3,
+            bgcolor: 'rgba(236,91,19,0.12)',
+            '& .MuiLinearProgress-bar': { bgcolor: CHAT_BRAND },
+          }}
+        />
       </Box>
       <Button
         variant="outlined"
         size="small"
         onClick={onEndChat}
         className={styles.endButton}
+        sx={{ borderColor: CHAT_BRAND, color: CHAT_BRAND, flexShrink: 0 }}
       >
         終了
       </Button>

--- a/frontend/components/mui-chat/components/ChatInputBar.tsx
+++ b/frontend/components/mui-chat/components/ChatInputBar.tsx
@@ -13,6 +13,7 @@ import {
 import { Send } from '@mui/icons-material'
 import styles from '../../mui-chat.module.css'
 import type { ChoiceOption } from '../types'
+import { CHAT_BRAND, CHAT_BRAND_HOVER } from '../utils'
 
 type ChatInputBarProps = {
   analysisComplete: boolean
@@ -66,6 +67,8 @@ export function ChatInputBar({
               px: 4,
               fontSize: '1.1rem',
               fontWeight: 'bold',
+              bgcolor: CHAT_BRAND,
+              '&:hover': { bgcolor: CHAT_BRAND_HOVER },
             }}
           >
             🎉 分析完了！結果を見る
@@ -142,10 +145,10 @@ export function ChatInputBar({
               onClick={() => onSend()}
               disabled={!input.trim() || isLoading || !!historyLoadError}
               sx={{
-                bgcolor: '#1976d2',
+                bgcolor: CHAT_BRAND,
                 color: '#fff',
                 '&:hover': {
-                  bgcolor: '#1565c0',
+                  bgcolor: CHAT_BRAND_HOVER,
                 },
                 '&.Mui-disabled': {
                   bgcolor: '#e0e0e0',

--- a/frontend/components/mui-chat/components/ChatInputBar.tsx
+++ b/frontend/components/mui-chat/components/ChatInputBar.tsx
@@ -13,6 +13,7 @@ import {
 import { Send } from '@mui/icons-material'
 import styles from '../../mui-chat.module.css'
 import type { ChoiceOption } from '../types'
+import { shouldSendChatOnKeyDown } from '../utils'
 
 type ChatInputBarProps = {
   analysisComplete: boolean
@@ -22,7 +23,7 @@ type ChatInputBarProps = {
   inputPlaceholder: string
   isLoading: boolean
   historyLoadError: string | null
-  inputRef: React.RefObject<HTMLInputElement | null>
+  inputRef: React.RefObject<HTMLTextAreaElement | null>
   onInputChange: (value: string) => void
   onSend: (overrideMessage?: string) => void
   onOtherChoice: () => void
@@ -114,16 +115,19 @@ export function ChatInputBar({
               </Stack>
             </Paper>
           )}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-end' }}>
             <TextField
               fullWidth
+              multiline
+              minRows={2}
+              maxRows={6}
               placeholder={inputPlaceholder}
               value={input}
               onChange={(e) => {
                 onInputChange(e.target.value)
               }}
-              onKeyPress={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
+              onKeyDown={(e) => {
+                if (shouldSendChatOnKeyDown(e)) {
                   e.preventDefault()
                   onSend()
                 }
@@ -131,9 +135,12 @@ export function ChatInputBar({
               disabled={isLoading || !!historyLoadError}
               size="small"
               inputRef={inputRef}
+              helperText="改行: Enter　／　送信: Ctrl+Enter（Mac は ⌘+Enter）"
+              FormHelperTextProps={{ sx: { mx: 0.5 } }}
               sx={{
                 '& .MuiOutlinedInput-root': {
                   borderRadius: 2,
+                  alignItems: 'flex-start',
                 },
               }}
             />
@@ -144,6 +151,7 @@ export function ChatInputBar({
               sx={{
                 bgcolor: '#1976d2',
                 color: '#fff',
+                mb: 2.5,
                 '&:hover': {
                   bgcolor: '#1565c0',
                 },

--- a/frontend/components/mui-chat/components/ChatMessageList.tsx
+++ b/frontend/components/mui-chat/components/ChatMessageList.tsx
@@ -15,7 +15,12 @@ import {
 import { Person, SmartToy } from '@mui/icons-material'
 import styles from '../../mui-chat.module.css'
 import { TypingIndicator } from './TypingIndicator'
-import { JOB_QUICK_OPTIONS } from '../utils'
+import {
+  CHAT_BRAND,
+  extractChoices,
+  JOB_QUICK_OPTIONS,
+  stripChoiceLines,
+} from '../utils'
 import type { Message } from '../types'
 
 type ChatMessageListProps = {
@@ -24,6 +29,7 @@ type ChatMessageListProps = {
   historyLoadError: string | null
   historyRetrying: boolean
   messagesEndRef: React.RefObject<HTMLDivElement | null>
+  messagesAreaRef: React.RefObject<HTMLDivElement | null>
   onRetryHistoryLoad: () => void
   onQuickSelect: (option: string) => void
 }
@@ -35,20 +41,26 @@ export function ChatMessageList({
   historyLoadError,
   historyRetrying,
   messagesEndRef,
+  messagesAreaRef,
   onRetryHistoryLoad,
   onQuickSelect,
 }: ChatMessageListProps) {
+  const hasUserMessage = messages.some((m) => m.role === 'user')
+  const showQuickSelect = !historyLoadError && !hasUserMessage && messages.length > 0
+
   return (
     <Box
+      ref={messagesAreaRef}
       className={styles.messagesArea}
       sx={{
         flexGrow: 1,
+        minHeight: 0,
         overflowY: 'auto',
         backgroundColor: '#fff',
       }}
     >
       {historyLoadError && (
-        <Box sx={{ textAlign: 'center', mt: 8, px: 3 }}>
+        <Box sx={{ textAlign: 'center', mt: 4, px: 2 }}>
           <Alert severity="error" sx={{ mb: 2, textAlign: 'left' }}>
             {historyLoadError}
           </Alert>
@@ -57,23 +69,10 @@ export function ChatMessageList({
             onClick={onRetryHistoryLoad}
             disabled={historyRetrying}
             startIcon={historyRetrying ? <CircularProgress size={16} color="inherit" /> : undefined}
+            sx={{ bgcolor: CHAT_BRAND, '&:hover': { bgcolor: '#d14f10' } }}
           >
             {historyRetrying ? '再読み込み中...' : '再試行'}
           </Button>
-        </Box>
-      )}
-
-      {messages.length === 0 && !historyLoadError && (
-        <Box sx={{ textAlign: 'center', mt: 8 }}>
-          <SmartToy sx={{ fontSize: 64, color: '#9e9e9e', mb: 2 }} />
-          <Typography variant="h6" color="text.secondary" gutterBottom>
-            こんにちは！IT業界専門のキャリアエージェントです。
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            4万社余りのIT企業の中から、あなたに最適な企業を選定いたします。
-            <br />
-            まず、どのような職種を希望されますか？
-          </Typography>
         </Box>
       )}
 
@@ -88,12 +87,17 @@ export function ChatMessageList({
           message.role === 'assistant' &&
           message.content.includes('チャットを終了させていただきます')
 
+        const choices =
+          message.role === 'assistant' ? extractChoices(message.content) : []
+        const displayContent =
+          choices.length > 0 ? stripChoiceLines(message.content) : message.content
+
         return (
           <Box
             key={message.id}
             sx={{
               display: 'flex',
-              mb: 3,
+              mb: { xs: 2, md: 2.5 },
               justifyContent: message.role === 'user' ? 'flex-end' : 'flex-start',
             }}
           >
@@ -104,98 +108,100 @@ export function ChatMessageList({
                     ? '#d32f2f'
                     : isValidationError
                       ? '#f57c00'
-                      : '#1976d2',
-                  width: 36,
-                  height: 36,
-                  mr: 2,
+                      : CHAT_BRAND,
+                  width: 32,
+                  height: 32,
+                  mr: 1.5,
+                  flexShrink: 0,
                 }}
               >
-                <SmartToy sx={{ fontSize: 20 }} />
+                <SmartToy sx={{ fontSize: 18 }} />
               </Avatar>
             )}
             <Paper
-              elevation={1}
+              elevation={0}
               className={styles.messageBubble}
               sx={{
                 backgroundColor:
                   message.role === 'user'
-                    ? '#1976d2'
+                    ? CHAT_BRAND
                     : isTerminationMessage
                       ? '#ffebee'
                       : isValidationError
                         ? '#fff3e0'
                         : '#f5f5f5',
-                color: message.role === 'user' ? '#fff' : '#000',
+                color: message.role === 'user' ? '#fff' : '#1a1a1a',
                 border: isTerminationMessage
                   ? '2px solid #d32f2f'
                   : isValidationError
                     ? '2px solid #f57c00'
-                    : 'none',
+                    : message.role === 'assistant'
+                      ? '1px solid #ebebeb'
+                      : 'none',
               }}
             >
-              <Typography variant="body1">{message.content}</Typography>
+              <Typography
+                variant="body1"
+                sx={{ whiteSpace: 'pre-line', lineHeight: 1.65, fontSize: { xs: '0.9375rem', md: '1rem' } }}
+              >
+                {displayContent}
+              </Typography>
             </Paper>
             {message.role === 'user' && (
               <Avatar
                 sx={{
                   bgcolor: '#757575',
-                  width: 36,
-                  height: 36,
-                  ml: 2,
+                  width: 32,
+                  height: 32,
+                  ml: 1.5,
+                  flexShrink: 0,
                 }}
               >
-                <Person sx={{ fontSize: 20 }} />
+                <Person sx={{ fontSize: 18 }} />
               </Avatar>
             )}
           </Box>
         )
       })}
 
-      {/* ローディングインジケーター */}
       {isLoading && (
-        <Box
-          sx={{
-            display: 'flex',
-            mb: 3,
-            justifyContent: 'flex-start',
-          }}
-        >
+        <Box sx={{ display: 'flex', mb: 2, justifyContent: 'flex-start' }}>
           <Avatar
             sx={{
-              bgcolor: '#1976d2',
-              width: 36,
-              height: 36,
-              mr: 2,
+              bgcolor: CHAT_BRAND,
+              width: 32,
+              height: 32,
+              mr: 1.5,
+              flexShrink: 0,
             }}
           >
-            <SmartToy sx={{ fontSize: 20 }} />
+            <SmartToy sx={{ fontSize: 18 }} />
           </Avatar>
           <Paper
-            elevation={1}
+            elevation={0}
             className={styles.messageBubble}
-            sx={{
-              backgroundColor: '#f5f5f5',
-            }}
+            sx={{ backgroundColor: '#f5f5f5', border: '1px solid #ebebeb' }}
           >
             <TypingIndicator />
           </Paper>
         </Box>
       )}
 
-      {messages.length === 0 && (
-        <Box sx={{ mt: 4 }}>
+      {showQuickSelect && (
+        <Box sx={{ mt: 1, mb: 2, px: 1 }}>
           <Typography
             variant="body2"
             color="text.secondary"
-            sx={{ mb: 2, textAlign: 'center' }}
+            sx={{ mb: 1.5, textAlign: 'center' }}
           >
-            クイック選択：
+            クイック選択（タップで送信）
           </Typography>
           <Stack
             direction="row"
             spacing={1}
             justifyContent="center"
             flexWrap="wrap"
+            useFlexGap
             gap={1}
           >
             {JOB_QUICK_OPTIONS.map((option) => (
@@ -203,7 +209,13 @@ export function ChatMessageList({
                 key={option}
                 label={option}
                 onClick={() => onQuickSelect(option)}
-                sx={{ cursor: 'pointer' }}
+                clickable
+                sx={{
+                  cursor: 'pointer',
+                  borderColor: CHAT_BRAND,
+                  '&:hover': { bgcolor: 'rgba(236,91,19,0.08)' },
+                }}
+                variant="outlined"
               />
             ))}
           </Stack>

--- a/frontend/components/mui-chat/components/ChatMessageList.tsx
+++ b/frontend/components/mui-chat/components/ChatMessageList.tsx
@@ -17,6 +17,7 @@ import styles from '../../mui-chat.module.css'
 import { TypingIndicator } from './TypingIndicator'
 import {
   CHAT_BRAND,
+  CHAT_BRAND_HOVER,
   extractChoices,
   JOB_QUICK_OPTIONS,
   stripChoiceLines,
@@ -69,7 +70,7 @@ export function ChatMessageList({
             onClick={onRetryHistoryLoad}
             disabled={historyRetrying}
             startIcon={historyRetrying ? <CircularProgress size={16} color="inherit" /> : undefined}
-            sx={{ bgcolor: CHAT_BRAND, '&:hover': { bgcolor: '#d14f10' } }}
+            sx={{ bgcolor: CHAT_BRAND, '&:hover': { bgcolor: CHAT_BRAND_HOVER } }}
           >
             {historyRetrying ? '再読み込み中...' : '再試行'}
           </Button>

--- a/frontend/components/mui-chat/hooks/useMuiChat.ts
+++ b/frontend/components/mui-chat/hooks/useMuiChat.ts
@@ -12,6 +12,8 @@ import {
   INITIAL_GREETING,
   RESET_GREETING,
   clearChatSessionOnEnd,
+  readStoredJobCategoryId,
+  writeStoredJobCategoryId,
 } from '../utils'
 import type { Message, PhaseProgress, ProgressTotals, ChoiceOption } from '../types'
 
@@ -38,8 +40,9 @@ export function useMuiChat() {
   const [phaseProgresses, setPhaseProgresses] = useState<PhaseProgress[] | null>(null)
   const [historyLoadError, setHistoryLoadError] = useState<string | null>(null)
   const [historyRetrying, setHistoryRetrying] = useState(false)
+  const [jobCategoryId, setJobCategoryId] = useState(0)
   const messagesEndRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
 
   const progressTotals: ProgressTotals | null = (() => {
     if (!phaseProgresses || phaseProgresses.length === 0) return null
@@ -183,6 +186,7 @@ export function useMuiChat() {
 
       sessionStorage.setItem('chatSessionId', storedSessionId)
       setSessionId(storedSessionId)
+      setJobCategoryId(readStoredJobCategoryId(storedSessionId))
 
       try {
         console.log('[MUI Chat] Loading history for session:', storedSessionId)
@@ -239,10 +243,15 @@ export function useMuiChat() {
         session_id: sessionId,
         message: messageText,
         industry_id: 1, // IT業界
-        job_category_id: 0, // 未設定（バックエンドで判定）
+        job_category_id: jobCategoryId,
       }
 
       const response: ChatResponse = await sendChatMessage(chatRequest)
+
+      if (typeof response.job_category_id === 'number' && response.job_category_id > 0) {
+        setJobCategoryId(response.job_category_id)
+        writeStoredJobCategoryId(sessionId, response.job_category_id)
+      }
 
       const assistantMessage: Message = {
         id: makeMessageId(),
@@ -408,6 +417,8 @@ export function useMuiChat() {
     const newSessionId = `session_${Date.now()}_${Math.random().toString(36).substring(7)}`
     setSessionId(newSessionId)
     sessionStorage.setItem('chatSessionId', newSessionId)
+    setJobCategoryId(0)
+    writeStoredJobCategoryId(newSessionId, 0)
 
     // 初回メッセージを再設定
     const initialMessage: Message = {
@@ -465,13 +476,7 @@ export function useMuiChat() {
     console.log('[MUI Chat] After reset - modal closed, analysisComplete set to false')
     // 入力フィールドを有効化するためにフォーカス
     setTimeout(() => {
-      const inputElement = document.querySelector('input[type="text"]') as HTMLInputElement | null
-      if (inputElement) {
-        console.log('[MUI Chat] Input field found, focusing')
-        inputElement.focus()
-      } else {
-        console.log('[MUI Chat] Input field not found')
-      }
+      inputRef.current?.focus()
     }, 100)
   }
 

--- a/frontend/components/mui-chat/hooks/useMuiChat.ts
+++ b/frontend/components/mui-chat/hooks/useMuiChat.ts
@@ -12,6 +12,8 @@ import {
   INITIAL_GREETING,
   RESET_GREETING,
   clearChatSessionOnEnd,
+  computeProgressTotals,
+  shouldAutoScrollToBottom,
 } from '../utils'
 import type { Message, PhaseProgress, ProgressTotals, ChoiceOption } from '../types'
 
@@ -39,30 +41,30 @@ export function useMuiChat() {
   const [historyLoadError, setHistoryLoadError] = useState<string | null>(null)
   const [historyRetrying, setHistoryRetrying] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesAreaRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const progressTotals: ProgressTotals | null = (() => {
-    if (!phaseProgresses || phaseProgresses.length === 0) return null
-    let valid = 0
-    let asked = 0
-    for (const phase of phaseProgresses) {
-      asked += phase.questions_asked || 0
-      valid += phase.valid_answers || 0
-    }
-    if (asked <= 0) return null
-    return {
-      valid,
-      required: asked,
-      percent: Math.round((valid / asked) * 100),
-    }
-  })()
+  const progressTotals: ProgressTotals = computeProgressTotals({
+    phases: phaseProgresses,
+    questionCount,
+    totalQuestions,
+  })
 
-  const scrollToBottom = () => {
+  const scrollToBottomIfNeeded = () => {
+    const area = messagesAreaRef.current
+    if (area) {
+      const allow = shouldAutoScrollToBottom({
+        scrollHeight: area.scrollHeight,
+        scrollTop: area.scrollTop,
+        clientHeight: area.clientHeight,
+      })
+      if (!allow) return
+    }
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   useEffect(() => {
-    scrollToBottom()
+    scrollToBottomIfNeeded()
   }, [messages, isLoading])
 
   const applyHistoryOrGreeting = useCallback((history: Awaited<ReturnType<typeof getChatHistory>>) => {
@@ -516,6 +518,7 @@ export function useMuiChat() {
     historyLoadError,
     historyRetrying,
     messagesEndRef,
+    messagesAreaRef,
     inputRef,
     progressTotals,
     choiceOptions,

--- a/frontend/components/mui-chat/hooks/useMuiChat.ts
+++ b/frontend/components/mui-chat/hooks/useMuiChat.ts
@@ -16,6 +16,7 @@ import {
   writeStoredJobCategoryId,
   computeProgressTotals,
   shouldAutoScrollToBottom,
+  findLastAssistantQuestionMessage,
 } from '../utils'
 import type { Message, PhaseProgress, ProgressTotals, ChoiceOption } from '../types'
 
@@ -213,7 +214,7 @@ export function useMuiChat() {
     if (!rawText || isLoading || !sessionId || !userId || historyLoadError) return
 
     // ボタン送信はそのまま。自由入力は直近の選択肢ラベルを記号へ正規化する
-    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant')
+    const lastAssistant = findLastAssistantQuestionMessage(messages)
     const currentChoices = lastAssistant ? extractChoices(lastAssistant.content) : []
     const messageText =
       overrideMessage !== undefined
@@ -482,7 +483,7 @@ export function useMuiChat() {
     }, 100)
   }
 
-  const lastAssistantMessage = [...messages].reverse().find((msg) => msg.role === 'assistant')
+  const lastAssistantMessage = findLastAssistantQuestionMessage(messages)
   const choiceOptions: ChoiceOption[] = lastAssistantMessage
     ? extractChoices(lastAssistantMessage.content)
     : []

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -55,9 +55,52 @@ export function clearChatSessionOnEnd(storage: {
   const currentSessionId = storage.sessionStorage.getItem('chatSessionId')
   if (currentSessionId) {
     storage.localStorage.removeItem(`chat_cache_${currentSessionId}`)
+    storage.sessionStorage.removeItem(jobCategoryStorageKey(currentSessionId))
   }
   storage.sessionStorage.removeItem('chatSessionId')
   storage.sessionStorage.removeItem('chatMessages')
   storage.localStorage.removeItem('chatMessages')
   storage.localStorage.removeItem('chat_session_id')
+}
+
+export function jobCategoryStorageKey(sessionId: string): string {
+  return `chat_job_category_id_${sessionId}`
+}
+
+export function readStoredJobCategoryId(
+  sessionId: string,
+  storage: Pick<Storage, 'getItem'> = sessionStorage,
+): number {
+  if (!sessionId) return 0
+  const raw = storage.getItem(jobCategoryStorageKey(sessionId))
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+export function writeStoredJobCategoryId(
+  sessionId: string,
+  jobCategoryId: number,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> = sessionStorage,
+): void {
+  if (!sessionId) return
+  const key = jobCategoryStorageKey(sessionId)
+  if (jobCategoryId > 0) {
+    storage.setItem(key, String(jobCategoryId))
+  } else {
+    storage.removeItem(key)
+  }
+}
+
+/** Ctrl+Enter / ⌘+Enter で送信。Enter 単独は改行。 */
+export function shouldSendChatOnKeyDown(e: {
+  key: string
+  ctrlKey: boolean
+  metaKey: boolean
+  nativeEvent?: { isComposing?: boolean }
+  isComposing?: boolean
+}): boolean {
+  if (e.key !== 'Enter') return false
+  const composing = e.isComposing || e.nativeEvent?.isComposing
+  if (composing) return false
+  return e.ctrlKey || e.metaKey
 }

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -44,9 +44,9 @@ export const JOB_QUICK_OPTIONS = [
   'まだ決めていない',
 ] as const
 
-/** チャット画面のブランドアクセント（サイドバーと揃える） */
-export const CHAT_BRAND = '#ec5b13'
-export const CHAT_BRAND_HOVER = '#d14f10'
+/** チャット画面のアクセント（MUI primary 青） */
+export const CHAT_BRAND = '#1976d2'
+export const CHAT_BRAND_HOVER = '#1565c0'
 
 /**
  * 選択肢行（A) / 1. など）を本文から除き、バブルとボタンの二重表示を防ぐ。

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -172,3 +172,27 @@ export function shouldSendChatOnKeyDown(e: {
   if (composing) return false
   return e.ctrlKey || e.metaKey
 }
+
+/** 無効回答の警告・強制終了メッセージか（選択肢抽出の対象外） */
+export function isValidationFeedbackMessage(content: string): boolean {
+  const trimmed = content.trim()
+  if (!trimmed) return false
+  return (
+    trimmed.includes('書かれた内容にはお答えできません') ||
+    trimmed.includes('質問と関係のない内容が3回続いた')
+  )
+}
+
+/** 警告を飛ばして直近のアシスタント質問メッセージを返す */
+export function findLastAssistantQuestionMessage<T extends { role: string; content: string }>(
+  messages: T[],
+): T | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role !== 'assistant') continue
+    if (isValidationFeedbackMessage(msg.content)) continue
+    return msg
+  }
+  return undefined
+}
+

--- a/frontend/components/mui-chat/utils.ts
+++ b/frontend/components/mui-chat/utils.ts
@@ -44,6 +44,74 @@ export const JOB_QUICK_OPTIONS = [
   'まだ決めていない',
 ] as const
 
+/** チャット画面のブランドアクセント（サイドバーと揃える） */
+export const CHAT_BRAND = '#ec5b13'
+export const CHAT_BRAND_HOVER = '#d14f10'
+
+/**
+ * 選択肢行（A) / 1. など）を本文から除き、バブルとボタンの二重表示を防ぐ。
+ */
+export function stripChoiceLines(content: string): string {
+  const kept = content.split('\n').filter((line) => {
+    const trimmed = line.trim()
+    if (!trimmed) return true
+    if (/^([A-E])\)\s*.+$/.test(trimmed)) return false
+    if (/^([A-E])[：、.．]\s*.+$/.test(trimmed)) return false
+    if (/^(\d+)[\.\)．]\s*.+$/.test(trimmed)) return false
+    return true
+  })
+  return kept.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+/**
+ * ヘッダー進捗をサイドバーと同じ「想定総質問数」ベースで計算する。
+ * asked ベースだと途中で 100% に見える問題を避ける。
+ */
+export function computeProgressTotals(args: {
+  phases: { questions_asked?: number; valid_answers?: number; min_questions?: number; max_questions?: number }[] | null
+  questionCount: number
+  totalQuestions: number
+}): { valid: number; required: number; percent: number } {
+  const totalFallback = Math.max(1, args.totalQuestions || 15)
+  if (args.phases && args.phases.length > 0) {
+    let valid = 0
+    let required = 0
+    for (const phase of args.phases) {
+      valid += phase.valid_answers || 0
+      const need =
+        (phase.max_questions && phase.max_questions > 0
+          ? phase.max_questions
+          : phase.min_questions) || 0
+      required += need
+    }
+    if (required <= 0) required = totalFallback
+    return {
+      valid,
+      required,
+      percent: Math.min(100, Math.round((valid / required) * 100)),
+    }
+  }
+  return {
+    valid: args.questionCount,
+    required: totalFallback,
+    percent: Math.min(100, Math.round((args.questionCount / totalFallback) * 100)),
+  }
+}
+
+/**
+ * メッセージ一覧の自動スクロールを「下部付近にいるときだけ」許可する。
+ */
+export function shouldAutoScrollToBottom(args: {
+  scrollHeight: number
+  scrollTop: number
+  clientHeight: number
+  thresholdPx?: number
+}): boolean {
+  const threshold = args.thresholdPx ?? 120
+  const distanceFromBottom = args.scrollHeight - args.scrollTop - args.clientHeight
+  return distanceFromBottom <= threshold
+}
+
 /**
  * チャット終了時にセッション ID とメッセージ／キャッシュを削除する。
  * sessionId は remove 前に取得する（先に消すと chat_cache_ が残る）。

--- a/frontend/e2e/chat-critical-flow.spec.ts
+++ b/frontend/e2e/chat-critical-flow.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  CHAT_SESSION_ID,
+  INTERVIEW_MCQ,
+  historyItem,
+  mockChatHistory,
+  mockEmptyChatAuxRoutes,
+  setupChatCriticalAuth,
+} from './fixtures/chat'
+
+async function mockChatPost(
+  page: Page,
+  handler: (body: { message?: string; job_category_id?: number }) => {
+    status?: number
+    body: Record<string, unknown>
+  },
+) {
+  // /api/chat のみ（/api/chat/history 等は別モックに任せる）
+  await page.route(/\/api\/chat\/?(?:\?.*)?$/, async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue()
+      return
+    }
+    const body = route.request().postDataJSON() as {
+      message?: string
+      job_category_id?: number
+    }
+    const result = handler(body)
+    await route.fulfill({
+      status: result.status ?? 200,
+      contentType: 'application/json',
+      body: JSON.stringify(result.body),
+    })
+  })
+}
+
+/**
+ * チャット主要機能の回帰 E2E。
+ * - 経験談MCQで「A」を選んでも職種clarificationに飛ばない
+ * - 無効回答警告後も元の選択肢ボタンが残る
+ * - Enter単独は送信せず Ctrl/Meta+Enter で送信
+ * - job_category_id が後続リクエストに載る
+ */
+test.describe('チャット主要機能（職種・選択肢・送信）', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupChatCriticalAuth(page)
+    await mockEmptyChatAuxRoutes(page)
+  })
+
+  test('経験談MCQの選択肢Aは職種判定メッセージを出さず送信される', async ({ page }) => {
+    await mockChatHistory(page, [
+      historyItem(1, 'assistant', 'これまでの経験を具体的に教えてください。'),
+      historyItem(
+        2,
+        'user',
+        '児童養護施設の案件でIT弱者の職員が使いやすいUIを作りました',
+      ),
+      historyItem(3, 'assistant', INTERVIEW_MCQ),
+    ])
+
+    const posted: Array<{ message?: string; job_category_id?: number }> = []
+    await mockChatPost(page, (body) => {
+      posted.push(body)
+      return {
+        body: {
+          response: 'なるほど、要件の曖昧さが一番の課題だったんですね。次の質問です。',
+          is_complete: false,
+          total_questions: 15,
+          answered_questions: 2,
+          job_category_id: 0,
+        },
+      }
+    })
+
+    await page.goto('/')
+    await expect(page.getByText('一番モヤっとした', { exact: false })).toBeVisible({
+      timeout: 15000,
+    })
+    await expect(page.getByRole('button', { name: /A\.\s*要件が曖昧/ })).toBeVisible()
+
+    await page.getByRole('button', { name: /A\.\s*要件が曖昧/ }).click()
+
+    await expect
+      .poll(() => posted.length, { timeout: 10000 })
+      .toBe(1)
+    expect(posted[0]?.message).toBe('A')
+    await expect(page.getByText('職種を特定できません')).toHaveCount(0)
+    await expect(page.getByText('要件の曖昧さが一番の課題')).toBeVisible()
+  })
+
+  test('無効回答警告のあとでも直前質問の選択肢ボタンが残る', async ({ page }) => {
+    await mockChatHistory(page, [
+      historyItem(1, 'assistant', INTERVIEW_MCQ),
+      historyItem(2, 'user', 'あ'),
+      historyItem(
+        3,
+        'assistant',
+        '書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）',
+      ),
+    ])
+
+    await page.goto('/')
+    await expect(page.getByText('1/3回目の警告')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByRole('button', { name: /A\.\s*要件が曖昧/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /B\.\s*技術制約/ })).toBeVisible()
+  })
+
+  test('Enter単独では送信せず Ctrl+Enter で送信する', async ({ page }) => {
+    await mockChatHistory(page, [])
+
+    const posted: string[] = []
+    await mockChatPost(page, (body) => {
+      posted.push(body.message ?? '')
+      return {
+        body: {
+          response: '受け取りました',
+          is_complete: false,
+          total_questions: 15,
+          answered_questions: 1,
+        },
+      }
+    })
+
+    await page.goto('/')
+    await expect(page.getByText('キャリアエージェント', { exact: false })).toBeVisible({
+      timeout: 15000,
+    })
+
+    const input = page.getByPlaceholder(/メッセージを入力|選択肢と同じ内容/)
+    await input.fill('Webエンジニアに興味があります')
+    await input.press('Enter')
+    await page.waitForTimeout(400)
+    expect(posted.length).toBe(0)
+
+    await input.press('Control+Enter')
+    await expect
+      .poll(() => posted.length, { timeout: 10000 })
+      .toBe(1)
+    expect(posted[0]).toBe('Webエンジニアに興味があります')
+  })
+
+  test('レスポンスの job_category_id が次の送信に載る', async ({ page }) => {
+    await mockChatHistory(page, [
+      historyItem(1, 'assistant', 'どのようなIT職種に興味がありますか？'),
+    ])
+
+    const posted: number[] = []
+    let call = 0
+    await mockChatPost(page, (body) => {
+      posted.push(body.job_category_id ?? 0)
+      call += 1
+      if (call === 1) {
+        return {
+          body: {
+            response:
+              'ありがとうございます。次の質問です。\nチームで困った経験を教えてください。',
+            is_complete: false,
+            total_questions: 15,
+            answered_questions: 1,
+            job_category_id: 3,
+          },
+        }
+      }
+      return {
+        body: {
+          response: 'なるほど、詳しく聞けて助かります。',
+          is_complete: false,
+          total_questions: 15,
+          answered_questions: 2,
+          job_category_id: 3,
+        },
+      }
+    })
+
+    await page.goto('/')
+    await expect(page.getByText('IT職種に興味がありますか', { exact: false })).toBeVisible({
+      timeout: 15000,
+    })
+
+    const input = page.getByPlaceholder(/メッセージを入力|選択肢と同じ内容/)
+    await input.fill('Webエンジニア')
+    await input.press('Control+Enter')
+    await expect(page.getByText('次の質問です', { exact: false })).toBeVisible({
+      timeout: 10000,
+    })
+
+    await input.fill('要件が曖昧で調整に苦労しました')
+    await input.press('Control+Enter')
+    await expect
+      .poll(() => posted.length, { timeout: 10000 })
+      .toBe(2)
+
+    expect(posted[0]).toBe(0)
+    expect(posted[1]).toBe(3)
+
+    const stored = await page.evaluate((sid) => {
+      return sessionStorage.getItem(`chat_job_category_id_${sid}`)
+    }, CHAT_SESSION_ID)
+    expect(stored).toBe('3')
+  })
+})

--- a/frontend/e2e/fixtures/chat.ts
+++ b/frontend/e2e/fixtures/chat.ts
@@ -1,0 +1,77 @@
+import { Page } from '@playwright/test'
+import { setupAuth, TEST_USER } from './auth'
+
+export const CHAT_SESSION_ID = 'e2e-chat-critical-session'
+
+export type ChatHistoryItem = {
+  id: number
+  session_id: string
+  user_id: number
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+export const INTERVIEW_MCQ = [
+  '児童養護施設向けUIの経験、素敵だと思います。',
+  '一番モヤっとした／妥協せざるを得なかったのはどれですか？（一番近いものを選んでください）',
+  '',
+  'A) 要件が曖昧でスコープが膨らむ',
+  'B) 技術制約でやりたいUIが出せない',
+  'C) ステークホルダー調整が難しい',
+].join('\n')
+
+export async function setupChatCriticalAuth(page: Page) {
+  await setupAuth(page, TEST_USER)
+  await page.addInitScript((sessionId: string) => {
+    sessionStorage.setItem('chatSessionId', sessionId)
+    localStorage.setItem('currentSessionId', sessionId)
+  }, CHAT_SESSION_ID)
+}
+
+export async function mockChatHistory(page: Page, messages: ChatHistoryItem[]) {
+  await page.route('**/api/chat/history*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(messages),
+    })
+  })
+}
+
+export async function mockEmptyChatAuxRoutes(page: Page) {
+  await page.route('**/api/chat/session', async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ session_id: CHAT_SESSION_ID }),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.route('**/api/chat/messages*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ messages: [] }),
+    })
+  })
+}
+
+export function historyItem(
+  id: number,
+  role: 'user' | 'assistant',
+  content: string,
+): ChatHistoryItem {
+  return {
+    id,
+    session_id: CHAT_SESSION_ID,
+    user_id: TEST_USER.user_id,
+    role,
+    content,
+    created_at: new Date(Date.UTC(2026, 0, 1, 0, 0, id)).toISOString(),
+  }
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -43,6 +43,7 @@ export interface ChatResponse {
     answered_questions: number
     evaluated_categories?: number
     total_categories?: number
+    job_category_id?: number
     current_phase?: PhaseProgress
     all_phases?: PhaseProgress[]
     current_scores?: Array<{

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,7 +3,14 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   // 新規作成したテストのみ実行（既存デバッグ用スペックを除外）
-  testMatch: ['auth.spec.ts', 'chat.spec.ts', 'resume.spec.ts', 'schedule.spec.ts', 'admin.spec.ts'],
+  testMatch: [
+    'auth.spec.ts',
+    'chat.spec.ts',
+    'chat-critical-flow.spec.ts',
+    'resume.spec.ts',
+    'schedule.spec.ts',
+    'admin.spec.ts',
+  ],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
@@ -24,17 +31,17 @@ export default defineConfig({
     },
   ],
 
-  webServer: process.env.CI
-    ? {
-        command: 'npm run build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public && node .next/standalone/server.js',
-        url: 'http://localhost:3000',
-        reuseExistingServer: false,
-        timeout: 180000,
-        env: {
-          PORT: '3000',
-          NEXT_PUBLIC_BACKEND_URL: 'http://localhost:3000',
-          BACKEND_URL: 'http://localhost:3000',
-        },
-      }
-    : undefined,
+  webServer: {
+    command: process.env.CI
+      ? 'npm run build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public && node .next/standalone/server.js'
+      : 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180000,
+    env: {
+      PORT: '3000',
+      NEXT_PUBLIC_BACKEND_URL: 'http://localhost:3000',
+      BACKEND_URL: 'http://localhost:3000',
+    },
+  },
 });

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -11,6 +11,7 @@ import {
   computeProgressTotals,
   shouldAutoScrollToBottom,
   CHAT_BRAND,
+  findLastAssistantQuestionMessage,
 } from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
@@ -245,5 +246,19 @@ describe('shouldAutoScrollToBottom', () => {
 describe('CHAT_BRAND', () => {
   it('プライマリ青である', () => {
     expect(CHAT_BRAND).toBe('#1976d2')
+  })
+})
+
+describe('findLastAssistantQuestionMessage', () => {
+  it('警告メッセージを飛ばして直前の質問を返す', () => {
+    const messages = [
+      { role: 'assistant', content: 'A) はい\nB) いいえ' },
+      { role: 'user', content: 'typo' },
+      {
+        role: 'assistant',
+        content: '書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）',
+      },
+    ]
+    expect(findLastAssistantQuestionMessage(messages)?.content).toBe('A) はい\nB) いいえ')
   })
 })

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -3,6 +3,10 @@ import {
   makeMessageId,
   INITIAL_GREETING,
   clearChatSessionOnEnd,
+  readStoredJobCategoryId,
+  writeStoredJobCategoryId,
+  shouldSendChatOnKeyDown,
+  jobCategoryStorageKey,
 } from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
@@ -83,6 +87,9 @@ describe('clearChatSessionOnEnd', () => {
     const store = { ...initial }
     return {
       getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value
+      },
       removeItem: (key: string) => {
         delete store[key]
       },
@@ -90,10 +97,11 @@ describe('clearChatSessionOnEnd', () => {
     }
   }
 
-  it('sessionId 削除前に chat_cache_ を消す', () => {
+  it('sessionId 削除前に chat_cache_ と職種IDを消す', () => {
     const sessionStorage = createMemoryStorage({
       chatSessionId: 'sess-42',
       chatMessages: '[]',
+      [jobCategoryStorageKey('sess-42')]: '3',
     })
     const localStorage = createMemoryStorage({
       'chat_cache_sess-42': 'cached',
@@ -104,6 +112,7 @@ describe('clearChatSessionOnEnd', () => {
     clearChatSessionOnEnd({ sessionStorage, localStorage })
 
     expect(localStorage._store['chat_cache_sess-42']).toBeUndefined()
+    expect(sessionStorage._store[jobCategoryStorageKey('sess-42')]).toBeUndefined()
     expect(sessionStorage._store.chatSessionId).toBeUndefined()
     expect(sessionStorage._store.chatMessages).toBeUndefined()
     expect(localStorage._store.chatMessages).toBeUndefined()
@@ -121,5 +130,51 @@ describe('clearChatSessionOnEnd', () => {
 
     expect(sessionStorage._store.chatMessages).toBeUndefined()
     expect(localStorage._store.chat_session_id).toBeUndefined()
+  })
+})
+
+describe('job category storage', () => {
+  function createMemoryStorage(initial: Record<string, string> = {}) {
+    const store = { ...initial }
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value
+      },
+      removeItem: (key: string) => {
+        delete store[key]
+      },
+      _store: store,
+    }
+  }
+
+  it('職種IDを読み書きできる', () => {
+    const storage = createMemoryStorage()
+    writeStoredJobCategoryId('s1', 7, storage)
+    expect(readStoredJobCategoryId('s1', storage)).toBe(7)
+    writeStoredJobCategoryId('s1', 0, storage)
+    expect(readStoredJobCategoryId('s1', storage)).toBe(0)
+  })
+})
+
+describe('shouldSendChatOnKeyDown', () => {
+  it('Enter 単独では送信しない', () => {
+    expect(shouldSendChatOnKeyDown({ key: 'Enter', ctrlKey: false, metaKey: false })).toBe(false)
+  })
+
+  it('Ctrl+Enter / Meta+Enter で送信する', () => {
+    expect(shouldSendChatOnKeyDown({ key: 'Enter', ctrlKey: true, metaKey: false })).toBe(true)
+    expect(shouldSendChatOnKeyDown({ key: 'Enter', ctrlKey: false, metaKey: true })).toBe(true)
+  })
+
+  it('IME 変換中は送信しない', () => {
+    expect(
+      shouldSendChatOnKeyDown({
+        key: 'Enter',
+        ctrlKey: true,
+        metaKey: false,
+        isComposing: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -12,6 +12,7 @@ import {
   shouldAutoScrollToBottom,
   CHAT_BRAND,
   findLastAssistantQuestionMessage,
+  isValidationFeedbackMessage,
 } from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
@@ -260,5 +261,37 @@ describe('findLastAssistantQuestionMessage', () => {
       },
     ]
     expect(findLastAssistantQuestionMessage(messages)?.content).toBe('A) はい\nB) いいえ')
+  })
+
+  it('警告が複数あっても最初の質問を返す', () => {
+    const q = 'A) 要件が曖昧\nB) 技術制約'
+    const messages = [
+      { role: 'assistant', content: q },
+      { role: 'user', content: 'あ' },
+      {
+        role: 'assistant',
+        content: '書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）',
+      },
+      { role: 'user', content: 'ああ' },
+      {
+        role: 'assistant',
+        content: '書かれた内容にはお答えできません。質問に回答してください。（2/3回目の警告）',
+      },
+    ]
+    expect(findLastAssistantQuestionMessage(messages)?.content).toBe(q)
+  })
+})
+
+describe('isValidationFeedbackMessage', () => {
+  it('警告と終了メッセージを判定する', () => {
+    expect(
+      isValidationFeedbackMessage(
+        '書かれた内容にはお答えできません。質問に回答してください。（1/3回目の警告）',
+      ),
+    ).toBe(true)
+    expect(
+      isValidationFeedbackMessage('質問と関係のない内容が3回続いたため、チャットを終了させていただきます。'),
+    ).toBe(true)
+    expect(isValidationFeedbackMessage('一番近いものを選んでください')).toBe(false)
   })
 })

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -3,6 +3,10 @@ import {
   makeMessageId,
   INITIAL_GREETING,
   clearChatSessionOnEnd,
+  stripChoiceLines,
+  computeProgressTotals,
+  shouldAutoScrollToBottom,
+  CHAT_BRAND,
 } from '@/components/mui-chat/utils'
 
 describe('extractChoices', () => {
@@ -121,5 +125,70 @@ describe('clearChatSessionOnEnd', () => {
 
     expect(sessionStorage._store.chatMessages).toBeUndefined()
     expect(localStorage._store.chat_session_id).toBeUndefined()
+  })
+})
+
+describe('stripChoiceLines', () => {
+  it('選択肢行を除去して質問文を残す', () => {
+    const content = [
+      'どの働き方が好みですか？',
+      '',
+      'A) リモート中心',
+      'B) オフィス中心',
+      '補足です',
+    ].join('\n')
+    expect(stripChoiceLines(content)).toBe('どの働き方が好みですか？\n\n補足です')
+  })
+})
+
+describe('computeProgressTotals', () => {
+  it('フェーズの想定総数を required に使う（asked ではない）', () => {
+    const totals = computeProgressTotals({
+      phases: [
+        { valid_answers: 2, questions_asked: 2, min_questions: 3, max_questions: 5 },
+        { valid_answers: 0, questions_asked: 0, min_questions: 2, max_questions: 4 },
+      ],
+      questionCount: 2,
+      totalQuestions: 15,
+    })
+    expect(totals.required).toBe(9)
+    expect(totals.valid).toBe(2)
+    expect(totals.percent).toBe(Math.round((2 / 9) * 100))
+  })
+
+  it('フェーズ無しなら totalQuestions ベース', () => {
+    expect(
+      computeProgressTotals({ phases: null, questionCount: 3, totalQuestions: 15 }),
+    ).toEqual({ valid: 3, required: 15, percent: 20 })
+  })
+})
+
+describe('shouldAutoScrollToBottom', () => {
+  it('下部付近なら true', () => {
+    expect(
+      shouldAutoScrollToBottom({
+        scrollHeight: 1000,
+        scrollTop: 900,
+        clientHeight: 100,
+        thresholdPx: 120,
+      }),
+    ).toBe(true)
+  })
+
+  it('上部を見ているときは false', () => {
+    expect(
+      shouldAutoScrollToBottom({
+        scrollHeight: 1000,
+        scrollTop: 0,
+        clientHeight: 100,
+        thresholdPx: 120,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('CHAT_BRAND', () => {
+  it('ブランドオレンジである', () => {
+    expect(CHAT_BRAND).toBe('#ec5b13')
   })
 })

--- a/frontend/tests/components/mui-chat/utils.test.ts
+++ b/frontend/tests/components/mui-chat/utils.test.ts
@@ -243,7 +243,7 @@ describe('shouldAutoScrollToBottom', () => {
 })
 
 describe('CHAT_BRAND', () => {
-  it('ブランドオレンジである', () => {
-    expect(CHAT_BRAND).toBe('#ec5b13')
+  it('プライマリ青である', () => {
+    expect(CHAT_BRAND).toBe('#1976d2')
   })
 })


### PR DESCRIPTION
## Summary
- 職種IDを FE セッションに保持し、毎回 `job_category_id` 付きで送信
- BE は解決済み職種をレスポンスに含め、保存失敗時はエラーにする
- 職種確認質問のキーワードを拡充（好きな作業／どれが近い 等）
- Enter は改行、Ctrl+Enter（Mac は ⌘+Enter）で送信。入力欄をマルチライン化

## Test plan
- [ ] 職種回答後、次の質問でも職種が「未指定」に戻らない（ログ/DB の job_category_ids）
- [ ] 「まだ決めていない」→確認質問→回答でも職種が解決される
- [ ] Enter 単独では送信されず改行できる
- [ ] Ctrl/⌘+Enter と送信ボタンで送信できる
- [ ] 日本語 IME 変換確定の Enter で誤送信しない

Closes #713

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チャット応答に職種カテゴリ情報が反映され、次回送信時にも引き継がれるようになりました。
  * 進捗状況の表示、選択肢の整理、自動スクロールを改善しました。
  * Enterキーで改行し、Ctrl+Enterまたは⌘+Enterで送信できるようになりました。

* **バグ修正**
  * 警告メッセージを質問として誤認する問題を修正しました。
  * 経験談への回答が不必要に無効扱いされる問題を改善しました。
  * チャット画面の高さやモバイル表示を調整しました。

* **テスト**
  * チャットの主要フローと回答判定に関する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->