### PR TITLE
Resolve #718: docker compose up -dでRAG/company-graphも起動可能に

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 ### RAG (Python)
 - `cd rag && pip install -r constraints.txt && python3 main.py` (9000)
 ### Docker
-- `docker compose up -d`（core: backend/frontend/db）
-- RAG + Chroma（必須 profile）: `make rag-up` または `docker compose --profile rag up -d --build chroma rag-review`
+- `docker compose up -d`（db/app/frontend/rag-review/chroma/company-graphを含む全サービスを起動。`docker compose stop` / `down` で全停止・削除可）
+- RAGのみ起動/リビルド: `make rag-up` または `docker compose up -d --build chroma rag-review`
 - スモーク: `make rag-smoke`（`/health` の `vector_store.ok` と Chroma heartbeat）
 - 旧イメージ疑い: `make rag-rebuild`
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 help:
 	@echo "Targets:"
-	@echo "  make core-up      # db + app + frontend"
-	@echo "  make rag-up       # chroma + rag-review (profile=rag, --build)"
+	@echo "  make core-up      # db + app + frontend (docker compose up -d で全サービス起動可)"
+	@echo "  make rag-up       # chroma + rag-review (--build)"
 	@echo "  make rag-smoke    # /health vector_store + chroma heartbeat"
 	@echo "  make rag-rebuild  # force-recreate rag-review image"
 	@echo "  make rag-down     # stop chroma + rag-review"
@@ -17,10 +17,10 @@ rag-up:
 	./scripts/dev-rag-up.sh
 
 rag-down:
-	docker compose --profile rag stop chroma rag-review
+	docker compose stop chroma rag-review
 
 rag-rebuild:
-	docker compose --profile rag up -d --build --force-recreate chroma rag-review
+	docker compose up -d --build --force-recreate chroma rag-review
 	$(MAKE) rag-smoke
 
 rag-smoke:

--- a/compose.yml
+++ b/compose.yml
@@ -119,8 +119,7 @@ services:
       context: ./tools/company-graph
       dockerfile: Dockerfile
     container_name: soc-ai-company-graph
-    profiles:
-      - company-graph
+    restart: unless-stopped
     ports:
       - "${COMPANY_GRAPH_PORT:-9100}:9100"
     environment:
@@ -129,14 +128,13 @@ services:
     networks:
       - soc-ai-network
 
-  # Resume review RAG（profile=rag 必須。make rag-up 推奨）
+  # Resume review RAG
   rag-review:
     build:
       context: ./rag
       dockerfile: Dockerfile
     container_name: soc-ai-rag-review
-    profiles:
-      - rag
+    restart: unless-stopped
     ports:
       - "${RAG_REVIEW_PORT:-9000}:9000"
     env_file:
@@ -162,8 +160,7 @@ services:
   chroma:
     image: chromadb/chroma:0.6.3
     container_name: soc-ai-chroma
-    profiles:
-      - rag
+    restart: unless-stopped
     ports:
       - "${CHROMA_HOST_PORT:-8000}:8000"
     volumes:

--- a/scripts/dev-rag-up.sh
+++ b/scripts/dev-rag-up.sh
@@ -5,10 +5,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-PROFILE_ARGS=(--profile rag)
-
-echo "==> Building and starting chroma + rag-review (compose.yml, profile=rag)"
-docker compose "${PROFILE_ARGS[@]}" up -d --build chroma rag-review
+echo "==> Building and starting chroma + rag-review (compose.yml)"
+docker compose up -d --build chroma rag-review
 
 echo "==> Waiting for health endpoints"
 for i in 1 2 3 4 5 6 7 8 9 10; do
@@ -31,15 +29,15 @@ echo "RAG /vector/status: ${STATUS:-FAILED}"
 if ! echo "${HEALTH}" | grep -q '"vector_store"'; then
   echo ""
   echo "ERROR: /health に vector_store がありません。旧 RAG イメージの可能性があります。"
-  echo "  docker compose --profile rag up -d --build --force-recreate rag-review"
+  echo "  docker compose up -d --build --force-recreate rag-review"
   exit 1
 fi
 
 if ! echo "${HEALTH}" | grep -q '"ok":true'; then
   echo ""
   echo "ERROR: vector_store.ok が true ではありません。Chroma 接続を確認してください。"
-  echo "  docker compose --profile rag ps"
-  echo "  docker compose --profile rag logs --tail 50 chroma rag-review"
+  echo "  docker compose ps"
+  echo "  docker compose logs --tail 50 chroma rag-review"
   exit 1
 fi
 


### PR DESCRIPTION
Closes #718

## 変更内容
- `compose.yml`: `rag-review` / `chroma` / `company-graph` の `profiles` 指定を削除し、`restart: unless-stopped` を付与（他サービスと統一）
- `Makefile`: `rag-down` / `rag-rebuild` から不要になった `--profile rag` 指定を削除、helpの文言を更新
- `scripts/dev-rag-up.sh`: `--profile rag` 指定・エラーメッセージ内の該当記述を削除
- `CLAUDE.md`: `docker compose up -d` で全サービス（db/app/frontend/chroma/rag-review/company-graph）が起動する旨に記述を更新

## 動作確認
- `docker compose up -d` のみで6サービス全て起動することを確認
- `docker compose stop` で全6サービスが正常停止することを確認
- 停止後、再度 `docker compose up -d` で復帰することを確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local Docker/dev workflow only; no application auth, data, or production deploy config changes in this diff.
> 
> **Overview**
> **`docker compose up -d` now brings up the full local stack**, including `chroma`, `rag-review`, and `company-graph`, without `--profile rag` or `--profile company-graph`.
> 
> In **`compose.yml`**, those three services no longer use Compose profiles and get **`restart: unless-stopped`** like the core services. **`Makefile`**, **`scripts/dev-rag-up.sh`**, and **`CLAUDE.md`** drop profile flags and update help/docs so RAG targets use plain `docker compose` while **`make core-up`** still only starts db/app/frontend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d659683fceb7b7ae014f31c73bed8a957512e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->