### PR TITLE
Resolve #720: 企業相関図の多段階グルーピング表示

### DIFF
--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -480,6 +480,27 @@ func (c *AdminCompanyGraphController) EnrichRelations(ctx echo.Context) error {
 	})
 }
 
+// RelationGraph handles GET /api/admin/companies/:id/relation-graph
+// 起点企業から資本関係を親会社→子会社→孫会社等の多段階で辿ったグラフと、
+// 起点企業直接分の取引関係を返す（相関図表示用）。
+func (c *AdminCompanyGraphController) RelationGraph(ctx echo.Context) error {
+	companyID, err := strconv.ParseUint(ctx.Param("id"), 10, 32)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid company id")
+	}
+	if c.companyRepo == nil || c.relationRepo == nil {
+		return echoInternalError(errors.New("relation repository is not configured"))
+	}
+
+	graphService := services.NewCompanyRelationGraphService(c.companyRepo, c.relationRepo)
+	graph, err := graphService.BuildGraph(uint(companyID))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "company not found")
+	}
+
+	return ctx.JSON(http.StatusOK, graph)
+}
+
 // fetchRelationsWithLLM はAIモデルの知識から企業の関連会社・取引先を抽出する。
 func (c *AdminCompanyGraphController) fetchRelationsWithLLM(ctx context.Context, companyName, url string) (*llmExtractedRelations, error) {
 	if c.openaiClient == nil {

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -56,6 +56,8 @@ func SetupAdminRoutes(
 	admin.POST("/companies/:id/confirm-info", adminCompanyController.ConfirmCompanyInfo)
 	admin.POST("/companies/:id/fetch-relations", adminCompanyController.FetchCompanyRelations)
 	admin.POST("/companies/:id/confirm-relations", adminCompanyController.ConfirmCompanyRelations)
+	// #720 資本関係の多段階可視化（親会社→子会社→孫会社等）
+	admin.GET("/companies/:id/relation-graph", adminCompanyGraphController.RelationGraph)
 	admin.POST("/companies/:id/fetch-jobs", adminCompanyController.FetchJobs)
 	admin.POST("/companies/:id/fetch-persona", adminCompanyController.FetchPersona)
 	admin.POST("/companies/:id/fetch-all", adminCompanyController.FetchAllMissing)

--- a/Backend/internal/services/company_relation_graph_service.go
+++ b/Backend/internal/services/company_relation_graph_service.go
@@ -1,0 +1,200 @@
+package services
+
+import (
+	"Backend/domain/repository"
+	"Backend/internal/models"
+	"fmt"
+)
+
+// 親会社→子会社→孫会社のように資本関係を辿る際の安全弁。
+// 深さ・ノード数のどちらかに達したら打ち切り、無限ループや巨大レスポンスを防ぐ。
+const (
+	RelationGraphMaxDepth = 4
+	RelationGraphMaxNodes = 60
+)
+
+// RelationGraphNode はグラフ上の1企業ノード。
+type RelationGraphNode struct {
+	ID         uint   `json:"id"`
+	Name       string `json:"name"`
+	MarketType string `json:"market_type,omitempty"`
+	IsListed   bool   `json:"is_listed"`
+	IsFocus    bool   `json:"is_focus"`
+}
+
+// RelationGraphCapitalEdge は資本関係の1辺（親→子）。
+type RelationGraphCapitalEdge struct {
+	ParentID     uint     `json:"parent_id"`
+	ChildID      uint     `json:"child_id"`
+	RelationType string   `json:"relation_type"`
+	Ratio        *float64 `json:"ratio,omitempty"`
+}
+
+// RelationGraphBusinessEntry は起点企業から見た取引関係1件（多段階化はしない）。
+type RelationGraphBusinessEntry struct {
+	CompanyID    uint   `json:"company_id"`
+	Name         string `json:"name"`
+	RelationType string `json:"relation_type"`
+	Description  string `json:"description,omitempty"`
+}
+
+// CompanyRelationGraph は起点企業を中心にした資本関係グラフ + 直接の取引関係。
+type CompanyRelationGraph struct {
+	CompanyID         uint                         `json:"company_id"`
+	Nodes             []RelationGraphNode          `json:"nodes"`
+	CapitalEdges      []RelationGraphCapitalEdge   `json:"capital_edges"`
+	BusinessRelations []RelationGraphBusinessEntry `json:"business_relations"`
+	// Truncated はノード数上限に達し、一部の資本関係を打ち切ったことを示す。
+	Truncated bool `json:"truncated"`
+}
+
+// CompanyRelationGraphService は起点企業から資本関係を多段階（親会社→子会社→孫会社等）に辿り、
+// 相関図表示用のグラフ構造を組み立てる。
+type CompanyRelationGraphService struct {
+	companyRepo  repository.CompanyRepository
+	relationRepo repository.CompanyRelationRepository
+}
+
+func NewCompanyRelationGraphService(companyRepo repository.CompanyRepository, relationRepo repository.CompanyRelationRepository) *CompanyRelationGraphService {
+	return &CompanyRelationGraphService{companyRepo: companyRepo, relationRepo: relationRepo}
+}
+
+// BuildGraph は companyID を起点に資本関係を BFS で辿ったグラフを返す。
+// 取引関係は起点企業から直接分のみ付加する（取引先の取引先までは辿らない）。
+func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelationGraph, error) {
+	graph := &CompanyRelationGraph{CompanyID: companyID}
+	nodeSeen := map[uint]struct{}{}
+	capitalEdgeSeen := map[string]struct{}{}
+	businessSeen := map[string]struct{}{}
+
+	// addNode は id をグラフに追加する。既に追加済みなら true、上限到達で追加できなければ false を返す。
+	addNode := func(id uint) (bool, error) {
+		if _, ok := nodeSeen[id]; ok {
+			return true, nil
+		}
+		if len(nodeSeen) >= RelationGraphMaxNodes {
+			graph.Truncated = true
+			return false, nil
+		}
+		company, err := s.companyRepo.FindByID(id)
+		if err != nil {
+			return false, fmt.Errorf("company not found (id=%d): %w", id, err)
+		}
+		marketType := ""
+		isListed := false
+		if info, err := s.relationRepo.GetMarketInfoByCompanyID(id); err == nil && info != nil {
+			marketType = info.MarketType
+			isListed = info.IsListed
+		}
+		nodeSeen[id] = struct{}{}
+		graph.Nodes = append(graph.Nodes, RelationGraphNode{
+			ID:         id,
+			Name:       company.Name,
+			MarketType: marketType,
+			IsListed:   isListed,
+			IsFocus:    id == companyID,
+		})
+		return true, nil
+	}
+
+	if _, err := addNode(companyID); err != nil {
+		return nil, err
+	}
+
+	type queueItem struct {
+		id    uint
+		depth int
+	}
+	queued := map[uint]struct{}{companyID: {}}
+	queue := []queueItem{{id: companyID, depth: 0}}
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+		if len(nodeSeen) >= RelationGraphMaxNodes {
+			graph.Truncated = true
+			break
+		}
+
+		relations, err := s.relationRepo.GetRelationsByCompanyID(item.id)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rel := range relations {
+			if models.IsCapitalRelationType(rel.RelationType) {
+				if rel.ParentID == nil || rel.ChildID == nil {
+					continue
+				}
+				edgeKey := fmt.Sprintf("%d-%d-%s", *rel.ParentID, *rel.ChildID, rel.RelationType)
+				if _, ok := capitalEdgeSeen[edgeKey]; !ok {
+					capitalEdgeSeen[edgeKey] = struct{}{}
+					graph.CapitalEdges = append(graph.CapitalEdges, RelationGraphCapitalEdge{
+						ParentID:     *rel.ParentID,
+						ChildID:      *rel.ChildID,
+						RelationType: rel.RelationType,
+						Ratio:        rel.Ratio,
+					})
+				}
+				if item.depth >= RelationGraphMaxDepth {
+					for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
+						if nextID != item.id {
+							if _, ok := nodeSeen[nextID]; !ok {
+								graph.Truncated = true
+							}
+						}
+					}
+					continue
+				}
+				for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
+					if nextID == item.id {
+						continue
+					}
+					added, err := addNode(nextID)
+					if err != nil {
+						return nil, err
+					}
+					if !added {
+						continue
+					}
+					if _, ok := queued[nextID]; !ok {
+						queued[nextID] = struct{}{}
+						queue = append(queue, queueItem{id: nextID, depth: item.depth + 1})
+					}
+				}
+				continue
+			}
+
+			// 取引関係は起点企業から直接分のみ採用する。
+			if item.id != companyID {
+				continue
+			}
+			var partnerID uint
+			switch {
+			case rel.FromID != nil && *rel.FromID == companyID && rel.ToID != nil:
+				partnerID = *rel.ToID
+			case rel.ToID != nil && *rel.ToID == companyID && rel.FromID != nil:
+				partnerID = *rel.FromID
+			default:
+				continue
+			}
+			key := fmt.Sprintf("%d-%s", partnerID, rel.RelationType)
+			if _, ok := businessSeen[key]; ok {
+				continue
+			}
+			partner, err := s.companyRepo.FindByID(partnerID)
+			if err != nil {
+				continue
+			}
+			businessSeen[key] = struct{}{}
+			graph.BusinessRelations = append(graph.BusinessRelations, RelationGraphBusinessEntry{
+				CompanyID:    partnerID,
+				Name:         partner.Name,
+				RelationType: rel.RelationType,
+				Description:  rel.Description,
+			})
+		}
+	}
+
+	return graph, nil
+}

--- a/Backend/test/services/company_relation_graph_service_test.go
+++ b/Backend/test/services/company_relation_graph_service_test.go
@@ -1,0 +1,157 @@
+package services_test
+
+import (
+	"fmt"
+	"testing"
+
+	"Backend/internal/models"
+	"Backend/internal/services"
+	"Backend/test/controllers/mocks"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func companyNode(id uint, name string) *models.Company {
+	return &models.Company{ID: id, Name: name}
+}
+
+func capitalRel(parentID, childID uint, relationType string) models.CompanyRelation {
+	return models.CompanyRelation{ParentID: ptrUint(parentID), ChildID: ptrUint(childID), RelationType: relationType}
+}
+
+func businessRel(fromID, toID uint, relationType, description string) models.CompanyRelation {
+	return models.CompanyRelation{FromID: ptrUint(fromID), ToID: ptrUint(toID), RelationType: relationType, Description: description}
+}
+
+func TestCompanyRelationGraphService_BuildGraph_MultiLevelCapitalChain(t *testing.T) {
+	// 1(起点) -> 2(子会社) -> 3(孫会社) の多段階資本関係を辿れること。
+	companyRepo := &mocks.CompanyRepositoryMock{}
+	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
+	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "子会社"), nil)
+	companyRepo.On("FindByID", uint(3)).Return(companyNode(3, "孫会社"), nil)
+
+	relRepo := &relationRepoMock{}
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
+	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
+	relRepo.On("GetMarketInfoByCompanyID", uint(3)).Return(nil, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_subsidiary")}, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{capitalRel(2, 3, "capital_affiliate")}, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(3)).Return([]models.CompanyRelation{}, nil)
+
+	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
+	graph, err := svc.BuildGraph(1)
+	require.NoError(t, err)
+
+	assert.Len(t, graph.Nodes, 3)
+	assert.Len(t, graph.CapitalEdges, 2)
+	assert.False(t, graph.Truncated)
+
+	var focusCount int
+	ids := map[uint]bool{}
+	for _, n := range graph.Nodes {
+		ids[n.ID] = true
+		if n.IsFocus {
+			focusCount++
+			assert.Equal(t, uint(1), n.ID)
+		}
+	}
+	assert.Equal(t, 1, focusCount)
+	assert.True(t, ids[1] && ids[2] && ids[3])
+}
+
+func TestCompanyRelationGraphService_BuildGraph_AncestorDirection(t *testing.T) {
+	// 起点企業(2)の親会社(1)も辿れること。
+	companyRepo := &mocks.CompanyRepositoryMock{}
+	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
+	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "起点企業"), nil)
+
+	relRepo := &relationRepoMock{}
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
+	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_subsidiary")}, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil)
+
+	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
+	graph, err := svc.BuildGraph(2)
+	require.NoError(t, err)
+
+	assert.Len(t, graph.Nodes, 2)
+	assert.Len(t, graph.CapitalEdges, 1)
+}
+
+func TestCompanyRelationGraphService_BuildGraph_CycleDoesNotLoopForever(t *testing.T) {
+	// 1 -> 2 -> 1 の循環関係があっても停止し、重複ノード・エッジを作らないこと。
+	companyRepo := &mocks.CompanyRepositoryMock{}
+	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "企業A"), nil)
+	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "企業B"), nil)
+
+	relRepo := &relationRepoMock{}
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
+	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_affiliate")}, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{
+		capitalRel(1, 2, "capital_affiliate"),
+		capitalRel(2, 1, "capital_affiliate"),
+	}, nil)
+
+	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
+	graph, err := svc.BuildGraph(1)
+	require.NoError(t, err)
+	assert.Len(t, graph.Nodes, 2)
+	assert.Len(t, graph.CapitalEdges, 2)
+}
+
+func TestCompanyRelationGraphService_BuildGraph_NodeCapTruncates(t *testing.T) {
+	// 起点企業直下に上限を超える子会社がぶら下がる場合、ノード数上限で打ち切られること。
+	companyRepo := &mocks.CompanyRepositoryMock{}
+	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
+
+	childCount := services.RelationGraphMaxNodes + 10
+	relations := make([]models.CompanyRelation, 0, childCount)
+	for i := 0; i < childCount; i++ {
+		childID := uint(100 + i)
+		companyRepo.On("FindByID", childID).Return(companyNode(childID, fmt.Sprintf("子会社%d", i)), nil)
+		relations = append(relations, capitalRel(1, childID, "capital_subsidiary"))
+	}
+
+	relRepo := &relationRepoMock{}
+	relRepo.On("GetMarketInfoByCompanyID", mock.Anything).Return(nil, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return(relations, nil)
+	for i := 0; i < childCount; i++ {
+		relRepo.On("GetRelationsByCompanyID", uint(100+i)).Return([]models.CompanyRelation{}, nil)
+	}
+
+	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
+	graph, err := svc.BuildGraph(1)
+	require.NoError(t, err)
+
+	assert.True(t, graph.Truncated)
+	assert.LessOrEqual(t, len(graph.Nodes), services.RelationGraphMaxNodes)
+}
+
+func TestCompanyRelationGraphService_BuildGraph_BusinessRelationsOnlyDirect(t *testing.T) {
+	// 取引関係は起点企業から直接分のみ。取引先(2)がさらに持つ取引関係(2->3)は含めない。
+	companyRepo := &mocks.CompanyRepositoryMock{}
+	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "起点企業"), nil)
+	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "取引先"), nil)
+
+	relRepo := &relationRepoMock{}
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{
+		businessRel(1, 2, "business_partner", "主要取引先"),
+	}, nil)
+
+	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
+	graph, err := svc.BuildGraph(1)
+	require.NoError(t, err)
+
+	require.Len(t, graph.BusinessRelations, 1)
+	assert.Equal(t, uint(2), graph.BusinessRelations[0].CompanyID)
+	assert.Equal(t, "取引先", graph.BusinessRelations[0].Name)
+	// 起点企業自身のみがグラフのノードとして扱われ、取引先はノード側には含まれない（資本関係専用）。
+	assert.Len(t, graph.Nodes, 1)
+	// GetRelationsByCompanyID(2) が呼ばれていないこと = 取引先の取引先までは辿っていないこと。
+	relRepo.AssertNotCalled(t, "GetRelationsByCompanyID", uint(2))
+}

--- a/frontend/app/admin/companies/[id]/relations/page.tsx
+++ b/frontend/app/admin/companies/[id]/relations/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import {
   Alert,
@@ -17,6 +17,8 @@ import {
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
+import CompanyRelationGraph from '@/components/admin/CompanyRelationGraph'
+import { groupRelationsByCategory, RELATION_CATEGORY_LABELS } from '@/lib/relation-graph'
 
 type RelationEntry = {
   name: string
@@ -218,6 +220,9 @@ export default function AdminCompanyRelationsPage() {
     return Number.isNaN(d.getTime()) ? v : d.toLocaleString('ja-JP')
   }
 
+  const groupedRelations = useMemo(() => groupRelationsByCategory(relations), [relations])
+  const numericId = Number(id)
+
   return (
     <AdminFormContainer
       title={`関係・市場情報: ${name}`}
@@ -315,6 +320,11 @@ export default function AdminCompanyRelationsPage() {
 
         <Divider />
 
+        <Typography variant="subtitle1" fontWeight="bold">相関図（保存済みデータ）</Typography>
+        {Number.isFinite(numericId) && numericId > 0 && <CompanyRelationGraph companyId={numericId} />}
+
+        <Divider />
+
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography variant="subtitle1" fontWeight="bold">企業関係</Typography>
           <Button size="small" variant="outlined" onClick={addRelation}>行を追加</Button>
@@ -324,40 +334,60 @@ export default function AdminCompanyRelationsPage() {
           <Typography variant="body2" color="text.secondary">関係データがありません。プレビュー取得または行追加してください。</Typography>
         )}
 
-        {relations.map((rel, index) => (
-          <Box key={index} sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+        {groupedRelations.map((categoryGroup) => (
+          <Box key={categoryGroup.category} sx={{ mb: 1 }}>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+              {RELATION_CATEGORY_LABELS[categoryGroup.category]}
+            </Typography>
             <Stack spacing={1.5}>
-              <Stack direction="row" spacing={1}>
-                <TextField
-                  label="関連企業名"
-                  value={rel.name}
-                  onChange={(e) => updateRelation(index, { name: e.target.value })}
-                  sx={{ flex: 2 }}
-                />
-                <TextField
-                  select
-                  label="関係タイプ"
-                  value={rel.relation_type}
-                  onChange={(e) => updateRelation(index, { relation_type: e.target.value })}
-                  sx={{ flex: 1 }}
+              {categoryGroup.companies.map((companyGroup) => (
+                <Box
+                  key={companyGroup.name}
+                  sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}
                 >
-                  <MenuItem value="capital_subsidiary">子会社</MenuItem>
-                  <MenuItem value="capital_affiliate">関連会社</MenuItem>
-                  <MenuItem value="business_partner">取引先</MenuItem>
-                  <MenuItem value="business_procurement">調達（gBiz）</MenuItem>
-                  <MenuItem value="business_subsidy">補助金（gBiz）</MenuItem>
-                </TextField>
-              </Stack>
-              <Stack direction="row" spacing={1} alignItems="center">
-                <TextField
-                  label="説明"
-                  value={rel.description || ''}
-                  onChange={(e) => updateRelation(index, { description: e.target.value })}
-                  sx={{ flex: 1 }}
-                />
-                <Chip size="small" label={RELATION_LABELS[rel.relation_type] || rel.relation_type} />
-                <Button size="small" color="error" onClick={() => removeRelation(index)}>削除</Button>
-              </Stack>
+                  <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                    <Typography variant="body1" fontWeight="bold">{companyGroup.name}</Typography>
+                    <Chip size="small" label={`${companyGroup.entries.length}件`} />
+                  </Stack>
+                  <Stack spacing={1.5} divider={<Divider flexItem />}>
+                    {companyGroup.entries.map(({ index, relation: rel }) => (
+                      <Stack key={index} spacing={1.5}>
+                        <Stack direction="row" spacing={1}>
+                          <TextField
+                            label="関連企業名"
+                            value={rel.name}
+                            onChange={(e) => updateRelation(index, { name: e.target.value })}
+                            sx={{ flex: 2 }}
+                          />
+                          <TextField
+                            select
+                            label="関係タイプ"
+                            value={rel.relation_type}
+                            onChange={(e) => updateRelation(index, { relation_type: e.target.value })}
+                            sx={{ flex: 1 }}
+                          >
+                            <MenuItem value="capital_subsidiary">子会社</MenuItem>
+                            <MenuItem value="capital_affiliate">関連会社</MenuItem>
+                            <MenuItem value="business_partner">取引先</MenuItem>
+                            <MenuItem value="business_procurement">調達（gBiz）</MenuItem>
+                            <MenuItem value="business_subsidy">補助金（gBiz）</MenuItem>
+                          </TextField>
+                        </Stack>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <TextField
+                            label="説明"
+                            value={rel.description || ''}
+                            onChange={(e) => updateRelation(index, { description: e.target.value })}
+                            sx={{ flex: 1 }}
+                          />
+                          <Chip size="small" label={RELATION_LABELS[rel.relation_type] || rel.relation_type} />
+                          <Button size="small" color="error" onClick={() => removeRelation(index)}>削除</Button>
+                        </Stack>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Box>
+              ))}
             </Stack>
           </Box>
         ))}

--- a/frontend/app/api/admin/companies/[id]/relation-graph/route.ts
+++ b/frontend/app/api/admin/companies/[id]/relation-graph/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/relation-graph`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+  })
+  const raw = await response.text()
+  let data: any = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/components/admin/CompanyRelationGraph.tsx
+++ b/frontend/components/admin/CompanyRelationGraph.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import ReactFlow, {
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+} from 'reactflow'
+import 'reactflow/dist/style.css'
+import { Alert, Box, Chip, CircularProgress, Stack, Typography } from '@mui/material'
+import { authService } from '@/lib/auth'
+import { marketColors, marketLabels, type MarketType } from '@/lib/company-data'
+import { layoutCapitalGraph, type CompanyRelationGraph as RelationGraphData } from '@/lib/relation-graph'
+
+interface CompanyRelationGraphProps {
+  companyId: number
+}
+
+const RELATION_TYPE_LABELS: Record<string, string> = {
+  business_partner: '取引先',
+  business_procurement: '調達（gBiz）',
+  business_subsidy: '補助金（gBiz）',
+}
+
+export default function CompanyRelationGraph({ companyId }: CompanyRelationGraphProps) {
+  const [graph, setGraph] = useState<RelationGraphData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError('')
+    fetch(`/api/admin/companies/${companyId}/relation-graph`, {
+      headers: authService.getAdminFetchHeaders(),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('相関図データの取得に失敗しました')
+        return res.json()
+      })
+      .then((data: RelationGraphData) => {
+        if (!cancelled) setGraph(data)
+      })
+      .catch(() => {
+        if (!cancelled) setError('相関図データの取得に失敗しました')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [companyId])
+
+  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
+    if (!graph || graph.nodes.length === 0) return { nodes: [], edges: [] }
+    const positions = layoutCapitalGraph(graph)
+
+    const flowNodes: Node[] = graph.nodes.map((n) => {
+      const pos = positions.get(n.id) ?? { x: 0, y: 0, level: 0, column: 0 }
+      const marketType = (n.market_type || 'unlisted') as MarketType
+      return {
+        id: String(n.id),
+        type: 'default',
+        position: { x: pos.x, y: pos.y },
+        data: {
+          label: (
+            <Box sx={{ textAlign: 'center', p: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: n.is_focus ? 'bold' : 'normal', mb: 0.5 }}>
+                {n.name}
+              </Typography>
+              <Chip
+                size="small"
+                label={marketLabels[marketType]}
+                sx={{ bgcolor: marketColors[marketType], color: 'white', fontSize: '10px', height: '18px' }}
+              />
+            </Box>
+          ),
+        },
+        style: {
+          background: n.is_focus ? '#FFF3CD' : '#fff',
+          border: `${n.is_focus ? 3 : 2}px solid ${n.is_focus ? '#FFC107' : marketColors[marketType]}`,
+          borderRadius: '8px',
+          padding: '8px',
+          minWidth: '180px',
+        },
+      }
+    })
+
+    const flowEdges: Edge[] = graph.capital_edges.map((e, idx) => ({
+      id: `capital-${idx}`,
+      source: String(e.parent_id),
+      target: String(e.child_id),
+      label: e.ratio ? `${e.ratio}%` : undefined,
+      style: {
+        stroke: '#555',
+        strokeWidth: 2,
+        strokeDasharray: e.relation_type === 'capital_affiliate' ? '5,5' : 'none',
+      },
+      markerEnd: { type: MarkerType.ArrowClosed, color: '#555' },
+    }))
+
+    return { nodes: flowNodes, edges: flowEdges }
+  }, [graph])
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 3 }}>
+        <CircularProgress size={20} />
+        <Typography variant="body2" color="text.secondary">相関図を読み込み中...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>
+  }
+
+  if (!graph || graph.nodes.length <= 1) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        保存済みの資本関係データがありません。関係を確定保存すると相関図が表示されます。
+      </Typography>
+    )
+  }
+
+  return (
+    <Stack spacing={1}>
+      {graph.truncated && (
+        <Alert severity="warning">関係の件数が多いため一部を省略して表示しています。</Alert>
+      )}
+      <Box sx={{ width: '100%', height: 420, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+        <ReactFlow nodes={nodes} edges={edges} fitView minZoom={0.1} maxZoom={2} nodesDraggable nodesConnectable={false}>
+          <Background />
+          <Controls />
+        </ReactFlow>
+      </Box>
+      {graph.business_relations.length > 0 && (
+        <Box>
+          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>取引関係</Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {graph.business_relations.map((rel) => (
+              <Chip
+                key={`${rel.company_id}-${rel.relation_type}`}
+                size="small"
+                label={`${rel.name}（${RELATION_TYPE_LABELS[rel.relation_type] || rel.relation_type}）`}
+              />
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -50,6 +50,7 @@ import {
   getTodayActionLabel,
   shouldShowResultsCta,
 } from '@/lib/sidebar-navigation'
+import { SIDEBAR_ADMIN_NAV, SIDEBAR_NAV_ITEMS } from '@/lib/sidebar-nav'
 
 const DRAWER_WIDTH = 280
 
@@ -97,6 +98,7 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
     const [isAdmin, setIsAdmin] = useState(!!user.is_admin)
     const theme = useTheme()
     const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+    const router = useRouter()
 
     useEffect(() => {
         setIsAdmin(!!user.is_admin)

--- a/frontend/lib/relation-graph.ts
+++ b/frontend/lib/relation-graph.ts
@@ -1,0 +1,167 @@
+import type { MarketType } from '@/lib/company-data'
+
+// --- 編集リストのグルーピング（企業ごと・関連会社ごとにまとめる） -----------------
+
+export type RelationEntry = {
+  name: string
+  relation_type: string
+  ratio?: number
+  description?: string
+}
+
+export type RelationCategory = 'capital' | 'business' | 'gbiz'
+
+export const RELATION_CATEGORY_ORDER: RelationCategory[] = ['capital', 'business', 'gbiz']
+
+export const RELATION_CATEGORY_LABELS: Record<RelationCategory, string> = {
+  capital: '資本関係（子会社・関連会社）',
+  business: '取引関係',
+  gbiz: 'gBiz関係（調達・補助金）',
+}
+
+const RELATION_TYPE_TO_CATEGORY: Record<string, RelationCategory> = {
+  capital_subsidiary: 'capital',
+  capital_affiliate: 'capital',
+  business_partner: 'business',
+  business_procurement: 'gbiz',
+  business_subsidy: 'gbiz',
+}
+
+export function categoryForRelationType(relationType: string): RelationCategory {
+  return RELATION_TYPE_TO_CATEGORY[relationType] ?? 'business'
+}
+
+export type GroupedRelationEntry<T extends RelationEntry> = {
+  /** 元の relations 配列でのインデックス（編集・削除ハンドラに渡す用） */
+  index: number
+  relation: T
+}
+
+export type CompanyRelationGroup<T extends RelationEntry> = {
+  name: string
+  entries: GroupedRelationEntry<T>[]
+}
+
+export type CategoryRelationGroup<T extends RelationEntry> = {
+  category: RelationCategory
+  companies: CompanyRelationGroup<T>[]
+}
+
+/**
+ * 関連企業リストを「関係カテゴリ別（資本/取引/gBiz）」×「関連企業名ごと」にグルーピングする。
+ * 同じ関連企業に複数の関係タイプが紐づく場合は1企業カードにまとめる。
+ * 元配列の並び順・インデックスは保持し、編集/削除ハンドラがそのまま使えるようにする。
+ */
+export function groupRelationsByCategory<T extends RelationEntry>(relations: T[]): CategoryRelationGroup<T>[] {
+  const byCategory = new Map<RelationCategory, Map<string, GroupedRelationEntry<T>[]>>()
+
+  relations.forEach((relation, index) => {
+    const category = categoryForRelationType(relation.relation_type)
+    const companyKey = relation.name.trim() || '(未入力)'
+    if (!byCategory.has(category)) byCategory.set(category, new Map())
+    const companies = byCategory.get(category)!
+    if (!companies.has(companyKey)) companies.set(companyKey, [])
+    companies.get(companyKey)!.push({ index, relation })
+  })
+
+  return RELATION_CATEGORY_ORDER.filter((category) => byCategory.has(category)).map((category) => ({
+    category,
+    companies: Array.from(byCategory.get(category)!.entries()).map(([name, entries]) => ({ name, entries })),
+  }))
+}
+
+// --- 多段階資本関係グラフのレイアウト（親会社→子会社→孫会社等） -----------------
+
+export interface RelationGraphNode {
+  id: number
+  name: string
+  market_type?: MarketType | ''
+  is_listed: boolean
+  is_focus: boolean
+}
+
+export interface RelationGraphCapitalEdge {
+  parent_id: number
+  child_id: number
+  relation_type: string
+  ratio?: number
+}
+
+export interface RelationGraphBusinessEntry {
+  company_id: number
+  name: string
+  relation_type: string
+  description?: string
+}
+
+export interface CompanyRelationGraph {
+  company_id: number
+  nodes: RelationGraphNode[]
+  capital_edges: RelationGraphCapitalEdge[]
+  business_relations: RelationGraphBusinessEntry[]
+  truncated?: boolean
+}
+
+export interface CapitalGraphPosition {
+  /** 起点企業からの世代差。0=起点企業、負値=親方向、正値=子方向。 */
+  level: number
+  /** 同じ level 内での並び順（0始まり）。 */
+  column: number
+  x: number
+  y: number
+}
+
+const LEVEL_HEIGHT = 160
+const COLUMN_WIDTH = 220
+
+/**
+ * 資本関係グラフのノードに、起点企業を基準とした世代(level)とX/Y座標を割り当てる。
+ * 子会社方向は正の level、親会社方向は負の level になる（同じ親を持つ兄弟会社は同じ level）。
+ * 循環関係があっても各ノードは最初に到達した時点の level で確定し無限ループしない。
+ */
+export function layoutCapitalGraph(graph: Pick<CompanyRelationGraph, 'company_id' | 'nodes' | 'capital_edges'>): Map<number, CapitalGraphPosition> {
+  const neighborDeltas = new Map<number, Array<{ id: number; delta: number }>>()
+  const addNeighbor = (from: number, to: number, delta: number) => {
+    if (!neighborDeltas.has(from)) neighborDeltas.set(from, [])
+    neighborDeltas.get(from)!.push({ id: to, delta })
+  }
+  for (const edge of graph.capital_edges) {
+    // parent -> child は子方向なので +1、child -> parent は親方向なので -1
+    addNeighbor(edge.parent_id, edge.child_id, 1)
+    addNeighbor(edge.child_id, edge.parent_id, -1)
+  }
+
+  const levelById = new Map<number, number>()
+  levelById.set(graph.company_id, 0)
+  const queue: number[] = [graph.company_id]
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    const currentLevel = levelById.get(current)!
+    for (const { id, delta } of neighborDeltas.get(current) ?? []) {
+      if (levelById.has(id)) continue
+      levelById.set(id, currentLevel + delta)
+      queue.push(id)
+    }
+  }
+
+  const nodesByLevel = new Map<number, number[]>()
+  for (const node of graph.nodes) {
+    const level = levelById.get(node.id) ?? 0
+    if (!nodesByLevel.has(level)) nodesByLevel.set(level, [])
+    nodesByLevel.get(level)!.push(node.id)
+  }
+
+  const positions = new Map<number, CapitalGraphPosition>()
+  for (const [level, ids] of nodesByLevel.entries()) {
+    ids.forEach((id, column) => {
+      positions.set(id, {
+        level,
+        column,
+        x: column * COLUMN_WIDTH,
+        y: level * LEVEL_HEIGHT,
+      })
+    })
+  }
+
+  return positions
+}

--- a/frontend/tests/lib/relation-graph.test.ts
+++ b/frontend/tests/lib/relation-graph.test.ts
@@ -1,0 +1,124 @@
+import {
+  groupRelationsByCategory,
+  layoutCapitalGraph,
+  type RelationEntry,
+  type CompanyRelationGraph,
+} from '@/lib/relation-graph'
+
+describe('relation-graph', () => {
+  describe('groupRelationsByCategory', () => {
+    it('groups entries by category and merges same-named companies', () => {
+      const relations: RelationEntry[] = [
+        { name: 'A社', relation_type: 'capital_subsidiary' },
+        { name: 'B社', relation_type: 'business_partner' },
+        { name: 'A社', relation_type: 'capital_affiliate' },
+        { name: 'C社', relation_type: 'business_procurement' },
+      ]
+
+      const grouped = groupRelationsByCategory(relations)
+
+      expect(grouped.map((g) => g.category)).toEqual(['capital', 'business', 'gbiz'])
+
+      const capital = grouped.find((g) => g.category === 'capital')!
+      expect(capital.companies).toHaveLength(1)
+      expect(capital.companies[0].name).toBe('A社')
+      expect(capital.companies[0].entries.map((e) => e.index)).toEqual([0, 2])
+
+      const business = grouped.find((g) => g.category === 'business')!
+      expect(business.companies[0].name).toBe('B社')
+
+      const gbiz = grouped.find((g) => g.category === 'gbiz')!
+      expect(gbiz.companies[0].name).toBe('C社')
+    })
+
+    it('treats unknown relation types as business category and blank names as a single group', () => {
+      const relations: RelationEntry[] = [
+        { name: '', relation_type: 'something_else' },
+        { name: '  ', relation_type: 'something_else' },
+      ]
+
+      const grouped = groupRelationsByCategory(relations)
+      expect(grouped).toHaveLength(1)
+      expect(grouped[0].category).toBe('business')
+      expect(grouped[0].companies).toHaveLength(1)
+      expect(grouped[0].companies[0].entries).toHaveLength(2)
+    })
+
+    it('returns an empty array for no relations', () => {
+      expect(groupRelationsByCategory([])).toEqual([])
+    })
+  })
+
+  describe('layoutCapitalGraph', () => {
+    const baseGraph = (): Pick<CompanyRelationGraph, 'company_id' | 'nodes' | 'capital_edges'> => ({
+      company_id: 1,
+      nodes: [
+        { id: 1, name: '起点企業', is_listed: false, is_focus: true },
+        { id: 2, name: '子会社', is_listed: false, is_focus: false },
+        { id: 3, name: '孫会社', is_listed: false, is_focus: false },
+        { id: 4, name: '親会社', is_listed: false, is_focus: false },
+      ],
+      capital_edges: [
+        { parent_id: 1, child_id: 2, relation_type: 'capital_subsidiary' },
+        { parent_id: 2, child_id: 3, relation_type: 'capital_affiliate' },
+        { parent_id: 4, child_id: 1, relation_type: 'capital_subsidiary' },
+      ],
+    })
+
+    it('assigns level 0 to the focus company', () => {
+      const positions = layoutCapitalGraph(baseGraph())
+      expect(positions.get(1)?.level).toBe(0)
+    })
+
+    it('assigns positive levels going down to children/grandchildren', () => {
+      const positions = layoutCapitalGraph(baseGraph())
+      expect(positions.get(2)?.level).toBe(1)
+      expect(positions.get(3)?.level).toBe(2)
+    })
+
+    it('assigns negative levels going up to the parent', () => {
+      const positions = layoutCapitalGraph(baseGraph())
+      expect(positions.get(4)?.level).toBe(-1)
+    })
+
+    it('places siblings sharing a parent at the same level as the focus company', () => {
+      const graph = baseGraph()
+      // 4(親) の別の子会社 5 を追加 -> 起点企業(1)の兄弟にあたるので level 0 になるはず
+      graph.nodes.push({ id: 5, name: '兄弟会社', is_listed: false, is_focus: false })
+      graph.capital_edges.push({ parent_id: 4, child_id: 5, relation_type: 'capital_subsidiary' })
+
+      const positions = layoutCapitalGraph(graph)
+      expect(positions.get(5)?.level).toBe(0)
+    })
+
+    it('does not loop forever when the edges contain a cycle', () => {
+      const graph: Pick<CompanyRelationGraph, 'company_id' | 'nodes' | 'capital_edges'> = {
+        company_id: 1,
+        nodes: [
+          { id: 1, name: 'A', is_listed: false, is_focus: true },
+          { id: 2, name: 'B', is_listed: false, is_focus: false },
+        ],
+        capital_edges: [
+          { parent_id: 1, child_id: 2, relation_type: 'capital_affiliate' },
+          { parent_id: 2, child_id: 1, relation_type: 'capital_affiliate' },
+        ],
+      }
+      const positions = layoutCapitalGraph(graph)
+      expect(positions.size).toBe(2)
+      expect(positions.get(1)?.level).toBe(0)
+    })
+
+    it('assigns distinct x within the same level and level-based y', () => {
+      const graph = baseGraph()
+      graph.nodes.push({ id: 5, name: '兄弟会社', is_listed: false, is_focus: false })
+      graph.capital_edges.push({ parent_id: 4, child_id: 5, relation_type: 'capital_subsidiary' })
+
+      const positions = layoutCapitalGraph(graph)
+      const focusX = positions.get(1)!.x
+      const siblingX = positions.get(5)!.x
+      expect(focusX).not.toBe(siblingX)
+      expect(positions.get(2)!.y).toBeGreaterThan(positions.get(1)!.y)
+      expect(positions.get(4)!.y).toBeLessThan(positions.get(1)!.y)
+    })
+  })
+})


### PR DESCRIPTION
Closes #720

## 変更内容

### 編集リストのグルーピング
- `frontend/app/admin/companies/[id]/relations/page.tsx`: 企業関係の編集リストを、資本関係/取引関係/gBiz関係のカテゴリ別 × 関連企業名ごとにグルーピングして表示するよう変更（同一関連企業に紐づく複数の関係タイプは1カードにまとめる）。編集・削除ハンドラは元配列のインデックスをそのまま使用するため既存ロジックは維持
- `frontend/lib/relation-graph.ts`: グルーピングの純粋関数 `groupRelationsByCategory` を追加

### 多段階の資本関係可視化（親会社→子会社→孫会社等）
- `Backend/internal/services/company_relation_graph_service.go`: 起点企業を中心に資本関係を BFS で辿るグラフ構築サービスを新規追加
  - 深さ上限4・ノード数上限60の安全弁付き（循環参照があっても無限ループしない）
  - 取引関係は起点企業から直接分のみ付加（取引先の取引先までは辿らない）
- `Backend/internal/controllers/admin_company_graph_controller.go` / `Backend/internal/routes/admin_routes.go`: `GET /api/admin/companies/:id/relation-graph` を追加（管理者認証必須）
- `frontend/app/api/admin/companies/[id]/relation-graph/route.ts`: 上記APIへのNext.jsプロキシルート
- `frontend/components/admin/CompanyRelationGraph.tsx`: react-flow（既存依存）で多段階資本関係ツリー + 取引関係一覧を表示するコンポーネントを追加し、relations画面に埋め込み
- `frontend/lib/relation-graph.ts`: グラフレイアウトの純粋関数 `layoutCapitalGraph`（起点企業からの世代差でlevel/座標を割り当て、循環に対しても安全）を追加

## テスト
- Go: `company_relation_graph_service_test.go`（多段階チェーン、祖先方向、循環安全性、ノード上限truncated、取引関係は直接分のみの5ケース）＋既存テスト一式・`go vet`・`go build` すべてパス
- Frontend: `relation-graph.test.ts`（グルーピング/レイアウトのユニットテスト9件）＋既存テスト一式（98件）すべてパス。`tsc --noEmit` / `eslint` も新規ファイルに問題なし
- 実MySQLコンテナにマイグレーション適用・多段階の資本関係データ（祖父母→親→本人→子→孫、循環参照含む）と取引関係を投入し、サービス層の直接呼び出しおよび管理者認証込みのHTTP APIの両方で正しいグラフが返ることを確認済み

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only admin graph endpoint behind existing admin auth; bounded BFS limits load; no changes to relation persistence logic beyond UI grouping.
> 
> **Overview**
> Adds **multi-stage capital-relation visualization** for admin company relations (#720): a new admin `GET /companies/:id/relation-graph` builds a BFS graph from saved relations (capital edges up to depth 4 / 60 nodes with `truncated`; direct business partners only from the focus company), exposed via `CompanyRelationGraphService` and a Next.js proxy.
> 
> The **relations admin page** embeds a **React Flow** correlation diagram from that API (market chips, truncation warning, business chips) and **reorganizes the edit list** into capital / business / gBiz categories grouped by related company name, preserving original array indices for edit/delete.
> 
> Shared frontend helpers in `relation-graph.ts` (`groupRelationsByCategory`, `layoutCapitalGraph`) and unit/service tests cover grouping, layout, cycles, caps, and direct-only business relations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12557c328cd93896bebab114b3d2a0ba957653e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->