### PR TITLE
Resolve #633: CodeRabbit指摘対応（取得済み判定・例外処理・型安全）

### DIFF
--- a/Backend/internal/controllers/github_controller.go
+++ b/Backend/internal/controllers/github_controller.go
@@ -96,7 +96,7 @@ func (c *GitHubController) SyncAndWait(ctx echo.Context) error {
 			return echo.NewHTTPError(http.StatusForbidden, err.Error())
 		}
 		if strings.Contains(err.Error(), "github profile not found") {
-			return echo.NewHTTPError(http.StatusNotFound, "github profile not found: please connect your GitHub account")
+			return echo.NewHTTPError(http.StatusNotFound, "GitHubプロフィールが見つかりません。GitHubアカウントを連携してください。")
 		}
 		return echoInternalError(err)
 	}

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -43,7 +43,7 @@ func (r *CompanyRepository) CountActive() (int64, error) {
 // ListActiveFiltered は名前・公開ステータスで絞り込んだアクティブ企業を返す。
 // status は "draft" / "published" / ""（指定なし=すべて）。
 func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status string) ([]models.Company, int64, error) {
-	q := r.db.Model(&models.Company{}).Where("is_active = ?", true)
+	q := r.db.Model(&models.Company{}).Where("is_active = ?", true).Session(&gorm.Session{})
 	if name = strings.TrimSpace(name); name != "" {
 		q = q.Where("name LIKE ?", "%"+name+"%")
 	}
@@ -53,12 +53,12 @@ func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status s
 	}
 
 	var total int64
-	if err := q.Count(&total).Error; err != nil {
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
 	var companies []models.Company
-	err := q.Order("id desc").Limit(limit).Offset(offset).Find(&companies).Error
+	err := q.Session(&gorm.Session{}).Order("id desc").Limit(limit).Offset(offset).Find(&companies).Error
 	return companies, total, err
 }
 

--- a/Backend/internal/services/company_relations_fetcher.go
+++ b/Backend/internal/services/company_relations_fetcher.go
@@ -149,8 +149,8 @@ func (f *CompanyRelationsFetcher) FetchAndSave(ctx context.Context, companyID ui
 	}
 	result.SavedCount = saved
 
-	// 空結果（関係0件 + unlistedのみ）で RelationsFetchedAt だけ進むと再取得不能になる
-	if relationsResultHasData(result) {
+	// AI が関係を返しても永続化が全失敗なら取得済みにしない。
+	if saved > 0 {
 		now := time.Now()
 		company.RelationsFetchedAt = &now
 		if err := f.companyRepo.Update(company); err != nil {
@@ -177,7 +177,7 @@ func (f *CompanyRelationsFetcher) ConfirmAndSave(companyID uint, result *Company
 
 	out := *result
 	out.SavedCount = saved
-	if relationsResultHasData(&out) {
+	if saved > 0 {
 		now := time.Now()
 		company.RelationsFetchedAt = &now
 		if err := f.companyRepo.Update(company); err != nil {
@@ -522,9 +522,7 @@ func mergeRelationsResult(
 
 	if baseMarket != nil {
 		out.MarketInfo = baseMarket
-	} else if ai != nil && ai.MarketInfo != nil {
-		out.MarketInfo = ai.MarketInfo
-	} else if baseMarket == nil && ai != nil {
+	} else if ai != nil {
 		out.MarketInfo = ai.MarketInfo
 	}
 	if out.MarketInfo == nil && ai != nil {

--- a/Backend/internal/services/tech_stack_fetcher.go
+++ b/Backend/internal/services/tech_stack_fetcher.go
@@ -152,7 +152,13 @@ func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL 
 
 	// 1) 公式サイト／採用ページから直接抽出（Search 予算を使わず成功率も高い）
 	if strings.TrimSpace(websiteURL) != "" {
-		if pageText, sourceURL, ferr := companyfetch.FirstFetchableText(ctx, companyfetch.CandidateCareerURLs(websiteURL)); ferr == nil && pageText != "" {
+		scrapeCtx, scrapeCancel := context.WithTimeout(ctx, 25*time.Second)
+		defer scrapeCancel()
+		candidateURLs := companyfetch.CandidateCareerURLs(websiteURL)
+		if len(candidateURLs) > 3 {
+			candidateURLs = candidateURLs[:3]
+		}
+		if pageText, sourceURL, ferr := companyfetch.FirstFetchableText(scrapeCtx, candidateURLs); ferr == nil && pageText != "" {
 			parseUser := fmt.Sprintf(
 				"企業「%s」の公開ページ本文です。本文に明示された技術のみ次のJSON形式で抽出してください。推測禁止。\n%s\n\n---\n本文:\n%s",
 				companyName, techStackJSONSchema, pageText,

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ import {
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
 
@@ -88,6 +89,7 @@ export default function AdminCompanyEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [fetchLoading, setFetchLoading] = useState(false)
+  const [primaryLoading, setPrimaryLoading] = useState(false)
   const [name, setName] = useState('')
   const [techStack, setTechStack] = useState<string[]>([])
   const [infraStack, setInfraStack] = useState<string[]>([])
@@ -150,6 +152,40 @@ export default function AdminCompanyEditPage() {
     }
   }
 
+  const handleFetchPrimary = async (force = false) => {
+    setPrimaryLoading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const { ok, status, data } = await fetchCompanyPrimary(
+        id,
+        authService.getAdminFetchHeaders(),
+        force,
+      )
+      if (!ok) {
+        setError(data?.error || `主3種の取得に失敗しました (${status})`)
+        return
+      }
+      if (data.company && typeof data.company === 'object') {
+        const company = data.company as Record<string, unknown>
+        setTechStack(parseJsonArray(String(company.tech_stack || '')))
+        setInfraStack(parseJsonArray(String(company.infra_stack || '')))
+        setCicdTools(parseJsonArray(String(company.cicd_tools || '')))
+        setDevStyle(String(company.development_style || ''))
+        setTechFetchedAt(company.tech_fetched_at ? String(company.tech_fetched_at) : null)
+      } else {
+        loadCompany()
+      }
+      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
+        setError(`一部失敗: ${data.errors.join('; ')}`)
+      }
+      const summary = formatFetchPrimarySummary(data)
+      setSuccess(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
+    } finally {
+      setPrimaryLoading(false)
+    }
+  }
+
   const handleSave = async () => {
     setError('')
     setSuccess('')
@@ -191,7 +227,8 @@ export default function AdminCompanyEditPage() {
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
       <Alert severity="info" sx={{ mb: 2 }}>
-        「AIで技術スタック取得」で採用ページ・技術ブログ等から言語/インフラ/CI・CDを取得します（TTL 30日）。
+        「主3種をまとめて取得」で Backend が基本・技術・ビジネス関係を順に取得して DB 保存します。
+        必要ならこの画面の個別取得で技術だけ再取得できます（TTL 30日）。
         最終取得: {formatTs(techFetchedAt)}
       </Alert>
 
@@ -215,8 +252,25 @@ export default function AdminCompanyEditPage() {
           <Button
             variant="contained"
             color="secondary"
+            onClick={() => handleFetchPrimary(false)}
+            disabled={fetchLoading || primaryLoading}
+            startIcon={primaryLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {primaryLoading ? '取得中...' : '主3種をまとめて取得'}
+          </Button>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => handleFetchPrimary(true)}
+            disabled={fetchLoading || primaryLoading}
+          >
+            主3種を強制再取得
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
             onClick={() => handleAiFetch(false)}
-            disabled={fetchLoading}
+            disabled={fetchLoading || primaryLoading}
             startIcon={fetchLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {fetchLoading ? '取得中...' : 'AIで技術スタック取得'}
@@ -224,7 +278,7 @@ export default function AdminCompanyEditPage() {
           <Button
             variant="outlined"
             onClick={() => handleAiFetch(true)}
-            disabled={fetchLoading}
+            disabled={fetchLoading || primaryLoading}
           >
             強制再取得
           </Button>

--- a/frontend/app/admin/companies/[id]/relations/page.tsx
+++ b/frontend/app/admin/companies/[id]/relations/page.tsx
@@ -20,6 +20,7 @@ import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
 import CompanyRelationGraph from '@/components/admin/CompanyRelationGraph'
 import { groupRelationsByCategory, RELATION_CATEGORY_LABELS } from '@/lib/relation-graph'
+import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 type RelationEntry = {
   name: string
@@ -55,6 +56,7 @@ export default function AdminCompanyRelationsPage() {
   const [success, setSuccess] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
   const [forceLoading, setForceLoading] = useState(false)
+  const [primaryLoading, setPrimaryLoading] = useState(false)
   const [confirmLoading, setConfirmLoading] = useState(false)
   const [previewPending, setPreviewPending] = useState(false)
 
@@ -171,6 +173,38 @@ export default function AdminCompanyRelationsPage() {
     }
   }
 
+  const handleFetchPrimary = async (force = false) => {
+    setPrimaryLoading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const { ok, status, data } = await fetchCompanyPrimary(
+        id,
+        authService.getAdminFetchHeaders(),
+        force,
+      )
+      if (!ok) {
+        setError(data?.error || `主3種の取得に失敗しました (${status})`)
+        return
+      }
+      if (data.relations) applyRelationsPayload(data.relations)
+      if (data.company && typeof data.company === 'object') {
+        const company = data.company as Record<string, unknown>
+        if (typeof company.website_url === 'string') setWebsiteUrl(company.website_url)
+        setRelationsFetchedAt(company.relations_fetched_at ? String(company.relations_fetched_at) : null)
+      } else {
+        loadCompany()
+      }
+      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
+        setError(`一部失敗: ${data.errors.join('; ')}`)
+      }
+      const summary = formatFetchPrimarySummary(data)
+      setSuccess(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
+    } finally {
+      setPrimaryLoading(false)
+    }
+  }
+
   const handleConfirmSave = async () => {
     setConfirmLoading(true)
     setError('')
@@ -241,15 +275,33 @@ export default function AdminCompanyRelationsPage() {
 
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          gBizINFO の調達・補助金関係を優先し、不足分のみ AI Search Lite で補完します（#633 Phase 2）。
+          「主3種をまとめて取得」で Backend が基本・技術・ビジネス関係を順に取得して DB 保存します。
+          必要ならこの画面の個別取得で関係だけ再取得できます。
         </Typography>
 
         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
           <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => handleFetchPrimary(false)}
+            disabled={aiLoading || forceLoading || primaryLoading}
+            startIcon={primaryLoading ? <CircularProgress size={16} color="inherit" /> : null}
+          >
+            {primaryLoading ? '取得中...' : '主3種をまとめて取得'}
+          </Button>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => handleFetchPrimary(true)}
+            disabled={aiLoading || forceLoading || primaryLoading}
+          >
+            主3種を強制再取得
+          </Button>
+          <Button
             variant="outlined"
             color="secondary"
             onClick={handleAiFetch}
-            disabled={!name.trim() || aiLoading}
+            disabled={!name.trim() || aiLoading || primaryLoading}
             startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {aiLoading ? '取得中...' : 'プレビュー取得（未保存）'}
@@ -266,7 +318,7 @@ export default function AdminCompanyRelationsPage() {
           <Button
             variant="outlined"
             onClick={handleForceFetchAndSave}
-            disabled={forceLoading}
+            disabled={forceLoading || primaryLoading}
             startIcon={forceLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {forceLoading ? '再取得中...' : '強制再取得して保存'}

--- a/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
@@ -15,15 +15,24 @@ export async function POST(
   const { id } = await params
   const force = request.nextUrl.searchParams.get('force')
   const qs = force === 'true' ? '?force=true' : ''
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-primary${qs}`, {
-    method: 'POST',
-    headers: {
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    // 基本 + 技術 + 関係で長時間になりうる
-    signal: AbortSignal.timeout(300_000),
-  })
+  let response: Response
+  try {
+    response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-primary${qs}`, {
+      method: 'POST',
+      headers: {
+        'X-Admin-Email': request.headers.get('x-admin-email') || '',
+        'X-Admin-Token': request.headers.get('x-admin-token') || '',
+      },
+      // 基本 + 技術 + 関係で長時間になりうる
+      signal: AbortSignal.timeout(300_000),
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === 'TimeoutError'
+        ? '企業情報の取得がタイムアウトしました'
+        : '企業情報取得中に通信エラーが発生しました'
+    return NextResponse.json({ error: message }, { status: 504 })
+  }
   const raw = await response.text()
   let data: Record<string, unknown> = {}
   if (raw) {

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -166,6 +166,8 @@ function ProfilePageContent() {
       }
       authService.logout?.()
       router.replace('/login?deleted=1')
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'アカウント削除に失敗しました')
     } finally {
       setDeleting(false)
       setDeleteDialogOpen(false)

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -99,7 +99,6 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
     const [isAdmin, setIsAdmin] = useState(!!user.is_admin)
     const theme = useTheme()
     const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-    const router = useRouter()
 
     useEffect(() => {
         setIsAdmin(!!user.is_admin)

--- a/frontend/components/diagram/RelationEdge.tsx
+++ b/frontend/components/diagram/RelationEdge.tsx
@@ -19,7 +19,22 @@ export function RelationEdge({
   const labelX = (sourceX + targetX) / 2
   const labelY = (sourceY + targetY) / 2
   const text = typeof label === 'string' ? label : label != null ? String(label) : ''
-  const pillWidth = Math.min(140, Math.max(36, text.length * 7.2 + 18))
+  const visualWidth = Array.from(text).reduce((sum, ch) => sum + (/[\u3000-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(ch) ? 2 : 1), 0)
+  const maxVisualWidth = 16
+  const truncatedText = (() => {
+    if (visualWidth <= maxVisualWidth) return text
+    let used = 0
+    let out = ''
+    for (const ch of Array.from(text)) {
+      const width = /[\u3000-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(ch) ? 2 : 1
+      if (used+ width > maxVisualWidth - 1) break
+      used += width
+      out += ch
+    }
+    return `${out}…`
+  })()
+  const truncatedWidth = Array.from(truncatedText).reduce((sum, ch) => sum + (/[\u3000-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(ch) ? 2 : 1), 0)
+  const pillWidth = Math.min(140, Math.max(36, truncatedWidth * 7.2 + 18))
 
   return (
     <>
@@ -52,7 +67,7 @@ export function RelationEdge({
               letterSpacing: '0.01em',
             }}
           >
-            {text.length > 14 ? `${text.slice(0, 14)}…` : text}
+            {truncatedText}
           </text>
         </g>
       ) : null}

--- a/frontend/lib/admin-company-fetch.ts
+++ b/frontend/lib/admin-company-fetch.ts
@@ -27,6 +27,46 @@ export type FetchPrimaryResponse = {
   error?: string
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function toRecordOrUndefined(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined
+}
+
+function toStepOrUndefined(value: unknown): FetchPrimaryStep | undefined {
+  if (!isRecord(value)) return undefined
+  return {
+    status: typeof value.status === 'string' ? value.status : undefined,
+    detail: typeof value.detail === 'string' ? value.detail : undefined,
+    count: typeof value.count === 'number' ? value.count : undefined,
+    skipped: typeof value.skipped === 'boolean' ? value.skipped : undefined,
+  }
+}
+
+function parseFetchPrimaryResponse(value: unknown): FetchPrimaryResponse {
+  if (!isRecord(value)) {
+    return {}
+  }
+  return {
+    ok: typeof value.ok === 'boolean' ? value.ok : undefined,
+    force: typeof value.force === 'boolean' ? value.force : undefined,
+    company_id: typeof value.company_id === 'number' ? value.company_id : undefined,
+    company_name: typeof value.company_name === 'string' ? value.company_name : undefined,
+    aspects: Array.isArray(value.aspects) ? value.aspects.filter((v): v is string => typeof v === 'string') : undefined,
+    errors: Array.isArray(value.errors) ? value.errors.filter((v): v is string => typeof v === 'string') : undefined,
+    info_step: toStepOrUndefined(value.info_step),
+    tech_step: toStepOrUndefined(value.tech_step),
+    relations_step: toStepOrUndefined(value.relations_step),
+    info: toRecordOrUndefined(value.info),
+    tech: toRecordOrUndefined(value.tech),
+    relations: toRecordOrUndefined(value.relations),
+    company: toRecordOrUndefined(value.company),
+    error: typeof value.error === 'string' ? value.error : undefined,
+  }
+}
+
 function stepLabel(step: FetchPrimaryStep | undefined, label: string): string | null {
   if (!step?.status) return null
   if (step.status === 'fetched') {
@@ -59,6 +99,7 @@ export async function fetchCompanyPrimary(
     method: 'POST',
     headers,
   })
-  const data = (await res.json().catch(() => ({}))) as FetchPrimaryResponse
+  const raw: unknown = await res.json().catch(() => ({}))
+  const data = parseFetchPrimaryResponse(raw)
   return { ok: res.ok, status: res.status, data }
 }


### PR DESCRIPTION
Related to #633
Follow-up to #721

## 変更内容
- RelationsFetchedAt を AI 返却件数ではなく永続化成功件数 (`saved > 0`) で進めるよう修正
- `ListActiveFiltered` で Count/Find を Session 分岐し GORM クエリ再利用を回避
- 技術スタック候補 URL フェッチに時間・件数上限を設け、Search フォールバック用の予算を確保
- GitHub 未連携時の 404 メッセージを日本語化
- `fetch-primary` BFF で timeout / 通信例外を捕捉して管理者向けエラーを返却
- `fetchCompanyPrimary` のレスポンスを実行時検証して型安全にパース
- 退会前トークン更新失敗を画面表示
- 相関図エッジの日本語ラベル幅計算を CJK 対応に修正
- 技術・関係編集画面に主3種一括取得ボタンを追加

## Test plan
- [ ] 管理画面の企業詳細で「主3種をまとめて取得」が成功し、基本/技術/関係が DB に保存される
- [ ] 関係取得で永続化が空の場合、`relations_fetched_at` が進まない
- [ ] 企業一覧の名前/ステータス絞り込みが正しく件数と一致する
- [ ] 退会時にトークン更新失敗するとエラーが表示される
- [ ] GitHub 未連携ユーザーの sync で日本語エラーが返る


Made with [Cursor](https://cursor.com)