### PR TITLE
Resolve #633: 企業管理の取得判定・関係情報・業種対応とLangChain導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7011,3 +7011,4 @@ rag/.venv/
 __pycache__/
 *.pyc
 .tools/
+frontend/test-results/.last-run.json

--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -22,8 +22,12 @@ type CompanyRepository interface {
 	FindAllActive(limit, offset int) ([]models.Company, error)
 	FindAllActiveNames(q string) ([]models.CompanyName, error)
 	CountActive() (int64, error)
-	// ListActiveFiltered は名前・公開ステータスで絞り込んだアクティブ企業一覧と総件数を返す。
-	ListActiveFiltered(limit, offset int, name, status string) ([]models.Company, int64, error)
+	// ListActiveFiltered は名前・公開ステータス・業界・情報充足で絞り込んだアクティブ企業一覧と総件数を返す。
+	// industry が "__unset__" のときは業界未設定のみ。readiness は "ready" / "missing" / ""。
+	// orderBy は "industry" のとき業界順、それ以外は id desc。
+	ListActiveFiltered(limit, offset int, name, status, industry, readiness, orderBy string) ([]models.Company, int64, error)
+	// ListActiveIndustries はアクティブ企業に付いている業界名の重複なし一覧を返す。
+	ListActiveIndustries() ([]string, error)
 	FindAllPublished(limit, offset int) ([]models.Company, error)
 	CountPublished() (int64, error)
 	FindByID(id uint) (*models.Company, error)

--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -43,7 +43,8 @@ type CompanyRepository interface {
 	ListPublishedL1WarmCandidates(limit int, infoTTL time.Duration) ([]models.CompanyL1WarmRow, error)
 	CountL1Coverage(infoTTL time.Duration) (*models.L1CoverageStats, error)
 	// ListActiveMissingFetchCandidates は基本情報/求人/Tech/関係のいずれかが不足しているアクティブ企業を返す。
-	ListActiveMissingFetchCandidates(limit int) ([]models.Company, error)
+	// primaryOnly=true のときは求人条件を除外し、主3種（基本・技術・関係）のみで候補を取る。
+	ListActiveMissingFetchCandidates(limit int, primaryOnly bool) ([]models.Company, error)
 }
 
 // CompanyRelationRepository は企業間関係の永続化インターフェース。

--- a/Backend/internal/companyfetch/org_name.go
+++ b/Backend/internal/companyfetch/org_name.go
@@ -57,10 +57,11 @@ func IsClearOrganizationName(name string) bool {
 	if utf8.RuneCountInString(core) < 2 {
 		return false
 	}
-	// 記号・数字だけの名前は除外
+	// 記号・数字だけの名前は除外（全角英数字も含める）
 	letters := 0
 	for _, r := range core {
 		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			(r >= 0xff21 && r <= 0xff3a) || (r >= 0xff41 && r <= 0xff5a) || (r >= 0xff10 && r <= 0xff19) ||
 			(r >= 0x3040 && r <= 0x30ff) || (r >= 0x4e00 && r <= 0x9fff) || (r >= 0xff66 && r <= 0xff9d) {
 			letters++
 		}

--- a/Backend/internal/companyfetch/org_name.go
+++ b/Backend/internal/companyfetch/org_name.go
@@ -1,0 +1,69 @@
+package companyfetch
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	// 法人格付きでも本体名が無い・曖昧な表記
+	unclearOrgExact = map[string]struct{}{
+		"不明": {}, "未定": {}, "その他": {}, "なし": {}, "無し": {}, "該当なし": {},
+		"n/a": {}, "na": {}, "-": {}, "—": {}, "－": {},
+		"複数社": {}, "各社": {}, "関係会社": {}, "グループ会社": {}, "グループ": {},
+		"共同企業体": {}, "特定共同企業体": {}, "コンソーシアム": {}, "jv": {}, "ｊｖ": {},
+		"株式会社": {}, "有限会社": {}, "合同会社": {}, "合資会社": {}, "合名会社": {},
+		"一般社団法人": {}, "一般財団法人": {}, "公益社団法人": {}, "公益財団法人": {},
+		"主要取引先": {}, "取引先": {},
+	}
+	unclearOrgContains = []string{
+		"不明", "未定", "その他多数", "ほか数社", "他数社", "等数社",
+		"共同企業体", "特定共同企業体",
+	}
+	corpPrefixRe = regexp.MustCompile(`^(株式会社|有限会社|合同会社|合資会社|合名会社|一般社団法人|一般財団法人|公益社団法人|公益財団法人)\s*`)
+	corpSuffixRe = regexp.MustCompile(`\s*(株式会社|有限会社|合同会社|合資会社|合名会社|Inc\.?|Ltd\.?|LLC|Corp\.?)$`)
+)
+
+// IsClearOrganizationName は関係先として保存してよい、はっきりした組織名か。
+// 曖昧・プレースホルダ・法人格のみ・短すぎる名前は false。
+func IsClearOrganizationName(name string) bool {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return false
+	}
+	lower := strings.ToLower(n)
+	if _, ok := unclearOrgExact[lower]; ok {
+		return false
+	}
+	if _, ok := unclearOrgExact[n]; ok {
+		return false
+	}
+	for _, frag := range unclearOrgContains {
+		if strings.Contains(n, frag) {
+			return false
+		}
+	}
+
+	core := strings.TrimSpace(corpPrefixRe.ReplaceAllString(n, ""))
+	core = strings.TrimSpace(corpSuffixRe.ReplaceAllString(core, ""))
+	core = strings.TrimSpace(core)
+	if core == "" {
+		return false
+	}
+	if _, ok := unclearOrgExact[strings.ToLower(core)]; ok {
+		return false
+	}
+	if utf8.RuneCountInString(core) < 2 {
+		return false
+	}
+	// 記号・数字だけの名前は除外
+	letters := 0
+	for _, r := range core {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			(r >= 0x3040 && r <= 0x30ff) || (r >= 0x4e00 && r <= 0x9fff) || (r >= 0xff66 && r <= 0xff9d) {
+			letters++
+		}
+	}
+	return letters >= 2
+}

--- a/Backend/internal/companyfetch/org_name_test.go
+++ b/Backend/internal/companyfetch/org_name_test.go
@@ -1,0 +1,25 @@
+package companyfetch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsClearOrganizationName(t *testing.T) {
+	assert.True(t, IsClearOrganizationName("デジタル庁"))
+	assert.True(t, IsClearOrganizationName("厚生労働省"))
+	assert.True(t, IsClearOrganizationName("株式会社パートナーA"))
+	assert.True(t, IsClearOrganizationName("トヨタ自動車株式会社"))
+	assert.True(t, IsClearOrganizationName("東京都"))
+
+	assert.False(t, IsClearOrganizationName(""))
+	assert.False(t, IsClearOrganizationName("不明"))
+	assert.False(t, IsClearOrganizationName("その他"))
+	assert.False(t, IsClearOrganizationName("株式会社"))
+	assert.False(t, IsClearOrganizationName("共同企業体"))
+	assert.False(t, IsClearOrganizationName("○○特定共同企業体"))
+	assert.False(t, IsClearOrganizationName("主要取引先"))
+	assert.False(t, IsClearOrganizationName("A"))
+	assert.False(t, IsClearOrganizationName("ほか数社"))
+}

--- a/Backend/internal/companyfetch/org_name_test.go
+++ b/Backend/internal/companyfetch/org_name_test.go
@@ -12,6 +12,8 @@ func TestIsClearOrganizationName(t *testing.T) {
 	assert.True(t, IsClearOrganizationName("株式会社パートナーA"))
 	assert.True(t, IsClearOrganizationName("トヨタ自動車株式会社"))
 	assert.True(t, IsClearOrganizationName("東京都"))
+	assert.True(t, IsClearOrganizationName("ＮＥＣ"))
+	assert.True(t, IsClearOrganizationName("ＡＢＣ株式会社"))
 
 	assert.False(t, IsClearOrganizationName(""))
 	assert.False(t, IsClearOrganizationName("不明"))

--- a/Backend/internal/companyfetch/relation_label.go
+++ b/Backend/internal/companyfetch/relation_label.go
@@ -3,6 +3,7 @@ package companyfetch
 import "strings"
 
 // DefaultRelationDescription は relation_type から図・一覧に表示する既定ラベルを返す。
+// 種別の表示用であり、取引内容の代替テキストとして DB に保存してはいけない。
 func DefaultRelationDescription(relationType string) string {
 	switch strings.TrimSpace(relationType) {
 	case "capital_subsidiary":
@@ -26,6 +27,17 @@ func DefaultRelationDescription(relationType string) string {
 	}
 }
 
+// IsGenericRelationLabel は関係種別のラベルだけで、取引内容ではない文字列か。
+func IsGenericRelationLabel(desc string) bool {
+	switch strings.TrimSpace(desc) {
+	case "子会社", "関連会社", "主要取引先", "取引先", "調達・契約", "補助金連携",
+		"ビジネス関係", "資本関係", "関連", "調達（gBiz）", "補助金（gBiz）":
+		return true
+	default:
+		return false
+	}
+}
+
 // IsSourceTagDescription は取得元タグのプレースホルダ説明かどうかを返す。
 // 例: web_search:株式会社サンプル, llm_web_search:サンプル
 func IsSourceTagDescription(desc string) bool {
@@ -46,10 +58,20 @@ func IsSourceTagDescription(desc string) bool {
 	}
 }
 
-// NormalizeRelationDescription は表示用の関係説明を返す。
-func NormalizeRelationDescription(description, relationType string) string {
+// SanitizeRelationDescription は DB 保存用に、実質的な関係・取引内容だけを残す。
+// 取得元タグや「主要取引先」などの種別ラベルだけの場合は空文字にする。
+func SanitizeRelationDescription(description string) string {
 	desc := strings.TrimSpace(description)
-	if desc != "" && !IsSourceTagDescription(desc) {
+	if desc == "" || IsSourceTagDescription(desc) || IsGenericRelationLabel(desc) {
+		return ""
+	}
+	return desc
+}
+
+// NormalizeRelationDescription は図・一覧の表示用ラベルを返す。
+// 実取引内容があればそれを優先し、無ければ関係種別の既定ラベルを使う。
+func NormalizeRelationDescription(description, relationType string) string {
+	if desc := SanitizeRelationDescription(description); desc != "" {
 		return desc
 	}
 	return DefaultRelationDescription(relationType)

--- a/Backend/internal/companyfetch/relation_label_test.go
+++ b/Backend/internal/companyfetch/relation_label_test.go
@@ -20,7 +20,16 @@ func TestIsSourceTagDescription(t *testing.T) {
 	assert.False(t, IsSourceTagDescription("調達契約 (2024-01-01)"))
 }
 
+func TestSanitizeRelationDescription(t *testing.T) {
+	assert.Equal(t, "", SanitizeRelationDescription("web_search:sky株式会社"))
+	assert.Equal(t, "", SanitizeRelationDescription("主要取引先"))
+	assert.Equal(t, "", SanitizeRelationDescription("取引先"))
+	assert.Equal(t, "決済代行", SanitizeRelationDescription("決済代行"))
+	assert.Equal(t, "クラウド基盤の共同開発", SanitizeRelationDescription("  クラウド基盤の共同開発  "))
+}
+
 func TestNormalizeRelationDescription(t *testing.T) {
 	assert.Equal(t, "主要取引先", NormalizeRelationDescription("web_search:sky株式会社", "business_partner"))
+	assert.Equal(t, "主要取引先", NormalizeRelationDescription("主要取引先", "business_partner"))
 	assert.Equal(t, "決済代行", NormalizeRelationDescription("決済代行", "business_partner"))
 }

--- a/Backend/internal/companyfetch/text.go
+++ b/Backend/internal/companyfetch/text.go
@@ -1,6 +1,7 @@
 package companyfetch
 
 import (
+	"Backend/internal/companyfields"
 	"context"
 	"fmt"
 	"html"
@@ -59,31 +60,68 @@ func IsEmptyTechPayload(techStack string) bool {
 	return t == "" || t == "[]" || t == "null" || t == "{}"
 }
 
-// HasTechData は tech_stack に実データがあるか。
+// HasTechData は IT 向け: tech_stack に実データがあるか。
 // infra / CI/CD / 開発手法だけ埋まっていても「技術取得済み」とはみなさない。
-// （管理UIの未取得表示・不足候補SQLと判定を揃える）
+// 業界別判定は HasTechDataForIndustry を使うこと。
 func HasTechData(techStack, infraStack, cicdTools, developmentStyle string) bool {
 	_, _, _ = infraStack, cicdTools, developmentStyle
 	return !IsEmptyTechPayload(techStack)
 }
 
-// HasBasicInfo は基本情報として最低限の概要・公式URLがあるか。
+// HasTechDataForIndustry は業界プロファイルに応じた技術・専門情報の充足判定。
+// 技術タブ非対象業種は常に true（不足扱いにしない）。
+func HasTechDataForIndustry(industry, techStack, infraStack, cicdTools, developmentStyle string) bool {
+	profile := companyfields.Resolve(industry)
+	if !profile.TechAspectEnabled {
+		return true
+	}
+	switch profile.ID {
+	case companyfields.ProfileManufacturing:
+		// 製造業: 主要技術・設備・生産方式のいずれかがあれば充足
+		return !IsEmptyTechPayload(techStack) ||
+			!IsEmptyTechPayload(infraStack) ||
+			strings.TrimSpace(developmentStyle) != ""
+	default:
+		// IT など: 言語・フレームワーク（tech_stack）必須
+		return HasTechData(techStack, infraStack, cicdTools, developmentStyle)
+	}
+}
+
+// HasBasicInfo は公開向けに十分な基本情報（概要・公式URL）があるか。
 func HasBasicInfo(description, websiteURL string) bool {
 	return strings.TrimSpace(description) != "" && strings.TrimSpace(websiteURL) != ""
 }
 
-// HasMeaningfulMarketInfo は「非上場のみ」を除き、上場区分や証券コードなど実質的な市場情報があるか。
-// market_type=unlisted だけのレコードは取得成功とみなさない（再取得を止めてしまうため）。
+// HasBasicInfoFootprint は取得フロー上の手がかり（概要+URL、または公式URL/所在地）があるか。
+// 非上場などで概要が公開事実として取れない場合でも、再取得ループを止める判定に使う。
+func HasBasicInfoFootprint(description, websiteURL, location string) bool {
+	if HasBasicInfo(description, websiteURL) {
+		return true
+	}
+	return strings.TrimSpace(websiteURL) != "" || strings.TrimSpace(location) != ""
+}
+
+// HasMeaningfulMarketInfo は市場区分が確定しているか（上場・非上場どちらも含む）。
+// unlisted 確定も取得成功とみなし、RelationsFetchedAt のスタンプ対象にする。
+// 再取得は force / TTL 切れで行う。
 func HasMeaningfulMarketInfo(isListed bool, marketType, stockCode string) bool {
 	if isListed || strings.TrimSpace(stockCode) != "" {
 		return true
 	}
 	switch strings.ToLower(strings.TrimSpace(marketType)) {
-	case "prime", "standard", "growth":
+	case "prime", "standard", "growth", "unlisted":
 		return true
 	default:
 		return false
 	}
+}
+
+// IsConfirmedUnlisted は証券コードなしの非上場確定か。
+func IsConfirmedUnlisted(isListed bool, marketType, stockCode string) bool {
+	if isListed || strings.TrimSpace(stockCode) != "" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(marketType), "unlisted")
 }
 
 // NormalizeHTMLText は HTML をプレーンテキストへ正規化する。

--- a/Backend/internal/companyfetch/text.go
+++ b/Backend/internal/companyfetch/text.go
@@ -64,7 +64,6 @@ func IsEmptyTechPayload(techStack string) bool {
 // infra / CI/CD / 開発手法だけ埋まっていても「技術取得済み」とはみなさない。
 // 業界別判定は HasTechDataForIndustry を使うこと。
 func HasTechData(techStack, infraStack, cicdTools, developmentStyle string) bool {
-	_, _, _ = infraStack, cicdTools, developmentStyle
 	return !IsEmptyTechPayload(techStack)
 }
 

--- a/Backend/internal/companyfetch/text.go
+++ b/Backend/internal/companyfetch/text.go
@@ -59,12 +59,12 @@ func IsEmptyTechPayload(techStack string) bool {
 	return t == "" || t == "[]" || t == "null" || t == "{}"
 }
 
-// HasTechData は技術・インフラ・CI/CD・開発手法のいずれかが入っているか。
+// HasTechData は tech_stack に実データがあるか。
+// infra / CI/CD / 開発手法だけ埋まっていても「技術取得済み」とはみなさない。
+// （管理UIの未取得表示・不足候補SQLと判定を揃える）
 func HasTechData(techStack, infraStack, cicdTools, developmentStyle string) bool {
-	return !IsEmptyTechPayload(techStack) ||
-		!IsEmptyTechPayload(infraStack) ||
-		!IsEmptyTechPayload(cicdTools) ||
-		strings.TrimSpace(developmentStyle) != ""
+	_, _, _ = infraStack, cicdTools, developmentStyle
+	return !IsEmptyTechPayload(techStack)
 }
 
 // HasBasicInfo は基本情報として最低限の概要・公式URLがあるか。

--- a/Backend/internal/companyfetch/text_test.go
+++ b/Backend/internal/companyfetch/text_test.go
@@ -37,9 +37,11 @@ func TestHasTechData(t *testing.T) {
 	assert.False(t, HasTechData("", "", "", ""))
 	assert.False(t, HasTechData("[]", "", "", ""))
 	assert.True(t, HasTechData(`["Go"]`, "", "", ""))
-	assert.True(t, HasTechData("", `["AWS"]`, "", ""))
-	assert.True(t, HasTechData("", "", `["Actions"]`, ""))
-	assert.True(t, HasTechData("", "", "", "スクラム"))
+	// infra / CI/CD / 開発手法のみでは不足扱い（スキップしない）
+	assert.False(t, HasTechData("", `["AWS"]`, "", ""))
+	assert.False(t, HasTechData("", "", `["Actions"]`, ""))
+	assert.False(t, HasTechData("", "", "", "スクラム"))
+	assert.True(t, HasTechData(`["Go"]`, `["AWS"]`, `["Actions"]`, "スクラム"))
 }
 
 func TestHasMeaningfulMarketInfo(t *testing.T) {

--- a/Backend/internal/companyfetch/text_test.go
+++ b/Backend/internal/companyfetch/text_test.go
@@ -44,15 +44,41 @@ func TestHasTechData(t *testing.T) {
 	assert.True(t, HasTechData(`["Go"]`, `["AWS"]`, `["Actions"]`, "スクラム"))
 }
 
+func TestHasTechDataForIndustry(t *testing.T) {
+	assert.True(t, HasTechDataForIndustry("金融・保険業", "", "", "", ""))
+	assert.True(t, HasTechDataForIndustry("", "", "", "", "")) // general: tech aspect off
+	assert.False(t, HasTechDataForIndustry("IT・ソフトウェア", "", `["AWS"]`, "", ""))
+	assert.True(t, HasTechDataForIndustry("IT・ソフトウェア", `["Go"]`, "", "", ""))
+	assert.True(t, HasTechDataForIndustry("製造業", "", `["国内工場"]`, "", ""))
+	assert.True(t, HasTechDataForIndustry("自動車製造", "", "", "", "セル生産"))
+	assert.False(t, HasTechDataForIndustry("製造業", "", "", "", ""))
+}
+
+func TestHasBasicInfoFootprint(t *testing.T) {
+	assert.True(t, HasBasicInfoFootprint("概要", "https://example.com", ""))
+	assert.True(t, HasBasicInfoFootprint("", "https://example.com", ""))
+	assert.True(t, HasBasicInfoFootprint("", "", "東京都"))
+	assert.False(t, HasBasicInfoFootprint("", "", ""))
+}
+
 func TestHasMeaningfulMarketInfo(t *testing.T) {
 	assert.False(t, HasMeaningfulMarketInfo(false, "", ""))
-	assert.False(t, HasMeaningfulMarketInfo(false, "unlisted", ""))
-	assert.False(t, HasMeaningfulMarketInfo(false, "UNLISTED", "  "))
+	assert.True(t, HasMeaningfulMarketInfo(false, "unlisted", ""))
+	assert.True(t, HasMeaningfulMarketInfo(false, "UNLISTED", "  "))
 	assert.True(t, HasMeaningfulMarketInfo(true, "unlisted", ""))
 	assert.True(t, HasMeaningfulMarketInfo(false, "prime", ""))
 	assert.True(t, HasMeaningfulMarketInfo(false, "standard", ""))
 	assert.True(t, HasMeaningfulMarketInfo(false, "growth", ""))
 	assert.True(t, HasMeaningfulMarketInfo(false, "unlisted", "4755"))
+}
+
+func TestIsConfirmedUnlisted(t *testing.T) {
+	assert.True(t, IsConfirmedUnlisted(false, "unlisted", ""))
+	assert.True(t, IsConfirmedUnlisted(false, "UNLISTED", "  "))
+	assert.False(t, IsConfirmedUnlisted(true, "unlisted", ""))
+	assert.False(t, IsConfirmedUnlisted(false, "unlisted", "4755"))
+	assert.False(t, IsConfirmedUnlisted(false, "prime", ""))
+	assert.False(t, IsConfirmedUnlisted(false, "", ""))
 }
 
 func TestTrimText(t *testing.T) {

--- a/Backend/internal/companyfields/profile.go
+++ b/Backend/internal/companyfields/profile.go
@@ -1,0 +1,139 @@
+// Package companyfields は業界ごとに入力可能な企業フィールドを定義する。
+// Frontend の frontend/lib/admin-company-field-profile.ts と対応を揃えること。
+package companyfields
+
+import (
+	"strings"
+)
+
+// ProfileID は業界プロファイル識別子。
+type ProfileID string
+
+const (
+	ProfileIT            ProfileID = "it"
+	ProfileManufacturing ProfileID = "manufacturing"
+	ProfileFinance       ProfileID = "finance"
+	ProfileConsulting    ProfileID = "consulting"
+	ProfileEducation     ProfileID = "education"
+	ProfileHealthcare    ProfileID = "healthcare"
+	ProfileGeneral       ProfileID = "general"
+)
+
+// Profile は業界ごとの入力・取得方針。
+type Profile struct {
+	ID                    ProfileID
+	Label                 string
+	MatchKeywords         []string
+	TechAspectEnabled     bool
+	RequireTechForPublish bool
+}
+
+// profiles はマッチ優先順（先に当たったものが採用される）。
+var profiles = []Profile{
+	{
+		ID:                    ProfileIT,
+		Label:                 "IT・ソフトウェア",
+		MatchKeywords:         []string{"it", "ｉｔ", "情報", "ソフト", "software", "web", "ウェブ", "saas", "システム開発", "通信", "インターネット", "ゲーム"},
+		TechAspectEnabled:     true,
+		RequireTechForPublish: true,
+	},
+	{
+		ID:                    ProfileManufacturing,
+		Label:                 "製造業",
+		MatchKeywords:         []string{"製造", "メーカー", "自動車", "機械", "電機", "電子", "ものづくり", "工場"},
+		TechAspectEnabled:     true,
+		RequireTechForPublish: false,
+	},
+	{
+		ID:                    ProfileFinance,
+		Label:                 "金融・保険",
+		MatchKeywords:         []string{"金融", "銀行", "保険", "証券", "クレジット"},
+		TechAspectEnabled:     false,
+		RequireTechForPublish: false,
+	},
+	{
+		ID:                    ProfileConsulting,
+		Label:                 "コンサルティング",
+		MatchKeywords:         []string{"コンサル"},
+		TechAspectEnabled:     false,
+		RequireTechForPublish: false,
+	},
+	{
+		ID:                    ProfileEducation,
+		Label:                 "教育",
+		MatchKeywords:         []string{"教育", "学校", "学習", "大学", "塾"},
+		TechAspectEnabled:     false,
+		RequireTechForPublish: false,
+	},
+	{
+		ID:                    ProfileHealthcare,
+		Label:                 "医療・福祉",
+		MatchKeywords:         []string{"医療", "福祉", "病院", "ヘルスケア", "介護"},
+		TechAspectEnabled:     false,
+		RequireTechForPublish: false,
+	},
+	{
+		ID:                    ProfileGeneral,
+		Label:                 "その他",
+		MatchKeywords:         nil,
+		TechAspectEnabled:     false,
+		RequireTechForPublish: false,
+	},
+}
+
+// Resolve は industry 文字列からプロファイルを返す。
+func Resolve(industry string) Profile {
+	normalized := strings.ToLower(strings.TrimSpace(industry))
+	if normalized == "" {
+		return profiles[len(profiles)-1] // general
+	}
+	for _, p := range profiles {
+		if p.ID == ProfileGeneral {
+			continue
+		}
+		for _, kw := range p.MatchKeywords {
+			if strings.Contains(normalized, strings.ToLower(kw)) {
+				return p
+			}
+		}
+	}
+	return profiles[len(profiles)-1]
+}
+
+// RequiresTech は技術情報の取得・公開必須判定。
+func RequiresTech(industry string) bool {
+	return Resolve(industry).RequireTechForPublish
+}
+
+// TechAspectEnabled は技術情報タブを出すか。
+func TechAspectEnabled(industry string) bool {
+	return Resolve(industry).TechAspectEnabled
+}
+
+// TechEmptyStepStatus は技術取得後にデータが空だったときのステップ結果を返す。
+// 公開必須でない業種は empty ではなく skipped(optional_empty) にする。
+func TechEmptyStepStatus(industry string) (status, detail string, countAsError bool) {
+	if !RequiresTech(industry) {
+		return "skipped", "optional_empty", false
+	}
+	return "empty", "no_tech_stack", true
+}
+
+// TechRequiredIndustrySQL は「技術情報が必須の業界」にマッチする SQL 断片と引数を返す。
+// column は companies.industry など。
+func TechRequiredIndustrySQL(column string) (cond string, args []any) {
+	var parts []string
+	for _, p := range profiles {
+		if !p.RequireTechForPublish {
+			continue
+		}
+		for _, kw := range p.MatchKeywords {
+			parts = append(parts, column+" LIKE ?")
+			args = append(args, "%"+kw+"%")
+		}
+	}
+	if len(parts) == 0 {
+		return "0=1", nil
+	}
+	return "(" + strings.Join(parts, " OR ") + ")", args
+}

--- a/Backend/internal/companyfields/profile_test.go
+++ b/Backend/internal/companyfields/profile_test.go
@@ -1,0 +1,83 @@
+package companyfields
+
+import "testing"
+
+func TestResolve_IT(t *testing.T) {
+	cases := []string{"IT・ソフトウェア", "ソフトウェア開発", "情報通信業", "Webサービス"}
+	for _, industry := range cases {
+		p := Resolve(industry)
+		if p.ID != ProfileIT {
+			t.Fatalf("industry=%q want it, got %s", industry, p.ID)
+		}
+		if !p.RequireTechForPublish || !p.TechAspectEnabled {
+			t.Fatalf("industry=%q should require/show tech", industry)
+		}
+	}
+}
+
+func TestResolve_NonTech(t *testing.T) {
+	cases := []struct {
+		industry string
+		want     ProfileID
+	}{
+		{"金融・保険業", ProfileFinance},
+		{"銀行", ProfileFinance},
+		{"教育・学習支援業", ProfileEducation},
+		{"医療・福祉", ProfileHealthcare},
+		{"コンサルティング", ProfileConsulting},
+		{"製造業", ProfileManufacturing},
+		{"", ProfileGeneral},
+		{"小売業", ProfileGeneral},
+	}
+	for _, tc := range cases {
+		p := Resolve(tc.industry)
+		if p.ID != tc.want {
+			t.Fatalf("industry=%q want %s, got %s", tc.industry, tc.want, p.ID)
+		}
+		if p.ID != ProfileManufacturing && p.RequireTechForPublish {
+			t.Fatalf("industry=%q should not require tech", tc.industry)
+		}
+	}
+}
+
+func TestRequiresTechAndTechAspectEnabled(t *testing.T) {
+	if !RequiresTech("IT・ソフトウェア") || !TechAspectEnabled("IT・ソフトウェア") {
+		t.Fatal("IT should require and enable tech")
+	}
+	if RequiresTech("製造業") {
+		t.Fatal("manufacturing should not require tech for publish")
+	}
+	if !TechAspectEnabled("製造業") {
+		t.Fatal("manufacturing should still show tech aspect")
+	}
+	if RequiresTech("金融・保険業") || TechAspectEnabled("金融・保険業") {
+		t.Fatal("finance should neither require nor enable tech")
+	}
+	if RequiresTech("") || TechAspectEnabled("") {
+		t.Fatal("empty industry (general) should not require/enable tech")
+	}
+}
+
+func TestTechEmptyStepStatus(t *testing.T) {
+	status, detail, asErr := TechEmptyStepStatus("IT・ソフトウェア")
+	if status != "empty" || detail != "no_tech_stack" || !asErr {
+		t.Fatalf("IT empty: status=%s detail=%s asErr=%v", status, detail, asErr)
+	}
+
+	status, detail, asErr = TechEmptyStepStatus("製造業")
+	if status != "skipped" || detail != "optional_empty" || asErr {
+		t.Fatalf("manufacturing empty: status=%s detail=%s asErr=%v", status, detail, asErr)
+	}
+
+	status, detail, asErr = TechEmptyStepStatus("金融・保険業")
+	if status != "skipped" || detail != "optional_empty" || asErr {
+		t.Fatalf("finance empty: status=%s detail=%s asErr=%v", status, detail, asErr)
+	}
+}
+
+func TestTechRequiredIndustrySQL_NonEmpty(t *testing.T) {
+	cond, args := TechRequiredIndustrySQL("industry")
+	if cond == "" || len(args) == 0 {
+		t.Fatal("expected non-empty SQL for tech-required industries")
+	}
+}

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
+	"Backend/internal/companyfields"
 	"Backend/internal/models"
 	"Backend/internal/openai"
 	"Backend/internal/services"
@@ -100,7 +101,10 @@ func (c *AdminCompanyController) List(ctx echo.Context) error {
 	}
 	name := strings.TrimSpace(ctx.QueryParam("name"))
 	status := strings.TrimSpace(ctx.QueryParam("status"))
-	companies, total, err := c.repo.ListActiveFiltered(limit, offset, name, status)
+	industry := strings.TrimSpace(ctx.QueryParam("industry"))
+	readiness := strings.TrimSpace(ctx.QueryParam("readiness"))
+	orderBy := strings.TrimSpace(ctx.QueryParam("order"))
+	companies, total, err := c.repo.ListActiveFiltered(limit, offset, name, status, industry, readiness, orderBy)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch companies")
 	}
@@ -111,7 +115,23 @@ func (c *AdminCompanyController) List(ctx echo.Context) error {
 		"offset":    offset,
 		"name":      name,
 		"status":    status,
+		"industry":  industry,
+		"readiness": readiness,
+		"order":     orderBy,
 	})
+}
+
+// Industries GET /api/admin/companies/industries
+// アクティブ企業に付いている業界名の一覧を返す（絞り込み用）。
+func (c *AdminCompanyController) Industries(ctx echo.Context) error {
+	industries, err := c.repo.ListActiveIndustries()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch industries")
+	}
+	if industries == nil {
+		industries = []string{}
+	}
+	return ctx.JSON(http.StatusOK, map[string]any{"industries": industries})
 }
 
 // Create POST /api/admin/companies
@@ -656,8 +676,7 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 	// 1) 基本情報
 	infoStep := fetchStepResult{Status: "skipped", Skipped: true, Detail: "fetcher unavailable"}
 	if c.infoFetcher != nil {
-		needInfo := forceRefresh || !companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) ||
-			!companyfetch.HasBasicInfo(company.Description, company.WebsiteURL)
+		needInfo := forceRefresh || !companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo)
 		if !needInfo {
 			infoStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: "ttl_fresh"}
 		} else {
@@ -688,6 +707,9 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				reload()
 				if companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
 					infoStep = fetchStepResult{Status: "fetched", Detail: "ok"}
+				} else if companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
+					// AI/gBiz は成功したが概要など公開事実が無い → 未取得ではなく確認済み（公開情報限定）
+					infoStep = fetchStepResult{Status: "empty", Detail: "public_info_sparse"}
 				} else {
 					infoStep = fetchStepResult{Status: "empty", Detail: "no_basic_info"}
 					errs = append(errs, "info: acquired but basic info still empty")
@@ -699,11 +721,13 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 	}
 	payload["info_step"] = infoStep
 
-	// 2) 技術
+	// 2) 技術（業界プロファイルで不要な場合はスキップ）
 	techStep := fetchStepResult{Status: "skipped", Skipped: true, Detail: "fetcher unavailable"}
-	if c.techFetcher != nil {
+	if !companyfields.TechAspectEnabled(company.Industry) {
+		techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: "industry_not_applicable"}
+	} else if c.techFetcher != nil {
 		needTech := forceRefresh || !companyfetch.IsFresh(company.TechFetchedAt, companyfetch.TTLTech) ||
-			!companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle)
+			!companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle)
 		if !needTech {
 			techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: "ttl_fresh"}
 		} else {
@@ -713,12 +737,15 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				errs = append(errs, "tech: "+terr.Error())
 			} else if result != nil && result.FromCache {
 				reload()
-				if companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+				if companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 					detail := result.SkipReason
 					if detail == "" {
 						detail = "cache"
 					}
 					techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: detail}
+				} else if !companyfields.RequiresTech(company.Industry) {
+					// 公開必須でない業種は空でも失敗扱いにしない
+					techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: "optional_empty"}
 				} else {
 					detail := result.SkipReason
 					if detail == "" {
@@ -730,11 +757,14 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				payload["tech"] = result
 			} else {
 				reload()
-				if companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+				if companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 					techStep = fetchStepResult{Status: "fetched", Detail: "ok"}
 				} else {
-					techStep = fetchStepResult{Status: "empty", Detail: "no_tech_stack"}
-					errs = append(errs, "tech: acquired but tech_stack still empty")
+					status, detail, asErr := companyfields.TechEmptyStepStatus(company.Industry)
+					techStep = fetchStepResult{Status: status, Skipped: status == "skipped", Detail: detail}
+					if asErr {
+						errs = append(errs, "tech: acquired but tech_stack still empty")
+					}
 				}
 				payload["tech"] = result
 			}
@@ -777,7 +807,12 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 					count = result.SavedCount
 				}
 				if count > 0 || c.relationsFetcher.HasStoredData(companyID) {
-					relationsStep = fetchStepResult{Status: "fetched", Detail: "ok", Count: count}
+					detail := "ok"
+					if result != nil && len(result.Relations) == 0 && result.MarketInfo != nil &&
+						companyfetch.IsConfirmedUnlisted(result.MarketInfo.IsListed, result.MarketInfo.MarketType, result.MarketInfo.StockCode) {
+						detail = "confirmed_unlisted"
+					}
+					relationsStep = fetchStepResult{Status: "fetched", Detail: detail, Count: count}
 				} else {
 					relationsStep = fetchStepResult{Status: "empty", Detail: "no_relations", Count: 0}
 					errs = append(errs, "relations: acquired but no relations/market saved")

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -666,7 +666,23 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				infoStep = fetchStepResult{Status: "error", Detail: ferr.Error()}
 				errs = append(errs, "info: "+ferr.Error())
 			} else if result != nil && result.FromCache {
-				infoStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: result.SkipReason}
+				reload()
+				// 予算超過などで中身なしのまま FromCache になると「スキップ＝成功」に見えるため、
+				// 実データがあるときだけ skipped とする。
+				if companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache"
+					}
+					infoStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: detail}
+				} else {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache_without_data"
+					}
+					infoStep = fetchStepResult{Status: "error", Detail: detail}
+					errs = append(errs, "info: cache returned without basic info ("+detail+")")
+				}
 				payload["info"] = result
 			} else {
 				reload()
@@ -696,7 +712,21 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				techStep = fetchStepResult{Status: "error", Detail: terr.Error()}
 				errs = append(errs, "tech: "+terr.Error())
 			} else if result != nil && result.FromCache {
-				techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: result.SkipReason}
+				reload()
+				if companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache"
+					}
+					techStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: detail}
+				} else {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache_without_data"
+					}
+					techStep = fetchStepResult{Status: "error", Detail: detail}
+					errs = append(errs, "tech: cache returned without tech_stack ("+detail+")")
+				}
 				payload["tech"] = result
 			} else {
 				reload()
@@ -726,14 +756,27 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 				relationsStep = fetchStepResult{Status: "error", Detail: rerr.Error()}
 				errs = append(errs, "relations: "+rerr.Error())
 			} else if result != nil && result.FromCache {
-				relationsStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: result.SkipReason, Count: result.SavedCount}
+				if c.relationsFetcher.HasStoredData(companyID) {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache"
+					}
+					relationsStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: detail, Count: result.SavedCount}
+				} else {
+					detail := result.SkipReason
+					if detail == "" {
+						detail = "cache_without_data"
+					}
+					relationsStep = fetchStepResult{Status: "error", Detail: detail, Count: result.SavedCount}
+					errs = append(errs, "relations: cache returned without stored data ("+detail+")")
+				}
 				payload["relations"] = result
 			} else {
 				count := 0
 				if result != nil {
 					count = result.SavedCount
 				}
-				if count > 0 || (result != nil && len(result.Relations) > 0) {
+				if count > 0 || c.relationsFetcher.HasStoredData(companyID) {
 					relationsStep = fetchStepResult{Status: "fetched", Detail: "ok", Count: count}
 				} else {
 					relationsStep = fetchStepResult{Status: "empty", Detail: "no_relations", Count: 0}

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -429,6 +429,7 @@ func (c *AdminCompanyController) WebSearchCompanyRelations(ctx echo.Context) err
 
 // FetchCompanyRelations POST /api/admin/companies/:id/fetch-relations
 // ?force=true を付けると DB キャッシュを無視して AI で再取得する。
+// ?cache_only=true を付けると DB の保存済みデータのみ返す（AI 再取得なし）。
 func (c *AdminCompanyController) FetchCompanyRelations(ctx echo.Context) error {
 	id, err := strconv.ParseUint(ctx.Param("id"), 10, 32)
 	if err != nil {
@@ -436,6 +437,14 @@ func (c *AdminCompanyController) FetchCompanyRelations(ctx echo.Context) error {
 	}
 	if c.relationsFetcher == nil {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "openai client not configured")
+	}
+
+	if ctx.QueryParam("cache_only") == "true" {
+		result, err := c.relationsFetcher.LoadSaved(uint(id))
+		if err != nil {
+			return echoInternalError(err)
+		}
+		return ctx.JSON(http.StatusOK, result)
 	}
 
 	forceRefresh := ctx.QueryParam("force") == "true"

--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -886,8 +886,9 @@ func (c *AdminCompanyController) WarmL1Catalog(ctx echo.Context) error {
 }
 
 // FetchMissingBatch POST /api/admin/companies/fetch-missing-batch
-// Body: { "limit": 20, "dry_run": true }
-// アクティブ企業のうち不足フィールド（基本情報/求人/Tech/関係）だけを上限付きで埋める。
+// Body: { "limit": 20, "dry_run": true, "primary_only": true, "concurrency": 4 }
+// アクティブ企業のうち不足フィールドだけを上限付きで埋める（企業間は並列）。
+// primary_only=true のときは主3種（基本・技術・関係）のみ（求人除外）。
 func (c *AdminCompanyController) FetchMissingBatch(ctx echo.Context) error {
 	if c.missingBatch == nil {
 		c.missingBatch = services.NewCompanyMissingBatchService(
@@ -907,6 +908,8 @@ func (c *AdminCompanyController) FetchMissingBatch(ctx echo.Context) error {
 	c.audit.Record(actor, "company.fetch_missing_batch", "company", 0, map[string]any{
 		"dry_run":       result.DryRun,
 		"limit":         result.Limit,
+		"primary_only":  result.PrimaryOnly,
+		"concurrency":   result.Concurrency,
 		"candidate_n":   result.CandidateN,
 		"processed":     result.Processed,
 		"info_ok":       result.InfoOK,

--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -259,7 +259,7 @@ func (c *AdminCompanyGraphController) syncRelationsFromNodes(nodes map[string]*s
 						continue
 					}
 				}
-				desc := companyfetch.NormalizeRelationDescription("", entry.relationType)
+				desc := companyfetch.SanitizeRelationDescription("")
 				var upsertErr error
 				if models.IsCapitalRelationType(entry.relationType) {
 					// 資本関係は parent/child で保存（資本図表示用）
@@ -446,7 +446,7 @@ func (c *AdminCompanyGraphController) EnrichRelations(ctx echo.Context) error {
 					continue
 				}
 			}
-			desc := companyfetch.NormalizeRelationDescription("", entry.relationType)
+			desc := companyfetch.SanitizeRelationDescription("")
 			var upsertErr error
 			if models.IsCapitalRelationType(entry.relationType) {
 				var ratio *float64

--- a/Backend/internal/openai/client_chat.go
+++ b/Backend/internal/openai/client_chat.go
@@ -162,14 +162,16 @@ func (cli *Client) WebSearchJSON(ctx context.Context, userPrompt string, maxToke
 
 		if err == nil && len(resp.Choices) > 0 {
 			content := strings.TrimSpace(resp.Choices[0].Message.Content)
-			if cli.OnUsage != nil {
-				cli.OnUsage(model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+			if content != "" {
+				if cli.OnUsage != nil {
+					cli.OnUsage(model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+				}
+				log.Printf("[openai] web_search model=%s prompt_tokens=%d completion_tokens=%d",
+					model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+				return content, nil
 			}
-			log.Printf("[openai] web_search model=%s prompt_tokens=%d completion_tokens=%d",
-				model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
-			return content, nil
-		}
-		if err == nil {
+			lastErr = errors.New("empty response from web search model")
+		} else if err == nil {
 			lastErr = errors.New("no response from web search model")
 		} else {
 			lastErr = err

--- a/Backend/internal/openai/client_chat.go
+++ b/Backend/internal/openai/client_chat.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -112,8 +113,21 @@ func (cli *Client) ChatCompletionJSON(ctx context.Context, systemPrompt, userPro
 	return "", lastErr
 }
 
+// isRetryableAPIErr は 429 / 5xx など再試行すれば成功しうるエラーか判定する。
+func isRetryableAPIErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *openai.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.HTTPStatusCode == http.StatusTooManyRequests || apiErr.HTTPStatusCode >= 500
+	}
+	return false
+}
+
 // WebSearchJSON は OpenAI Web Search モデルで 1 クエリだけ実行し、短い JSON テキストを返す。
 // 企業実在確認などトークンを抑えた検証用途向け。RAG の多段調査パイプラインは使わない。
+// gpt-4o(-mini)-search-preview は一時的な 5xx / 429 が出やすいため、Parse 系と同様にリトライする。
 func (cli *Client) WebSearchJSON(ctx context.Context, userPrompt string, maxTokens int, modelOverride ...string) (string, error) {
 	if cli == nil || cli.c == nil {
 		return "", errors.New("openai client is nil")
@@ -130,9 +144,6 @@ func (cli *Client) WebSearchJSON(ctx context.Context, userPrompt string, maxToke
 		model = "gpt-4o-search-preview"
 	}
 
-	ctxReq, cancel := context.WithTimeout(ctx, 45*time.Second)
-	defer cancel()
-
 	req := openai.ChatCompletionRequest{
 		Model: model,
 		Messages: []openai.ChatCompletionMessage{
@@ -142,20 +153,42 @@ func (cli *Client) WebSearchJSON(ctx context.Context, userPrompt string, maxToke
 		MaxCompletionTokens: maxTokens,
 	}
 
-	resp, err := cli.c.CreateChatCompletion(ctxReq, req)
-	if err != nil {
-		return "", err
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		ctxReq, cancel := context.WithTimeout(ctx, 45*time.Second)
+		resp, err := cli.c.CreateChatCompletion(ctxReq, req)
+		cancel()
+
+		if err == nil && len(resp.Choices) > 0 {
+			content := strings.TrimSpace(resp.Choices[0].Message.Content)
+			if cli.OnUsage != nil {
+				cli.OnUsage(model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+			}
+			log.Printf("[openai] web_search model=%s prompt_tokens=%d completion_tokens=%d",
+				model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+			return content, nil
+		}
+		if err == nil {
+			lastErr = errors.New("no response from web search model")
+		} else {
+			lastErr = err
+			if !isRetryableAPIErr(err) {
+				return "", err
+			}
+		}
+		if attempt == maxAttempts {
+			break
+		}
+		backoff := time.Duration(1<<attempt) * time.Second
+		jitter := time.Duration(rand.Intn(1000)) * time.Millisecond
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(backoff + jitter):
+		}
 	}
-	if len(resp.Choices) == 0 {
-		return "", errors.New("no response from web search model")
-	}
-	content := strings.TrimSpace(resp.Choices[0].Message.Content)
-	if cli.OnUsage != nil {
-		cli.OnUsage(model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
-	}
-	log.Printf("[openai] web_search model=%s prompt_tokens=%d completion_tokens=%d",
-		model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
-	return content, nil
+	return "", lastErr
 }
 
 // ResponsesWithMaxTokens は Responses API を使い、maxOutputTokens を指定してテキストを取得します。

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -65,7 +65,7 @@ func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status, 
 	}
 	const (
 		infoReady = `(info_fetched_at IS NOT NULL AND COALESCE(description, '') <> '' AND COALESCE(website_url, '') <> '')`
-		techReady = `(tech_fetched_at IS NOT NULL AND COALESCE(tech_stack, '') <> '' AND tech_stack <> '[]')`
+		techReady = `(tech_fetched_at IS NOT NULL AND TRIM(COALESCE(tech_stack, '')) <> '' AND TRIM(COALESCE(tech_stack, '')) NOT IN ('[]', 'null', '{}'))`
 		relReady  = `(relations_fetched_at IS NOT NULL)`
 	)
 	techRequiredSQL, techRequiredArgs := companyfields.TechRequiredIndustrySQL("industry")

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -313,8 +313,9 @@ WHERE c.is_active = ?
 }
 
 // ListActiveMissingFetchCandidates は info/jobs/tech/relations のいずれかが未取得または TTL 切れのアクティブ企業を返す。
+// primaryOnly=true のときは求人不足だけを理由に候補へ入れない（まとめて取得の主3種モード用）。
 // 公開企業を優先し、不足埋めバッチ（#633）で使う。
-func (r *CompanyRepository) ListActiveMissingFetchCandidates(limit int) ([]models.Company, error) {
+func (r *CompanyRepository) ListActiveMissingFetchCandidates(limit int, primaryOnly bool) ([]models.Company, error) {
 	if limit <= 0 {
 		limit = 60
 	}
@@ -324,38 +325,47 @@ func (r *CompanyRepository) ListActiveMissingFetchCandidates(limit int) ([]model
 	techCutoff := now.Add(-companyfetch.TTLTech)
 	relCutoff := now.Add(-companyfetch.TTLRelations)
 
-	var companies []models.Company
-	err := r.db.Where("is_active = ?", true).
-		Where(`
-			info_fetched_at IS NULL OR info_fetched_at < ? OR TRIM(COALESCE(description, '')) = '' OR TRIM(COALESCE(website_url, '')) = ''
+	primaryCond := `
+		info_fetched_at IS NULL OR info_fetched_at < ? OR TRIM(COALESCE(description, '')) = '' OR TRIM(COALESCE(website_url, '')) = ''
+		OR tech_fetched_at IS NULL OR tech_fetched_at < ?
+		OR TRIM(COALESCE(tech_stack, '')) = ''
+		OR TRIM(COALESCE(tech_stack, '')) IN ('[]', 'null', '{}')
+		OR relations_fetched_at IS NULL OR relations_fetched_at < ?
+		OR (
+			NOT EXISTS (
+				SELECT 1 FROM company_relations cr
+				WHERE cr.deleted_at IS NULL AND cr.is_active = 1 AND (
+					cr.parent_id = companies.id OR cr.child_id = companies.id
+					OR cr.from_id = companies.id OR cr.to_id = companies.id
+				)
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM company_market_info mi
+				WHERE mi.company_id = companies.id AND mi.deleted_at IS NULL
+				AND (
+					mi.is_listed = 1
+					OR TRIM(COALESCE(mi.stock_code, '')) <> ''
+					OR LOWER(TRIM(COALESCE(mi.market_type, ''))) IN ('prime', 'standard', 'growth')
+				)
+			)
+		)
+	`
+	args := []any{infoCutoff, techCutoff, relCutoff}
+	whereSQL := primaryCond
+	if !primaryOnly {
+		whereSQL = primaryCond + `
 			OR jobs_fetched_at IS NULL OR jobs_fetched_at < ?
 			OR NOT EXISTS (
 				SELECT 1 FROM company_job_positions jp
 				WHERE jp.company_id = companies.id AND jp.deleted_at IS NULL
 			)
-			OR tech_fetched_at IS NULL OR tech_fetched_at < ?
-			OR TRIM(COALESCE(tech_stack, '')) = ''
-			OR TRIM(COALESCE(tech_stack, '')) IN ('[]', 'null', '{}')
-			OR relations_fetched_at IS NULL OR relations_fetched_at < ?
-			OR (
-				NOT EXISTS (
-					SELECT 1 FROM company_relations cr
-					WHERE cr.deleted_at IS NULL AND cr.is_active = 1 AND (
-						cr.parent_id = companies.id OR cr.child_id = companies.id
-						OR cr.from_id = companies.id OR cr.to_id = companies.id
-					)
-				)
-				AND NOT EXISTS (
-					SELECT 1 FROM company_market_info mi
-					WHERE mi.company_id = companies.id AND mi.deleted_at IS NULL
-					AND (
-						mi.is_listed = 1
-						OR TRIM(COALESCE(mi.stock_code, '')) <> ''
-						OR LOWER(TRIM(COALESCE(mi.market_type, ''))) IN ('prime', 'standard', 'growth')
-					)
-				)
-			)
-		`, infoCutoff, jobsCutoff, techCutoff, relCutoff).
+		`
+		args = append(args, jobsCutoff)
+	}
+
+	var companies []models.Company
+	err := r.db.Where("is_active = ?", true).
+		Where(whereSQL, args...).
 		Order("CASE WHEN data_status = 'published' THEN 0 ELSE 1 END, id ASC").
 		Limit(limit).
 		Find(&companies).Error

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"Backend/internal/companyfetch"
+	"Backend/internal/companyfields"
 	"Backend/internal/models"
 	"strings"
 	"time"
@@ -40,9 +41,12 @@ func (r *CompanyRepository) CountActive() (int64, error) {
 	return count, err
 }
 
-// ListActiveFiltered は名前・公開ステータスで絞り込んだアクティブ企業を返す。
+// ListActiveFiltered は名前・公開ステータス・業界・情報充足で絞り込んだアクティブ企業を返す。
 // status は "draft" / "published" / ""（指定なし=すべて）。
-func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status string) ([]models.Company, int64, error) {
+// industry が "__unset__" のときは業界未設定のみ。
+// readiness は "ready"（主3種そろい）/ "missing"（主3種不足）/ ""。
+// orderBy が "industry" のときは業界順、それ以外は id desc。
+func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status, industry, readiness, orderBy string) ([]models.Company, int64, error) {
 	q := r.db.Model(&models.Company{}).Where("is_active = ?", true).Session(&gorm.Session{})
 	if name = strings.TrimSpace(name); name != "" {
 		q = q.Where("name LIKE ?", "%"+name+"%")
@@ -51,15 +55,53 @@ func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status s
 	case "draft", "published":
 		q = q.Where("data_status = ?", status)
 	}
+	switch industry = strings.TrimSpace(industry); industry {
+	case "":
+		// no-op
+	case "__unset__":
+		q = q.Where("(industry IS NULL OR industry = '')")
+	default:
+		q = q.Where("industry = ?", industry)
+	}
+	const (
+		infoReady = `(info_fetched_at IS NOT NULL AND COALESCE(description, '') <> '' AND COALESCE(website_url, '') <> '')`
+		techReady = `(tech_fetched_at IS NOT NULL AND COALESCE(tech_stack, '') <> '' AND tech_stack <> '[]')`
+		relReady  = `(relations_fetched_at IS NOT NULL)`
+	)
+	techRequiredSQL, techRequiredArgs := companyfields.TechRequiredIndustrySQL("industry")
+	// 技術必須業界のみ techReady を要求。それ以外は会社概要+関連企業で充足とみなす。
+	primaryReady := "(" + infoReady + " AND " + relReady + " AND (" + techReady + " OR NOT " + techRequiredSQL + "))"
+	switch strings.TrimSpace(readiness) {
+	case "ready":
+		q = q.Where(primaryReady, techRequiredArgs...)
+	case "missing":
+		q = q.Where("NOT "+primaryReady, techRequiredArgs...)
+	}
 
 	var total int64
 	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
+	order := "id desc"
+	if strings.TrimSpace(orderBy) == "industry" {
+		order = "CASE WHEN industry IS NULL OR industry = '' THEN 1 ELSE 0 END ASC, industry ASC, id DESC"
+	}
+
 	var companies []models.Company
-	err := q.Session(&gorm.Session{}).Order("id desc").Limit(limit).Offset(offset).Find(&companies).Error
+	err := q.Session(&gorm.Session{}).Order(order).Limit(limit).Offset(offset).Find(&companies).Error
 	return companies, total, err
+}
+
+// ListActiveIndustries はアクティブ企業に設定されている業界名の重複なし一覧を返す。
+func (r *CompanyRepository) ListActiveIndustries() ([]string, error) {
+	var industries []string
+	err := r.db.Model(&models.Company{}).
+		Where("is_active = ? AND industry IS NOT NULL AND industry <> ''", true).
+		Distinct().
+		Order("industry ASC").
+		Pluck("industry", &industries).Error
+	return industries, err
 }
 
 // FindAllActiveNames アクティブ企業のIDと名前を取得（フィルタ q で部分一致）
@@ -325,11 +367,17 @@ func (r *CompanyRepository) ListActiveMissingFetchCandidates(limit int, primaryO
 	techCutoff := now.Add(-companyfetch.TTLTech)
 	relCutoff := now.Add(-companyfetch.TTLRelations)
 
+	techRequiredSQL, techRequiredArgs := companyfields.TechRequiredIndustrySQL("industry")
 	primaryCond := `
 		info_fetched_at IS NULL OR info_fetched_at < ? OR TRIM(COALESCE(description, '')) = '' OR TRIM(COALESCE(website_url, '')) = ''
-		OR tech_fetched_at IS NULL OR tech_fetched_at < ?
-		OR TRIM(COALESCE(tech_stack, '')) = ''
-		OR TRIM(COALESCE(tech_stack, '')) IN ('[]', 'null', '{}')
+		OR (
+			(` + techRequiredSQL + `)
+			AND (
+				tech_fetched_at IS NULL OR tech_fetched_at < ?
+				OR TRIM(COALESCE(tech_stack, '')) = ''
+				OR TRIM(COALESCE(tech_stack, '')) IN ('[]', 'null', '{}')
+			)
+		)
 		OR relations_fetched_at IS NULL OR relations_fetched_at < ?
 		OR (
 			NOT EXISTS (
@@ -350,7 +398,9 @@ func (r *CompanyRepository) ListActiveMissingFetchCandidates(limit int, primaryO
 			)
 		)
 	`
-	args := []any{infoCutoff, techCutoff, relCutoff}
+	args := []any{infoCutoff}
+	args = append(args, techRequiredArgs...)
+	args = append(args, techCutoff, relCutoff)
 	whereSQL := primaryCond
 	if !primaryOnly {
 		whereSQL = primaryCond + `

--- a/Backend/internal/routes/admin_routes.go
+++ b/Backend/internal/routes/admin_routes.go
@@ -37,6 +37,7 @@ func SetupAdminRoutes(
 	// 企業管理
 	admin.GET("/companies", adminCompanyController.List)
 	admin.POST("/companies", adminCompanyController.Create)
+	admin.GET("/companies/industries", adminCompanyController.Industries)
 	// 軽量な企業名一覧（セレクト用）
 	admin.GET("/companies/names", adminCompanyController.Names)
 	admin.GET("/companies/l1-coverage", adminCompanyController.GetL1Coverage)

--- a/Backend/internal/services/catalog_warm_service_test.go
+++ b/Backend/internal/services/catalog_warm_service_test.go
@@ -29,9 +29,10 @@ func (s *warmRepoStub) FindAllActiveNames(string) ([]models.CompanyName, error) 
 	return nil, nil
 }
 func (s *warmRepoStub) CountActive() (int64, error) { return 0, nil }
-func (s *warmRepoStub) ListActiveFiltered(int, int, string, string) ([]models.Company, int64, error) {
+func (s *warmRepoStub) ListActiveFiltered(int, int, string, string, string, string, string) ([]models.Company, int64, error) {
 	return nil, 0, nil
 }
+func (s *warmRepoStub) ListActiveIndustries() ([]string, error) { return nil, nil }
 func (s *warmRepoStub) FindAllPublished(int, int) ([]models.Company, error) { return nil, nil }
 func (s *warmRepoStub) CountPublished() (int64, error)                             { return 0, nil }
 func (s *warmRepoStub) FindByID(uint) (*models.Company, error)                     { return nil, nil }

--- a/Backend/internal/services/catalog_warm_service_test.go
+++ b/Backend/internal/services/catalog_warm_service_test.go
@@ -56,7 +56,7 @@ func (s *warmRepoStub) ListJobPositions(*uint, int) ([]models.CompanyJobPosition
 }
 func (s *warmRepoStub) CreateOrUpdateWeightProfile(*models.CompanyWeightProfile) error { return nil }
 func (s *warmRepoStub) CountWeightProfiles() (int64, error)                            { return 0, nil }
-func (s *warmRepoStub) ListActiveMissingFetchCandidates(int) ([]models.Company, error) {
+func (s *warmRepoStub) ListActiveMissingFetchCandidates(int, bool) ([]models.Company, error) {
 	return nil, nil
 }
 

--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -93,8 +93,8 @@ func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint, f
 		return nil, fmt.Errorf("company not found: %w", err)
 	}
 
-	if !forceRefresh && companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) &&
-		companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+	// スタンプ済み（公開情報限定の確認済み含む）なら TTL 内は再取得しない。強制更新は force。
+	if !forceRefresh && companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) {
 		return markInfoCacheSkip(companyInfoFromModel(company), "ttl", false), nil
 	}
 
@@ -128,9 +128,9 @@ func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint, f
 	// Search フォールバック時も SourceURL を明示更新し、旧スクレイプ URL の残存を防ぐ
 	company.SourceURL = result.SourceURL
 	company.SourceFetchedAt = &now
-	// 空結果で InfoFetchedAt だけ進むと「取得済みだが中身なし」で再取得不能になるため、
-	// 最低限の基本情報が揃ったときのみスタンプする。
-	if companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+	// 概要が無くても公式URL/所在地など手がかりがあれば確認済みとしてスタンプする。
+	// 完全に空の結果だけはスタンプせず再取得可能にする。
+	if companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
 		company.InfoFetchedAt = &now
 	}
 	company.LastModelUsed = result.ModelUsed
@@ -162,8 +162,7 @@ func (f *CompanyInfoFetcher) ConfirmAndSave(companyID uint, result *CompanyInfoR
 		company.SourceURL = result.SourceURL
 	}
 	company.SourceFetchedAt = &now
-	// 空プレビュー確定で InfoFetchedAt だけ進まないようにする
-	if companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+	if companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
 		company.InfoFetchedAt = &now
 	}
 	if result.ModelUsed != "" {
@@ -276,7 +275,8 @@ func (f *CompanyInfoFetcher) enrichGapsWithAI(ctx context.Context, companyName, 
 	}
 	ai, err := f.acquireViaAISearch(ctx, companyName, firstNonEmpty(websiteURL, base.WebsiteURL))
 	if err != nil {
-		return base, nil // gBiz 分は活かす
+		// gBiz Sync 済みの法人データは DB に残る。AI 失敗は握りつぶさず呼び出し元へ返す。
+		return nil, fmt.Errorf("ai gap enrich: %w", err)
 	}
 	mergeCompanyInfoGaps(base, ai)
 	if ai.ModelUsed != "" {

--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -128,8 +128,8 @@ func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint, f
 	// Search フォールバック時も SourceURL を明示更新し、旧スクレイプ URL の残存を防ぐ
 	company.SourceURL = result.SourceURL
 	company.SourceFetchedAt = &now
-	// 概要が無くても公式URL/所在地など手がかりがあれば確認済みとしてスタンプする。
-	// 完全に空の結果だけはスタンプせず再取得可能にする。
+	// 更新後の company（今回の取得結果＋既存の URL/所在地など）で判定する。
+	// 手がかりが残っていれば疎データでもスタンプし、TTL 内の無駄な再取得を避ける。
 	if companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
 		company.InfoFetchedAt = &now
 	}

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -231,6 +231,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 
 // MissingNeedsFromCompany は不足判定ヘルパ（基本情報・技術・ビジネス関係・求人）。
 // タイムスタンプが新しくても、中身が空なら不足とみなす。
+// 関係の DB 実体欠落は Run() 側で HasStoredData により追加判定する。
 func MissingNeedsFromCompany(c *models.Company) (needInfo, needJobs, needTech, needRelations bool) {
 	if c == nil {
 		return false, false, false, false

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
+	"Backend/internal/companyfields"
 	"Backend/internal/models"
 	"context"
 	"fmt"
@@ -206,6 +207,9 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 			if company != nil && companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
 				item.InfoStatus = "skipped_cache"
 				inc(func() { result.Skipped++ })
+			} else if company != nil && companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
+				item.InfoStatus = "empty"
+				inc(func() { result.Skipped++ })
 			} else {
 				detail := "cache_without_data"
 				if res.SkipReason != "" {
@@ -220,6 +224,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 			item.InfoStatus = "ok"
 			inc(func() { result.InfoOK++ })
 		} else {
+			// 公開情報限定（概要なし）も empty として扱う（エラーではない）
 			item.InfoStatus = "empty"
 			inc(func() { result.Skipped++ })
 		}
@@ -236,7 +241,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 			inc(func() { result.Errors++ })
 		} else if res != nil && res.FromCache {
 			company, _ := s.repo.FindByID(item.CompanyID)
-			if company != nil && companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+			if company != nil && companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 				item.TechStatus = "skipped_cache"
 				inc(func() { result.Skipped++ })
 			} else {
@@ -251,7 +256,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 				inc(func() { result.Errors++ })
 			}
 		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil &&
-			companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+			companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 			item.TechStatus = "ok"
 			inc(func() { result.TechOK++ })
 		} else {
@@ -313,17 +318,17 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 }
 
 // MissingNeedsFromCompany は不足判定ヘルパ（基本情報・技術・ビジネス関係・求人）。
-// タイムスタンプが新しくても、中身が空なら不足とみなす。
-// 関係の DB 実体欠落は Run() 側で HasStoredData により追加判定する。
+// InfoFetchedAt / RelationsFetchedAt が TTL 内なら、公開情報限定の確認済みも含め再取得不要。
+// 技術は中身が空なら不足とみなす。関係の DB 実体欠落は Run() 側で HasStoredData により追加判定する。
 func MissingNeedsFromCompany(c *models.Company) (needInfo, needJobs, needTech, needRelations bool) {
 	if c == nil {
 		return false, false, false, false
 	}
-	needInfo = !companyfetch.IsFresh(c.InfoFetchedAt, companyfetch.TTLInfo) ||
-		!companyfetch.HasBasicInfo(c.Description, c.WebsiteURL)
+	needInfo = !companyfetch.IsFresh(c.InfoFetchedAt, companyfetch.TTLInfo)
 	needJobs = !companyfetch.IsFresh(c.JobsFetchedAt, companyfetch.TTLJobs)
-	needTech = !companyfetch.IsFresh(c.TechFetchedAt, companyfetch.TTLTech) ||
-		!companyfetch.HasTechData(c.TechStack, c.InfraStack, c.CicdTools, c.DevelopmentStyle)
+	needTech = companyfields.RequiresTech(c.Industry) &&
+		(!companyfetch.IsFresh(c.TechFetchedAt, companyfetch.TTLTech) ||
+			!companyfetch.HasTechDataForIndustry(c.Industry, c.TechStack, c.InfraStack, c.CicdTools, c.DevelopmentStyle))
 	needRelations = !companyfetch.IsFresh(c.RelationsFetchedAt, companyfetch.TTLRelations)
 	return
 }

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -7,17 +7,26 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 const (
-	defaultMissingBatchLimit = 20
-	maxMissingBatchLimit     = 50
+	defaultMissingBatchLimit       = 20
+	maxMissingBatchLimit           = 50
+	defaultMissingBatchConcurrency = 4
+	maxMissingBatchConcurrency     = 8
 )
 
 // MissingBatchOptions は企業管理全体の不足データ一括取得オプション。
 type MissingBatchOptions struct {
 	Limit  int  `json:"limit"`
 	DryRun bool `json:"dry_run"`
+	// PrimaryOnly が true のとき基本・技術・関係のみ対象（求人は除外）。
+	PrimaryOnly bool `json:"primary_only"`
+	// Concurrency は同時に処理する企業数（未指定時は defaultMissingBatchConcurrency）。
+	Concurrency int `json:"concurrency"`
 }
 
 // MissingBatchItem は1社分の不足埋め結果。
@@ -38,17 +47,19 @@ type MissingBatchItem struct {
 
 // MissingBatchResult は一括取得の集計結果。
 type MissingBatchResult struct {
-	DryRun     bool               `json:"dry_run"`
-	Limit      int                `json:"limit"`
-	CandidateN int                `json:"candidate_n"`
-	Processed  int                `json:"processed"`
-	InfoOK     int                `json:"info_ok"`
-	JobsOK     int                `json:"jobs_ok"`
-	TechOK     int                `json:"tech_ok"`
-	RelationsOK int               `json:"relations_ok"`
-	Skipped    int                `json:"skipped"`
-	Errors     int                `json:"errors"`
-	Items      []MissingBatchItem `json:"items"`
+	DryRun      bool               `json:"dry_run"`
+	Limit       int                `json:"limit"`
+	PrimaryOnly bool               `json:"primary_only"`
+	Concurrency int                `json:"concurrency"`
+	CandidateN  int                `json:"candidate_n"`
+	Processed   int                `json:"processed"`
+	InfoOK      int                `json:"info_ok"`
+	JobsOK      int                `json:"jobs_ok"`
+	TechOK      int                `json:"tech_ok"`
+	RelationsOK int                `json:"relations_ok"`
+	Skipped     int                `json:"skipped"`
+	Errors      int                `json:"errors"`
+	Items       []MissingBatchItem `json:"items"`
 }
 
 // CompanyMissingBatchService は未取得フィールドだけを上限付きで埋める。
@@ -76,7 +87,18 @@ func NewCompanyMissingBatchService(
 	}
 }
 
-// Run は不足企業を最大 Limit 社まで処理する（force なし＝TTL内はスキップ）。
+func clampMissingBatchConcurrency(n int) int {
+	if n <= 0 {
+		return defaultMissingBatchConcurrency
+	}
+	if n > maxMissingBatchConcurrency {
+		return maxMissingBatchConcurrency
+	}
+	return n
+}
+
+// Run は不足企業を最大 Limit 社まで並列処理する（force なし＝TTL内はスキップ）。
+// 1社内の主3種は依存があるため直列、企業間は Concurrency 上限で並列化する。
 func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchOptions) (*MissingBatchResult, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = defaultMissingBatchLimit
@@ -84,8 +106,9 @@ func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchO
 	if opts.Limit > maxMissingBatchLimit {
 		opts.Limit = maxMissingBatchLimit
 	}
+	concurrency := clampMissingBatchConcurrency(opts.Concurrency)
 
-	candidates, err := s.repo.ListActiveMissingFetchCandidates(opts.Limit * 3)
+	candidates, err := s.repo.ListActiveMissingFetchCandidates(opts.Limit*3, opts.PrimaryOnly)
 	if err != nil {
 		return nil, fmt.Errorf("list missing candidates: %w", err)
 	}
@@ -99,10 +122,13 @@ func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchO
 		}
 		item.NeedInfo, item.NeedJobs, item.NeedTech, item.NeedRelations = MissingNeedsFromCompany(&c)
 		// DB 実データの欠落も不足扱い（*_fetched_at だけ進んでいる残骸対策）
-		if !item.NeedJobs {
+		if !opts.PrimaryOnly && !item.NeedJobs {
 			if jobs, err := s.repo.ListJobPositions(&c.ID, 1); err == nil && len(jobs) == 0 {
 				item.NeedJobs = true
 			}
+		}
+		if opts.PrimaryOnly {
+			item.NeedJobs = false
 		}
 		if !item.NeedRelations && s.relationsFetcher != nil && !s.relationsFetcher.HasStoredData(c.ID) {
 			item.NeedRelations = true
@@ -117,114 +143,171 @@ func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchO
 	}
 
 	result := &MissingBatchResult{
-		DryRun:     opts.DryRun,
-		Limit:      opts.Limit,
-		CandidateN: len(items),
-		Items:      items,
+		DryRun:      opts.DryRun,
+		Limit:       opts.Limit,
+		PrimaryOnly: opts.PrimaryOnly,
+		Concurrency: concurrency,
+		CandidateN:  len(items),
+		Items:       items,
 	}
 	if opts.DryRun {
 		return result, nil
 	}
 
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+	var mu sync.Mutex
+
 	for i := range result.Items {
 		item := &result.Items[i]
-		if err := ctx.Err(); err != nil {
-			item.Error = err.Error()
-			result.Errors++
-			break
-		}
-		result.Processed++
-		s.processItem(ctx, item, result)
+		g.Go(func() error {
+			if err := gctx.Err(); err != nil {
+				mu.Lock()
+				item.Error = err.Error()
+				result.Errors++
+				mu.Unlock()
+				return nil
+			}
+			mu.Lock()
+			result.Processed++
+			mu.Unlock()
+			s.processItem(gctx, item, result, &mu)
+			return nil
+		})
 	}
+	_ = g.Wait()
 
 	log.Printf(
-		"fetch_missing_batch: processed=%d info_ok=%d jobs_ok=%d tech_ok=%d relations_ok=%d errors=%d",
-		result.Processed, result.InfoOK, result.JobsOK, result.TechOK, result.RelationsOK, result.Errors,
+		"fetch_missing_batch: concurrency=%d processed=%d info_ok=%d jobs_ok=%d tech_ok=%d relations_ok=%d errors=%d",
+		concurrency, result.Processed, result.InfoOK, result.JobsOK, result.TechOK, result.RelationsOK, result.Errors,
 	)
 	return result, nil
 }
 
-func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *MissingBatchItem, result *MissingBatchResult) {
-	// 主3種: 基本情報 → 技術 → ビジネス関係。求人は最後。
+func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *MissingBatchItem, result *MissingBatchResult, mu *sync.Mutex) {
+	inc := func(apply func()) {
+		mu.Lock()
+		defer mu.Unlock()
+		apply()
+	}
+
+	// 不足判定済みの項目は force=true で取りに行く。
+	// force=false だと予算超過時に空キャッシュを「スキップ」扱いして実質未取得のまま終わるため。
 	if item.NeedInfo {
 		if s.infoFetcher == nil {
 			item.InfoStatus = "skipped_no_fetcher"
-			result.Skipped++
-		} else if res, err := s.infoFetcher.FetchAndSave(ctx, item.CompanyID, false); err != nil {
+			inc(func() { result.Skipped++ })
+		} else if res, err := s.infoFetcher.FetchAndSave(ctx, item.CompanyID, true); err != nil {
 			item.InfoStatus = "error"
 			item.Error = err.Error()
-			result.Errors++
+			inc(func() { result.Errors++ })
 		} else if res != nil && res.FromCache {
-			item.InfoStatus = "skipped_cache"
-			result.Skipped++
+			company, _ := s.repo.FindByID(item.CompanyID)
+			if company != nil && companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+				item.InfoStatus = "skipped_cache"
+				inc(func() { result.Skipped++ })
+			} else {
+				detail := "cache_without_data"
+				if res.SkipReason != "" {
+					detail = res.SkipReason
+				}
+				item.InfoStatus = "error"
+				item.Error = "info: " + detail
+				inc(func() { result.Errors++ })
+			}
 		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil &&
 			companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
 			item.InfoStatus = "ok"
-			result.InfoOK++
+			inc(func() { result.InfoOK++ })
 		} else {
 			item.InfoStatus = "empty"
-			result.Skipped++
+			inc(func() { result.Skipped++ })
 		}
 	}
 	if item.NeedTech {
 		if s.techFetcher == nil {
 			item.TechStatus = "skipped_no_fetcher"
-			result.Skipped++
-		} else if res, err := s.techFetcher.FetchAndSave(ctx, item.CompanyID, false); err != nil {
+			inc(func() { result.Skipped++ })
+		} else if res, err := s.techFetcher.FetchAndSave(ctx, item.CompanyID, true); err != nil {
 			item.TechStatus = "error"
 			if item.Error == "" {
 				item.Error = err.Error()
 			}
-			result.Errors++
+			inc(func() { result.Errors++ })
 		} else if res != nil && res.FromCache {
-			item.TechStatus = "skipped_cache"
-			result.Skipped++
+			company, _ := s.repo.FindByID(item.CompanyID)
+			if company != nil && companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+				item.TechStatus = "skipped_cache"
+				inc(func() { result.Skipped++ })
+			} else {
+				detail := "cache_without_data"
+				if res.SkipReason != "" {
+					detail = res.SkipReason
+				}
+				item.TechStatus = "error"
+				if item.Error == "" {
+					item.Error = "tech: " + detail
+				}
+				inc(func() { result.Errors++ })
+			}
 		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil &&
 			companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 			item.TechStatus = "ok"
-			result.TechOK++
+			inc(func() { result.TechOK++ })
 		} else {
 			item.TechStatus = "empty"
-			result.Skipped++
+			inc(func() { result.Skipped++ })
 		}
 	}
 	if item.NeedRelations {
 		if s.relationsFetcher == nil {
 			item.RelationsStatus = "skipped_no_fetcher"
-			result.Skipped++
-		} else if res, err := s.relationsFetcher.FetchAndSave(ctx, item.CompanyID, false); err != nil {
+			inc(func() { result.Skipped++ })
+		} else if res, err := s.relationsFetcher.FetchAndSave(ctx, item.CompanyID, true); err != nil {
 			item.RelationsStatus = "error"
 			if item.Error == "" {
 				item.Error = err.Error()
 			}
-			result.Errors++
+			inc(func() { result.Errors++ })
 		} else if res != nil && res.FromCache {
-			item.RelationsStatus = "skipped_cache"
-			result.Skipped++
+			if s.relationsFetcher.HasStoredData(item.CompanyID) {
+				item.RelationsStatus = "skipped_cache"
+				inc(func() { result.Skipped++ })
+			} else {
+				detail := "cache_without_data"
+				if res.SkipReason != "" {
+					detail = res.SkipReason
+				}
+				item.RelationsStatus = "error"
+				if item.Error == "" {
+					item.Error = "relations: " + detail
+				}
+				inc(func() { result.Errors++ })
+			}
 		} else if s.relationsFetcher.HasStoredData(item.CompanyID) {
 			item.RelationsStatus = "ok"
-			result.RelationsOK++
+			inc(func() { result.RelationsOK++ })
 		} else {
 			item.RelationsStatus = "empty"
-			result.Skipped++
+			inc(func() { result.Skipped++ })
 		}
 	}
 	if item.NeedJobs {
 		if s.jobFetcher == nil {
 			item.JobsStatus = "skipped_no_fetcher"
-			result.Skipped++
-		} else if positions, err := s.jobFetcher.FetchAndSaveJobs(ctx, item.CompanyID, false); err != nil {
+			inc(func() { result.Skipped++ })
+		} else if positions, err := s.jobFetcher.FetchAndSaveJobs(ctx, item.CompanyID, true); err != nil {
 			item.JobsStatus = "error"
 			if item.Error == "" {
 				item.Error = err.Error()
 			}
-			result.Errors++
+			inc(func() { result.Errors++ })
 		} else if len(positions) == 0 {
 			item.JobsStatus = "empty"
-			result.Skipped++
+			inc(func() { result.Skipped++ })
 		} else {
 			item.JobsStatus = fmt.Sprintf("ok(%d)", len(positions))
-			result.JobsOK++
+			inc(func() { result.JobsOK++ })
 		}
 	}
 }

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -98,7 +98,7 @@ func clampMissingBatchConcurrency(n int) int {
 	return n
 }
 
-// Run は不足企業を最大 Limit 社まで並列処理する（force なし＝TTL内はスキップ）。
+// Run は不足企業を最大 Limit 社まで並列処理する（不足判定済みの項目は force=true で取得）。
 // 1社内の主3種は依存があるため直列、企業間は Concurrency 上限で並列化する。
 func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchOptions) (*MissingBatchResult, error) {
 	if opts.Limit <= 0 {
@@ -219,7 +219,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 				item.Error = "info: " + detail
 				inc(func() { result.Errors++ })
 			}
-		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil &&
+		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil && company != nil &&
 			companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
 			item.InfoStatus = "ok"
 			inc(func() { result.InfoOK++ })
@@ -255,7 +255,7 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 				}
 				inc(func() { result.Errors++ })
 			}
-		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil &&
+		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil && company != nil &&
 			companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 			item.TechStatus = "ok"
 			inc(func() { result.TechOK++ })

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -13,6 +13,7 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 	stale := now.Add(-200 * 24 * time.Hour)
 
 	fresh := &models.Company{
+		Industry:           "IT・ソフトウェア",
 		Description:        "概要",
 		WebsiteURL:         "https://example.com",
 		TechStack:          `["Go"]`,
@@ -26,13 +27,26 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 		t.Fatalf("fresh company should need nothing, got info=%v jobs=%v tech=%v rel=%v", info, jobs, tech, rel)
 	}
 
-	empty := &models.Company{}
+	empty := &models.Company{Industry: "IT・ソフトウェア"}
 	info, jobs, tech, rel = MissingNeedsFromCompany(empty)
 	if !info || !jobs || !tech || !rel {
-		t.Fatalf("empty company should need all, got info=%v jobs=%v tech=%v rel=%v", info, jobs, tech, rel)
+		t.Fatalf("empty IT company should need all, got info=%v jobs=%v tech=%v rel=%v", info, jobs, tech, rel)
+	}
+
+	financeEmpty := &models.Company{Industry: "金融・保険業"}
+	_, _, tech, _ = MissingNeedsFromCompany(financeEmpty)
+	if tech {
+		t.Fatal("finance company should not need tech stack")
+	}
+
+	mfgEmpty := &models.Company{Industry: "製造業"}
+	_, _, tech, _ = MissingNeedsFromCompany(mfgEmpty)
+	if tech {
+		t.Fatal("manufacturing company should not require tech for publish/missing batch")
 	}
 
 	staleInfo := &models.Company{
+		Industry:           "IT・ソフトウェア",
 		Description:        "概要",
 		WebsiteURL:         "https://example.com",
 		TechStack:          `["Go"]`,
@@ -47,6 +61,7 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 	}
 
 	emptyTech := &models.Company{
+		Industry:           "IT・ソフトウェア",
 		Description:        "概要",
 		WebsiteURL:         "https://example.com",
 		TechStack:          "[]",
@@ -61,6 +76,7 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 	}
 
 	emptyInfoDespiteStamp := &models.Company{
+		Industry:           "IT・ソフトウェア",
 		Description:        "",
 		WebsiteURL:         "",
 		TechStack:          `["Go"]`,
@@ -70,12 +86,29 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 		RelationsFetchedAt: &now,
 	}
 	info, _, _, _ = MissingNeedsFromCompany(emptyInfoDespiteStamp)
-	if !info {
-		t.Fatal("fresh InfoFetchedAt with empty description/url should still need info")
+	if info {
+		t.Fatal("fresh InfoFetchedAt should not need info even without description (confirmed sparse)")
+	}
+
+	sparseFootprintStamped := &models.Company{
+		Industry:           "IT・ソフトウェア",
+		Description:        "",
+		WebsiteURL:         "https://example.com",
+		Location:           "東京都",
+		TechStack:          `["Go"]`,
+		InfoFetchedAt:      &now,
+		JobsFetchedAt:      &now,
+		TechFetchedAt:      &now,
+		RelationsFetchedAt: &now,
+	}
+	info, _, _, _ = MissingNeedsFromCompany(sparseFootprintStamped)
+	if info {
+		t.Fatal("stamped sparse basic info should not need refetch until TTL")
 	}
 
 	// infra / 開発手法のみでは技術取得済みとみなさない
 	infraOnly := &models.Company{
+		Industry:           "IT・ソフトウェア",
 		Description:        "概要",
 		WebsiteURL:         "https://example.com",
 		TechStack:          "",

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"Backend/internal/models"
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -87,5 +89,82 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 	_, _, tech, _ = MissingNeedsFromCompany(infraOnly)
 	if !tech {
 		t.Fatal("infra/style only should still need tech_stack")
+	}
+}
+
+func TestClampMissingBatchConcurrency(t *testing.T) {
+	if got := clampMissingBatchConcurrency(0); got != defaultMissingBatchConcurrency {
+		t.Fatalf("0 -> %d want %d", got, defaultMissingBatchConcurrency)
+	}
+	if got := clampMissingBatchConcurrency(3); got != 3 {
+		t.Fatalf("3 -> %d", got)
+	}
+	if got := clampMissingBatchConcurrency(100); got != maxMissingBatchConcurrency {
+		t.Fatalf("100 -> %d want %d", got, maxMissingBatchConcurrency)
+	}
+}
+
+type missingBatchRepoStub struct {
+	warmRepoStub
+	companies []models.Company
+	inFlight  atomic.Int32
+	peak      atomic.Int32
+}
+
+func (s *missingBatchRepoStub) ListActiveMissingFetchCandidates(limit int, _ bool) ([]models.Company, error) {
+	if limit < len(s.companies) {
+		return s.companies[:limit], nil
+	}
+	return s.companies, nil
+}
+
+func (s *missingBatchRepoStub) FindByID(id uint) (*models.Company, error) {
+	cur := s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+	for {
+		prev := s.peak.Load()
+		if cur <= prev || s.peak.CompareAndSwap(prev, cur) {
+			break
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+	for i := range s.companies {
+		if s.companies[i].ID == id {
+			c := s.companies[i]
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func TestCompanyMissingBatchService_RunParallelNilFetchers(t *testing.T) {
+	companies := make([]models.Company, 8)
+	for i := range companies {
+		companies[i] = models.Company{ID: uint(i + 1), Name: "社", DataStatus: "draft"}
+	}
+	repo := &missingBatchRepoStub{companies: companies}
+	svc := NewCompanyMissingBatchService(repo, nil, nil, nil, nil)
+
+	result, err := svc.Run(context.Background(), MissingBatchOptions{
+		Limit:       8,
+		PrimaryOnly: true,
+		Concurrency: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Concurrency != 4 {
+		t.Fatalf("concurrency=%d", result.Concurrency)
+	}
+	if result.Processed != 8 {
+		t.Fatalf("processed=%d", result.Processed)
+	}
+	if result.Skipped < 8 {
+		t.Fatalf("skipped=%d want >=8 (nil fetchers)", result.Skipped)
+	}
+	for _, item := range result.Items {
+		if item.InfoStatus != "skipped_no_fetcher" {
+			t.Fatalf("info_status=%q", item.InfoStatus)
+		}
 	}
 }

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -71,4 +71,21 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 	if !info {
 		t.Fatal("fresh InfoFetchedAt with empty description/url should still need info")
 	}
+
+	// infra / 開発手法のみでは技術取得済みとみなさない
+	infraOnly := &models.Company{
+		Description:        "概要",
+		WebsiteURL:         "https://example.com",
+		TechStack:          "",
+		InfraStack:         `["AWS"]`,
+		DevelopmentStyle:   "スクラム",
+		InfoFetchedAt:      &now,
+		JobsFetchedAt:      &now,
+		TechFetchedAt:      &now,
+		RelationsFetchedAt: &now,
+	}
+	_, _, tech, _ = MissingNeedsFromCompany(infraOnly)
+	if !tech {
+		t.Fatal("infra/style only should still need tech_stack")
+	}
 }

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"Backend/internal/models"
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -126,22 +125,28 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 }
 
 func TestClampMissingBatchConcurrency(t *testing.T) {
-	if got := clampMissingBatchConcurrency(0); got != defaultMissingBatchConcurrency {
-		t.Fatalf("0 -> %d want %d", got, defaultMissingBatchConcurrency)
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"未指定はデフォルト", 0, defaultMissingBatchConcurrency},
+		{"範囲内はそのまま", 3, 3},
+		{"上限でクランプ", 100, maxMissingBatchConcurrency},
+		{"負数はデフォルト", -1, defaultMissingBatchConcurrency},
 	}
-	if got := clampMissingBatchConcurrency(3); got != 3 {
-		t.Fatalf("3 -> %d", got)
-	}
-	if got := clampMissingBatchConcurrency(100); got != maxMissingBatchConcurrency {
-		t.Fatalf("100 -> %d want %d", got, maxMissingBatchConcurrency)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampMissingBatchConcurrency(tt.in); got != tt.want {
+				t.Fatalf("%d -> %d want %d", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 
 type missingBatchRepoStub struct {
 	warmRepoStub
 	companies []models.Company
-	inFlight  atomic.Int32
-	peak      atomic.Int32
 }
 
 func (s *missingBatchRepoStub) ListActiveMissingFetchCandidates(limit int, _ bool) ([]models.Company, error) {
@@ -152,15 +157,6 @@ func (s *missingBatchRepoStub) ListActiveMissingFetchCandidates(limit int, _ boo
 }
 
 func (s *missingBatchRepoStub) FindByID(id uint) (*models.Company, error) {
-	cur := s.inFlight.Add(1)
-	defer s.inFlight.Add(-1)
-	for {
-		prev := s.peak.Load()
-		if cur <= prev || s.peak.CompareAndSwap(prev, cur) {
-			break
-		}
-	}
-	time.Sleep(20 * time.Millisecond)
 	for i := range s.companies {
 		if s.companies[i].ID == id {
 			c := s.companies[i]

--- a/Backend/internal/services/company_relation_graph_service.go
+++ b/Backend/internal/services/company_relation_graph_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"Backend/domain/repository"
+	"Backend/internal/companyfetch"
 	"Backend/internal/models"
 	"fmt"
 )
@@ -196,7 +197,7 @@ func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelati
 				CompanyID:    partnerID,
 				Name:         partner.Name,
 				RelationType: rel.RelationType,
-				Description:  rel.Description,
+				Description:  companyfetch.SanitizeRelationDescription(rel.Description),
 			})
 		}
 	}

--- a/Backend/internal/services/company_relation_graph_service.go
+++ b/Backend/internal/services/company_relation_graph_service.go
@@ -62,7 +62,12 @@ func NewCompanyRelationGraphService(companyRepo repository.CompanyRepository, re
 // BuildGraph は companyID を起点に資本関係を BFS で辿ったグラフを返す。
 // 取引関係は起点企業から直接分のみ付加する（取引先の取引先までは辿らない）。
 func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelationGraph, error) {
-	graph := &CompanyRelationGraph{CompanyID: companyID}
+	graph := &CompanyRelationGraph{
+		CompanyID:         companyID,
+		Nodes:             []RelationGraphNode{},
+		CapitalEdges:      []RelationGraphCapitalEdge{},
+		BusinessRelations: []RelationGraphBusinessEntry{},
+	}
 	nodeSeen := map[uint]struct{}{}
 	capitalEdgeSeen := map[string]struct{}{}
 	businessSeen := map[string]struct{}{}

--- a/Backend/internal/services/company_relations_fetcher.go
+++ b/Backend/internal/services/company_relations_fetcher.go
@@ -88,9 +88,9 @@ func (f *CompanyRelationsFetcher) SetSearchFlight(flight *CompanySearchFlight) {
 }
 
 const companyRelationsJSONSchema = `{
-  "subsidiaries": [{"name": "子会社・グループ会社名", "ratio": 出資比率（不明なら省略）, "description": "関係の説明（例: 完全子会社）"}],
-  "affiliates": [{"name": "資本提携・関連会社名", "description": "関係の説明（例: 資本提携）"}],
-  "business_partners": [{"name": "主要取引先名", "description": "取引内容の1行説明（例: クラウド基盤の共同開発）"}],
+  "subsidiaries": [{"name": "子会社・グループ会社名", "ratio": 出資比率（不明なら省略）, "description": "資本関係の具体内容（例: 完全子会社・議決権○%）"}],
+  "affiliates": [{"name": "資本提携・関連会社名", "description": "資本関係の具体内容（例: 資本業務提携・出資比率○%）"}],
+  "business_partners": [{"name": "はっきりした取引先名または省庁・自治体名（曖昧・JV・その他は禁止）", "description": "取引内容。公開事実が無くても業界・事業内容から妥当に推定できる内容を書いてよい。推定もできず種別しか分からない場合は空文字（表示は主要取引先）"}],
   "market_info": {
     "is_listed": true/false,
     "market_type": "prime|standard|growth|unlisted",
@@ -110,7 +110,8 @@ func (f *CompanyRelationsFetcher) FetchAndSave(ctx context.Context, companyID ui
 		if err != nil {
 			return nil, err
 		}
-		// 関係・市場が空なら TTL 内でも再取得する
+		// 取引内容が空でも「主要取引先」フォールバックとして確定済みなら TTL 内は再取得しない。
+		// 推定し直したい場合は force=true。
 		if relationsResultHasData(result) {
 			return markRelationsCacheSkip(result, "ttl", false), nil
 		}
@@ -195,20 +196,16 @@ func (f *CompanyRelationsFetcher) Acquire(ctx context.Context, companyName, webs
 }
 
 func (f *CompanyRelationsFetcher) acquireForCompany(ctx context.Context, company *models.Company) (*CompanyRelationsResult, error) {
-	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 180*time.Second)
 	defer cancel()
 
-	existingNames := map[string]struct{}{}
+	var existingEntries []RelationEntry
 	if f.relationRepo != nil {
 		relations, err := f.relationRepo.GetRelationsByCompanyID(company.ID)
 		if err != nil {
 			return nil, err
 		}
-		for _, rel := range relations {
-			for _, name := range relationPartnerNames(company.ID, rel) {
-				existingNames[normalizeRelationName(name)] = struct{}{}
-			}
-		}
+		existingEntries = relationsToEntries(company.ID, relations)
 	}
 
 	source := companyfetch.SourceGBiz
@@ -221,11 +218,7 @@ func (f *CompanyRelationsFetcher) acquireForCompany(ctx context.Context, company
 			if err != nil {
 				return nil, err
 			}
-			for _, rel := range relations {
-				for _, name := range relationPartnerNames(company.ID, rel) {
-					existingNames[normalizeRelationName(name)] = struct{}{}
-				}
-			}
+			existingEntries = relationsToEntries(company.ID, relations)
 		}
 	}
 
@@ -236,28 +229,29 @@ func (f *CompanyRelationsFetcher) acquireForCompany(ctx context.Context, company
 		}
 	}
 
-	needsAI := len(existingNames) == 0 || marketInfo == nil || marketInfo.StockCode == ""
+	// 取引先名があっても取引内容が空なら AI で補完する
+	needsAI := len(existingEntries) == 0 || marketInfo == nil || marketInfo.StockCode == "" ||
+		relationsNeedDescriptionEnrichment(existingEntries)
 	if !needsAI {
-		return f.buildResultFromExisting(company, existingNames, marketInfo, source, modelUsed, confidence)
+		return f.buildResultFromExisting(company, nil, marketInfo, source, modelUsed, confidence)
 	}
 
 	ai, err := f.acquireViaAISearch(ctx, company.Name, company.WebsiteURL)
 	if err != nil {
-		// 予算超過は呼び出し元でキャッシュ継続＋メタ付与するため伝播する
 		if errors.Is(err, companyfetch.ErrSearchBudgetExceeded) {
 			return nil, err
 		}
-		if len(existingNames) > 0 || marketInfo != nil {
-			return f.buildResultFromExisting(company, existingNames, marketInfo, source, modelUsed, confidence)
+		if len(existingEntries) > 0 || marketInfo != nil {
+			return f.buildResultFromExisting(company, nil, marketInfo, source, modelUsed, confidence)
 		}
 		return nil, err
 	}
 
-	merged := mergeRelationsResult(existingNames, marketInfo, ai)
+	merged := mergeRelationsResult(existingEntries, marketInfo, ai)
 	if ai.ModelUsed != "" {
 		modelUsed = source + "+" + ai.ModelUsed
 	}
-	if len(existingNames) > 0 {
+	if len(existingEntries) > 0 {
 		source = companyfetch.SourceGBiz + "+" + companyfetch.SourceWebSearch
 		confidence = companyfetch.ConfidenceMedium
 	} else {
@@ -265,6 +259,17 @@ func (f *CompanyRelationsFetcher) acquireForCompany(ctx context.Context, company
 		confidence = ai.Confidence
 		modelUsed = ai.ModelUsed
 	}
+
+	// まだ取引内容が空の取引先があれば、取引内容に特化した追撃検索
+	if relationsNeedDescriptionEnrichment(merged.Relations) {
+		if enriched, eerr := f.enrichTransactionDescriptions(ctx, company.Name, company.WebsiteURL, merged.Relations); eerr == nil && enriched != nil {
+			merged = mergeRelationsResult(merged.Relations, merged.MarketInfo, enriched)
+			if enriched.ModelUsed != "" {
+				modelUsed = modelUsed + "+desc:" + enriched.ModelUsed
+			}
+		}
+	}
+
 	merged.Source = source
 	merged.ModelUsed = modelUsed
 	merged.Confidence = confidence
@@ -277,20 +282,30 @@ func (f *CompanyRelationsFetcher) acquireViaAISearch(ctx context.Context, compan
 		return nil, fmt.Errorf("openai client is nil")
 	}
 
-	systemPrompt := `あなたは日本企業の資本関係・取引関係・上場情報に詳しいアシスタントです。検索結果に明示された事実のみをJSON化してください。推測で企業名を作らないでください。`
+	systemPrompt := `あなたは日本企業の資本関係・取引関係・上場情報に詳しいアシスタントです。検索結果と、そこから妥当に導ける業界・事業上の推定をJSON化してください。
+重要な制約:
+- 実在がはっきりしない・曖昧な組織名（「共同企業体」「その他」「株式会社」のみ、「○○JV」など）は一切載せない。不明なら省略する。
+- 入札・調達・補助金の相手は、共同企業体名ではなく発注元の省庁・自治体・公的機関名を name に書く（例: デジタル庁、厚生労働省）。発注機関が不明ならその件は載せない。
+- 取引先の description は具体的な取引内容（推定可）。推定も弱く種別しか分からない場合は空文字（表示は主要取引先）。空の代わりに「主要取引先」と書かない。`
 	siteHint := ""
 	if websiteURL != "" {
 		siteHint = fmt.Sprintf("（参考公式URL: %s）", websiteURL)
 	}
 	searchPrompt := fmt.Sprintf(
-		`日本の企業「%s」%sについて、公開情報から確認できる子会社・グループ会社・資本提携先・主要取引先・上場区分・証券コードを調べてください。各事実の根拠URLを含めてください。不明な項目は推測せず空配列または空文字にしてください。`,
+		`日本の企業「%s」%sについて、公開情報から次を調べてください。
+1. 子会社・グループ会社と資本関係の内容（はっきりした社名のみ）
+2. 資本提携・関連会社と提携内容（はっきりした社名のみ）
+3. 取引先（顧客・仕入先・業務提携先など）と取引内容。曖昧な社名は載せない
+4. 入札・調達・補助金がある場合は発注元の省庁・自治体名（共同企業体名は載せない）
+5. 上場区分・証券コード
+根拠URLがあれば含めてください。組織名が不明・曖昧ならその件は省略してください。`,
 		companyName, siteHint,
 	)
 	parseUser := fmt.Sprintf(
-		"企業名「%s」について、検索結果の事実のみに基づき次のJSON形式で回答してください。検索結果に無い項目は空配列または空文字。\n%s",
+		"企業名「%s」について次のJSON形式で回答してください。name ははっきりした組織名のみ（曖昧・JV・その他は禁止）。入札案件は省庁・自治体名。description は取引内容（推定可、弱ければ空）。\n%s",
 		companyName, companyRelationsJSONSchema,
 	)
-	raw, modelsUsed, err := f.llm.SearchLiteThenParse(ctx, searchPrompt, systemPrompt, parseUser, 800)
+	raw, modelsUsed, err := f.llm.SearchLiteThenParse(ctx, searchPrompt, systemPrompt, parseUser, 1200)
 	if err != nil {
 		return nil, fmt.Errorf("企業関係情報のAI取得失敗: %w", err)
 	}
@@ -300,6 +315,81 @@ func (f *CompanyRelationsFetcher) acquireViaAISearch(ctx context.Context, compan
 	}
 	result.Source = companyfetch.SourceWebSearch
 	result.SourceURL = strings.TrimSpace(websiteURL)
+	result.ModelUsed = modelsUsed
+	result.Confidence = companyfetch.ConfidenceMedium
+
+	// プレビュー取得でも取引内容が薄い場合は追撃する
+	if relationsNeedDescriptionEnrichment(result.Relations) {
+		if enriched, eerr := f.enrichTransactionDescriptions(ctx, companyName, websiteURL, result.Relations); eerr == nil && enriched != nil {
+			result = mergeRelationsResult(result.Relations, result.MarketInfo, enriched)
+			if enriched.ModelUsed != "" {
+				result.ModelUsed = modelsUsed + "+desc:" + enriched.ModelUsed
+			}
+			result.Source = companyfetch.SourceWebSearch
+			result.Confidence = companyfetch.ConfidenceMedium
+		}
+	}
+	return result, nil
+}
+
+// enrichTransactionDescriptions は取引先名は分かっているが取引内容が空の件を、取引内容に特化した検索で埋める。
+func (f *CompanyRelationsFetcher) enrichTransactionDescriptions(
+	ctx context.Context,
+	companyName, websiteURL string,
+	relations []RelationEntry,
+) (*CompanyRelationsResult, error) {
+	if f.llm == nil || f.llm.Client == nil {
+		return nil, fmt.Errorf("openai client is nil")
+	}
+	targets := make([]string, 0)
+	for _, rel := range relations {
+		if companyfetch.SanitizeRelationDescription(rel.Description) != "" {
+			continue
+		}
+		name := strings.TrimSpace(rel.Name)
+		if name == "" {
+			continue
+		}
+		targets = append(targets, name)
+		if len(targets) >= 12 {
+			break
+		}
+	}
+	if len(targets) == 0 {
+		return &CompanyRelationsResult{Relations: nil}, nil
+	}
+
+	siteHint := ""
+	if websiteURL != "" {
+		siteHint = fmt.Sprintf("（参考公式URL: %s）", websiteURL)
+	}
+	partnerList := strings.Join(targets, "、")
+	systemPrompt := `あなたは日本企業の取引関係に詳しいアシスタントです。検索結果と妥当な推定をJSON化してください。
+はっきりした組織名のみ載せる。曖昧名・共同企業体・「その他」は禁止。入札・調達の相手は省庁・自治体名。不明なら省略。
+description は具体的な取引内容（推定可）。弱い場合は空文字（『主要取引先』と書かない）。`
+	searchPrompt := fmt.Sprintf(
+		`日本の企業「%s」%sと、次の関連企業との関係について、公開情報および事業内容から妥当な取引・協業・資本関係の内容を調べてください: %s。各ペアについて「何を取引・提携しているか」を1行で示してください。根拠URLがあれば含めてください。推定もできないペアは省略するか description を空にしてください。`,
+		companyName, siteHint, partnerList,
+	)
+	parseSchema := `{
+  "business_partners": [{"name": "関連企業名", "description": "取引内容（推定可）。弱い場合は空文字"}],
+  "affiliates": [{"name": "関連企業名", "description": "資本・提携の具体内容"}],
+  "subsidiaries": [{"name": "関連企業名", "description": "資本関係の具体内容", "ratio": null}],
+  "market_info": {"is_listed": false, "market_type": "", "stock_code": ""}
+}`
+	parseUser := fmt.Sprintf(
+		"企業「%s」と関連企業（%s）について次のJSONを返してください。description は具体的な取引内容（推定可）。弱いフォールバックなら空文字（『主要取引先』と書かない）。\n%s",
+		companyName, partnerList, parseSchema,
+	)
+	raw, modelsUsed, err := f.llm.SearchLiteThenParse(ctx, searchPrompt, systemPrompt, parseUser, 1000)
+	if err != nil {
+		return nil, err
+	}
+	result, err := parseCompanyRelationsResult(raw)
+	if err != nil {
+		return nil, err
+	}
+	result.Source = companyfetch.SourceWebSearch
 	result.ModelUsed = modelsUsed
 	result.Confidence = companyfetch.ConfidenceMedium
 	return result, nil
@@ -329,7 +419,7 @@ func (f *CompanyRelationsFetcher) resultFromDB(company *models.Company, source, 
 
 func (f *CompanyRelationsFetcher) buildResultFromExisting(
 	company *models.Company,
-	existingNames map[string]struct{},
+	_ map[string]struct{},
 	marketInfo *CompanyMarketInfoResult,
 	source, modelUsed, confidence string,
 ) (*CompanyRelationsResult, error) {
@@ -370,7 +460,7 @@ func (f *CompanyRelationsFetcher) persistResult(company *models.Company, result 
 
 	for _, entry := range result.Relations {
 		name := strings.TrimSpace(entry.Name)
-		if name == "" {
+		if !companyfetch.IsClearOrganizationName(name) {
 			continue
 		}
 		toCompany, err := f.companyRepo.FindByName(name)
@@ -389,7 +479,8 @@ func (f *CompanyRelationsFetcher) persistResult(company *models.Company, result 
 				continue
 			}
 		}
-		desc := companyfetch.NormalizeRelationDescription(entry.Description, entry.RelationType)
+		// 種別ラベル（主要取引先など）は保存せず、具体的な取引内容のみ残す
+		desc := companyfetch.SanitizeRelationDescription(entry.Description)
 		var upsertErr error
 		if models.IsCapitalRelationType(entry.RelationType) {
 			ratio := entry.Ratio
@@ -457,30 +548,30 @@ func parseCompanyRelationsResult(text string) (*CompanyRelationsResult, error) {
 
 	result := &CompanyRelationsResult{}
 	for _, item := range payload.Subsidiaries {
-		if name := strings.TrimSpace(item.Name); name != "" {
+		if name := strings.TrimSpace(item.Name); companyfetch.IsClearOrganizationName(name) {
 			result.Relations = append(result.Relations, RelationEntry{
 				Name:         name,
 				RelationType: "capital_subsidiary",
 				Ratio:        item.Ratio,
-				Description:  strings.TrimSpace(item.Description),
+				Description:  companyfetch.SanitizeRelationDescription(item.Description),
 			})
 		}
 	}
 	for _, item := range payload.Affiliates {
-		if name := strings.TrimSpace(item.Name); name != "" {
+		if name := strings.TrimSpace(item.Name); companyfetch.IsClearOrganizationName(name) {
 			result.Relations = append(result.Relations, RelationEntry{
 				Name:         name,
 				RelationType: "capital_affiliate",
-				Description:  strings.TrimSpace(item.Description),
+				Description:  companyfetch.SanitizeRelationDescription(item.Description),
 			})
 		}
 	}
 	for _, item := range payload.BusinessPartners {
-		if name := strings.TrimSpace(item.Name); name != "" {
+		if name := strings.TrimSpace(item.Name); companyfetch.IsClearOrganizationName(name) {
 			result.Relations = append(result.Relations, RelationEntry{
 				Name:         name,
 				RelationType: "business_partner",
-				Description:  strings.TrimSpace(item.Description),
+				Description:  companyfetch.SanitizeRelationDescription(item.Description),
 			})
 		}
 	}
@@ -494,31 +585,79 @@ func parseCompanyRelationsResult(text string) (*CompanyRelationsResult, error) {
 	return result, nil
 }
 
+func relationsNeedDescriptionEnrichment(relations []RelationEntry) bool {
+	for _, rel := range relations {
+		// 取引関係のみ、取引内容の欠落を再取得トリガーにする（資本関係の空説明は許容）
+		if !strings.HasPrefix(rel.RelationType, "business_") {
+			continue
+		}
+		if strings.TrimSpace(rel.Name) == "" {
+			continue
+		}
+		if companyfetch.SanitizeRelationDescription(rel.Description) == "" {
+			return true
+		}
+	}
+	return false
+}
+
 func mergeRelationsResult(
-	existingNames map[string]struct{},
+	existing []RelationEntry,
 	baseMarket *CompanyMarketInfoResult,
 	ai *CompanyRelationsResult,
 ) *CompanyRelationsResult {
 	out := &CompanyRelationsResult{}
-	seen := map[string]struct{}{}
-	for key := range existingNames {
-		seen[key] = struct{}{}
+	byKey := map[string]RelationEntry{}
+	order := make([]string, 0)
+
+	addOrMerge := func(entry RelationEntry) {
+		name := strings.TrimSpace(entry.Name)
+		if !companyfetch.IsClearOrganizationName(name) {
+			return
+		}
+		entry.Name = name
+		entry.Description = companyfetch.SanitizeRelationDescription(entry.Description)
+		key := normalizeRelationName(name) + "|" + entry.RelationType
+		if prev, ok := byKey[key]; ok {
+			if prev.Description == "" && entry.Description != "" {
+				prev.Description = entry.Description
+			}
+			if prev.Ratio == nil && entry.Ratio != nil {
+				prev.Ratio = entry.Ratio
+			}
+			byKey[key] = prev
+			return
+		}
+		// 同名で種別違いがある場合、空の説明だけ AI 内容で補完
+		norm := normalizeRelationName(name)
+		if entry.Description != "" {
+			for k, prev := range byKey {
+				if normalizeRelationName(prev.Name) != norm {
+					continue
+				}
+				if prev.Description == "" {
+					prev.Description = entry.Description
+					byKey[k] = prev
+				}
+			}
+		}
+		byKey[key] = entry
+		order = append(order, key)
 	}
 
+	for _, entry := range existing {
+		addOrMerge(entry)
+	}
 	if ai != nil {
 		for _, entry := range ai.Relations {
-			key := normalizeRelationName(entry.Name) + "|" + entry.RelationType
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			norm := normalizeRelationName(entry.Name)
-			if _, ok := existingNames[norm]; ok {
-				continue
-			}
-			out.Relations = append(out.Relations, entry)
-			seen[key] = struct{}{}
+			addOrMerge(entry)
 		}
 	}
+	for _, key := range order {
+		out.Relations = append(out.Relations, byKey[key])
+	}
+	// order に無い（AI 新規のみで addOrMerge が order に追加済み）— already in order via addOrMerge
+	// ただし既存に無く AI で新規追加されたものは order に入る。OK
 
 	if baseMarket != nil {
 		out.MarketInfo = baseMarket
@@ -555,7 +694,7 @@ func relationsToEntries(companyID uint, relations []models.CompanyRelation) []Re
 			Name:         name,
 			RelationType: relationType,
 			Ratio:        rel.Ratio,
-			Description:  rel.Description,
+			Description:  companyfetch.SanitizeRelationDescription(rel.Description),
 		})
 	}
 	return entries
@@ -626,8 +765,7 @@ func markRelationsCacheSkip(r *CompanyRelationsResult, reason string, budgetExce
 	return r
 }
 
-// HasStoredData は DB に関係、または実質的な市場情報があるか。
-// market_type=unlisted のみは「データあり」とみなさない。
+// HasStoredData は DB に関係、または確定した市場情報（上場・非上場）があるか。
 func (f *CompanyRelationsFetcher) HasStoredData(companyID uint) bool {
 	if f == nil || f.relationRepo == nil {
 		return false

--- a/Backend/internal/services/company_relations_fetcher.go
+++ b/Backend/internal/services/company_relations_fetcher.go
@@ -161,6 +161,15 @@ func (f *CompanyRelationsFetcher) FetchAndSave(ctx context.Context, companyID ui
 	return result, nil
 }
 
+// LoadSaved は DB に保存済みの関係・市場情報だけを返す（AI 再取得なし）。
+func (f *CompanyRelationsFetcher) LoadSaved(companyID uint) (*CompanyRelationsResult, error) {
+	company, err := f.companyRepo.FindByID(companyID)
+	if err != nil {
+		return nil, fmt.Errorf("company not found: %w", err)
+	}
+	return f.resultFromDB(company, companyfetch.SourceGBiz, "db", companyfetch.ConfidenceHigh)
+}
+
 // ConfirmAndSave はプレビュー済みの関係・市場情報を LLM 再実行なしで DB に確定保存する。
 func (f *CompanyRelationsFetcher) ConfirmAndSave(companyID uint, result *CompanyRelationsResult) (*CompanyRelationsResult, error) {
 	if result == nil {
@@ -192,7 +201,21 @@ func (f *CompanyRelationsFetcher) ConfirmAndSave(companyID uint, result *Company
 func (f *CompanyRelationsFetcher) Acquire(ctx context.Context, companyName, websiteURL string) (*CompanyRelationsResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
-	return f.acquireViaAISearch(ctx, companyName, websiteURL)
+	result, err := f.acquireViaAISearch(ctx, companyName, websiteURL)
+	if err != nil {
+		return nil, err
+	}
+	if result != nil && relationsNeedDescriptionEnrichment(result.Relations) {
+		if enriched, eerr := f.enrichTransactionDescriptions(ctx, companyName, websiteURL, result.Relations); eerr == nil && enriched != nil {
+			result = mergeRelationsResult(result.Relations, result.MarketInfo, enriched)
+			if enriched.ModelUsed != "" {
+				result.ModelUsed = result.ModelUsed + "+desc:" + enriched.ModelUsed
+			}
+			result.Source = companyfetch.SourceWebSearch
+			result.Confidence = companyfetch.ConfidenceMedium
+		}
+	}
+	return result, nil
 }
 
 func (f *CompanyRelationsFetcher) acquireForCompany(ctx context.Context, company *models.Company) (*CompanyRelationsResult, error) {
@@ -317,18 +340,7 @@ func (f *CompanyRelationsFetcher) acquireViaAISearch(ctx context.Context, compan
 	result.SourceURL = strings.TrimSpace(websiteURL)
 	result.ModelUsed = modelsUsed
 	result.Confidence = companyfetch.ConfidenceMedium
-
-	// プレビュー取得でも取引内容が薄い場合は追撃する
-	if relationsNeedDescriptionEnrichment(result.Relations) {
-		if enriched, eerr := f.enrichTransactionDescriptions(ctx, companyName, websiteURL, result.Relations); eerr == nil && enriched != nil {
-			result = mergeRelationsResult(result.Relations, result.MarketInfo, enriched)
-			if enriched.ModelUsed != "" {
-				result.ModelUsed = modelsUsed + "+desc:" + enriched.ModelUsed
-			}
-			result.Source = companyfetch.SourceWebSearch
-			result.Confidence = companyfetch.ConfidenceMedium
-		}
-	}
+	// 取引内容の追撃は acquireForCompany 側（既存関係マージ後）に集約し、二重 LLM を避ける。
 	return result, nil
 }
 

--- a/Backend/internal/services/company_relations_merge_test.go
+++ b/Backend/internal/services/company_relations_merge_test.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRelationsResult_FillsTransactionDescription(t *testing.T) {
+	existing := []RelationEntry{
+		{Name: "取引先C", RelationType: "business_partner", Description: ""},
+		{Name: "子会社A", RelationType: "capital_subsidiary", Description: "主要取引先"}, // 種別ラベルは sanitize で空扱い
+	}
+	ai := &CompanyRelationsResult{
+		Relations: []RelationEntry{
+			{Name: "取引先C", RelationType: "business_partner", Description: "決済代行"},
+			{Name: "子会社A", RelationType: "capital_subsidiary", Description: "完全子会社"},
+			{Name: "新規D", RelationType: "business_partner", Description: "クラウド基盤の共同開発"},
+		},
+		MarketInfo: &CompanyMarketInfoResult{IsListed: true, MarketType: "prime", StockCode: "4755"},
+	}
+
+	out := mergeRelationsResult(existing, nil, ai)
+	require.Len(t, out.Relations, 3)
+
+	byName := map[string]RelationEntry{}
+	for _, r := range out.Relations {
+		byName[r.Name] = r
+	}
+	assert.Equal(t, "決済代行", byName["取引先C"].Description)
+	assert.Equal(t, "完全子会社", byName["子会社A"].Description)
+	assert.Equal(t, "クラウド基盤の共同開発", byName["新規D"].Description)
+	assert.Equal(t, "4755", out.MarketInfo.StockCode)
+}
+
+func TestRelationsNeedDescriptionEnrichment(t *testing.T) {
+	assert.False(t, relationsNeedDescriptionEnrichment(nil))
+	assert.False(t, relationsNeedDescriptionEnrichment([]RelationEntry{
+		{Name: "A", RelationType: "business_partner", Description: "決済代行"},
+	}))
+	assert.False(t, relationsNeedDescriptionEnrichment([]RelationEntry{
+		{Name: "子会社A", RelationType: "capital_subsidiary", Description: ""},
+	}))
+	assert.True(t, relationsNeedDescriptionEnrichment([]RelationEntry{
+		{Name: "A", RelationType: "business_partner", Description: "決済代行"},
+		{Name: "B", RelationType: "business_partner", Description: ""},
+	}))
+	assert.True(t, relationsNeedDescriptionEnrichment([]RelationEntry{
+		{Name: "B", RelationType: "business_partner", Description: "主要取引先"},
+	}))
+}

--- a/Backend/internal/services/gbizinfo_service.go
+++ b/Backend/internal/services/gbizinfo_service.go
@@ -386,39 +386,95 @@ func (s *GBizInfoService) updateBusinessRelations(company *models.Company, procu
 
 // upsertProcurementStyleRelation は調達・補助金の関係先として、はっきりした省庁・発注機関名のみを保存する。
 func (s *GBizInfoService) upsertProcurementStyleRelation(company *models.Company, agency, title, date, relationType string) error {
-	name := strings.TrimSpace(agency)
-	if company == nil || !companyfetch.IsClearOrganizationName(name) {
+	if company == nil {
 		return nil
 	}
-	if strings.EqualFold(name, company.Name) {
-		return nil
-	}
-	partnerCompany, err := s.companyRepo.FindByName(name)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-	if partnerCompany == nil || errors.Is(err, gorm.ErrRecordNotFound) {
-		now := time.Now()
-		partnerCompany = &models.Company{
-			Name:            name,
-			SourceType:      "gbizinfo",
-			SourceFetchedAt: &now,
-			IsProvisional:   true,
-			DataStatus:      "draft",
+	for _, name := range splitClearAgencyNames(agency) {
+		if strings.EqualFold(name, company.Name) {
+			continue
 		}
-		if err := s.companyRepo.Create(partnerCompany); err != nil {
+		partnerCompany, err := s.findOrCreateProvisionalPartner(name)
+		if err != nil {
+			return err
+		}
+		if partnerCompany == nil {
+			continue
+		}
+		parts := make([]string, 0, 2)
+		if t := strings.TrimSpace(title); t != "" {
+			parts = append(parts, t)
+		}
+		if d := strings.TrimSpace(date); d != "" {
+			parts = append(parts, d)
+		}
+		description := strings.Join(parts, " / ")
+		if err := s.relationRepo.UpsertBusinessRelation(company.ID, partnerCompany.ID, relationType, description); err != nil {
 			return err
 		}
 	}
-	parts := make([]string, 0, 2)
-	if t := strings.TrimSpace(title); t != "" {
-		parts = append(parts, t)
+	return nil
+}
+
+// splitClearAgencyNames は「デジタル庁／厚労省」のような連結表記を分割し、明確な単一機関名だけ返す。
+func splitClearAgencyNames(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
 	}
-	if d := strings.TrimSpace(date); d != "" {
-		parts = append(parts, d)
+	seps := func(r rune) bool {
+		switch r {
+		case '/', '／', '、', ',', '，', ';', '；', '|', '｜':
+			return true
+		default:
+			return false
+		}
 	}
-	description := strings.Join(parts, " / ")
-	return s.relationRepo.UpsertBusinessRelation(company.ID, partnerCompany.ID, relationType, description)
+	parts := strings.FieldsFunc(raw, seps)
+	if len(parts) == 0 {
+		parts = []string{raw}
+	}
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if !companyfetch.IsClearOrganizationName(name) {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func (s *GBizInfoService) findOrCreateProvisionalPartner(name string) (*models.Company, error) {
+	partnerCompany, err := s.companyRepo.FindByName(name)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	if partnerCompany != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return partnerCompany, nil
+	}
+	now := time.Now()
+	partnerCompany = &models.Company{
+		Name:            name,
+		SourceType:      "gbizinfo",
+		SourceFetchedAt: &now,
+		IsProvisional:   true,
+		DataStatus:      "draft",
+	}
+	if err := s.companyRepo.Create(partnerCompany); err != nil {
+		// 並列同期で同名作成が競合した場合は再取得を試みる
+		existing, findErr := s.companyRepo.FindByName(name)
+		if findErr == nil && existing != nil {
+			return existing, nil
+		}
+		return nil, err
+	}
+	return partnerCompany, nil
 }
 
 func parseJointSignatures(raw string) []string {

--- a/Backend/internal/services/gbizinfo_service.go
+++ b/Backend/internal/services/gbizinfo_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"Backend/domain/repository"
+	"Backend/internal/companyfetch"
 	"Backend/internal/config"
 	"Backend/internal/models"
 	"context"
@@ -358,48 +359,66 @@ func (s *GBizInfoService) updateBusinessRelations(company *models.Company, procu
 		return nil
 	}
 	for _, item := range procurements {
-		if err := s.createRelationsFromJointSignatures(company, item.Title, item.DateOfOrder, item.JointSignatures, "business_procurement"); err != nil {
+		// 入札・調達の相手は発注元の省庁・自治体を記載する。曖昧な共同企業体名は入れない。
+		if err := s.upsertProcurementStyleRelation(
+			company,
+			item.GovernmentDepartments,
+			item.Title,
+			item.DateOfOrder,
+			"business_procurement",
+		); err != nil {
 			return err
 		}
 	}
 	for _, item := range subsidies {
-		if err := s.createRelationsFromJointSignatures(company, item.Title, item.DateOfApproval, item.JointSignatures, "business_subsidy"); err != nil {
+		if err := s.upsertProcurementStyleRelation(
+			company,
+			item.GovernmentDepartments,
+			item.Title,
+			item.DateOfApproval,
+			"business_subsidy",
+		); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *GBizInfoService) createRelationsFromJointSignatures(company *models.Company, title, date, jointSignatures, relationType string) error {
-	partners := parseJointSignatures(jointSignatures)
-	for _, partner := range partners {
-		name := strings.TrimSpace(partner)
-		if name == "" || company == nil || strings.EqualFold(name, company.Name) {
-			continue
+// upsertProcurementStyleRelation は調達・補助金の関係先として、はっきりした省庁・発注機関名のみを保存する。
+func (s *GBizInfoService) upsertProcurementStyleRelation(company *models.Company, agency, title, date, relationType string) error {
+	name := strings.TrimSpace(agency)
+	if company == nil || !companyfetch.IsClearOrganizationName(name) {
+		return nil
+	}
+	if strings.EqualFold(name, company.Name) {
+		return nil
+	}
+	partnerCompany, err := s.companyRepo.FindByName(name)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if partnerCompany == nil || errors.Is(err, gorm.ErrRecordNotFound) {
+		now := time.Now()
+		partnerCompany = &models.Company{
+			Name:            name,
+			SourceType:      "gbizinfo",
+			SourceFetchedAt: &now,
+			IsProvisional:   true,
+			DataStatus:      "draft",
 		}
-		partnerCompany, err := s.companyRepo.FindByName(name)
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
-		if partnerCompany == nil || errors.Is(err, gorm.ErrRecordNotFound) {
-			now := time.Now()
-			partnerCompany = &models.Company{
-				Name:            name,
-				SourceType:      "gbizinfo",
-				SourceFetchedAt: &now,
-				IsProvisional:   true,
-				DataStatus:      "draft",
-			}
-			if err := s.companyRepo.Create(partnerCompany); err != nil {
-				return err
-			}
-		}
-		description := fmt.Sprintf("%s (%s)", strings.TrimSpace(title), strings.TrimSpace(date))
-		if err := s.relationRepo.UpsertBusinessRelation(company.ID, partnerCompany.ID, relationType, description); err != nil {
+		if err := s.companyRepo.Create(partnerCompany); err != nil {
 			return err
 		}
 	}
-	return nil
+	parts := make([]string, 0, 2)
+	if t := strings.TrimSpace(title); t != "" {
+		parts = append(parts, t)
+	}
+	if d := strings.TrimSpace(date); d != "" {
+		parts = append(parts, d)
+	}
+	description := strings.Join(parts, " / ")
+	return s.relationRepo.UpsertBusinessRelation(company.ID, partnerCompany.ID, relationType, description)
 }
 
 func parseJointSignatures(raw string) []string {

--- a/Backend/internal/services/tech_stack_fetcher.go
+++ b/Backend/internal/services/tech_stack_fetcher.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
+	"Backend/internal/companyfields"
 	"Backend/internal/models"
 	"Backend/internal/openai"
 	"context"
@@ -56,11 +57,18 @@ func (f *TechStackFetcher) SetSearchFlight(flight *CompanySearchFlight) {
 	}
 }
 
-const techStackJSONSchema = `{
+const techStackJSONSchemaIT = `{
   "tech_stack": ["言語・フレームワーク名（例: Go, React, TypeScript）"],
   "infra_stack": ["インフラ名（例: AWS, GCP, Azure, オンプレ）"],
   "cicd_tools": ["CI/CDツール名（例: GitHub Actions, Jenkins, CircleCI）"],
   "development_style": "開発手法（例: スクラム, ウォーターフォール, カンバン）"
+}`
+
+const techStackJSONSchemaManufacturing = `{
+  "tech_stack": ["主要技術・製品技術（例: 精密加工, 車載センサー, CAD/CAM）"],
+  "infra_stack": ["生産設備・拠点（例: 国内工場, SMTライン, クリーンルーム）"],
+  "cicd_tools": [],
+  "development_style": "生産・開発の進め方（例: セル生産, ライン生産, 受注生産）"
 }`
 
 // FetchAndSave は技術スタックを取得して DB を更新する。
@@ -72,7 +80,7 @@ func (f *TechStackFetcher) FetchAndSave(ctx context.Context, companyID uint, for
 
 	// TTL内でも技術データが空なら再取得する（スタンプだけ進んだ残骸対策）
 	if !forceRefresh && companyfetch.IsFresh(company.TechFetchedAt, companyfetch.TTLTech) &&
-		companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+		companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 		result := techResultFromCompany(company)
 		result.FromCache = true
 		result.SkipReason = "ttl"
@@ -80,7 +88,7 @@ func (f *TechStackFetcher) FetchAndSave(ctx context.Context, companyID uint, for
 	}
 
 	run := func() (any, error) {
-		return f.Acquire(ctx, company.Name, company.WebsiteURL)
+		return f.Acquire(ctx, company.Name, company.WebsiteURL, company.Industry)
 	}
 	var result *TechStackResult
 	if f.flight != nil {
@@ -90,7 +98,7 @@ func (f *TechStackFetcher) FetchAndSave(ctx context.Context, companyID uint, for
 			result, _ = v.(*TechStackResult)
 		}
 	} else {
-		result, err = f.Acquire(ctx, company.Name, company.WebsiteURL)
+		result, err = f.Acquire(ctx, company.Name, company.WebsiteURL, company.Industry)
 	}
 	if err != nil {
 		if errors.Is(err, companyfetch.ErrSearchBudgetExceeded) {
@@ -123,7 +131,7 @@ func (f *TechStackFetcher) FetchAndSave(ctx context.Context, companyID uint, for
 
 	now := time.Now()
 	// 空のまま TechFetchedAt だけ進むと不足埋めが止まるため、中身があるときのみスタンプ
-	if companyfetch.HasTechData(company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
+	if companyfetch.HasTechDataForIndustry(company.Industry, company.TechStack, company.InfraStack, company.CicdTools, company.DevelopmentStyle) {
 		company.TechFetchedAt = &now
 	}
 	company.SourceFetchedAt = &now
@@ -140,15 +148,38 @@ func (f *TechStackFetcher) FetchAndSave(ctx context.Context, companyID uint, for
 	return result, nil
 }
 
-// Acquire は DB 非更新で技術スタックを取得する（公式ページ抽出→不足時のみ Search）。
-func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL string) (*TechStackResult, error) {
+// techAcquirePrompts は業種に応じた抽出スキーマ・システムプロンプト・検索プロンプト・表示名を返す。
+func techAcquirePrompts(industry, companyName, websiteURL string) (schema, systemPrompt, searchPrompt, domainLabel string) {
+	profile := companyfields.Resolve(industry)
+	siteHint := websiteURLOrUnknown(websiteURL)
+	if profile.ID == companyfields.ProfileManufacturing {
+		return techStackJSONSchemaManufacturing,
+			`あなたは製造業の技術・設備情報の構造化アシスタントです。入力テキストに明示された製品技術・生産設備・生産方式のみをJSON化してください。推測で埋めてはいけません。ITのプログラミング言語を無理に埋めないでください。不明な項目は空配列または空文字にしてください。`,
+			fmt.Sprintf(
+				`日本の製造企業「%s」の主要技術・製品技術・生産設備・拠点・生産方式を調べてください。公式サイト: %s。会社案内・製品紹介・工場紹介・採用ページに書かれている事実のみを根拠URL付きで列挙してください。プログラミング言語やCI/CDは、公開情報に明示がある場合のみ。`,
+				companyName, siteHint,
+			),
+			"設備・技術"
+	}
+	return techStackJSONSchemaIT,
+		`あなたは技術スタックの構造化アシスタントです。入力テキストに明示された技術のみをJSON化してください。推測で埋めてはいけません。不明な項目は空配列または空文字にしてください。`,
+		fmt.Sprintf(
+			`日本のIT企業「%s」の技術スタックを調べてください。公式サイト: %s。採用ページ・技術ブログ・エンジニア向け情報・求人票に書かれている言語・フレームワーク・クラウド・CI/CD・開発手法を、根拠URL付きで列挙してください。公開情報として確認できる事実のみ。非上場企業も含めます。`,
+			companyName, siteHint,
+		),
+		"技術スタック"
+}
+
+// Acquire は DB 非更新で技術・専門情報を取得する（公式ページ抽出→不足時のみ Search）。
+// industry に応じてプロンプトと抽出スキーマを切り替える。
+func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL, industry string) (*TechStackResult, error) {
 	if f.llm == nil || f.llm.Client == nil {
 		return nil, fmt.Errorf("openai client is nil")
 	}
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	systemPrompt := `あなたは技術スタックの構造化アシスタントです。入力テキストに明示された技術のみをJSON化してください。推測で埋めてはいけません。不明な項目は空配列または空文字にしてください。`
+	schema, systemPrompt, searchPrompt, domainLabel := techAcquirePrompts(industry, companyName, websiteURL)
 
 	// 1) 公式サイト／採用ページから直接抽出（Search 予算を使わず成功率も高い）
 	if strings.TrimSpace(websiteURL) != "" {
@@ -160,8 +191,8 @@ func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL 
 		}
 		if pageText, sourceURL, ferr := companyfetch.FirstFetchableText(scrapeCtx, candidateURLs); ferr == nil && pageText != "" {
 			parseUser := fmt.Sprintf(
-				"企業「%s」の公開ページ本文です。本文に明示された技術のみ次のJSON形式で抽出してください。推測禁止。\n%s\n\n---\n本文:\n%s",
-				companyName, techStackJSONSchema, pageText,
+				"企業「%s」の公開ページ本文です。本文に明示された%sのみ次のJSON形式で抽出してください。推測禁止。\n%s\n\n---\n本文:\n%s",
+				companyName, domainLabel, schema, pageText,
 			)
 			raw, model, err := f.llm.ExtractJSON(ctx, systemPrompt, parseUser, 400)
 			if err == nil {
@@ -177,21 +208,13 @@ func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL 
 	}
 
 	// 2) Search Lite → Parse
-	siteHint := websiteURL
-	if siteHint == "" {
-		siteHint = "不明"
-	}
-	searchPrompt := fmt.Sprintf(
-		`日本のIT企業「%s」の技術スタックを調べてください。公式サイト: %s。採用ページ・技術ブログ・エンジニア向け情報・求人票に書かれている言語・フレームワーク・クラウド・CI/CD・開発手法を、根拠URL付きで列挙してください。公開情報として確認できる事実のみ。非上場企業も含めます。`,
-		companyName, siteHint,
-	)
 	parseUser := fmt.Sprintf(
 		"企業「%s」について、検索結果の事実のみに基づき次のJSON形式で回答してください。検索結果に無い項目は空配列/空文字。推測禁止。\n%s",
-		companyName, techStackJSONSchema,
+		companyName, schema,
 	)
 	raw, modelsUsed, err := f.llm.SearchLiteThenParse(ctx, searchPrompt, systemPrompt, parseUser, 400)
 	if err != nil {
-		return nil, fmt.Errorf("技術スタックの取得失敗: %w", err)
+		return nil, fmt.Errorf("%sの取得失敗: %w", domainLabel, err)
 	}
 	result, err := parseTechStackResult(raw)
 	if err != nil {
@@ -202,6 +225,13 @@ func (f *TechStackFetcher) Acquire(ctx context.Context, companyName, websiteURL 
 	result.ModelUsed = modelsUsed
 	result.Confidence = companyfetch.ConfidenceMedium
 	return result, nil
+}
+
+func websiteURLOrUnknown(websiteURL string) string {
+	if strings.TrimSpace(websiteURL) == "" {
+		return "不明"
+	}
+	return websiteURL
 }
 
 func parseTechStackResult(text string) (*TechStackResult, error) {

--- a/Backend/internal/services/tech_stack_fetcher_test.go
+++ b/Backend/internal/services/tech_stack_fetcher_test.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTechAcquirePrompts_IT(t *testing.T) {
+	schema, system, search, label := techAcquirePrompts("IT・ソフトウェア", "サンプル株式会社", "https://example.com")
+	if label != "技術スタック" {
+		t.Fatalf("label=%q", label)
+	}
+	if !strings.Contains(schema, "言語・フレームワーク") {
+		t.Fatalf("IT schema should mention languages: %s", schema)
+	}
+	if !strings.Contains(system, "技術スタック") {
+		t.Fatalf("IT system prompt unexpected: %s", system)
+	}
+	if !strings.Contains(search, "日本のIT企業") || !strings.Contains(search, "サンプル株式会社") {
+		t.Fatalf("IT search prompt unexpected: %s", search)
+	}
+}
+
+func TestTechAcquirePrompts_Manufacturing(t *testing.T) {
+	schema, system, search, label := techAcquirePrompts("製造業", "ものづくり株式会社", "https://mfg.example.com")
+	if label != "設備・技術" {
+		t.Fatalf("label=%q", label)
+	}
+	if !strings.Contains(schema, "生産設備") {
+		t.Fatalf("manufacturing schema should mention equipment: %s", schema)
+	}
+	if !strings.Contains(system, "製造業") {
+		t.Fatalf("manufacturing system prompt unexpected: %s", system)
+	}
+	if !strings.Contains(search, "日本の製造企業") || strings.Contains(search, "日本のIT企業") {
+		t.Fatalf("manufacturing search prompt unexpected: %s", search)
+	}
+}
+
+func TestWebsiteURLOrUnknown(t *testing.T) {
+	if got := websiteURLOrUnknown(""); got != "不明" {
+		t.Fatalf("empty -> %q", got)
+	}
+	if got := websiteURLOrUnknown("https://example.com"); got != "https://example.com" {
+		t.Fatalf("url -> %q", got)
+	}
+}

--- a/Backend/test/controllers/mocks/company_repository_mock.go
+++ b/Backend/test/controllers/mocks/company_repository_mock.go
@@ -164,8 +164,8 @@ func (m *CompanyRepositoryMock) CountL1Coverage(infoTTL time.Duration) (*models.
 	return nil, args.Error(1)
 }
 
-func (m *CompanyRepositoryMock) ListActiveMissingFetchCandidates(limit int) ([]models.Company, error) {
-	args := m.Called(limit)
+func (m *CompanyRepositoryMock) ListActiveMissingFetchCandidates(limit int, primaryOnly bool) ([]models.Company, error) {
+	args := m.Called(limit, primaryOnly)
 	if v := args.Get(0); v != nil {
 		return v.([]models.Company), args.Error(1)
 	}

--- a/Backend/test/controllers/mocks/company_repository_mock.go
+++ b/Backend/test/controllers/mocks/company_repository_mock.go
@@ -33,12 +33,20 @@ func (m *CompanyRepositoryMock) CountActive() (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *CompanyRepositoryMock) ListActiveFiltered(limit, offset int, name, status string) ([]models.Company, int64, error) {
-	args := m.Called(limit, offset, name, status)
+func (m *CompanyRepositoryMock) ListActiveFiltered(limit, offset int, name, status, industry, readiness, orderBy string) ([]models.Company, int64, error) {
+	args := m.Called(limit, offset, name, status, industry, readiness, orderBy)
 	if v := args.Get(0); v != nil {
 		return v.([]models.Company), args.Get(1).(int64), args.Error(2)
 	}
 	return nil, args.Get(1).(int64), args.Error(2)
+}
+
+func (m *CompanyRepositoryMock) ListActiveIndustries() ([]string, error) {
+	args := m.Called()
+	if v := args.Get(0); v != nil {
+		return v.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *CompanyRepositoryMock) FindAllPublished(limit, offset int) ([]models.Company, error) {

--- a/Backend/test/repositories/company_list_filtered_test.go
+++ b/Backend/test/repositories/company_list_filtered_test.go
@@ -42,7 +42,7 @@ func TestListActiveFiltered_ByNameAndStatus(t *testing.T) {
 			AddRow(2, "ソニー損保", "draft", true).
 			AddRow(1, "ソニー株式会社", "published", true))
 
-	all, total, err := repo.ListActiveFiltered(50, 0, "ソニー", "")
+	all, total, err := repo.ListActiveFiltered(50, 0, "ソニー", "", "", "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,12 +58,51 @@ func TestListActiveFiltered_ByNameAndStatus(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "data_status", "is_active"}).
 			AddRow(1, "ソニー株式会社", "published", true))
 
-	published, total, err := repo.ListActiveFiltered(50, 0, "ソニー", "published")
+	published, total, err := repo.ListActiveFiltered(50, 0, "ソニー", "published", "", "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if total != 1 || len(published) != 1 || published[0].Name != "ソニー株式会社" {
 		t.Fatalf("unexpected published result: total=%d companies=%v", total, published)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestListActiveFiltered_ByIndustryAndReadiness(t *testing.T) {
+	repo, mock := newCompanyRepoTestDB(t)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND industry = \\?").
+		WithArgs(true, "IT・ソフトウェア").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND industry = \\? ORDER BY id desc LIMIT \\?").
+		WithArgs(true, "IT・ソフトウェア", 50).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "industry", "is_active"}).
+			AddRow(1, "サンプルIT", "IT・ソフトウェア", true))
+
+	byIndustry, total, err := repo.ListActiveFiltered(50, 0, "", "", "IT・ソフトウェア", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 || len(byIndustry) != 1 {
+		t.Fatalf("want total=1 len=1, got total=%d len=%d", total, len(byIndustry))
+	}
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND \\(\\(industry IS NULL OR industry = ''\\)\\)").
+		WithArgs(true).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND \\(\\(industry IS NULL OR industry = ''\\)\\) ORDER BY id desc LIMIT \\?").
+		WithArgs(true, 50).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
+
+	unset, total, err := repo.ListActiveFiltered(50, 0, "", "", "__unset__", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 || len(unset) != 0 {
+		t.Fatalf("want empty unset, got total=%d len=%d", total, len(unset))
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/Backend/test/services/company_info_fetcher_test.go
+++ b/Backend/test/services/company_info_fetcher_test.go
@@ -67,32 +67,24 @@ func TestCompanyInfoFetcher_FetchAndSave_TTLCache(t *testing.T) {
 	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 
-func TestCompanyInfoFetcher_FetchAndSave_EmptyDespiteTTLReFetches(t *testing.T) {
+func TestCompanyInfoFetcher_FetchAndSave_StampedSparseUsesTTL(t *testing.T) {
 	now := time.Now()
-	srv := makeChatCompletionsServer(t, validCompanyInfoJSON())
-	defer srv.Close()
-
 	repo := &mocks.CompanyRepositoryMock{}
 	repo.On("FindByID", uint(1)).Return(&models.Company{
 		ID:            1,
 		Name:          "テスト株式会社",
 		Description:   "",
-		WebsiteURL:    "",
-		InfoFetchedAt: &now, // スタンプ済みだが中身なし
+		WebsiteURL:    "https://example.com",
+		Location:      "東京都",
+		InfoFetchedAt: &now, // 公開情報限定でもスタンプ済みなら TTL スキップ
 	}, nil)
-	repo.On("Update", mock.AnythingOfType("*models.Company")).Return(nil).Run(func(args mock.Arguments) {
-		c := args.Get(0).(*models.Company)
-		assert.NotEmpty(t, c.Description)
-		assert.NotEmpty(t, c.WebsiteURL)
-		assert.NotNil(t, c.InfoFetchedAt)
-	})
 
-	client := openai.NewWithBaseURL(srv.URL, "gpt-4o-mini")
-	fetcher := services.NewCompanyInfoFetcher(repo, client)
+	fetcher := services.NewCompanyInfoFetcher(repo, nil)
 	result, err := fetcher.FetchAndSave(context.Background(), 1, false)
 	require.NoError(t, err)
-	assert.False(t, result.FromCache)
-	assert.NotEmpty(t, result.Description)
+	assert.True(t, result.FromCache)
+	assert.Equal(t, "ttl", result.SkipReason)
+	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 
 type denySearchBudget struct{}

--- a/Backend/test/services/company_relations_fetcher_test.go
+++ b/Backend/test/services/company_relations_fetcher_test.go
@@ -170,12 +170,12 @@ func TestCompanyRelationsFetcher_FetchAndSave_EmptyUnlistedStamps(t *testing.T) 
 
 	relRepo := &relationRepoMock{}
 	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil).Once()
+	// HasStoredData / acquire 双方から呼ばれるため、非上場情報を一貫して返す
 	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(&models.CompanyMarketInfo{
 		CompanyID:  1,
 		IsListed:   false,
 		MarketType: "unlisted",
-	}, nil).Maybe()
+	}, nil)
 	relRepo.On("UpsertMarketInfo", mock.MatchedBy(func(info *models.CompanyMarketInfo) bool {
 		return info != nil && info.CompanyID == 1 && info.MarketType == "unlisted" && !info.IsListed
 	})).Return(nil)

--- a/Backend/test/services/company_relations_fetcher_test.go
+++ b/Backend/test/services/company_relations_fetcher_test.go
@@ -53,7 +53,7 @@ func (m *relationRepoMock) UpsertMarketInfo(info *models.CompanyMarketInfo) erro
 }
 
 func validCompanyRelationsJSON() string {
-	return `{"subsidiaries":[{"name":"子会社A","ratio":100}],"affiliates":[{"name":"関連会社B"}],"business_partners":[{"name":"取引先C"}],"market_info":{"is_listed":true,"market_type":"prime","stock_code":"4755"}}`
+	return `{"subsidiaries":[{"name":"子会社A","ratio":100,"description":"完全子会社"}],"affiliates":[{"name":"関連会社B","description":"資本業務提携"}],"business_partners":[{"name":"取引先C","description":"決済代行"}],"market_info":{"is_listed":true,"market_type":"prime","stock_code":"4755"}}`
 }
 
 func TestCompanyRelationsFetcher_FetchAndSave_TTLCache(t *testing.T) {
@@ -156,29 +156,41 @@ func TestCompanyRelationsFetcher_ConfirmAndSave(t *testing.T) {
 	assert.Equal(t, 2, result.SavedCount)
 }
 
-func TestCompanyRelationsFetcher_FetchAndSave_EmptyUnlistedDoesNotStamp(t *testing.T) {
+func TestCompanyRelationsFetcher_FetchAndSave_EmptyUnlistedStamps(t *testing.T) {
 	emptyJSON := `{"subsidiaries":[],"affiliates":[],"business_partners":[],"market_info":{"is_listed":false,"market_type":"unlisted","stock_code":""}}`
 	srv := makeChatCompletionsServer(t, emptyJSON)
 	defer srv.Close()
 
 	repo := &mocks.CompanyRepositoryMock{}
 	repo.On("FindByID", uint(1)).Return(&models.Company{ID: 1, Name: "テスト株式会社"}, nil)
+	repo.On("Update", mock.AnythingOfType("*models.Company")).Return(nil).Run(func(args mock.Arguments) {
+		c := args.Get(0).(*models.Company)
+		assert.NotNil(t, c.RelationsFetchedAt)
+	})
 
 	relRepo := &relationRepoMock{}
 	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil).Once()
+	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(&models.CompanyMarketInfo{
+		CompanyID:  1,
+		IsListed:   false,
+		MarketType: "unlisted",
+	}, nil).Maybe()
+	relRepo.On("UpsertMarketInfo", mock.MatchedBy(func(info *models.CompanyMarketInfo) bool {
+		return info != nil && info.CompanyID == 1 && info.MarketType == "unlisted" && !info.IsListed
+	})).Return(nil)
 
 	client := openai.NewWithBaseURL(srv.URL, "gpt-4o-mini")
 	fetcher := services.NewCompanyRelationsFetcher(repo, relRepo, client)
 	result, err := fetcher.FetchAndSave(context.Background(), 1, true)
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.SavedCount)
+	assert.Equal(t, 1, result.SavedCount)
 	assert.Empty(t, result.Relations)
-	repo.AssertNotCalled(t, "Update", mock.Anything)
-	assert.False(t, fetcher.HasStoredData(1))
+	assert.True(t, fetcher.HasStoredData(1))
+	repo.AssertCalled(t, "Update", mock.AnythingOfType("*models.Company"))
 }
 
-func TestCompanyRelationsFetcher_TTLSkipsOnlyWhenMeaningfulData(t *testing.T) {
+func TestCompanyRelationsFetcher_TTLSkipsWhenConfirmedUnlisted(t *testing.T) {
 	now := time.Now()
 	repo := &mocks.CompanyRepositoryMock{}
 	repo.On("FindByID", uint(1)).Return(&models.Company{
@@ -188,23 +200,18 @@ func TestCompanyRelationsFetcher_TTLSkipsOnlyWhenMeaningfulData(t *testing.T) {
 	}, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil).Maybe()
+	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil)
 	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(&models.CompanyMarketInfo{
 		CompanyID:  1,
 		IsListed:   false,
 		MarketType: "unlisted",
-	}, nil).Maybe()
+	}, nil)
 
-	// unlisted のみなら TTL スキップせず Acquire に進むため LLM が必要
-	emptyJSON := `{"subsidiaries":[],"affiliates":[],"business_partners":[],"market_info":{"is_listed":false,"market_type":"unlisted","stock_code":""}}`
-	srv := makeChatCompletionsServer(t, emptyJSON)
-	defer srv.Close()
-	client := openai.NewWithBaseURL(srv.URL, "gpt-4o-mini")
-	fetcher := services.NewCompanyRelationsFetcher(repo, relRepo, client)
-
+	fetcher := services.NewCompanyRelationsFetcher(repo, relRepo, nil)
 	result, err := fetcher.FetchAndSave(context.Background(), 1, false)
 	require.NoError(t, err)
-	assert.False(t, result.FromCache)
+	assert.True(t, result.FromCache)
+	assert.Equal(t, "ttl", result.SkipReason)
 	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -15,8 +15,8 @@ import {
 } from '@mui/material'
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
-import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
 
@@ -89,7 +89,6 @@ export default function AdminCompanyEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [fetchLoading, setFetchLoading] = useState(false)
-  const [primaryLoading, setPrimaryLoading] = useState(false)
   const [name, setName] = useState('')
   const [techStack, setTechStack] = useState<string[]>([])
   const [infraStack, setInfraStack] = useState<string[]>([])
@@ -152,40 +151,6 @@ export default function AdminCompanyEditPage() {
     }
   }
 
-  const handleFetchPrimary = async (force = false) => {
-    setPrimaryLoading(true)
-    setError('')
-    setSuccess('')
-    try {
-      const { ok, status, data } = await fetchCompanyPrimary(
-        id,
-        authService.getAdminFetchHeaders(),
-        force,
-      )
-      if (!ok) {
-        setError(data?.error || `主3種の取得に失敗しました (${status})`)
-        return
-      }
-      if (data.company && typeof data.company === 'object') {
-        const company = data.company as Record<string, unknown>
-        setTechStack(parseJsonArray(String(company.tech_stack || '')))
-        setInfraStack(parseJsonArray(String(company.infra_stack || '')))
-        setCicdTools(parseJsonArray(String(company.cicd_tools || '')))
-        setDevStyle(String(company.development_style || ''))
-        setTechFetchedAt(company.tech_fetched_at ? String(company.tech_fetched_at) : null)
-      } else {
-        loadCompany()
-      }
-      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
-        setError(`一部失敗: ${data.errors.join('; ')}`)
-      }
-      const summary = formatFetchPrimarySummary(data)
-      setSuccess(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
-    } finally {
-      setPrimaryLoading(false)
-    }
-  }
-
   const handleSave = async () => {
     setError('')
     setSuccess('')
@@ -218,18 +183,18 @@ export default function AdminCompanyEditPage() {
 
   return (
     <AdminFormContainer
-      title={`技術スタック編集: ${name}`}
+      title={`${name || '企業'}（技術情報）`}
+      description="使っている技術や開発の様子を確認・編集します。"
       maxWidth={800}
       backLabel="企業一覧に戻る"
       backHref="/admin/companies"
-      onBack={() => router.back()}
     >
+      <CompanyAspectTabs companyId={id} active="tech" />
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
       <Alert severity="info" sx={{ mb: 2 }}>
-        「主3種をまとめて取得」で Backend が基本・技術・ビジネス関係を順に取得して DB 保存します。
-        必要ならこの画面の個別取得で技術だけ再取得できます（TTL 30日）。
-        最終取得: {formatTs(techFetchedAt)}
+        「技術情報を取得」で、採用ページや技術ブログなどから言語・インフラ・開発手法を集めます。最終取得:{' '}
+        {formatTs(techFetchedAt)}
       </Alert>
 
       <Box sx={{ mb: 3, p: 2, bgcolor: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -252,25 +217,8 @@ export default function AdminCompanyEditPage() {
           <Button
             variant="contained"
             color="secondary"
-            onClick={() => handleFetchPrimary(false)}
-            disabled={fetchLoading || primaryLoading}
-            startIcon={primaryLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {primaryLoading ? '取得中...' : '主3種をまとめて取得'}
-          </Button>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={() => handleFetchPrimary(true)}
-            disabled={fetchLoading || primaryLoading}
-          >
-            主3種を強制再取得
-          </Button>
-          <Button
-            variant="contained"
-            color="secondary"
             onClick={() => handleAiFetch(false)}
-            disabled={fetchLoading || primaryLoading}
+            disabled={fetchLoading}
             startIcon={fetchLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {fetchLoading ? '取得中...' : 'AIで技術スタック取得'}
@@ -278,7 +226,7 @@ export default function AdminCompanyEditPage() {
           <Button
             variant="outlined"
             onClick={() => handleAiFetch(true)}
-            disabled={fetchLoading || primaryLoading}
+            disabled={fetchLoading}
           >
             強制再取得
           </Button>

--- a/frontend/app/admin/companies/[id]/edit/page.tsx
+++ b/frontend/app/admin/companies/[id]/edit/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import {
   Alert,
   Box,
@@ -14,20 +15,26 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
-import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import {
+  resolveIndustryFieldProfile,
+  type TechFieldKey,
+} from '@/lib/admin-company-field-profile'
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
+import { AdminPanel } from '@/components/admin/AdminPanel'
+import { PageContainer, ADMIN_PAGE_WIDTH } from '@/components/admin/PageContainer'
 import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
-
-const DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
 
 function ChipEditor({
   label,
   values,
   onChange,
+  placeholder,
 }: {
   label: string
   values: string[]
   onChange: (v: string[]) => void
+  placeholder?: string
 }) {
   const [input, setInput] = useState('')
   const add = () => {
@@ -44,6 +51,11 @@ function ChipEditor({
         {values.map((v) => (
           <Chip key={v} label={v} onDelete={() => onChange(values.filter((x) => x !== v))} size="small" />
         ))}
+        {values.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            まだ登録がありません
+          </Typography>
+        )}
       </Stack>
       <Stack direction="row" spacing={1}>
         <TextField
@@ -51,7 +63,7 @@ function ChipEditor({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && add()}
-          placeholder="入力してEnter"
+          placeholder={placeholder || '入力してEnter'}
           sx={{ flex: 1 }}
         />
         <Button variant="outlined" size="small" onClick={add}>
@@ -78,7 +90,6 @@ function asStringArray(v: unknown): string[] {
 
 export default function AdminCompanyEditPage() {
   const params = useParams()
-  const router = useRouter()
   const id = params.id as string
 
   useEffect(() => {
@@ -89,12 +100,16 @@ export default function AdminCompanyEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [fetchLoading, setFetchLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
   const [name, setName] = useState('')
+  const [industry, setIndustry] = useState('')
   const [techStack, setTechStack] = useState<string[]>([])
   const [infraStack, setInfraStack] = useState<string[]>([])
   const [cicdTools, setCicdTools] = useState<string[]>([])
   const [devStyle, setDevStyle] = useState('')
   const [techFetchedAt, setTechFetchedAt] = useState<string | null>(null)
+
+  const profile = useMemo(() => resolveIndustryFieldProfile(industry), [industry])
 
   const loadCompany = () => {
     fetch(`/api/admin/companies/${id}`, {
@@ -103,6 +118,7 @@ export default function AdminCompanyEditPage() {
       .then((r) => r.json())
       .then((data) => {
         setName(data.name || '')
+        setIndustry(data.industry || '')
         setTechStack(parseJsonArray(data.tech_stack || ''))
         setInfraStack(parseJsonArray(data.infra_stack || ''))
         setCicdTools(parseJsonArray(data.cicd_tools || ''))
@@ -128,7 +144,7 @@ export default function AdminCompanyEditPage() {
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        setError(data?.error || `技術スタック取得に失敗しました (${res.status})`)
+        setError(data?.error || `技術情報の取得に失敗しました (${res.status})`)
         return
       }
       const nextTech = asStringArray(data.tech_stack)
@@ -142,9 +158,11 @@ export default function AdminCompanyEditPage() {
       }
       loadCompany()
       if (nextTech.length === 0 && nextInfra.length === 0 && nextCicd.length === 0) {
-        setSuccess('取得は完了しましたが、公開情報から技術スタックを特定できませんでした。手入力するか強制再取得を試してください。')
+        setSuccess(
+          '取得は完了しましたが、公開情報から内容を特定できませんでした。手入力するか「最新の情報に更新」を試してください。',
+        )
       } else {
-        setSuccess(force ? '技術スタックを強制再取得して保存しました。' : '技術スタックを取得して保存しました。')
+        setSuccess(force ? '情報を更新して保存しました。' : '情報を取得して保存しました。')
       }
     } finally {
       setFetchLoading(false)
@@ -154,25 +172,30 @@ export default function AdminCompanyEditPage() {
   const handleSave = async () => {
     setError('')
     setSuccess('')
-    const res = await fetch(`/api/admin/companies/${id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        ...authService.getAdminFetchHeaders(),
-      },
-      body: JSON.stringify({
-        tech_stack: JSON.stringify(techStack),
-        infra_stack: JSON.stringify(infraStack),
-        cicd_tools: JSON.stringify(cicdTools),
-        development_style: devStyle,
-      }),
-    })
-    if (!res.ok) {
-      const d = await res.json().catch(() => ({}))
-      setError(d?.error || '保存に失敗しました')
-      return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/admin/companies/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authService.getAdminFetchHeaders(),
+        },
+        body: JSON.stringify({
+          tech_stack: JSON.stringify(techStack),
+          infra_stack: JSON.stringify(infraStack),
+          cicd_tools: JSON.stringify(cicdTools),
+          development_style: devStyle,
+        }),
+      })
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        setError(d?.error || '保存に失敗しました')
+        return
+      }
+      setSuccess('保存しました')
+    } finally {
+      setSaving(false)
     }
-    setSuccess('保存しました')
   }
 
   const formatTs = (v: string | null) => {
@@ -181,89 +204,178 @@ export default function AdminCompanyEditPage() {
     return Number.isNaN(d.getTime()) ? v : d.toLocaleString('ja-JP')
   }
 
+  const busy = fetchLoading || saving
+  const chipValues: Record<Exclude<TechFieldKey, 'development_style'>, string[]> = {
+    tech_stack: techStack,
+    infra_stack: infraStack,
+    cicd_tools: cicdTools,
+  }
+  const chipSetters: Record<Exclude<TechFieldKey, 'development_style'>, (v: string[]) => void> = {
+    tech_stack: setTechStack,
+    infra_stack: setInfraStack,
+    cicd_tools: setCicdTools,
+  }
+
   return (
-    <AdminFormContainer
-      title={`${name || '企業'}（技術情報）`}
-      description="使っている技術や開発の様子を確認・編集します。"
-      maxWidth={800}
-      backLabel="企業一覧に戻る"
-      backHref="/admin/companies"
-    >
-      <CompanyAspectTabs companyId={id} active="tech" />
+    <PageContainer maxWidth={ADMIN_PAGE_WIDTH.full}>
+      <AdminPageHeader
+        title={`${name || '企業'}（${profile.techAspectLabel}）`}
+        description={
+          profile.techAspectEnabled
+            ? `${profile.label}向けの項目を表示しています。業種を変えると入力できる内容も変わります。`
+            : 'この業界ではこの画面の登録は不要です。'
+        }
+        backHref="/admin/companies"
+        backAriaLabel="企業一覧に戻る"
+        actions={
+          profile.techAspectEnabled ? (
+            <Button variant="contained" onClick={handleSave} disabled={busy} disableElevation>
+              {saving ? '保存中…' : '保存'}
+            </Button>
+          ) : null
+        }
+      />
+
+      <CompanyAspectTabs companyId={id} active="tech" industry={industry} />
       <ErrorAlert error={error} />
-      {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
-      <Alert severity="info" sx={{ mb: 2 }}>
-        「技術情報を取得」で、採用ページや技術ブログなどから言語・インフラ・開発手法を集めます。最終取得:{' '}
-        {formatTs(techFetchedAt)}
-      </Alert>
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+          {success}
+        </Alert>
+      )}
 
-      <Box sx={{ mb: 3, p: 2, bgcolor: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Box>
-          <Typography sx={{ fontWeight: 700, fontSize: 14, color: '#0c4a6e' }}>面接カスタム質問</Typography>
-          <Typography sx={{ fontSize: 13, color: '#075985' }}>AI面接で使用する企業別の質問リストを管理できます</Typography>
-        </Box>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => router.push(`/admin/companies/${id}/interview-questions`)}
-          sx={{ borderColor: '#0284c7', color: '#0284c7', whiteSpace: 'nowrap' }}
-        >
-          質問を管理 →
-        </Button>
-      </Box>
-
-      <Stack spacing={3}>
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-          <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => handleAiFetch(false)}
-            disabled={fetchLoading}
-            startIcon={fetchLoading ? <CircularProgress size={16} color="inherit" /> : null}
+      {!profile.techAspectEnabled ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {profile.techDisabledMessage || 'この業界では技術情報の登録は不要です。'}
+          <Box sx={{ mt: 1.5 }}>
+            <Button component={Link} href={`/admin/companies/${id}/info`} variant="outlined" size="small">
+              会社概要へ
+            </Button>
+          </Box>
+        </Alert>
+      ) : (
+        <>
+          <Box
+            sx={{
+              mb: 2,
+              p: 2,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: '10px',
+              bgcolor: 'background.paper',
+            }}
           >
-            {fetchLoading ? '取得中...' : 'AIで技術スタック取得'}
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={() => handleAiFetch(true)}
-            disabled={fetchLoading}
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              alignItems={{ md: 'center' }}
+              justifyContent="space-between"
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography fontWeight={700} sx={{ mb: 0.25 }}>
+                  情報の取得・保存
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  業種: {industry || '未設定'}（{profile.label}）／ 最終取得: {formatTs(techFetchedAt)}
+                </Typography>
+              </Box>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  onClick={() => handleAiFetch(false)}
+                  disabled={busy}
+                  startIcon={fetchLoading ? <CircularProgress size={16} color="inherit" /> : null}
+                >
+                  {fetchLoading ? '取得中…' : `${profile.techAspectLabel}を取得`}
+                </Button>
+                <Button variant="outlined" onClick={() => handleAiFetch(true)} disabled={busy}>
+                  最新の情報に更新
+                </Button>
+                <Button variant="contained" onClick={handleSave} disabled={busy} disableElevation>
+                  {saving ? '保存中…' : '保存'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.7fr) minmax(280px, 0.9fr)' },
+              gap: 2.5,
+              alignItems: 'start',
+            }}
           >
-            強制再取得
-          </Button>
-        </Stack>
+            <AdminPanel title={profile.techAspectLabel}>
+              <Box sx={{ px: 2.5, py: 2 }}>
+                <Stack spacing={3}>
+                  {profile.techFields.map((field) => {
+                    if (field.key === 'development_style') {
+                      return (
+                        <TextField
+                          key={field.key}
+                          select
+                          label={field.label}
+                          value={devStyle}
+                          onChange={(e) => setDevStyle(e.target.value)}
+                          size="small"
+                          fullWidth
+                        >
+                          <MenuItem value="">未設定</MenuItem>
+                          {(field.options || []).map((s) => (
+                            <MenuItem key={s} value={s}>
+                              {s}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      )
+                    }
+                    return (
+                      <ChipEditor
+                        key={field.key}
+                        label={field.label}
+                        values={chipValues[field.key]}
+                        onChange={chipSetters[field.key]}
+                        placeholder={field.placeholder}
+                      />
+                    )
+                  })}
+                </Stack>
+              </Box>
+            </AdminPanel>
 
-        <ChipEditor
-          label="言語・フレームワーク（例: Go, React, TypeScript）"
-          values={techStack}
-          onChange={setTechStack}
-        />
-        <ChipEditor
-          label="インフラ（例: AWS, GCP, Azure, オンプレ）"
-          values={infraStack}
-          onChange={setInfraStack}
-        />
-        <ChipEditor
-          label="CI/CDツール（例: GitHub Actions, Jenkins, CircleCI）"
-          values={cicdTools}
-          onChange={setCicdTools}
-        />
-        <TextField
-          select
-          label="開発手法"
-          value={devStyle}
-          onChange={(e) => setDevStyle(e.target.value)}
-          size="small"
-        >
-          <MenuItem value="">未設定</MenuItem>
-          {DEV_STYLES.map((s) => (
-            <MenuItem key={s} value={s}>{s}</MenuItem>
-          ))}
-        </TextField>
+            <Stack spacing={2.5}>
+              <AdminPanel title="業種について">
+                <Box sx={{ px: 2.5, py: 2 }}>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                    表示項目は会社概要の「業種」に合わせて変わります。業種を変更する場合は会社概要で編集してください。
+                  </Typography>
+                  <Button component={Link} href={`/admin/companies/${id}/info`} variant="outlined" size="small">
+                    会社概要で業種を変更
+                  </Button>
+                </Box>
+              </AdminPanel>
 
-        <Button variant="contained" onClick={handleSave} sx={{ alignSelf: 'flex-end' }}>
-          保存
-        </Button>
-      </Stack>
-    </AdminFormContainer>
+              <AdminPanel title="面接カスタム質問">
+                <Box sx={{ px: 2.5, py: 2 }}>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                    AI面接で使う、この企業向けの質問リストを管理できます。
+                  </Typography>
+                  <Button
+                    component={Link}
+                    href={`/admin/companies/${id}/interview-questions`}
+                    variant="outlined"
+                    size="small"
+                  >
+                    質問を管理
+                  </Button>
+                </Box>
+              </AdminPanel>
+            </Stack>
+          </Box>
+        </>
+      )}
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/companies/[id]/info/page.tsx
+++ b/frontend/app/admin/companies/[id]/info/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import {
   Alert,
@@ -13,6 +13,7 @@ import {
   Typography,
 } from '@mui/material'
 import { authService } from '@/lib/auth'
+import { infoFieldEnabled, resolveIndustryFieldProfile } from '@/lib/admin-company-field-profile'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
@@ -125,14 +126,19 @@ export default function AdminCompanyInfoEditPage() {
         },
         body: JSON.stringify({ name, website_url: websiteUrl }),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError(data?.error || '企業情報取得に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '企業情報の取得に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyInfoPayload(data)
       setPreviewPending(true)
       setSuccess('プレビュー取得が完了しました。内容を確認・修正してから「確定して保存」してください。')
+    } catch {
+      setError('企業情報の取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setAiLoading(false)
     }
@@ -147,9 +153,12 @@ export default function AdminCompanyInfoEditPage() {
         method: 'POST',
         headers: authService.getAdminFetchHeaders(),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError(data?.error || '強制再取得に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '強制再取得に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyInfoPayload(data)
@@ -161,6 +170,8 @@ export default function AdminCompanyInfoEditPage() {
       } else {
         setSuccess('DBへ強制再取得・保存しました。')
       }
+    } catch {
+      setError('強制再取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setForceLoading(false)
     }
@@ -195,14 +206,19 @@ export default function AdminCompanyInfoEditPage() {
           confidence: lastFetchConfidence,
         }),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError(data?.error || '確定保存に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '確定保存に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyInfoPayload(data)
       loadCompany()
-      setSuccess('プレビュー内容を確定して保存しました（取得メタデータも更新済み）。')
+      setSuccess('プレビュー内容を確定して保存しました。')
+    } catch {
+      setError('確定保存中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setConfirmLoading(false)
     }
@@ -257,15 +273,18 @@ export default function AdminCompanyInfoEditPage() {
     return Number.isNaN(d.getTime()) ? v : d.toLocaleString('ja-JP')
   }
 
+  const profile = useMemo(() => resolveIndustryFieldProfile(industry), [industry])
+  const show = (key: Parameters<typeof infoFieldEnabled>[1]) => infoFieldEnabled(profile, key)
+
   return (
     <AdminFormContainer
       title={`${name || '企業'}（会社概要）`}
-      description="会社の基本情報を確認・編集します。"
-      maxWidth={700}
+      description={`会社の基本情報を確認・編集します。業種「${profile.label}」に合わせて、関連する入力画面が変わります。`}
+      maxWidth={900}
       backLabel="企業一覧に戻る"
       backHref="/admin/companies"
     >
-      <CompanyAspectTabs companyId={id} active="info" />
+      <CompanyAspectTabs companyId={id} active="info" industry={industry} />
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
       {isLowTrust && (
@@ -281,6 +300,11 @@ export default function AdminCompanyInfoEditPage() {
       {dataStatus === 'published' && (
         <Alert severity="success" sx={{ mb: 2 }}>
           この企業は公開中です。公開したまま情報を更新できます。
+        </Alert>
+      )}
+      {!profile.techAspectEnabled && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          この業種では「技術情報」の登録は不要です。会社概要と関連企業を確認すれば公開準備ができます。
         </Alert>
       )}
 
@@ -318,78 +342,108 @@ export default function AdminCompanyInfoEditPage() {
         </Stack>
 
         <Typography variant="body2" color="text.secondary">
-          最終取得: 会社概要 {formatTs(infoFetchedAt)} ／ 技術 {formatTs(techFetchedAt)} ／ 取引先{' '}
-          {formatTs(relationsFetchedAt)}
+          最終取得: 会社概要 {formatTs(infoFetchedAt)}
+          {profile.techAspectEnabled ? ` ／ ${profile.techAspectLabel} ${formatTs(techFetchedAt)}` : ''}
+          {' ／ '}関連企業 {formatTs(relationsFetchedAt)}
         </Typography>
 
         <Divider />
 
-        <TextField
-          label="企業概要"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          multiline
-          minRows={2}
-        />
-        <TextField label="業種" value={industry} onChange={(e) => setIndustry(e.target.value)} />
-        <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
-        <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
-        <Stack direction="row" spacing={2}>
+        {show('description') && (
           <TextField
-            label="設立年"
-            value={foundedYear}
-            onChange={(e) => setFoundedYear(e.target.value)}
-            type="number"
-            sx={{ flex: 1 }}
+            label="企業概要"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            multiline
+            minRows={2}
           />
+        )}
+        {show('industry') && (
           <TextField
-            label="従業員数"
-            value={employeeCount}
-            onChange={(e) => setEmployeeCount(e.target.value)}
-            type="number"
-            sx={{ flex: 1 }}
+            label="業種"
+            value={industry}
+            onChange={(e) => setIndustry(e.target.value)}
+            helperText={`判定中のプロファイル: ${profile.label}${profile.techAspectEnabled ? `（「${profile.techAspectLabel}」タブあり）` : '（技術タブなし）'}`}
           />
-        </Stack>
-        <TextField
-          label="主要事業内容"
-          value={mainBusiness}
-          onChange={(e) => setMainBusiness(e.target.value)}
-          multiline
-          minRows={2}
-        />
-        <TextField
-          label="企業文化"
-          value={culture}
-          onChange={(e) => setCulture(e.target.value)}
-          multiline
-          minRows={2}
-        />
-        <TextField
-          select
-          label="勤務スタイル"
-          value={workStyle}
-          onChange={(e) => setWorkStyle(e.target.value)}
-        >
-          <MenuItem value="">未設定</MenuItem>
-          <MenuItem value="リモート">リモート</MenuItem>
-          <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
-          <MenuItem value="オフィス">オフィス</MenuItem>
-        </TextField>
-        <TextField
-          label="技術スタック"
-          value={techStack}
-          onChange={(e) => setTechStack(e.target.value)}
-          placeholder="例: Go, TypeScript, React"
-          multiline
-          minRows={1}
-        />
-        <TextField
-          label="福利厚生"
-          value={welfareDetails}
-          onChange={(e) => setWelfareDetails(e.target.value)}
-          multiline
-          minRows={2}
-        />
+        )}
+        {show('location') && (
+          <TextField label="所在地" value={location} onChange={(e) => setLocation(e.target.value)} />
+        )}
+        {show('website_url') && (
+          <TextField label="公式サイトURL" value={websiteUrl} onChange={(e) => setWebsiteUrl(e.target.value)} />
+        )}
+        {(show('founded_year') || show('employee_count')) && (
+          <Stack direction="row" spacing={2}>
+            {show('founded_year') && (
+              <TextField
+                label="設立年"
+                value={foundedYear}
+                onChange={(e) => setFoundedYear(e.target.value)}
+                type="number"
+                sx={{ flex: 1 }}
+              />
+            )}
+            {show('employee_count') && (
+              <TextField
+                label="従業員数"
+                value={employeeCount}
+                onChange={(e) => setEmployeeCount(e.target.value)}
+                type="number"
+                sx={{ flex: 1 }}
+              />
+            )}
+          </Stack>
+        )}
+        {show('main_business') && (
+          <TextField
+            label="主要事業内容"
+            value={mainBusiness}
+            onChange={(e) => setMainBusiness(e.target.value)}
+            multiline
+            minRows={2}
+          />
+        )}
+        {show('culture') && (
+          <TextField
+            label="企業文化"
+            value={culture}
+            onChange={(e) => setCulture(e.target.value)}
+            multiline
+            minRows={2}
+          />
+        )}
+        {show('work_style') && (
+          <TextField
+            select
+            label="勤務スタイル"
+            value={workStyle}
+            onChange={(e) => setWorkStyle(e.target.value)}
+          >
+            <MenuItem value="">未設定</MenuItem>
+            <MenuItem value="リモート">リモート</MenuItem>
+            <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
+            <MenuItem value="オフィス">オフィス</MenuItem>
+          </TextField>
+        )}
+        {show('tech_stack') && (
+          <TextField
+            label="技術スタック"
+            value={techStack}
+            onChange={(e) => setTechStack(e.target.value)}
+            placeholder="例: Go, TypeScript, React"
+            multiline
+            minRows={1}
+          />
+        )}
+        {show('welfare_details') && (
+          <TextField
+            label="福利厚生"
+            value={welfareDetails}
+            onChange={(e) => setWelfareDetails(e.target.value)}
+            multiline
+            minRows={2}
+          />
+        )}
 
         <Divider />
 

--- a/frontend/app/admin/companies/[id]/info/page.tsx
+++ b/frontend/app/admin/companies/[id]/info/page.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import {
   Alert,
   Button,
-  Chip,
   CircularProgress,
   Divider,
   MenuItem,
@@ -16,8 +14,8 @@ import {
 } from '@mui/material'
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
-import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 export default function AdminCompanyInfoEditPage() {
   const params = useParams()
@@ -31,8 +29,8 @@ export default function AdminCompanyInfoEditPage() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
+  const [forceLoading, setForceLoading] = useState(false)
   const [confirmLoading, setConfirmLoading] = useState(false)
-  const [fetchAllLoading, setFetchAllLoading] = useState(false)
   const [previewPending, setPreviewPending] = useState(false)
 
   const [name, setName] = useState('')
@@ -140,42 +138,31 @@ export default function AdminCompanyInfoEditPage() {
     }
   }
 
-  const handleFetchPrimary = async (force = false) => {
-    setFetchAllLoading(true)
+  const handleForceFetchAndSave = async () => {
+    setForceLoading(true)
     setError('')
     setSuccess('')
     try {
-      const { ok, status, data } = await fetchCompanyPrimary(
-        id,
-        authService.getAdminFetchHeaders(),
-        force,
-      )
-      if (!ok) {
-        setError(data?.error || `主3種の取得に失敗しました (${status})`)
+      const res = await fetch(`/api/admin/companies/${id}/fetch-info?force=true`, {
+        method: 'POST',
+        headers: authService.getAdminFetchHeaders(),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || '強制再取得に失敗しました')
         return
       }
-      if (data.info) applyInfoPayload(data.info)
-      if (data.tech && Array.isArray(data.tech.tech_stack) && data.tech.tech_stack.length > 0) {
-        setTechStack(JSON.stringify(data.tech.tech_stack))
-      }
-      if (data.company) {
-        const company = data.company
-        if (typeof company.description === 'string') setDescription(company.description)
-        if (typeof company.website_url === 'string') setWebsiteUrl(company.website_url)
-        if (typeof company.tech_stack === 'string') setTechStack(company.tech_stack)
-        if (company.info_fetched_at) setInfoFetchedAt(String(company.info_fetched_at))
-        if (company.tech_fetched_at) setTechFetchedAt(String(company.tech_fetched_at))
-        if (company.relations_fetched_at) setRelationsFetchedAt(String(company.relations_fetched_at))
-      }
+      applyInfoPayload(data)
       loadCompany()
-      const summary = formatFetchPrimarySummary(data)
-      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
-        setError(`一部失敗: ${data.errors.join('; ')}`)
+      if (data.budget_exceeded) {
+        setSuccess('月次 Search 予算超過のため、既存キャッシュのみ返却しました（新規 Search なし）。コスト画面を確認してください。')
+      } else if (data.from_cache && data.skip_reason === 'ttl') {
+        setSuccess('TTL 内のためキャッシュを返却しました。再取得する場合は「強制再取得して保存」を使ってください。')
+      } else {
+        setSuccess('DBへ強制再取得・保存しました。')
       }
-      setSuccess(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
-      setPreviewPending(false)
     } finally {
-      setFetchAllLoading(false)
+      setForceLoading(false)
     }
   }
 
@@ -272,26 +259,28 @@ export default function AdminCompanyInfoEditPage() {
 
   return (
     <AdminFormContainer
-      title={`基本情報編集: ${name}`}
+      title={`${name || '企業'}（会社概要）`}
+      description="会社の基本情報を確認・編集します。"
       maxWidth={700}
       backLabel="企業一覧に戻る"
       backHref="/admin/companies"
     >
+      <CompanyAspectTabs companyId={id} active="info" />
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
       {isLowTrust && (
         <Alert severity="warning" sx={{ mb: 2 }}>
-          出典がモデル知識由来、または信頼度が low です。公式サイトURLを設定して強制再取得してください。
+          出典の信頼度が低めです。公式サイトURLを設定してから、もう一度取得してください。
         </Alert>
       )}
       {previewPending && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          プレビュー未確定です。「確定して保存」で DB と取得メタデータ（info_fetched_at 等）を更新します。
+          まだ下書きの取得結果です。内容を確認してから「確定して保存」を押してください。
         </Alert>
       )}
       {dataStatus === 'published' && (
         <Alert severity="success" sx={{ mb: 2 }}>
-          この企業は公開中です。公開状態のままプレビュー取得・強制再取得で企業情報や公式URLを更新できます。
+          この企業は公開中です。公開したまま情報を更新できます。
         </Alert>
       )}
 
@@ -300,30 +289,13 @@ export default function AdminCompanyInfoEditPage() {
 
         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
           <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => handleFetchPrimary(false)}
-            disabled={fetchAllLoading || aiLoading}
-            startIcon={fetchAllLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {fetchAllLoading ? '取得中...' : '主3種をまとめて取得'}
-          </Button>
-          <Button
             variant="outlined"
             color="secondary"
-            onClick={() => handleFetchPrimary(true)}
-            disabled={fetchAllLoading || aiLoading}
-          >
-            主3種を強制再取得
-          </Button>
-          <Button
-            variant="outlined"
-            size="small"
             onClick={handleAiFetch}
-            disabled={!name.trim() || aiLoading || fetchAllLoading}
+            disabled={!name.trim() || aiLoading || forceLoading}
             startIcon={aiLoading ? <CircularProgress size={14} color="inherit" /> : null}
           >
-            {aiLoading ? '取得中...' : '基本のみプレビュー'}
+            {aiLoading ? '取得中...' : 'プレビュー取得（未保存）'}
           </Button>
           <Button
             variant="contained"
@@ -333,31 +305,21 @@ export default function AdminCompanyInfoEditPage() {
             disabled={!previewPending || confirmLoading || !name.trim()}
             startIcon={confirmLoading ? <CircularProgress size={14} color="inherit" /> : null}
           >
-            {confirmLoading ? '確定中...' : 'プレビュー確定'}
+            {confirmLoading ? '確定中...' : '確定して保存'}
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={handleForceFetchAndSave}
+            disabled={forceLoading || aiLoading}
+            startIcon={forceLoading ? <CircularProgress size={14} color="inherit" /> : null}
+          >
+            {forceLoading ? '再取得中...' : '強制再取得して保存'}
           </Button>
         </Stack>
 
-        {fetchAllLoading && (
-          <Alert severity="info">主3種（基本・技術・ビジネス関係）を1つのAPIで取得中...</Alert>
-        )}
-
-        <Typography variant="caption" color="text.secondary">
-          「主3種をまとめて取得」で基本・技術・ビジネス関係を1回のAPIで取得します。詳細編集は
-          <Link href={`/admin/companies/${id}/edit`}> 技術編集 </Link>/
-          <Link href={`/admin/companies/${id}/relations`}> 関係編集 </Link>
-          へ。
-        </Typography>
-
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-          <Chip size="small" label={`source: ${sourceType || '-'}`} />
-          <Chip size="small" label={`confidence: ${lastFetchConfidence || '-'}`} color={isLowTrust ? 'warning' : 'default'} />
-          <Chip size="small" label={`model: ${lastModelUsed || '-'}`} />
-        </Stack>
         <Typography variant="body2" color="text.secondary">
-          基本情報: {formatTs(infoFetchedAt)} / 技術: {formatTs(techFetchedAt)} / ビジネス関係: {formatTs(relationsFetchedAt)} / 求人: {formatTs(jobsFetchedAt)}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          TTL: 基本情報 90日 / 技術 30日 / ビジネス関係 60日 / 求人 7日。詳細な関係・市場は「ビジネス関係」画面、技術配列は「技術情報」画面で確認できます。
+          最終取得: 会社概要 {formatTs(infoFetchedAt)} ／ 技術 {formatTs(techFetchedAt)} ／ 取引先{' '}
+          {formatTs(relationsFetchedAt)}
         </Typography>
 
         <Divider />

--- a/frontend/app/admin/companies/[id]/relations/page.tsx
+++ b/frontend/app/admin/companies/[id]/relations/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Box,
   Button,
@@ -14,9 +17,12 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { authService } from '@/lib/auth'
-import { formatRelationLabel } from '@/lib/relation-labels'
-import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { sanitizeRelationDescription, isClearOrganizationName } from '@/lib/relation-labels'
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
+import { AdminPanel } from '@/components/admin/AdminPanel'
+import { PageContainer, ADMIN_PAGE_WIDTH } from '@/components/admin/PageContainer'
 import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
 import CompanyRelationGraph from '@/components/admin/CompanyRelationGraph'
@@ -60,6 +66,7 @@ export default function AdminCompanyRelationsPage() {
   const [previewPending, setPreviewPending] = useState(false)
 
   const [name, setName] = useState('')
+  const [industry, setIndustry] = useState('')
   const [websiteUrl, setWebsiteUrl] = useState('')
   const [relations, setRelations] = useState<RelationEntry[]>([])
   const [marketInfo, setMarketInfo] = useState<MarketInfo>({
@@ -71,6 +78,7 @@ export default function AdminCompanyRelationsPage() {
   const [lastModelUsed, setLastModelUsed] = useState('')
   const [lastFetchConfidence, setLastFetchConfidence] = useState('')
   const [relationsFetchedAt, setRelationsFetchedAt] = useState<string | null>(null)
+  const [graphRefreshKey, setGraphRefreshKey] = useState(0)
 
   const loadCompany = () => {
     fetch(`/api/admin/companies/${id}`, {
@@ -79,6 +87,7 @@ export default function AdminCompanyRelationsPage() {
       .then((r) => r.json())
       .then((data) => {
         setName(data.name || '')
+        setIndustry(data.industry || '')
         setWebsiteUrl(data.website_url || '')
         setRelationsFetchedAt(data.relations_fetched_at || null)
         setPreviewPending(false)
@@ -86,22 +95,21 @@ export default function AdminCompanyRelationsPage() {
       .catch(() => setError('企業情報の取得に失敗しました'))
   }
 
-  useEffect(() => {
-    loadCompany()
-  }, [id])
-
   const applyRelationsPayload = (data: Record<string, unknown>) => {
     if (Array.isArray(data.relations)) {
       setRelations(
-        data.relations.map((r) => {
-          const item = r as RelationEntry
-          return {
-            name: item.name || '',
-            relation_type: item.relation_type || 'business_partner',
-            ratio: item.ratio,
-            description: formatRelationLabel(item.description || '', item.relation_type || 'business_partner'),
-          }
-        }),
+        data.relations
+          .map((r) => {
+            const item = r as RelationEntry
+            return {
+              name: item.name || '',
+              relation_type: item.relation_type || 'business_partner',
+              ratio: item.ratio,
+              // 種別ラベル（主要取引先など）は説明欄に入れない。取引内容だけ残す。
+              description: sanitizeRelationDescription(item.description || ''),
+            }
+          })
+          .filter((r) => isClearOrganizationName(r.name)),
       )
     }
     if (data.market_info && typeof data.market_info === 'object') {
@@ -116,6 +124,25 @@ export default function AdminCompanyRelationsPage() {
     if (typeof data.model_used === 'string' && data.model_used) setLastModelUsed(data.model_used)
     if (typeof data.confidence === 'string' && data.confidence) setLastFetchConfidence(data.confidence)
   }
+
+  const loadSavedRelations = () => {
+    fetch(`/api/admin/companies/${id}/fetch-relations`, {
+      method: 'POST',
+      headers: authService.getAdminFetchHeaders(),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: Record<string, unknown> | null) => {
+        if (data) applyRelationsPayload(data)
+      })
+      .catch(() => {
+        // 保存済みが無い場合は空のまま
+      })
+  }
+
+  useEffect(() => {
+    loadCompany()
+    loadSavedRelations()
+  }, [id])
 
   const handleAiFetch = async () => {
     if (!name.trim()) return
@@ -168,12 +195,13 @@ export default function AdminCompanyRelationsPage() {
       }
       applyRelationsPayload(data)
       loadCompany()
+      setGraphRefreshKey((k) => k + 1)
       if (data.budget_exceeded) {
-        setSuccess('月次 Search 予算超過のため、既存キャッシュのみ返却しました（新規 Search なし）。コスト画面を確認してください。')
+        setSuccess('月次の情報取得上限に達しているため、保存済みの情報のみ表示しています。コスト画面を確認するか、時間をおいて再度お試しください。')
       } else if (data.from_cache && data.skip_reason === 'ttl') {
-        setSuccess('TTL 内のためキャッシュを返却しました。再取得する場合は「強制再取得して保存」を使ってください。')
+        setSuccess('最近取得した情報があるため、保存済みの内容を表示しています。最新にしたい場合は「最新の情報に更新」を使ってください。')
       } else {
-        setSuccess(`DBへ強制再取得・保存しました（${data.saved_count ?? 0}件）。`)
+        setSuccess(`関連企業情報を更新して保存しました（${data.saved_count ?? 0}件）。`)
       }
     } catch {
       setError('強制再取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
@@ -194,7 +222,12 @@ export default function AdminCompanyRelationsPage() {
           ...authService.getAdminFetchHeaders(),
         },
         body: JSON.stringify({
-          relations,
+          relations: relations
+            .filter((r) => isClearOrganizationName(r.name || ''))
+            .map((r) => ({
+              ...r,
+              description: sanitizeRelationDescription(r.description || ''),
+            })),
           market_info: marketInfo,
           source: sourceType,
           model_used: lastModelUsed,
@@ -211,7 +244,9 @@ export default function AdminCompanyRelationsPage() {
       }
       applyRelationsPayload(data)
       loadCompany()
-      setSuccess(`プレビュー内容を確定して保存しました（${data.saved_count ?? 0}件）。`)
+      setGraphRefreshKey((k) => k + 1)
+      setSuccess(`内容を確定して保存しました（${data.saved_count ?? 0}件）。`)
+      setPreviewPending(false)
     } catch {
       setError('確定保存中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
@@ -239,178 +274,298 @@ export default function AdminCompanyRelationsPage() {
 
   const groupedRelations = useMemo(() => groupRelationsByCategory(relations), [relations])
   const numericId = Number(id)
+  const busy = aiLoading || forceLoading || confirmLoading
 
   return (
-    <AdminFormContainer
-      title={`${name || '企業'}（関連企業）`}
-      description="関連企業や市場の情報を確認・編集します。"
-      maxWidth={800}
-      backLabel="企業一覧に戻る"
-      backHref="/admin/companies"
-    >
-      <CompanyAspectTabs companyId={id} active="relations" />
+    <PageContainer maxWidth={ADMIN_PAGE_WIDTH.full}>
+      <AdminPageHeader
+        title={`${name || '企業'}（関連企業）`}
+        description="関連企業のつながりを図で確認し、必要なら一覧で修正して保存します。"
+        backHref="/admin/companies"
+        backAriaLabel="企業一覧に戻る"
+      />
+
+      <CompanyAspectTabs companyId={id} active="relations" industry={industry} />
       <ErrorAlert error={error} />
-      {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+          {success}
+        </Alert>
+      )}
       {previewPending && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          まだ下書きの取得結果です。内容を確認してから「確定して保存」を押してください。
+          まだ下書きの取得結果です。内容を確認してから「確定して保存」を押してください。下書きの間は上の相関図は更新されません。
         </Alert>
       )}
 
-      <Stack spacing={2}>
-        <Typography variant="body2" color="text.secondary">
-          最終取得: {formatTs(relationsFetchedAt)}
-        </Typography>
-
-        <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={handleAiFetch}
-            disabled={!name.trim() || aiLoading || forceLoading}
-            startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {aiLoading ? '取得中...' : 'プレビュー取得（未保存）'}
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleConfirmSave}
-            disabled={!previewPending || confirmLoading}
-            startIcon={confirmLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {confirmLoading ? '確定中...' : '確定して保存'}
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={handleForceFetchAndSave}
-            disabled={forceLoading || aiLoading}
-            startIcon={forceLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {forceLoading ? '再取得中...' : '強制再取得して保存'}
-          </Button>
-        </Stack>
-
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-          <Chip size="small" label={`source: ${sourceType || '-'}`} />
-          <Chip size="small" label={`confidence: ${lastFetchConfidence || '-'}`} />
-          <Chip size="small" label={`model: ${lastModelUsed || '-'}`} />
-        </Stack>
-        <Typography variant="body2" color="text.secondary">
-          relations: {formatTs(relationsFetchedAt)}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          TTL: 関係・市場情報 60日。同一企業の同時取得は singleflight で1本化。月次 Search 上限はコスト画面で確認できます。
-        </Typography>
-
-        <Divider />
-
-        <Typography variant="subtitle1" fontWeight="bold">市場情報（任意）</Typography>
-        <Stack direction="row" spacing={2}>
-          <TextField
-            select
-            label="上場区分"
-            value={marketInfo.market_type}
-            onChange={(e) => setMarketInfo({ ...marketInfo, market_type: e.target.value })}
-            sx={{ flex: 1 }}
-          >
-            <MenuItem value="unlisted">非上場</MenuItem>
-            <MenuItem value="prime">プライム</MenuItem>
-            <MenuItem value="standard">スタンダード</MenuItem>
-            <MenuItem value="growth">グロース</MenuItem>
-          </TextField>
-          <TextField
-            label="証券コード"
-            value={marketInfo.stock_code || ''}
-            onChange={(e) => setMarketInfo({ ...marketInfo, stock_code: e.target.value })}
-            sx={{ flex: 1 }}
-          />
-          <TextField
-            select
-            label="上場"
-            value={marketInfo.is_listed ? 'yes' : 'no'}
-            onChange={(e) => setMarketInfo({ ...marketInfo, is_listed: e.target.value === 'yes' })}
-            sx={{ flex: 1 }}
-          >
-            <MenuItem value="no">非上場</MenuItem>
-            <MenuItem value="yes">上場</MenuItem>
-          </TextField>
-        </Stack>
-
-        <Divider />
-
-        <Typography variant="subtitle1" fontWeight="bold">相関図（保存済みデータ）</Typography>
-        {Number.isFinite(numericId) && numericId > 0 && <CompanyRelationGraph companyId={numericId} />}
-
-        <Divider />
-
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography variant="subtitle1" fontWeight="bold">企業関係</Typography>
-          <Button size="small" variant="outlined" onClick={addRelation}>行を追加</Button>
-        </Stack>
-
-        {relations.length === 0 && (
-          <Typography variant="body2" color="text.secondary">関係データがありません。プレビュー取得または行追加してください。</Typography>
-        )}
-
-        {groupedRelations.map((categoryGroup) => (
-          <Box key={categoryGroup.category} sx={{ mb: 1 }}>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-              {RELATION_CATEGORY_LABELS[categoryGroup.category]}
+      <Box
+        sx={{
+          mb: 2,
+          p: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: '10px',
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={2}
+          alignItems={{ md: 'center' }}
+          justifyContent="space-between"
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography fontWeight={700} sx={{ mb: 0.25 }}>
+              情報の取得・保存
             </Typography>
-            <Stack spacing={1.5}>
-              {categoryGroup.companies.map((companyGroup) => (
-                <Box
-                  key={companyGroup.name}
-                  sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}
-                >
-                  <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
-                    <Typography variant="body1" fontWeight="bold">{companyGroup.name}</Typography>
-                    <Chip size="small" label={`${companyGroup.entries.length}件`} />
-                  </Stack>
-                  <Stack spacing={1.5} divider={<Divider flexItem />}>
-                    {companyGroup.entries.map(({ index, relation: rel }) => (
-                      <Stack key={index} spacing={1.5}>
-                        <Stack direction="row" spacing={1}>
-                          <TextField
-                            label="関連企業名"
-                            value={rel.name}
-                            onChange={(e) => updateRelation(index, { name: e.target.value })}
-                            sx={{ flex: 2 }}
-                          />
-                          <TextField
-                            select
-                            label="関係タイプ"
-                            value={rel.relation_type}
-                            onChange={(e) => updateRelation(index, { relation_type: e.target.value })}
-                            sx={{ flex: 1 }}
-                          >
-                            <MenuItem value="capital_subsidiary">子会社</MenuItem>
-                            <MenuItem value="capital_affiliate">関連会社</MenuItem>
-                            <MenuItem value="business_partner">取引先</MenuItem>
-                            <MenuItem value="business_procurement">調達（gBiz）</MenuItem>
-                            <MenuItem value="business_subsidy">補助金（gBiz）</MenuItem>
-                          </TextField>
-                        </Stack>
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <TextField
-                            label="説明"
-                            value={rel.description || ''}
-                            onChange={(e) => updateRelation(index, { description: e.target.value })}
-                            sx={{ flex: 1 }}
-                          />
-                          <Chip size="small" label={RELATION_LABELS[rel.relation_type] || rel.relation_type} />
-                          <Button size="small" color="error" onClick={() => removeRelation(index)}>削除</Button>
-                        </Stack>
-                      </Stack>
-                    ))}
-                  </Stack>
-                </Box>
-              ))}
-            </Stack>
+            <Typography variant="body2" color="text.secondary">
+              最終取得: {formatTs(relationsFetchedAt)}
+              {previewPending ? ' ／ いまは下書きを編集中です' : ''}
+            </Typography>
           </Box>
-        ))}
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={handleAiFetch}
+              disabled={!name.trim() || busy}
+              startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
+            >
+              {aiLoading ? '取得中…' : '情報を取得して確認'}
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleConfirmSave}
+              disabled={!previewPending || busy}
+              startIcon={confirmLoading ? <CircularProgress size={16} color="inherit" /> : null}
+              disableElevation
+            >
+              {confirmLoading ? '保存中…' : '確定して保存'}
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={handleForceFetchAndSave}
+              disabled={busy}
+              startIcon={forceLoading ? <CircularProgress size={16} color="inherit" /> : null}
+            >
+              {forceLoading ? '更新中…' : '最新の情報に更新'}
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Stack spacing={2.5}>
+        <AdminPanel
+          title="関連企業のつながり"
+          headerRight={
+            <Typography variant="body2" color="text.secondary">
+              保存済みの資本関係を図で表示します
+            </Typography>
+          }
+        >
+          <Box sx={{ px: { xs: 1.5, sm: 2 }, py: 2 }}>
+            {Number.isFinite(numericId) && numericId > 0 ? (
+              <CompanyRelationGraph key={graphRefreshKey} companyId={numericId} />
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                企業を読み込み中です…
+              </Typography>
+            )}
+          </Box>
+        </AdminPanel>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.6fr) minmax(280px, 0.9fr)' },
+            gap: 2.5,
+            alignItems: 'start',
+          }}
+        >
+          <AdminPanel
+            title="関連企業の一覧"
+            headerRight={
+              <Button size="small" variant="outlined" onClick={addRelation} disabled={busy}>
+                行を追加
+              </Button>
+            }
+          >
+            <Box sx={{ px: 2.5, py: 2 }}>
+              {relations.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  まだ関連企業がありません。「情報を取得して確認」か「行を追加」で登録できます。
+                </Typography>
+              ) : (
+                <Stack spacing={2}>
+                  {groupedRelations.map((categoryGroup) => (
+                    <Box key={categoryGroup.category}>
+                      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                        {RELATION_CATEGORY_LABELS[categoryGroup.category]}
+                      </Typography>
+                      <Stack spacing={1.5}>
+                        {categoryGroup.companies.map((companyGroup) => (
+                          <Box
+                            key={companyGroup.name}
+                            sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: '10px' }}
+                          >
+                            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                              <Typography variant="body1" fontWeight={700}>
+                                {companyGroup.name}
+                              </Typography>
+                              <Chip size="small" label={`${companyGroup.entries.length}件`} />
+                            </Stack>
+                            <Stack spacing={1.5} divider={<Divider flexItem />}>
+                              {companyGroup.entries.map(({ index, relation: rel }) => (
+                                <Stack key={index} spacing={1.5}>
+                                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+                                    <TextField
+                                      label="関連企業名"
+                                      value={rel.name}
+                                      onChange={(e) => updateRelation(index, { name: e.target.value })}
+                                      sx={{ flex: 2 }}
+                                      size="small"
+                                    />
+                                    <TextField
+                                      select
+                                      label="関係の種類"
+                                      value={rel.relation_type}
+                                      onChange={(e) => updateRelation(index, { relation_type: e.target.value })}
+                                      sx={{ flex: 1, minWidth: 140 }}
+                                      size="small"
+                                    >
+                                      <MenuItem value="capital_subsidiary">子会社</MenuItem>
+                                      <MenuItem value="capital_affiliate">関連会社</MenuItem>
+                                      <MenuItem value="business_partner">取引先</MenuItem>
+                                      <MenuItem value="business_procurement">調達（gBiz）</MenuItem>
+                                      <MenuItem value="business_subsidy">補助金（gBiz）</MenuItem>
+                                    </TextField>
+                                  </Stack>
+                                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'flex-start' }}>
+                                    <TextField
+                                      label="取引内容・関係の内容"
+                                      value={rel.description || ''}
+                                      onChange={(e) => updateRelation(index, { description: e.target.value })}
+                                      placeholder={
+                                        rel.relation_type === 'business_partner'
+                                          ? '例: 決済代行（空なら表示は「主要取引先」）'
+                                          : '例: 完全子会社'
+                                      }
+                                      helperText={
+                                        rel.relation_type === 'business_partner'
+                                          ? rel.description?.trim()
+                                            ? '具体的な取引内容（推定でも可）'
+                                            : '未入力のため一覧・図では「主要取引先」と表示されます'
+                                          : '出資比率・提携内容など、分かる範囲で具体的に'
+                                      }
+                                      sx={{ flex: 1 }}
+                                      size="small"
+                                      multiline
+                                      minRows={2}
+                                    />
+                                    <Chip
+                                      size="small"
+                                      label={
+                                        rel.relation_type === 'business_partner' && !rel.description?.trim()
+                                          ? '主要取引先'
+                                          : RELATION_LABELS[rel.relation_type] || rel.relation_type
+                                      }
+                                      sx={{ mt: { sm: 1 } }}
+                                    />
+                                    <Button size="small" color="error" onClick={() => removeRelation(index)} sx={{ mt: { sm: 1 } }}>
+                                      削除
+                                    </Button>
+                                  </Stack>
+                                </Stack>
+                              ))}
+                            </Stack>
+                          </Box>
+                        ))}
+                      </Stack>
+                    </Box>
+                  ))}
+                </Stack>
+              )}
+            </Box>
+          </AdminPanel>
+
+          <Stack spacing={2.5}>
+            <AdminPanel title="市場情報（任意）">
+              <Box sx={{ px: 2.5, py: 2 }}>
+                <Stack spacing={2}>
+                  <TextField
+                    select
+                    label="上場区分"
+                    value={marketInfo.market_type}
+                    onChange={(e) => setMarketInfo({ ...marketInfo, market_type: e.target.value })}
+                    fullWidth
+                    size="small"
+                  >
+                    <MenuItem value="unlisted">非上場</MenuItem>
+                    <MenuItem value="prime">プライム</MenuItem>
+                    <MenuItem value="standard">スタンダード</MenuItem>
+                    <MenuItem value="growth">グロース</MenuItem>
+                  </TextField>
+                  <TextField
+                    label="証券コード"
+                    value={marketInfo.stock_code || ''}
+                    onChange={(e) => setMarketInfo({ ...marketInfo, stock_code: e.target.value })}
+                    fullWidth
+                    size="small"
+                  />
+                  <TextField
+                    select
+                    label="上場"
+                    value={marketInfo.is_listed ? 'yes' : 'no'}
+                    onChange={(e) => setMarketInfo({ ...marketInfo, is_listed: e.target.value === 'yes' })}
+                    fullWidth
+                    size="small"
+                  >
+                    <MenuItem value="no">非上場</MenuItem>
+                    <MenuItem value="yes">上場</MenuItem>
+                  </TextField>
+                </Stack>
+              </Box>
+            </AdminPanel>
+
+            <Accordion
+              disableGutters
+              elevation={0}
+              sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: '10px !important',
+                '&:before': { display: 'none' },
+                overflow: 'hidden',
+              }}
+            >
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Box>
+                  <Typography fontWeight={700}>詳しい取得情報</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    通常は開かなくて大丈夫です
+                  </Typography>
+                </Box>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Stack spacing={1}>
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    <Chip size="small" label={`取得元: ${sourceType || '-'}`} />
+                    <Chip size="small" label={`確信度: ${lastFetchConfidence || '-'}`} />
+                    <Chip size="small" label={`モデル: ${lastModelUsed || '-'}`} />
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary">
+                    関連情報の最終取得: {formatTs(relationsFetchedAt)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    関係・市場情報は約60日間キャッシュされます。月次の情報取得上限はコスト画面で確認できます。
+                  </Typography>
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+          </Stack>
+        </Box>
       </Stack>
-    </AdminFormContainer>
+    </PageContainer>
   )
 }

--- a/frontend/app/admin/companies/[id]/relations/page.tsx
+++ b/frontend/app/admin/companies/[id]/relations/page.tsx
@@ -17,10 +17,10 @@ import {
 import { authService } from '@/lib/auth'
 import { formatRelationLabel } from '@/lib/relation-labels'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
+import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
 import CompanyRelationGraph from '@/components/admin/CompanyRelationGraph'
 import { groupRelationsByCategory, RELATION_CATEGORY_LABELS } from '@/lib/relation-graph'
-import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 type RelationEntry = {
   name: string
@@ -56,7 +56,6 @@ export default function AdminCompanyRelationsPage() {
   const [success, setSuccess] = useState('')
   const [aiLoading, setAiLoading] = useState(false)
   const [forceLoading, setForceLoading] = useState(false)
-  const [primaryLoading, setPrimaryLoading] = useState(false)
   const [confirmLoading, setConfirmLoading] = useState(false)
   const [previewPending, setPreviewPending] = useState(false)
 
@@ -132,14 +131,19 @@ export default function AdminCompanyRelationsPage() {
         },
         body: JSON.stringify({ name, website_url: websiteUrl }),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError((data?.error as string) || '関係情報取得に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '関係情報の取得に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyRelationsPayload(data)
       setPreviewPending(true)
       setSuccess('プレビュー取得が完了しました。内容を確認・修正してから「確定して保存」してください。')
+    } catch {
+      setError('関係情報の取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setAiLoading(false)
     }
@@ -154,9 +158,12 @@ export default function AdminCompanyRelationsPage() {
         method: 'POST',
         headers: authService.getAdminFetchHeaders(),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError((data?.error as string) || '強制再取得に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '強制再取得に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyRelationsPayload(data)
@@ -168,40 +175,10 @@ export default function AdminCompanyRelationsPage() {
       } else {
         setSuccess(`DBへ強制再取得・保存しました（${data.saved_count ?? 0}件）。`)
       }
+    } catch {
+      setError('強制再取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setForceLoading(false)
-    }
-  }
-
-  const handleFetchPrimary = async (force = false) => {
-    setPrimaryLoading(true)
-    setError('')
-    setSuccess('')
-    try {
-      const { ok, status, data } = await fetchCompanyPrimary(
-        id,
-        authService.getAdminFetchHeaders(),
-        force,
-      )
-      if (!ok) {
-        setError(data?.error || `主3種の取得に失敗しました (${status})`)
-        return
-      }
-      if (data.relations) applyRelationsPayload(data.relations)
-      if (data.company && typeof data.company === 'object') {
-        const company = data.company as Record<string, unknown>
-        if (typeof company.website_url === 'string') setWebsiteUrl(company.website_url)
-        setRelationsFetchedAt(company.relations_fetched_at ? String(company.relations_fetched_at) : null)
-      } else {
-        loadCompany()
-      }
-      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
-        setError(`一部失敗: ${data.errors.join('; ')}`)
-      }
-      const summary = formatFetchPrimarySummary(data)
-      setSuccess(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
-    } finally {
-      setPrimaryLoading(false)
     }
   }
 
@@ -224,14 +201,19 @@ export default function AdminCompanyRelationsPage() {
           confidence: lastFetchConfidence,
         }),
       })
-      const data = await res.json()
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
-        setError((data?.error as string) || '確定保存に失敗しました')
+        setError(
+          (typeof data.error === 'string' && data.error) ||
+            '確定保存に失敗しました。時間をおいて再度お試しください。',
+        )
         return
       }
       applyRelationsPayload(data)
       loadCompany()
-      setSuccess(`プレビュー内容を確定して保存しました（${data.saved_count ?? 0}件、relations_fetched_at 更新済み）。`)
+      setSuccess(`プレビュー内容を確定して保存しました（${data.saved_count ?? 0}件）。`)
+    } catch {
+      setError('確定保存中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
       setConfirmLoading(false)
     }
@@ -260,48 +242,32 @@ export default function AdminCompanyRelationsPage() {
 
   return (
     <AdminFormContainer
-      title={`関係・市場情報: ${name}`}
+      title={`${name || '企業'}（関連企業）`}
+      description="関連企業や市場の情報を確認・編集します。"
       maxWidth={800}
       backLabel="企業一覧に戻る"
       backHref="/admin/companies"
     >
+      <CompanyAspectTabs companyId={id} active="relations" />
       <ErrorAlert error={error} />
       {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
       {previewPending && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          プレビュー未確定です。「確定して保存」で company_relations / company_market_info と relations_fetched_at を更新します。
+          まだ下書きの取得結果です。内容を確認してから「確定して保存」を押してください。
         </Alert>
       )}
 
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          「主3種をまとめて取得」で Backend が基本・技術・ビジネス関係を順に取得して DB 保存します。
-          必要ならこの画面の個別取得で関係だけ再取得できます。
+          最終取得: {formatTs(relationsFetchedAt)}
         </Typography>
 
         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
           <Button
-            variant="contained"
-            color="secondary"
-            onClick={() => handleFetchPrimary(false)}
-            disabled={aiLoading || forceLoading || primaryLoading}
-            startIcon={primaryLoading ? <CircularProgress size={16} color="inherit" /> : null}
-          >
-            {primaryLoading ? '取得中...' : '主3種をまとめて取得'}
-          </Button>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={() => handleFetchPrimary(true)}
-            disabled={aiLoading || forceLoading || primaryLoading}
-          >
-            主3種を強制再取得
-          </Button>
-          <Button
             variant="outlined"
             color="secondary"
             onClick={handleAiFetch}
-            disabled={!name.trim() || aiLoading || primaryLoading}
+            disabled={!name.trim() || aiLoading || forceLoading}
             startIcon={aiLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {aiLoading ? '取得中...' : 'プレビュー取得（未保存）'}
@@ -318,7 +284,7 @@ export default function AdminCompanyRelationsPage() {
           <Button
             variant="outlined"
             onClick={handleForceFetchAndSave}
-            disabled={forceLoading || primaryLoading}
+            disabled={forceLoading || aiLoading}
             startIcon={forceLoading ? <CircularProgress size={16} color="inherit" /> : null}
           >
             {forceLoading ? '再取得中...' : '強制再取得して保存'}

--- a/frontend/app/admin/companies/[id]/relations/page.tsx
+++ b/frontend/app/admin/companies/[id]/relations/page.tsx
@@ -126,7 +126,7 @@ export default function AdminCompanyRelationsPage() {
   }
 
   const loadSavedRelations = () => {
-    fetch(`/api/admin/companies/${id}/fetch-relations`, {
+    fetch(`/api/admin/companies/${id}/fetch-relations?cache_only=true`, {
       method: 'POST',
       headers: authService.getAdminFetchHeaders(),
     })
@@ -215,6 +215,13 @@ export default function AdminCompanyRelationsPage() {
     setError('')
     setSuccess('')
     try {
+      const excludedCount = relations.filter((r) => !isClearOrganizationName(r.name || '')).length
+      const clearRelations = relations
+        .filter((r) => isClearOrganizationName(r.name || ''))
+        .map((r) => ({
+          ...r,
+          description: sanitizeRelationDescription(r.description || ''),
+        }))
       const res = await fetch(`/api/admin/companies/${id}/confirm-relations`, {
         method: 'POST',
         headers: {
@@ -222,12 +229,7 @@ export default function AdminCompanyRelationsPage() {
           ...authService.getAdminFetchHeaders(),
         },
         body: JSON.stringify({
-          relations: relations
-            .filter((r) => isClearOrganizationName(r.name || ''))
-            .map((r) => ({
-              ...r,
-              description: sanitizeRelationDescription(r.description || ''),
-            })),
+          relations: clearRelations,
           market_info: marketInfo,
           source: sourceType,
           model_used: lastModelUsed,
@@ -245,7 +247,11 @@ export default function AdminCompanyRelationsPage() {
       applyRelationsPayload(data)
       loadCompany()
       setGraphRefreshKey((k) => k + 1)
-      setSuccess(`内容を確定して保存しました（${data.saved_count ?? 0}件）。`)
+      const excludedNote =
+        excludedCount > 0
+          ? `（曖昧な社名 ${excludedCount} 件は保存対象外としました）`
+          : ''
+      setSuccess(`内容を確定して保存しました（${data.saved_count ?? 0}件）${excludedNote}。`)
       setPreviewPending(false)
     } catch {
       setError('確定保存中に通信エラーが発生しました。時間をおいて再度お試しください。')

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -12,11 +12,14 @@ import {
   Checkbox,
   Chip,
   CircularProgress,
+  FormControl,
   FormControlLabel,
   IconButton,
   InputAdornment,
+  InputLabel,
   Menu,
   MenuItem,
+  Select,
   Stack,
   TextField,
   ToggleButton,
@@ -38,11 +41,14 @@ import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import { AdminPanel } from '@/components/admin/AdminPanel'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
 import { companyAspectHref, type CompanyAspect } from '@/components/admin/CompanyAspectTabs'
-import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
+import { fetchCompanyPrimary, formatFetchPrimarySummary, formatFetchPrimaryEmptyAspects, hasActionableSoftEmpty } from '@/lib/admin-company-fetch'
+import { resolveIndustryFieldProfile } from '@/lib/admin-company-field-profile'
 
 const PAGE_SIZE = 50
 /** 並列取得（Backend concurrency=4）前提。タイムアウト回避のため上限は控えめ */
 const GLOBAL_BATCH_LIMIT = 20
+/** Backend の業界未設定フィルタ用センチネル */
+const INDUSTRY_UNSET = '__unset__'
 
 type Company = {
   id: number
@@ -60,6 +66,9 @@ type Company = {
   description?: string
   tech_stack?: string
 }
+
+type FilterStatus = 'all' | 'draft' | 'published'
+type FilterReadiness = 'all' | 'ready' | 'missing'
 
 type L1Coverage = {
   published_total: number
@@ -90,18 +99,31 @@ const ASPECT_PAGE: Partial<Record<AspectKey, CompanyAspect>> = {
 }
 
 function missingAspects(c: Company): AspectKey[] {
+  const profile = resolveIndustryFieldProfile(c.industry)
   const missing: AspectKey[] = []
   if (!c.info_fetched_at || !c.description || !c.website_url) missing.push('info')
-  if (!c.tech_fetched_at || !c.tech_stack || c.tech_stack === '[]') missing.push('tech')
+  if (
+    profile.requireTechForPublish &&
+    (!c.tech_fetched_at || !c.tech_stack || c.tech_stack === '[]')
+  ) {
+    missing.push('tech')
+  }
   if (!c.relations_fetched_at) missing.push('relations')
   if (!c.jobs_fetched_at) missing.push('jobs')
   return missing
 }
 
-/** 公開前かつ主3種がそろっている企業だけ一括公開の対象にする。 */
+/** 公開前かつ主情報がそろっている企業だけ一括公開の対象にする。 */
 function canSelectForPublish(c: Company): boolean {
   if (c.data_status === 'published') return false
   return missingAspects(c).filter((k) => k !== 'jobs').length === 0
+}
+
+function aspectLabel(key: AspectKey, industry?: string): string {
+  if (key === 'tech') {
+    return resolveIndustryFieldProfile(industry).techAspectLabel
+  }
+  return ASPECT_LABEL[key]
 }
 
 function subtitleLine(c: Company): string {
@@ -119,6 +141,27 @@ function pct(rate: number) {
   return `${Math.round((rate || 0) * 100)}%`
 }
 
+function industryGroupLabel(industry?: string): string {
+  const trimmed = industry?.trim()
+  return trimmed ? trimmed : '業界未設定'
+}
+
+function groupCompaniesByIndustry(companies: Company[]): { key: string; label: string; items: Company[] }[] {
+  const groups: { key: string; label: string; items: Company[] }[] = []
+  const indexByKey = new Map<string, number>()
+  for (const company of companies) {
+    const key = company.industry?.trim() || INDUSTRY_UNSET
+    const existing = indexByKey.get(key)
+    if (existing === undefined) {
+      indexByKey.set(key, groups.length)
+      groups.push({ key, label: industryGroupLabel(company.industry), items: [company] })
+    } else {
+      groups[existing].items.push(company)
+    }
+  }
+  return groups
+}
+
 export default function AdminCompaniesPage() {
   useEffect(() => {
     const user = authService.getStoredUser()
@@ -131,7 +174,11 @@ export default function AdminCompaniesPage() {
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [error, setError] = useState('')
-  const [filterStatus, setFilterStatus] = useState<'all' | 'draft' | 'published'>('all')
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>('all')
+  const [filterIndustry, setFilterIndustry] = useState('')
+  const [filterReadiness, setFilterReadiness] = useState<FilterReadiness>('all')
+  const [groupByIndustry, setGroupByIndustry] = useState(false)
+  const [industries, setIndustries] = useState<string[]>([])
   const [searchInput, setSearchInput] = useState('')
   const [searchName, setSearchName] = useState('')
   const [coverage, setCoverage] = useState<L1Coverage | null>(null)
@@ -155,28 +202,51 @@ export default function AdminCompaniesPage() {
     setCoverage(data)
   }, [])
 
-  const fetchCompanies = useCallback(async (p: number, name: string, status: 'all' | 'draft' | 'published') => {
-    setError('')
-    const offset = (p - 1) * PAGE_SIZE
-    const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
-      offset: String(offset),
-    })
-    const trimmed = name.trim()
-    if (trimmed) params.set('name', trimmed)
-    if (status !== 'all') params.set('status', status)
-    const res = await fetch(`/api/admin/companies?${params}`, {
+  const fetchIndustries = useCallback(async () => {
+    const res = await fetch('/api/admin/companies/industries', {
       headers: authService.getAdminFetchHeaders(),
       cache: 'no-store',
     })
+    if (!res.ok) return
     const data = await res.json()
-    if (!res.ok) {
-      setError(data?.error || '企業一覧の取得に失敗しました')
-      return
-    }
-    setCompanies(data?.companies || [])
-    setTotal(data?.total ?? 0)
+    setIndustries(Array.isArray(data?.industries) ? data.industries : [])
   }, [])
+
+  const fetchCompanies = useCallback(
+    async (
+      p: number,
+      name: string,
+      status: FilterStatus,
+      industry: string,
+      readiness: FilterReadiness,
+      groupIndustry: boolean,
+    ) => {
+      setError('')
+      const offset = (p - 1) * PAGE_SIZE
+      const params = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String(offset),
+      })
+      const trimmed = name.trim()
+      if (trimmed) params.set('name', trimmed)
+      if (status !== 'all') params.set('status', status)
+      if (industry) params.set('industry', industry)
+      if (readiness !== 'all') params.set('readiness', readiness)
+      if (groupIndustry) params.set('order', 'industry')
+      const res = await fetch(`/api/admin/companies?${params}`, {
+        headers: authService.getAdminFetchHeaders(),
+        cache: 'no-store',
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data?.error || '企業一覧の取得に失敗しました')
+        return
+      }
+      setCompanies(data?.companies || [])
+      setTotal(data?.total ?? 0)
+    },
+    [],
+  )
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -190,12 +260,12 @@ export default function AdminCompaniesPage() {
   }, [searchInput])
 
   useEffect(() => {
-    void fetchCompanies(page, searchName, filterStatus)
-  }, [fetchCompanies, page, searchName, filterStatus])
+    void fetchCompanies(page, searchName, filterStatus, filterIndustry, filterReadiness, groupByIndustry)
+  }, [fetchCompanies, page, searchName, filterStatus, filterIndustry, filterReadiness, groupByIndustry])
 
   useEffect(() => {
     setSelectedIds([])
-  }, [page, searchName, filterStatus])
+  }, [page, searchName, filterStatus, filterIndustry, filterReadiness, groupByIndustry])
 
   useEffect(() => {
     // 取得後に情報が足りなくなった選択は外す（中身が同じなら state を更新しない）
@@ -211,15 +281,49 @@ export default function AdminCompaniesPage() {
 
   useEffect(() => {
     void fetchCoverage()
-  }, [fetchCoverage])
+    void fetchIndustries()
+  }, [fetchCoverage, fetchIndustries])
 
   const handlePageChange = (_: React.ChangeEvent<unknown>, value: number) => {
     setPage(value)
   }
 
   const reloadCurrentList = async () => {
-    await fetchCompanies(page, searchName, filterStatus)
+    await fetchCompanies(page, searchName, filterStatus, filterIndustry, filterReadiness, groupByIndustry)
+    await fetchIndustries()
   }
+
+  const resetFilters = () => {
+    setSearchInput('')
+    setSearchName('')
+    setFilterStatus('all')
+    setFilterIndustry('')
+    setFilterReadiness('all')
+    setGroupByIndustry(false)
+    setPage(1)
+  }
+
+  const hasActiveFilters =
+    Boolean(searchName) ||
+    filterStatus !== 'all' ||
+    Boolean(filterIndustry) ||
+    filterReadiness !== 'all' ||
+    groupByIndustry
+
+  const companyGroups = groupByIndustry
+    ? groupCompaniesByIndustry(companies)
+    : [{ key: 'all', label: '', items: companies }]
+
+  const filterSummaryParts: string[] = []
+  if (searchName) filterSummaryParts.push(`「${searchName}」`)
+  if (filterStatus === 'draft') filterSummaryParts.push('公開前')
+  if (filterStatus === 'published') filterSummaryParts.push('学生に公開中')
+  if (filterIndustry === INDUSTRY_UNSET) filterSummaryParts.push('業界未設定')
+  else if (filterIndustry) filterSummaryParts.push(filterIndustry)
+  if (filterReadiness === 'ready') filterSummaryParts.push('情報がそろっている')
+  if (filterReadiness === 'missing') filterSummaryParts.push('情報が足りない')
+  if (groupByIndustry) filterSummaryParts.push('業界別に表示')
+  const filterSummary = filterSummaryParts.join(' / ')
 
   const handleSeedL1 = async () => {
     setWarming(true)
@@ -466,6 +570,7 @@ export default function AdminCompaniesPage() {
     setFetchSeverity('success')
     setFetchPrimaryId(companyId)
     setMenuAnchor(null)
+    const knownIndustry = companies.find((c) => c.id === companyId)?.industry
     try {
       const { ok, status, data } = await fetchCompanyPrimary(
         companyId,
@@ -480,14 +585,15 @@ export default function AdminCompaniesPage() {
       const fetched = steps.filter((s) => s?.status === 'fetched').length
       const allSkipped = steps.every((s) => s?.status === 'skipped')
       const hardFailed = steps.some((s) => s?.status === 'error')
-      const softEmpty = steps.some((s) => s?.status === 'empty')
+      const softEmpty = hasActionableSoftEmpty(data, knownIndustry)
       const budgetHit = steps.some((s) => s?.detail === 'budget') ||
         (Array.isArray(data.errors) && data.errors.some((e) => e.includes('budget')))
+      const summary = formatFetchPrimarySummary(data, knownIndustry)
 
       if (budgetHit) {
         setFetchSeverity('warning')
         setError('月次の情報取得上限に達しているため、新しい取得ができませんでした。コスト画面を確認するか、時間をおいて再度お試しください。')
-        setFetchMessage(formatFetchPrimarySummary(data) || '予算超過のため取得をスキップしました。')
+        setFetchMessage(summary || '予算超過のため取得をスキップしました。')
       } else if (hardFailed) {
         setFetchSeverity('warning')
         setError(
@@ -496,22 +602,25 @@ export default function AdminCompaniesPage() {
             : '一部の情報取得に失敗しました。',
         )
         setFetchMessage(
-          `情報の取得が一部失敗しました（${formatFetchPrimarySummary(data)}）。「最新の情報に更新」で再試行できます。`,
+          `情報の取得が一部失敗しました（${summary}）。「最新の情報に更新」で再試行できます。`,
         )
       } else if (softEmpty) {
+        const emptyAspects = formatFetchPrimaryEmptyAspects(data, knownIndustry)
         setFetchSeverity('warning')
         setFetchMessage(
-          `取得を試しましたが、公開情報から特定できない項目がありました（${formatFetchPrimarySummary(data)}）。手入力するか、時間をおいて再度お試しください。`,
+          emptyAspects
+            ? `${emptyAspects}は公開情報から特定できませんでした（${summary}）。手入力するか、時間をおいて再度お試しください。`
+            : `取得を試しましたが、公開情報から特定できない項目がありました（${summary}）。手入力するか、時間をおいて再度お試しください。`,
         )
       } else if (allSkipped) {
         setFetchSeverity('warning')
-        setFetchMessage('すでに新しい情報があるため、取得をスキップしました。')
+        setFetchMessage(`すでに新しい情報があるか、業種により対象外のためスキップしました（${summary}）。`)
       } else {
         setFetchSeverity('success')
         setFetchMessage(
           force
-            ? `情報を更新しました（${fetched} 項目）。`
-            : `情報を取得しました（${fetched} 項目）。内容を確認して問題なければ「学生に公開」できます。`,
+            ? `情報を更新しました（${fetched} 項目）。${summary}`
+            : `情報を取得しました（${fetched} 項目）。${summary} 内容を確認して問題なければ「学生に公開」できます。`,
         )
       }
       await reloadCurrentList()
@@ -532,8 +641,8 @@ export default function AdminCompaniesPage() {
       <AdminPageHeader
         title="企業情報の管理"
         description={
-          searchName
-            ? `「${searchName}」の検索結果 ${total.toLocaleString()} 件`
+          filterSummary
+            ? `${filterSummary} の結果 ${total.toLocaleString()} 件`
             : `学生課の先生が、学生に見せる企業情報を登録・確認・公開するための画面です。登録 ${total.toLocaleString()} 社`
         }
         backHref="/admin"
@@ -621,48 +730,136 @@ export default function AdminCompaniesPage() {
         </Stack>
       </Box>
 
-      <AdminPanel
-        title="企業一覧"
-        headerRight={
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
-            <TextField
-              size="small"
-              placeholder="企業名で探す"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              sx={{ minWidth: { sm: 240 } }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon fontSize="small" color="action" />
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <ToggleButtonGroup
-              exclusive
-              size="small"
-              value={filterStatus}
-              onChange={(_, v) => {
-                if (!v) return
-                setFilterStatus(v)
-                setPage(1)
-              }}
-              sx={{
-                '& .MuiToggleButton-root': {
-                  px: 1.75,
-                  textTransform: 'none',
-                  borderColor: 'divider',
-                },
-              }}
+      <AdminPanel title="企業一覧">
+        <Box
+          sx={{
+            px: 2.5,
+            py: 1.75,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'grey.50',
+          }}
+        >
+          <Stack spacing={1.5}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
+              <TextField
+                size="small"
+                placeholder="企業名で探す"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                sx={{ minWidth: { sm: 240 }, bgcolor: 'background.paper' }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" color="action" />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+              <FormControl size="small" sx={{ minWidth: { sm: 220 }, bgcolor: 'background.paper' }}>
+                <InputLabel id="filter-industry-label">業界</InputLabel>
+                <Select
+                  labelId="filter-industry-label"
+                  label="業界"
+                  value={filterIndustry}
+                  onChange={(e) => {
+                    setFilterIndustry(e.target.value)
+                    setPage(1)
+                  }}
+                >
+                  <MenuItem value="">すべての業界</MenuItem>
+                  <MenuItem value={INDUSTRY_UNSET}>業界未設定</MenuItem>
+                  {industries.map((industry) => (
+                    <MenuItem key={industry} value={industry}>
+                      {industry}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              {hasActiveFilters && (
+                <Button size="small" variant="text" onClick={resetFilters} sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}>
+                  絞り込みを解除
+                </Button>
+              )}
+            </Stack>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={1.5}
+              alignItems={{ md: 'center' }}
+              flexWrap="wrap"
+              useFlexGap
             >
-              <ToggleButton value="all">すべて</ToggleButton>
-              <ToggleButton value="draft">公開前</ToggleButton>
-              <ToggleButton value="published">学生に公開中</ToggleButton>
-            </ToggleButtonGroup>
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  公開の状態
+                </Typography>
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={filterStatus}
+                  onChange={(_, v: FilterStatus | null) => {
+                    if (!v) return
+                    setFilterStatus(v)
+                    setPage(1)
+                  }}
+                  sx={{
+                    bgcolor: 'background.paper',
+                    '& .MuiToggleButton-root': {
+                      px: 1.5,
+                      textTransform: 'none',
+                      borderColor: 'divider',
+                    },
+                  }}
+                >
+                  <ToggleButton value="all">すべて</ToggleButton>
+                  <ToggleButton value="draft">公開前</ToggleButton>
+                  <ToggleButton value="published">学生に公開中</ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  情報のそろい具合
+                </Typography>
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={filterReadiness}
+                  onChange={(_, v: FilterReadiness | null) => {
+                    if (!v) return
+                    setFilterReadiness(v)
+                    setPage(1)
+                  }}
+                  sx={{
+                    bgcolor: 'background.paper',
+                    '& .MuiToggleButton-root': {
+                      px: 1.5,
+                      textTransform: 'none',
+                      borderColor: 'divider',
+                    },
+                  }}
+                >
+                  <ToggleButton value="all">すべて</ToggleButton>
+                  <ToggleButton value="missing">足りない</ToggleButton>
+                  <ToggleButton value="ready">そろっている</ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={groupByIndustry}
+                    onChange={(e) => {
+                      setGroupByIndustry(e.target.checked)
+                      setPage(1)
+                    }}
+                    size="small"
+                  />
+                }
+                label="業界別に分けて表示"
+                sx={{ ml: 0, mr: 0, alignSelf: { xs: 'flex-start', md: 'flex-end' }, pb: { md: 0.25 } }}
+              />
+            </Stack>
           </Stack>
-        }
-      >
+        </Box>
         {selectableOnPage.length > 0 ? (
           <Box
             sx={{
@@ -738,9 +935,15 @@ export default function AdminCompaniesPage() {
           {companies.length === 0 && (
             <Box sx={{ px: 2.5, py: 6, textAlign: 'center' }}>
               <Typography color="text.secondary" sx={{ mb: 1 }}>
-                {searchName ? `「${searchName}」に一致する企業がありません` : '該当する企業がありません'}
+                {hasActiveFilters
+                  ? '条件に一致する企業がありません。絞り込みを変えてみてください。'
+                  : '該当する企業がありません'}
               </Typography>
-              {!searchName && (
+              {hasActiveFilters ? (
+                <Button variant="outlined" size="small" onClick={resetFilters}>
+                  絞り込みを解除
+                </Button>
+              ) : (
                 <Button component={Link} href="/admin/companies/new" variant="outlined" size="small">
                   最初の企業を追加
                 </Button>
@@ -748,177 +951,239 @@ export default function AdminCompaniesPage() {
             </Box>
           )}
 
-          {companies.map((company) => {
-            const missing = missingAspects(company)
-            const primaryMissing = missing.filter((k) => k !== 'jobs')
-            const ready = primaryMissing.length === 0
-            const fetching = fetchPrimaryId === company.id
-            const isDraft = company.data_status !== 'published'
-            const meta = subtitleLine(company)
-            const status = statusLabel(company.data_status)
-            const selected = selectedIds.includes(company.id)
-
-            return (
-              <Box
-                key={company.id}
-                sx={{
-                  px: 2.5,
-                  py: 2,
-                  bgcolor: selected ? 'action.selected' : undefined,
-                  '&:hover': { bgcolor: selected ? 'action.selected' : 'action.hover' },
-                }}
-              >
-                <Stack
-                  direction={{ xs: 'column', md: 'row' }}
-                  spacing={1.5}
-                  alignItems={{ md: 'center' }}
-                  justifyContent="space-between"
+          {companyGroups.map((group) => (
+            <Box key={group.key}>
+              {groupByIndustry && group.label ? (
+                <Box
+                  sx={{
+                    px: 2.5,
+                    py: 1,
+                    bgcolor: 'grey.100',
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                    position: 'sticky',
+                    top: 0,
+                    zIndex: 1,
+                  }}
                 >
-                  <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ minWidth: 0, flex: 1 }}>
-                    <Checkbox
-                      checked={selected}
-                      onChange={() => toggleSelect(company.id)}
-                      disabled={busy || !canSelectForPublish(company)}
-                      inputProps={{ 'aria-label': `${company.name}を選択` }}
-                      sx={{ mt: -0.5 }}
-                    />
-                    <Box sx={{ minWidth: 0, flex: 1 }}>
-                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
-                        <Typography
-                          component={Link}
-                          href={companyAspectHref(company.id, 'info')}
-                          variant="subtitle1"
-                          fontWeight={700}
-                          sx={{
-                            color: 'text.primary',
-                            textDecoration: 'none',
-                            '&:hover': { color: 'primary.main' },
-                          }}
-                        >
-                          {company.name}
-                        </Typography>
-                        <Chip label={status.label} color={status.color} size="small" />
-                      </Stack>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography variant="subtitle2" fontWeight={700}>
+                      {group.label}
+                    </Typography>
+                    <Chip size="small" label={`${group.items.length} 社`} variant="outlined" />
+                  </Stack>
+                </Box>
+              ) : null}
 
-                      {meta ? (
-                        <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
-                          {meta}
-                        </Typography>
-                      ) : null}
+              <Stack divider={<Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }} />}>
+                {group.items.map((company) => {
+                  const missing = missingAspects(company)
+                  const primaryMissing = missing.filter((k) => k !== 'jobs')
+                  const ready = primaryMissing.length === 0
+                  const fetching = fetchPrimaryId === company.id
+                  const isDraft = company.data_status !== 'published'
+                  const industryLabel = company.industry?.trim() || ''
+                  const locationLabel = company.location?.trim() || ''
+                  const meta =
+                    groupByIndustry || !industryLabel
+                      ? subtitleLine(company)
+                      : locationLabel
+                  const status = statusLabel(company.data_status)
+                  const selected = selectedIds.includes(company.id)
 
-                      <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
-                        {ready ? (
-                          <Chip
-                            size="small"
-                            icon={<CheckCircleOutlineIcon />}
-                            label="公開の準備ができています"
-                            color="success"
-                            variant="outlined"
+                  return (
+                    <Box
+                      key={company.id}
+                      sx={{
+                        px: 2.5,
+                        py: 2,
+                        bgcolor: selected ? 'action.selected' : undefined,
+                        '&:hover': { bgcolor: selected ? 'action.selected' : 'action.hover' },
+                      }}
+                    >
+                      <Stack
+                        direction={{ xs: 'column', md: 'row' }}
+                        spacing={1.5}
+                        alignItems={{ md: 'center' }}
+                        justifyContent="space-between"
+                      >
+                        <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ minWidth: 0, flex: 1 }}>
+                          <Checkbox
+                            checked={selected}
+                            onChange={() => toggleSelect(company.id)}
+                            disabled={busy || !canSelectForPublish(company)}
+                            inputProps={{ 'aria-label': `${company.name}を選択` }}
+                            sx={{ mt: -0.5 }}
                           />
-                        ) : (
-                          <>
-                            <Chip
-                              size="small"
-                              icon={<ErrorOutlineIcon />}
-                              label="まだ足りない情報があります"
-                              color="warning"
-                              variant="outlined"
-                            />
-                            {primaryMissing.map((key) => {
-                              const page = ASPECT_PAGE[key]
-                              if (!page) {
-                                return <Chip key={key} size="small" label={ASPECT_LABEL[key]} variant="outlined" />
-                              }
-                              return (
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Stack
+                              direction="row"
+                              spacing={1}
+                              alignItems="center"
+                              flexWrap="wrap"
+                              useFlexGap
+                              sx={{ mb: 0.5 }}
+                            >
+                              <Typography
+                                component={Link}
+                                href={companyAspectHref(company.id, 'info')}
+                                variant="subtitle1"
+                                fontWeight={700}
+                                sx={{
+                                  color: 'text.primary',
+                                  textDecoration: 'none',
+                                  '&:hover': { color: 'primary.main' },
+                                }}
+                              >
+                                {company.name}
+                              </Typography>
+                              <Chip label={status.label} color={status.color} size="small" />
+                              {!groupByIndustry && industryLabel ? (
                                 <Chip
-                                  key={key}
                                   size="small"
-                                  label={ASPECT_LABEL[key]}
+                                  label={industryLabel}
                                   variant="outlined"
-                                  component={Link}
-                                  href={companyAspectHref(company.id, page)}
-                                  clickable
+                                  onClick={() => {
+                                    setFilterIndustry(industryLabel)
+                                    setPage(1)
+                                  }}
+                                  sx={{ cursor: 'pointer' }}
                                 />
-                              )
-                            })}
-                          </>
-                        )}
-                      </Stack>
+                              ) : null}
+                            </Stack>
 
-                      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-                        <Button
-                          component={Link}
-                          href={companyAspectHref(company.id, 'info')}
-                          size="small"
-                          variant="text"
+                            {meta ? (
+                              <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+                                {meta}
+                              </Typography>
+                            ) : null}
+
+                            <Stack
+                              direction="row"
+                              spacing={0.75}
+                              alignItems="center"
+                              flexWrap="wrap"
+                              useFlexGap
+                              sx={{ mb: 1 }}
+                            >
+                              {ready ? (
+                                <Chip
+                                  size="small"
+                                  icon={<CheckCircleOutlineIcon />}
+                                  label="公開の準備ができています"
+                                  color="success"
+                                  variant="outlined"
+                                />
+                              ) : (
+                                <>
+                                  <Chip
+                                    size="small"
+                                    icon={<ErrorOutlineIcon />}
+                                    label="まだ足りない情報があります"
+                                    color="warning"
+                                    variant="outlined"
+                                  />
+                                  {primaryMissing.map((key) => {
+                                    const page = ASPECT_PAGE[key]
+                                    const label = aspectLabel(key, company.industry)
+                                    if (!page) {
+                                      return (
+                                        <Chip key={key} size="small" label={label} variant="outlined" />
+                                      )
+                                    }
+                                    return (
+                                      <Chip
+                                        key={key}
+                                        size="small"
+                                        label={label}
+                                        variant="outlined"
+                                        component={Link}
+                                        href={companyAspectHref(company.id, page)}
+                                        clickable
+                                      />
+                                    )
+                                  })}
+                                </>
+                              )}
+                            </Stack>
+
+                            <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                              <Button
+                                component={Link}
+                                href={companyAspectHref(company.id, 'info')}
+                                size="small"
+                                variant="text"
+                              >
+                                会社概要
+                              </Button>
+                              <Button
+                                component={Link}
+                                href={companyAspectHref(company.id, 'tech')}
+                                size="small"
+                                variant="text"
+                              >
+                                技術情報
+                              </Button>
+                              <Button
+                                component={Link}
+                                href={companyAspectHref(company.id, 'relations')}
+                                size="small"
+                                variant="text"
+                              >
+                                関連企業
+                              </Button>
+                            </Stack>
+                          </Box>
+                        </Stack>
+
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          alignItems="center"
+                          justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
+                          sx={{ flexShrink: 0, pl: { xs: 5, md: 0 } }}
                         >
-                          会社概要
-                        </Button>
-                        <Button
-                          component={Link}
-                          href={companyAspectHref(company.id, 'tech')}
-                          size="small"
-                          variant="text"
-                        >
-                          技術情報
-                        </Button>
-                        <Button
-                          component={Link}
-                          href={companyAspectHref(company.id, 'relations')}
-                          size="small"
-                          variant="text"
-                        >
-                          関連企業
-                        </Button>
+                          {!ready ? (
+                            <Button
+                              variant="contained"
+                              size="small"
+                              color="secondary"
+                              onClick={() => handleFetchPrimary(company.id, true)}
+                              disabled={busy}
+                              startIcon={fetching ? <CircularProgress size={14} color="inherit" /> : null}
+                              disableElevation
+                            >
+                              {fetching ? '取得中…' : '情報を取得'}
+                            </Button>
+                          ) : isDraft ? (
+                            <Button
+                              variant="contained"
+                              size="small"
+                              color="success"
+                              onClick={() => handlePublish(company.id)}
+                              disabled={busy}
+                              disableElevation
+                            >
+                              学生に公開
+                            </Button>
+                          ) : null}
+
+                          <IconButton
+                            size="small"
+                            aria-label={`${company.name}のその他の操作`}
+                            disabled={busy && !fetching}
+                            onClick={(e) => setMenuAnchor({ el: e.currentTarget, company })}
+                          >
+                            <MoreVertIcon fontSize="small" />
+                          </IconButton>
+                        </Stack>
                       </Stack>
                     </Box>
-                  </Stack>
-
-                  <Stack
-                    direction="row"
-                    spacing={1}
-                    alignItems="center"
-                    justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
-                    sx={{ flexShrink: 0, pl: { xs: 5, md: 0 } }}
-                  >
-                    {!ready ? (
-                      <Button
-                        variant="contained"
-                        size="small"
-                        color="secondary"
-                        onClick={() => handleFetchPrimary(company.id, true)}
-                        disabled={busy}
-                        startIcon={fetching ? <CircularProgress size={14} color="inherit" /> : null}
-                        disableElevation
-                      >
-                        {fetching ? '取得中…' : '情報を取得'}
-                      </Button>
-                    ) : isDraft ? (
-                      <Button
-                        variant="contained"
-                        size="small"
-                        color="success"
-                        onClick={() => handlePublish(company.id)}
-                        disabled={busy}
-                        disableElevation
-                      >
-                        学生に公開
-                      </Button>
-                    ) : null}
-
-                    <IconButton
-                      size="small"
-                      aria-label={`${company.name}のその他の操作`}
-                      disabled={busy && !fetching}
-                      onClick={(e) => setMenuAnchor({ el: e.currentTarget, company })}
-                    >
-                      <MoreVertIcon fontSize="small" />
-                    </IconButton>
-                  </Stack>
-                </Stack>
-              </Box>
-            )
-          })}
+                  )
+                })}
+              </Stack>
+            </Box>
+          ))}
         </Stack>
 
         {pageCount > 1 && (

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -102,9 +102,10 @@ function missingAspects(c: Company): AspectKey[] {
   const profile = resolveIndustryFieldProfile(c.industry)
   const missing: AspectKey[] = []
   if (!c.info_fetched_at || !c.description || !c.website_url) missing.push('info')
+  const tech = (c.tech_stack ?? '').trim()
   if (
     profile.requireTechForPublish &&
-    (!c.tech_fetched_at || !c.tech_stack || c.tech_stack === '[]')
+    (!c.tech_fetched_at || !tech || tech === '[]' || tech === 'null' || tech === '{}')
   ) {
     missing.push('tech')
   }
@@ -1148,7 +1149,7 @@ export default function AdminCompaniesPage() {
                               variant="contained"
                               size="small"
                               color="secondary"
-                              onClick={() => handleFetchPrimary(company.id, true)}
+                              onClick={() => handleFetchPrimary(company.id, false)}
                               disabled={busy}
                               startIcon={fetching ? <CircularProgress size={14} color="inherit" /> : null}
                               disableElevation
@@ -1202,7 +1203,7 @@ export default function AdminCompaniesPage() {
       >
         <MenuItem
           disabled={busy}
-          onClick={() => menuAnchor && handleFetchPrimary(menuAnchor.company.id, true)}
+          onClick={() => menuAnchor && handleFetchPrimary(menuAnchor.company.id, false)}
         >
           <ListItemIcon>
             <RefreshIcon fontSize="small" />

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -89,6 +89,7 @@ export default function AdminCompaniesPage() {
   const [warmMessage, setWarmMessage] = useState('')
   const [fetchAllId, setFetchAllId] = useState<number | null>(null)
   const [fetchAllMessage, setFetchAllMessage] = useState('')
+  const [fetchAllSeverity, setFetchAllSeverity] = useState<'success' | 'warning'>('success')
   const [missingBatchLoading, setMissingBatchLoading] = useState(false)
 
   const fetchCoverage = useCallback(async () => {
@@ -288,6 +289,7 @@ export default function AdminCompaniesPage() {
   const handleFetchAll = async (companyId: number, force = false) => {
     setError('')
     setFetchAllMessage('')
+    setFetchAllSeverity('success')
     setFetchAllId(companyId)
     try {
       const { ok, status, data } = await fetchCompanyPrimary(
@@ -303,6 +305,10 @@ export default function AdminCompaniesPage() {
       if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
         setError(`一部失敗: ${data.errors.join('; ')}`)
       }
+      const steps = [data.info_step, data.tech_step, data.relations_step]
+      const allSkipped = steps.every((s) => s?.status === 'skipped')
+      const anyFailed = steps.some((s) => s?.status === 'error' || s?.status === 'empty')
+      setFetchAllSeverity(allSkipped || anyFailed ? 'warning' : 'success')
       setFetchAllMessage(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
       await reloadCurrentList()
       await fetchCoverage()
@@ -350,7 +356,7 @@ export default function AdminCompaniesPage() {
 
       <ErrorAlert error={error} />
       {fetchAllMessage && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setFetchAllMessage('')}>
+        <Alert severity={fetchAllSeverity} sx={{ mb: 2 }} onClose={() => setFetchAllMessage('')}>
           {fetchAllMessage}
         </Alert>
       )}

--- a/frontend/app/admin/companies/page.tsx
+++ b/frontend/app/admin/companies/page.tsx
@@ -9,27 +9,40 @@ import {
   Alert,
   Box,
   Button,
+  Checkbox,
   Chip,
   CircularProgress,
+  FormControlLabel,
+  IconButton,
   InputAdornment,
+  Menu,
+  MenuItem,
   Stack,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
   Pagination,
+  ListItemIcon,
+  ListItemText,
 } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import SearchIcon from '@mui/icons-material/Search'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import { authService } from '@/lib/auth'
 import { PageContainer, ADMIN_PAGE_WIDTH } from '@/components/admin/PageContainer'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import { AdminPanel } from '@/components/admin/AdminPanel'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
-import { StatusBadge } from '@/components/admin/StatusBadge'
+import { companyAspectHref, type CompanyAspect } from '@/components/admin/CompanyAspectTabs'
 import { fetchCompanyPrimary, formatFetchPrimarySummary } from '@/lib/admin-company-fetch'
 
 const PAGE_SIZE = 50
+/** 並列取得（Backend concurrency=4）前提。タイムアウト回避のため上限は控えめ */
+const GLOBAL_BATCH_LIMIT = 20
 
 type Company = {
   id: number
@@ -61,13 +74,50 @@ type L1Coverage = {
   alerts?: string[]
 }
 
-const sourceLabel = (sourceType?: string) => {
-  if (sourceType === 'official') return '公式'
-  if (sourceType === 'job_site') return 'クローリング'
-  return '手動'
+type AspectKey = 'info' | 'tech' | 'relations' | 'jobs'
+
+const ASPECT_LABEL: Record<AspectKey, string> = {
+  info: '会社概要',
+  tech: '技術情報',
+  relations: '関連企業',
+  jobs: '求人',
 }
 
-const pct = (rate: number) => `${Math.round((rate || 0) * 100)}%`
+const ASPECT_PAGE: Partial<Record<AspectKey, CompanyAspect>> = {
+  info: 'info',
+  tech: 'tech',
+  relations: 'relations',
+}
+
+function missingAspects(c: Company): AspectKey[] {
+  const missing: AspectKey[] = []
+  if (!c.info_fetched_at || !c.description || !c.website_url) missing.push('info')
+  if (!c.tech_fetched_at || !c.tech_stack || c.tech_stack === '[]') missing.push('tech')
+  if (!c.relations_fetched_at) missing.push('relations')
+  if (!c.jobs_fetched_at) missing.push('jobs')
+  return missing
+}
+
+/** 公開前かつ主3種がそろっている企業だけ一括公開の対象にする。 */
+function canSelectForPublish(c: Company): boolean {
+  if (c.data_status === 'published') return false
+  return missingAspects(c).filter((k) => k !== 'jobs').length === 0
+}
+
+function subtitleLine(c: Company): string {
+  const parts = [c.industry, c.location].filter((v) => Boolean(v && v.trim()))
+  return parts.join('  ·  ')
+}
+
+function statusLabel(status?: string): { label: string; color: 'warning' | 'success' | 'error' | 'default' } {
+  if (status === 'published') return { label: '学生に公開中', color: 'success' }
+  if (status === 'rejected') return { label: '非公開', color: 'error' }
+  return { label: '公開前', color: 'warning' }
+}
+
+function pct(rate: number) {
+  return `${Math.round((rate || 0) * 100)}%`
+}
 
 export default function AdminCompaniesPage() {
   useEffect(() => {
@@ -87,10 +137,13 @@ export default function AdminCompaniesPage() {
   const [coverage, setCoverage] = useState<L1Coverage | null>(null)
   const [warming, setWarming] = useState(false)
   const [warmMessage, setWarmMessage] = useState('')
-  const [fetchAllId, setFetchAllId] = useState<number | null>(null)
-  const [fetchAllMessage, setFetchAllMessage] = useState('')
-  const [fetchAllSeverity, setFetchAllSeverity] = useState<'success' | 'warning'>('success')
+  const [fetchPrimaryId, setFetchPrimaryId] = useState<number | null>(null)
+  const [fetchMessage, setFetchMessage] = useState('')
+  const [fetchSeverity, setFetchSeverity] = useState<'success' | 'warning'>('success')
   const [missingBatchLoading, setMissingBatchLoading] = useState(false)
+  const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; company: Company } | null>(null)
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [bulkPublishing, setBulkPublishing] = useState(false)
 
   const fetchCoverage = useCallback(async () => {
     const res = await fetch('/api/admin/companies/l1-coverage', {
@@ -125,14 +178,11 @@ export default function AdminCompaniesPage() {
     setTotal(data?.total ?? 0)
   }, [])
 
-  // 検索入力をデバウンスして反映
   useEffect(() => {
     const timer = setTimeout(() => {
       const next = searchInput.trim()
       setSearchName((prev) => {
-        if (prev !== next) {
-          setPage(1)
-        }
+        if (prev !== next) setPage(1)
         return next
       })
     }, 350)
@@ -142,6 +192,22 @@ export default function AdminCompaniesPage() {
   useEffect(() => {
     void fetchCompanies(page, searchName, filterStatus)
   }, [fetchCompanies, page, searchName, filterStatus])
+
+  useEffect(() => {
+    setSelectedIds([])
+  }, [page, searchName, filterStatus])
+
+  useEffect(() => {
+    // 取得後に情報が足りなくなった選択は外す（中身が同じなら state を更新しない）
+    setSelectedIds((prev) => {
+      const next = prev.filter((id) => {
+        const company = companies.find((c) => c.id === id)
+        return company ? canSelectForPublish(company) : false
+      })
+      if (next.length === prev.length && next.every((id, i) => id === prev[i])) return prev
+      return next
+    })
+  }, [companies])
 
   useEffect(() => {
     void fetchCoverage()
@@ -166,11 +232,11 @@ export default function AdminCompaniesPage() {
       })
       const data = await res.json()
       if (!res.ok) {
-        setError(data?.error || data?.message || 'L1シード投入に失敗しました')
+        setError(data?.error || data?.message || 'マッチング用データの準備に失敗しました')
         return
       }
       setWarmMessage(
-        `シード投入: 作成 ${data.created ?? 0} / 更新 ${data.updated ?? 0} / スキップ ${data.skipped ?? 0}`,
+        `準備完了: 新規 ${data.created ?? 0} 社 / 更新 ${data.updated ?? 0} 社 / 変更なし ${data.skipped ?? 0} 社`,
       )
       await fetchCoverage()
       await reloadCurrentList()
@@ -194,14 +260,15 @@ export default function AdminCompaniesPage() {
       })
       const data = await res.json()
       if (!res.ok) {
-        setError(data?.error || data?.message || 'L1温存に失敗しました')
+        setError(data?.error || data?.message || 'マッチング用データの更新に失敗しました')
         return
       }
       if (dryRun) {
-        setWarmMessage(`ドライラン: 候補 ${data.candidate_count ?? 0} 社（上限 ${data.limit}）`)
+        setWarmMessage(`確認のみ: 対象は約 ${data.candidate_count ?? 0} 社です（一度に最大 ${data.limit} 社）`)
       } else {
         setWarmMessage(
-          `温存完了: 処理 ${data.processed ?? 0} / info ${data.info_ok ?? 0} / persona ${data.persona_ok ?? 0} / エラー ${data.errors ?? 0}`,
+          `更新完了: ${data.processed ?? 0} 社を処理しました` +
+            `（会社情報 ${data.info_ok ?? 0} / マッチング情報 ${data.persona_ok ?? 0} / 失敗 ${data.errors ?? 0}）`,
         )
       }
       if (data.coverage) setCoverage(data.coverage)
@@ -213,7 +280,8 @@ export default function AdminCompaniesPage() {
 
   const handleFetchMissingBatch = async (dryRun: boolean) => {
     setMissingBatchLoading(true)
-    setFetchAllMessage('')
+    setFetchMessage('')
+    setFetchSeverity('success')
     setError('')
     try {
       const res = await fetch('/api/admin/companies/fetch-missing-batch', {
@@ -222,29 +290,67 @@ export default function AdminCompaniesPage() {
           ...authService.getAdminFetchHeaders(),
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ limit: 20, dry_run: dryRun }),
+        body: JSON.stringify({
+          limit: GLOBAL_BATCH_LIMIT,
+          dry_run: dryRun,
+          primary_only: true,
+          concurrency: 4,
+        }),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        setError(data?.error || data?.message || `不足データ一括取得に失敗しました (${res.status})`)
+        setError(data?.error || data?.message || `まとめて取得に失敗しました (${res.status})`)
         return
       }
       if (dryRun) {
         const names = Array.isArray(data.items)
-          ? (data.items as { name?: string }[]).slice(0, 5).map((i) => i.name).filter(Boolean).join(', ')
+          ? (data.items as { name?: string }[])
+              .slice(0, 5)
+              .map((i) => i.name)
+              .filter(Boolean)
+              .join('、')
           : ''
-        setFetchAllMessage(
-          `不足データ対象: ${data.candidate_n ?? 0} 社（上限 ${data.limit}）` +
-            (names ? ` — 例: ${names}${(data.candidate_n ?? 0) > 5 ? ' …' : ''}` : ''),
-        )
+        const n = Number(data.candidate_n ?? 0)
+        if (n === 0) {
+          setFetchSeverity('warning')
+          setFetchMessage('いま取得対象になる企業はありません（会社概要・技術情報・関連企業がすでにそろっているか、対象候補が見つかりませんでした）。')
+        } else {
+          setFetchMessage(
+            `情報が足りない企業は ${n} 社です` +
+              (names ? `（例: ${names}${n > 5 ? ' など' : ''}）` : '') +
+              `。一度に最大 ${data.limit} 社まで取得できます。`,
+          )
+        }
       } else {
-        setFetchAllMessage(
-          `一括取得完了: ${data.processed ?? 0} 社` +
-            `（基本 ${data.info_ok ?? 0} / 技術 ${data.tech_ok ?? 0} / 関係 ${data.relations_ok ?? 0} / 求人 ${data.jobs_ok ?? 0}）` +
-            ` / エラー ${data.errors ?? 0}`,
-        )
-        if ((data.errors ?? 0) > 0) {
-          setError(`一部の企業で取得に失敗しました（エラー ${data.errors} 件）。`)
+        const errs = Number(data.errors ?? 0)
+        const processed = Number(data.processed ?? 0)
+        const infoOk = Number(data.info_ok ?? 0)
+        const techOk = Number(data.tech_ok ?? 0)
+        const relOk = Number(data.relations_ok ?? 0)
+        const skipped = Number(data.skipped ?? 0)
+        const filled = infoOk + techOk + relOk
+        if (processed === 0) {
+          setFetchSeverity('warning')
+          setFetchMessage('取得対象の企業が見つかりませんでした。一覧で「まだ足りない情報があります」と出ている企業がある場合は、時間をおいて再度お試しください。')
+        } else if (filled === 0) {
+          setFetchSeverity('warning')
+          setFetchMessage(
+            `${processed} 社を処理しましたが、新しく保存できた情報はありません` +
+              `（スキップ ${skipped} / エラー ${errs}）。すでに取得済みか、取得に失敗した可能性があります。`,
+          )
+          if (errs > 0) {
+            setError(`${errs} 社で取得に失敗しました。時間をおいて再度お試しください。`)
+          }
+        } else {
+          setFetchSeverity(errs > 0 ? 'warning' : 'success')
+          setFetchMessage(
+            `${processed} 社を処理し、会社概要 ${infoOk} / 技術 ${techOk} / 関連企業 ${relOk} を更新しました` +
+              (skipped > 0 ? `（スキップ ${skipped}）` : '') +
+              (errs > 0 ? `。${errs} 社はうまく取得できませんでした。` : '。内容を確認してから公開してください。'),
+          )
+          if (errs > 0) {
+            setError(`${errs} 社で取得に失敗しました。時間をおいて再度お試しください。`)
+          }
         }
         await reloadCurrentList()
         await fetchCoverage()
@@ -254,43 +360,112 @@ export default function AdminCompaniesPage() {
     }
   }
 
-  const handlePublish = async (companyId: number) => {
-    setError('')
+  const publishCompany = async (companyId: number): Promise<boolean> => {
     const res = await fetch(`/api/admin/companies/${companyId}/publish`, {
       method: 'PATCH',
       headers: authService.getAdminFetchHeaders(),
     })
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      setError(data?.error || `承認に失敗しました (${res.status})`)
+    return res.ok
+  }
+
+  const handlePublish = async (companyId: number) => {
+    setError('')
+    setMenuAnchor(null)
+    const ok = await publishCompany(companyId)
+    if (!ok) {
+      setError('公開に失敗しました')
       return
     }
+    setFetchSeverity('success')
+    setFetchMessage('企業を学生に公開しました。')
+    setSelectedIds((prev) => prev.filter((id) => id !== companyId))
     await reloadCurrentList()
+  }
+
+  const handleBulkPublish = async () => {
+    const targets = companies.filter((c) => selectedIds.includes(c.id) && canSelectForPublish(c))
+    if (targets.length === 0) {
+      setFetchSeverity('warning')
+      setFetchMessage('公開できる企業（情報がそろった公開前）が選択されていません。')
+      return
+    }
+
+    const ok = window.confirm(`選択した ${targets.length} 社を学生に公開しますか？`)
+    if (!ok) return
+
+    setBulkPublishing(true)
+    setError('')
+    setFetchMessage('')
+    try {
+      let success = 0
+      let failed = 0
+      for (const company of targets) {
+        if (await publishCompany(company.id)) success += 1
+        else failed += 1
+      }
+      setSelectedIds([])
+      if (failed > 0) {
+        setFetchSeverity('warning')
+        setFetchMessage(`${success} 社を公開しました。${failed} 社は公開できませんでした。`)
+        setError(`${failed} 社の公開に失敗しました。`)
+      } else {
+        setFetchSeverity('success')
+        setFetchMessage(`${success} 社を学生に公開しました。`)
+      }
+      await reloadCurrentList()
+    } finally {
+      setBulkPublishing(false)
+    }
+  }
+
+  const toggleSelect = (companyId: number) => {
+    const company = companies.find((c) => c.id === companyId)
+    if (!company || !canSelectForPublish(company)) return
+    setSelectedIds((prev) =>
+      prev.includes(companyId) ? prev.filter((id) => id !== companyId) : [...prev, companyId],
+    )
+  }
+
+  const selectableOnPage = companies.filter(canSelectForPublish)
+  const selectedSelectableCount = selectableOnPage.filter((c) => selectedIds.includes(c.id)).length
+  const allSelectableSelected =
+    selectableOnPage.length > 0 && selectedSelectableCount === selectableOnPage.length
+
+  const toggleSelectAllSelectable = () => {
+    if (allSelectableSelected) {
+      setSelectedIds((prev) => prev.filter((id) => !selectableOnPage.some((c) => c.id === id)))
+      return
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      for (const c of selectableOnPage) next.add(c.id)
+      return Array.from(next)
+    })
   }
 
   const handleReject = async (companyId: number) => {
     setError('')
+    setMenuAnchor(null)
     const res = await fetch(`/api/admin/companies/${companyId}/reject`, {
       method: 'PATCH',
       headers: authService.getAdminFetchHeaders(),
     })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
-      setError(data?.error || `却下に失敗しました (${res.status})`)
+      setError(data?.error || `非公開への変更に失敗しました (${res.status})`)
       return
     }
+    setFetchSeverity('success')
+    setFetchMessage('企業を非公開にしました。学生には表示されません。')
     await reloadCurrentList()
   }
 
-  const summarizeFetchAll = (data: Record<string, unknown>) => {
-    return formatFetchPrimarySummary(data as Parameters<typeof formatFetchPrimarySummary>[0])
-  }
-
-  const handleFetchAll = async (companyId: number, force = false) => {
+  const handleFetchPrimary = async (companyId: number, force = false) => {
     setError('')
-    setFetchAllMessage('')
-    setFetchAllSeverity('success')
-    setFetchAllId(companyId)
+    setFetchMessage('')
+    setFetchSeverity('success')
+    setFetchPrimaryId(companyId)
+    setMenuAnchor(null)
     try {
       const { ok, status, data } = await fetchCompanyPrimary(
         companyId,
@@ -301,189 +476,150 @@ export default function AdminCompaniesPage() {
         setError(data?.error || `企業情報の取得に失敗しました (${status})`)
         return
       }
-      const summary = summarizeFetchAll(data as Record<string, unknown>)
-      if (data.ok === false && Array.isArray(data.errors) && data.errors.length > 0) {
-        setError(`一部失敗: ${data.errors.join('; ')}`)
-      }
       const steps = [data.info_step, data.tech_step, data.relations_step]
+      const fetched = steps.filter((s) => s?.status === 'fetched').length
       const allSkipped = steps.every((s) => s?.status === 'skipped')
-      const anyFailed = steps.some((s) => s?.status === 'error' || s?.status === 'empty')
-      setFetchAllSeverity(allSkipped || anyFailed ? 'warning' : 'success')
-      setFetchAllMessage(summary ? `主3種取得完了: ${summary}` : '主3種取得完了')
+      const hardFailed = steps.some((s) => s?.status === 'error')
+      const softEmpty = steps.some((s) => s?.status === 'empty')
+      const budgetHit = steps.some((s) => s?.detail === 'budget') ||
+        (Array.isArray(data.errors) && data.errors.some((e) => e.includes('budget')))
+
+      if (budgetHit) {
+        setFetchSeverity('warning')
+        setError('月次の情報取得上限に達しているため、新しい取得ができませんでした。コスト画面を確認するか、時間をおいて再度お試しください。')
+        setFetchMessage(formatFetchPrimarySummary(data) || '予算超過のため取得をスキップしました。')
+      } else if (hardFailed) {
+        setFetchSeverity('warning')
+        setError(
+          Array.isArray(data.errors) && data.errors.length > 0
+            ? `一部うまくいきませんでした: ${data.errors.join(' / ')}`
+            : '一部の情報取得に失敗しました。',
+        )
+        setFetchMessage(
+          `情報の取得が一部失敗しました（${formatFetchPrimarySummary(data)}）。「最新の情報に更新」で再試行できます。`,
+        )
+      } else if (softEmpty) {
+        setFetchSeverity('warning')
+        setFetchMessage(
+          `取得を試しましたが、公開情報から特定できない項目がありました（${formatFetchPrimarySummary(data)}）。手入力するか、時間をおいて再度お試しください。`,
+        )
+      } else if (allSkipped) {
+        setFetchSeverity('warning')
+        setFetchMessage('すでに新しい情報があるため、取得をスキップしました。')
+      } else {
+        setFetchSeverity('success')
+        setFetchMessage(
+          force
+            ? `情報を更新しました（${fetched} 項目）。`
+            : `情報を取得しました（${fetched} 項目）。内容を確認して問題なければ「学生に公開」できます。`,
+        )
+      }
       await reloadCurrentList()
       await fetchCoverage()
+    } catch {
+      setError('企業情報の取得中に通信エラーが発生しました。時間をおいて再度お試しください。')
     } finally {
-      setFetchAllId(null)
+      setFetchPrimaryId(null)
     }
   }
 
-  const missingLabels = (c: Company) => {
-    const labels: string[] = []
-    if (!c.info_fetched_at || !c.description || !c.website_url) labels.push('基本')
-    if (!c.tech_fetched_at || !c.tech_stack || c.tech_stack === '[]') labels.push('技術')
-    if (!c.relations_fetched_at) labels.push('関係')
-    if (!c.jobs_fetched_at) labels.push('求人')
-    return labels
-  }
-
   const pageCount = Math.ceil(total / PAGE_SIZE)
-  const busy = warming || missingBatchLoading || fetchAllId !== null
+  const busy = warming || missingBatchLoading || fetchPrimaryId !== null || bulkPublishing
+  const selectedCount = selectedIds.length
 
   return (
     <PageContainer maxWidth={ADMIN_PAGE_WIDTH.standard}>
       <AdminPageHeader
-        title="企業管理"
+        title="企業情報の管理"
         description={
           searchName
             ? `「${searchName}」の検索結果 ${total.toLocaleString()} 件`
-            : `公開ステータスと企業情報（基本・技術・ビジネス関係）を管理します。全 ${total.toLocaleString()} 件`
+            : `学生課の先生が、学生に見せる企業情報を登録・確認・公開するための画面です。登録 ${total.toLocaleString()} 社`
         }
         backHref="/admin"
         actions={
-          <>
-            <Button component={Link} href="/admin/job-positions" size="small" color="inherit">
-              求人
-            </Button>
-            <Button component={Link} href="/admin/graduate-employments" size="small" color="inherit">
-              就職情報
-            </Button>
-            <Button variant="contained" component={Link} href="/admin/companies/new" disableElevation>
-              企業を追加
-            </Button>
-          </>
+          <Button variant="contained" component={Link} href="/admin/companies/new" disableElevation>
+            企業を追加
+          </Button>
         }
       />
 
       <ErrorAlert error={error} />
-      {fetchAllMessage && (
-        <Alert severity={fetchAllSeverity} sx={{ mb: 2 }} onClose={() => setFetchAllMessage('')}>
-          {fetchAllMessage}
+      {fetchMessage && (
+        <Alert severity={fetchSeverity} sx={{ mb: 2 }} onClose={() => setFetchMessage('')}>
+          {fetchMessage}
         </Alert>
       )}
 
-      <Accordion
-        disableGutters
-        elevation={0}
+      <Box
         sx={{
           mb: 2,
+          p: 2,
           border: '1px solid',
           borderColor: 'divider',
-          borderRadius: '10px !important',
-          '&:before': { display: 'none' },
-          overflow: 'hidden',
+          borderRadius: '10px',
+          bgcolor: 'grey.50',
         }}
       >
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Stack spacing={0.25}>
-            <Typography fontWeight={600}>運用ツール</Typography>
-            <Typography variant="caption" color="text.secondary">
-              不足データの一括取得・L1カタログ温存
-              {coverage
-                ? `（公開 ${coverage.published_total} / Info ${pct(coverage.info_rate)} / Profile ${pct(coverage.profile_rate)}）`
-                : ''}
-            </Typography>
-          </Stack>
-        </AccordionSummary>
-        <AccordionDetails sx={{ pt: 0, borderTop: '1px solid', borderColor: 'divider' }}>
-          <Stack spacing={2.5} sx={{ py: 1.5 }}>
-            <Stack
-              direction={{ xs: 'column', md: 'row' }}
-              spacing={2}
-              alignItems={{ md: 'center' }}
-              justifyContent="space-between"
-            >
-              <Box sx={{ minWidth: 0 }}>
-                <Typography variant="subtitle2" fontWeight={600}>
-                  不足データを一括取得
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  未取得／TTL切れの基本・技術・ビジネス関係（＋求人）を最大20社まで埋めます。
-                </Typography>
-              </Box>
-              <Stack direction="row" spacing={1} flexShrink={0}>
-                <Button variant="outlined" size="small" disabled={busy} onClick={() => handleFetchMissingBatch(true)}>
-                  対象確認
-                </Button>
-                <Button
-                  variant="contained"
-                  size="small"
-                  color="secondary"
-                  disabled={busy}
-                  onClick={() => handleFetchMissingBatch(false)}
-                  startIcon={missingBatchLoading ? <CircularProgress size={14} color="inherit" /> : null}
-                  disableElevation
-                >
-                  {missingBatchLoading ? '取得中…' : '一括取得'}
-                </Button>
-              </Stack>
-            </Stack>
+        <Typography fontWeight={700} sx={{ mb: 1 }}>
+          使い方（3ステップ）
+        </Typography>
+        <Stack spacing={0.5}>
+          <Typography variant="body2" color="text.secondary">
+            1. 企業名で探し、情報が足りなければ「情報を取得」します
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            2. 「会社概要」「技術情報」「関連企業」で内容を確認・修正します
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            3. 情報がそろった企業を選んで「学生に公開」します（足りない企業は選べません）
+          </Typography>
+        </Stack>
+      </Box>
 
-            <Box sx={{ borderTop: '1px solid', borderColor: 'divider', pt: 2 }}>
-              <Stack
-                direction={{ xs: 'column', md: 'row' }}
-                spacing={2}
-                alignItems={{ md: 'flex-start' }}
-                justifyContent="space-between"
-              >
-                <Box sx={{ minWidth: 0 }}>
-                  <Typography variant="subtitle2" fontWeight={600}>
-                    L1カタログ充足
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    マッチング用。公開企業の基本情報と WeightProfile を温存します。
-                  </Typography>
-                  {coverage && (
-                    <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-                      <Chip size="small" variant="outlined" label={`公開 ${coverage.published_total}`} />
-                      <Chip
-                        size="small"
-                        variant="outlined"
-                        color={coverage.info_rate < (coverage.info_target ?? 0.8) ? 'error' : 'default'}
-                        label={`Info ${pct(coverage.info_rate)}`}
-                      />
-                      <Chip
-                        size="small"
-                        variant="outlined"
-                        color={coverage.profile_rate < (coverage.profile_target ?? 0.95) ? 'error' : 'default'}
-                        label={`Profile ${pct(coverage.profile_rate)}`}
-                      />
-                      <Chip size="small" variant="outlined" label={`要温存 ${coverage.needs_warm}`} />
-                    </Stack>
-                  )}
-                  {coverage?.alerts?.length ? (
-                    <Typography variant="caption" color="error" sx={{ display: 'block', mt: 1 }}>
-                      {coverage.alerts.join(' / ')}
-                    </Typography>
-                  ) : null}
-                  {warmMessage && (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-                      {warmMessage}
-                    </Typography>
-                  )}
-                </Box>
-                <Stack direction="row" spacing={1} flexShrink={0} flexWrap="wrap" useFlexGap>
-                  <Button variant="text" size="small" disabled={busy} onClick={() => handleSeedL1()}>
-                    シード投入
-                  </Button>
-                  <Button variant="outlined" size="small" disabled={busy} onClick={() => handleWarmL1(true)}>
-                    ドライラン
-                  </Button>
-                  <Button
-                    variant="contained"
-                    size="small"
-                    disabled={busy}
-                    onClick={() => handleWarmL1(false)}
-                    startIcon={warming ? <CircularProgress size={14} color="inherit" /> : undefined}
-                    disableElevation
-                  >
-                    L1温存
-                  </Button>
-                </Stack>
-              </Stack>
-            </Box>
+      <Box
+        sx={{
+          mb: 2,
+          p: 2.5,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: '10px',
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ sm: 'center' }}
+          justifyContent="space-between"
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography fontWeight={700} sx={{ mb: 0.5 }}>
+              足りない情報をまとめて取得
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              まだそろっていない会社概要・技術情報・関連企業を、一度に最大 {GLOBAL_BATCH_LIMIT}{' '}
+              社まで自動で集めます（複数社を同時に取得します。足りなければ繰り返してください）。
+              取得後は必ず内容を確認してから公開してください。
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={1} flexShrink={0}>
+            <Button variant="outlined" disabled={busy} onClick={() => handleFetchMissingBatch(true)}>
+              対象を確認
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              disabled={busy}
+              onClick={() => handleFetchMissingBatch(false)}
+              startIcon={missingBatchLoading ? <CircularProgress size={16} color="inherit" /> : <RefreshIcon />}
+              disableElevation
+            >
+              {missingBatchLoading ? '取得中…' : 'まとめて取得'}
+            </Button>
           </Stack>
-        </AccordionDetails>
-      </Accordion>
+        </Stack>
+      </Box>
 
       <AdminPanel
         title="企業一覧"
@@ -491,7 +627,7 @@ export default function AdminCompaniesPage() {
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
             <TextField
               size="small"
-              placeholder="企業名で検索"
+              placeholder="企業名で探す"
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               sx={{ minWidth: { sm: 240 } }}
@@ -514,131 +650,270 @@ export default function AdminCompaniesPage() {
               }}
               sx={{
                 '& .MuiToggleButton-root': {
-                  px: 1.5,
+                  px: 1.75,
                   textTransform: 'none',
                   borderColor: 'divider',
                 },
               }}
             >
               <ToggleButton value="all">すべて</ToggleButton>
-              <ToggleButton value="draft">下書き</ToggleButton>
-              <ToggleButton value="published">公開</ToggleButton>
+              <ToggleButton value="draft">公開前</ToggleButton>
+              <ToggleButton value="published">学生に公開中</ToggleButton>
             </ToggleButtonGroup>
           </Stack>
         }
       >
+        {selectableOnPage.length > 0 ? (
+          <Box
+            sx={{
+              px: 2.5,
+              py: 1.25,
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+              bgcolor: selectedCount > 0 ? 'action.selected' : 'grey.50',
+            }}
+          >
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={1.5}
+              alignItems={{ sm: 'center' }}
+              justifyContent="space-between"
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={allSelectableSelected}
+                    indeterminate={selectedSelectableCount > 0 && !allSelectableSelected}
+                    onChange={toggleSelectAllSelectable}
+                    disabled={busy}
+                  />
+                }
+                label={
+                  selectedSelectableCount > 0
+                    ? `公開できる企業 ${selectedSelectableCount} 社を選択中`
+                    : `このページで公開できる企業（${selectableOnPage.length} 社）を選択`
+                }
+              />
+              <Stack direction="row" spacing={1}>
+                {selectedCount > 0 && (
+                  <Button size="small" variant="text" disabled={busy} onClick={() => setSelectedIds([])}>
+                    選択解除
+                  </Button>
+                )}
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="success"
+                  disabled={busy || selectedSelectableCount === 0}
+                  onClick={() => handleBulkPublish()}
+                  startIcon={bulkPublishing ? <CircularProgress size={14} color="inherit" /> : null}
+                  disableElevation
+                >
+                  {bulkPublishing
+                    ? '公開中…'
+                    : selectedSelectableCount > 0
+                      ? `選択した ${selectedSelectableCount} 社を学生に公開`
+                      : '選択して学生に公開'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              px: 2.5,
+              py: 1.25,
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'grey.50',
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              このページに、まとめて公開できる企業はありません（公開前かつ情報がそろっている企業だけ選べます）。
+            </Typography>
+          </Box>
+        )}
+
         <Stack divider={<Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }} />}>
           {companies.length === 0 && (
             <Box sx={{ px: 2.5, py: 6, textAlign: 'center' }}>
-              <Typography color="text.secondary">
+              <Typography color="text.secondary" sx={{ mb: 1 }}>
                 {searchName ? `「${searchName}」に一致する企業がありません` : '該当する企業がありません'}
               </Typography>
+              {!searchName && (
+                <Button component={Link} href="/admin/companies/new" variant="outlined" size="small">
+                  最初の企業を追加
+                </Button>
+              )}
             </Box>
           )}
 
           {companies.map((company) => {
-            const missing = missingLabels(company)
-            const fetching = fetchAllId === company.id
+            const missing = missingAspects(company)
+            const primaryMissing = missing.filter((k) => k !== 'jobs')
+            const ready = primaryMissing.length === 0
+            const fetching = fetchPrimaryId === company.id
+            const isDraft = company.data_status !== 'published'
+            const meta = subtitleLine(company)
+            const status = statusLabel(company.data_status)
+            const selected = selectedIds.includes(company.id)
+
             return (
               <Box
                 key={company.id}
                 sx={{
                   px: 2.5,
                   py: 2,
-                  '&:hover': { bgcolor: 'action.hover' },
+                  bgcolor: selected ? 'action.selected' : undefined,
+                  '&:hover': { bgcolor: selected ? 'action.selected' : 'action.hover' },
                 }}
               >
                 <Stack
                   direction={{ xs: 'column', md: 'row' }}
-                  spacing={2}
+                  spacing={1.5}
                   alignItems={{ md: 'center' }}
                   justifyContent="space-between"
                 >
-                  <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
-                      <Typography
-                        component={Link}
-                        href={`/admin/companies/${company.id}/info`}
-                        variant="subtitle1"
-                        fontWeight={700}
-                        sx={{
-                          color: 'text.primary',
-                          textDecoration: 'none',
-                          '&:hover': { color: 'primary.main' },
-                        }}
-                      >
-                        {company.name}
-                      </Typography>
-                      <StatusBadge status={company.data_status} />
-                      <Typography variant="caption" color="text.secondary">
-                        {sourceLabel(company.source_type)}
-                        {company.is_provisional ? ' · 暫定' : ''}
-                      </Typography>
-                    </Stack>
-                    <Typography variant="body2" color="text.secondary">
-                      {[company.industry || '業種未設定', company.location || '所在地未設定'].join('  ·  ')}
-                    </Typography>
-                    {missing.length > 0 && (
-                      <Typography variant="caption" sx={{ color: 'warning.dark', display: 'block', mt: 0.75 }}>
-                        未取得: {missing.join(' · ')}
-                      </Typography>
-                    )}
-                  </Box>
+                  <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ minWidth: 0, flex: 1 }}>
+                    <Checkbox
+                      checked={selected}
+                      onChange={() => toggleSelect(company.id)}
+                      disabled={busy || !canSelectForPublish(company)}
+                      inputProps={{ 'aria-label': `${company.name}を選択` }}
+                      sx={{ mt: -0.5 }}
+                    />
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
+                        <Typography
+                          component={Link}
+                          href={companyAspectHref(company.id, 'info')}
+                          variant="subtitle1"
+                          fontWeight={700}
+                          sx={{
+                            color: 'text.primary',
+                            textDecoration: 'none',
+                            '&:hover': { color: 'primary.main' },
+                          }}
+                        >
+                          {company.name}
+                        </Typography>
+                        <Chip label={status.label} color={status.color} size="small" />
+                      </Stack>
+
+                      {meta ? (
+                        <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+                          {meta}
+                        </Typography>
+                      ) : null}
+
+                      <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+                        {ready ? (
+                          <Chip
+                            size="small"
+                            icon={<CheckCircleOutlineIcon />}
+                            label="公開の準備ができています"
+                            color="success"
+                            variant="outlined"
+                          />
+                        ) : (
+                          <>
+                            <Chip
+                              size="small"
+                              icon={<ErrorOutlineIcon />}
+                              label="まだ足りない情報があります"
+                              color="warning"
+                              variant="outlined"
+                            />
+                            {primaryMissing.map((key) => {
+                              const page = ASPECT_PAGE[key]
+                              if (!page) {
+                                return <Chip key={key} size="small" label={ASPECT_LABEL[key]} variant="outlined" />
+                              }
+                              return (
+                                <Chip
+                                  key={key}
+                                  size="small"
+                                  label={ASPECT_LABEL[key]}
+                                  variant="outlined"
+                                  component={Link}
+                                  href={companyAspectHref(company.id, page)}
+                                  clickable
+                                />
+                              )
+                            })}
+                          </>
+                        )}
+                      </Stack>
+
+                      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+                        <Button
+                          component={Link}
+                          href={companyAspectHref(company.id, 'info')}
+                          size="small"
+                          variant="text"
+                        >
+                          会社概要
+                        </Button>
+                        <Button
+                          component={Link}
+                          href={companyAspectHref(company.id, 'tech')}
+                          size="small"
+                          variant="text"
+                        >
+                          技術情報
+                        </Button>
+                        <Button
+                          component={Link}
+                          href={companyAspectHref(company.id, 'relations')}
+                          size="small"
+                          variant="text"
+                        >
+                          関連企業
+                        </Button>
+                      </Stack>
+                    </Box>
+                  </Stack>
 
                   <Stack
                     direction="row"
-                    spacing={0.75}
-                    flexWrap="wrap"
-                    useFlexGap
+                    spacing={1}
                     alignItems="center"
                     justifyContent={{ xs: 'flex-start', md: 'flex-end' }}
-                    sx={{ flexShrink: 0 }}
+                    sx={{ flexShrink: 0, pl: { xs: 5, md: 0 } }}
                   >
-                    <Button
-                      variant="contained"
-                      size="small"
-                      color="secondary"
-                      onClick={() => handleFetchAll(company.id)}
-                      disabled={busy}
-                      startIcon={fetching ? <CircularProgress size={14} color="inherit" /> : null}
-                      disableElevation
-                    >
-                      {fetching ? '取得中…' : '主3種取得'}
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      color="inherit"
-                      onClick={() => handleFetchAll(company.id, true)}
-                      disabled={busy}
-                    >
-                      強制再取得
-                    </Button>
-                    <Button component={Link} href={`/admin/companies/${company.id}/info`} size="small" variant="text">
-                      編集
-                    </Button>
-                    {company.data_status !== 'published' ? (
-                      <>
-                        <Button
-                          variant="outlined"
-                          color="success"
-                          size="small"
-                          onClick={() => handlePublish(company.id)}
-                          disabled={busy}
-                        >
-                          承認
-                        </Button>
-                        <Button
-                          variant="text"
-                          color="error"
-                          size="small"
-                          onClick={() => handleReject(company.id)}
-                          disabled={busy}
-                        >
-                          却下
-                        </Button>
-                      </>
+                    {!ready ? (
+                      <Button
+                        variant="contained"
+                        size="small"
+                        color="secondary"
+                        onClick={() => handleFetchPrimary(company.id, true)}
+                        disabled={busy}
+                        startIcon={fetching ? <CircularProgress size={14} color="inherit" /> : null}
+                        disableElevation
+                      >
+                        {fetching ? '取得中…' : '情報を取得'}
+                      </Button>
+                    ) : isDraft ? (
+                      <Button
+                        variant="contained"
+                        size="small"
+                        color="success"
+                        onClick={() => handlePublish(company.id)}
+                        disabled={busy}
+                        disableElevation
+                      >
+                        学生に公開
+                      </Button>
                     ) : null}
+
+                    <IconButton
+                      size="small"
+                      aria-label={`${company.name}のその他の操作`}
+                      disabled={busy && !fetching}
+                      onClick={(e) => setMenuAnchor({ el: e.currentTarget, company })}
+                    >
+                      <MoreVertIcon fontSize="small" />
+                    </IconButton>
                   </Stack>
                 </Stack>
               </Box>
@@ -652,6 +927,124 @@ export default function AdminCompaniesPage() {
           </Box>
         )}
       </AdminPanel>
+
+      <Menu
+        anchorEl={menuAnchor?.el}
+        open={Boolean(menuAnchor)}
+        onClose={() => setMenuAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <MenuItem
+          disabled={busy}
+          onClick={() => menuAnchor && handleFetchPrimary(menuAnchor.company.id, true)}
+        >
+          <ListItemIcon>
+            <RefreshIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>情報を取得</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={busy}
+          onClick={() => menuAnchor && handleFetchPrimary(menuAnchor.company.id, true)}
+        >
+          <ListItemIcon>
+            <RefreshIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>最新の情報に更新</ListItemText>
+        </MenuItem>
+        {menuAnchor?.company.data_status !== 'published' ? (
+          [
+            <MenuItem
+              key="publish"
+              disabled={busy}
+              onClick={() => menuAnchor && handlePublish(menuAnchor.company.id)}
+            >
+              <ListItemText>学生に公開</ListItemText>
+            </MenuItem>,
+            <MenuItem
+              key="reject"
+              disabled={busy}
+              onClick={() => menuAnchor && handleReject(menuAnchor.company.id)}
+            >
+              <ListItemText sx={{ color: 'error.main' }}>公開しない</ListItemText>
+            </MenuItem>,
+          ]
+        ) : (
+          <MenuItem disabled={busy} onClick={() => menuAnchor && handleReject(menuAnchor.company.id)}>
+            <ListItemText sx={{ color: 'error.main' }}>非公開にする</ListItemText>
+          </MenuItem>
+        )}
+      </Menu>
+
+      <Accordion
+        disableGutters
+        elevation={0}
+        sx={{
+          mt: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: '10px !important',
+          '&:before': { display: 'none' },
+          overflow: 'hidden',
+        }}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box>
+            <Typography fontWeight={700}>高度な設定（通常は使いません）</Typography>
+            <Typography variant="body2" color="text.secondary">
+              システム担当向け。マッチング用データの更新や、求人・就職情報への移動
+            </Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 0 }}>
+          <Stack spacing={2}>
+            <Box>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                マッチング用データの更新
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                公開中の企業について、学生とのマッチングに使う情報を最新にします。
+                {coverage
+                  ? `（公開 ${coverage.published_total} 社 / 会社情報 ${pct(coverage.info_rate)} / マッチング情報 ${pct(coverage.profile_rate)}）`
+                  : ''}
+              </Typography>
+              {warmMessage && (
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                  {warmMessage}
+                </Typography>
+              )}
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                <Button variant="text" size="small" disabled={busy} onClick={() => handleSeedL1()}>
+                  初期データを用意
+                </Button>
+                <Button variant="outlined" size="small" disabled={busy} onClick={() => handleWarmL1(true)}>
+                  対象を確認
+                </Button>
+                <Button
+                  variant="contained"
+                  size="small"
+                  disabled={busy}
+                  onClick={() => handleWarmL1(false)}
+                  startIcon={warming ? <CircularProgress size={14} color="inherit" /> : undefined}
+                  disableElevation
+                >
+                  マッチング情報を更新
+                </Button>
+              </Stack>
+            </Box>
+
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              <Button component={Link} href="/admin/job-positions" size="small" variant="outlined">
+                求人一覧へ
+              </Button>
+              <Button component={Link} href="/admin/graduate-employments" size="small" variant="outlined">
+                就職情報へ
+              </Button>
+            </Stack>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
     </PageContainer>
   )
 }

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -49,8 +49,8 @@ export default function AdminDashboardPage() {
   return (
     <PageContainer maxWidth={ADMIN_PAGE_WIDTH.standard}>
       <AdminPageHeader
-        title="管理者ダッシュボード"
-        description="管理者向けの操作メニューです。権限がない場合は表示されません。"
+        title="管理メニュー"
+        description="学生課の先生向けに、企業情報や求人・就職情報を管理できます。"
         backHref="/"
       />
 
@@ -59,10 +59,10 @@ export default function AdminDashboardPage() {
           <Card elevation={0} sx={cardSx}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                企業データ
+                企業情報
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                企業プロフィールの追加・更新、公開ステータスの管理を行います。
+                学生に見せる企業の登録・確認・公開を行います。
               </Typography>
               <Chip
                 label={companyCount === null ? '読み込み中' : `登録数 ${companyCount}`}
@@ -71,7 +71,7 @@ export default function AdminDashboardPage() {
               />
               <Divider sx={{ mb: 2 }} />
               <Button variant="contained" component={Link} href="/admin/companies">
-                企業管理へ
+                企業情報の管理へ
               </Button>
             </CardContent>
           </Card>

--- a/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
@@ -19,7 +19,7 @@ export async function POST(
   try {
     const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-info${qs}`, {
       headers: adminProxyHeaders(request.headers),
-      timeoutMs: 180_000,
+      timeoutMs: 120_000,
     })
     return jsonFromProxyResult(result)
   } catch (err) {

--- a/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-info/route.ts
@@ -1,8 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 180
 
 export async function POST(
   request: NextRequest,
@@ -11,22 +16,13 @@ export async function POST(
   const { id } = await params
   const force = request.nextUrl.searchParams.get('force')
   const qs = force === 'true' ? '?force=true' : ''
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-info${qs}`, {
-    method: 'POST',
-    headers: {
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    signal: AbortSignal.timeout(120_000),
-  })
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-info${qs}`, {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 180_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
@@ -1,8 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 300
 
 /**
  * 主3種（基本・技術・ビジネス関係）を1リクエストで取得する BFF。
@@ -15,32 +20,13 @@ export async function POST(
   const { id } = await params
   const force = request.nextUrl.searchParams.get('force')
   const qs = force === 'true' ? '?force=true' : ''
-  let response: Response
   try {
-    response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-primary${qs}`, {
-      method: 'POST',
-      headers: {
-        'X-Admin-Email': request.headers.get('x-admin-email') || '',
-        'X-Admin-Token': request.headers.get('x-admin-token') || '',
-      },
-      // 基本 + 技術 + 関係で長時間になりうる
-      signal: AbortSignal.timeout(300_000),
+    const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-primary${qs}`, {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 300_000,
     })
-  } catch (error) {
-    const message =
-      error instanceof Error && error.name === 'TimeoutError'
-        ? '企業情報の取得がタイムアウトしました'
-        : '企業情報取得中に通信エラーが発生しました'
-    return NextResponse.json({ error: message }, { status: 504 })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
-  }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-primary/route.ts
@@ -23,7 +23,8 @@ export async function POST(
   try {
     const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-primary${qs}`, {
       headers: adminProxyHeaders(request.headers),
-      timeoutMs: 300_000,
+      // maxDuration より短くし、タイムアウト時に整形エラーを返せるようにする
+      timeoutMs: 270_000,
     })
     return jsonFromProxyResult(result)
   } catch (err) {

--- a/frontend/app/api/admin/companies/[id]/fetch-relations/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-relations/route.ts
@@ -1,8 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 180
 
 export async function POST(
   request: NextRequest,
@@ -11,22 +16,13 @@ export async function POST(
   const { id } = await params
   const force = request.nextUrl.searchParams.get('force')
   const qs = force === 'true' ? '?force=true' : ''
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}/fetch-relations${qs}`, {
-    method: 'POST',
-    headers: {
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    signal: AbortSignal.timeout(120_000),
-  })
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-relations${qs}`, {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 180_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/[id]/fetch-relations/route.ts
+++ b/frontend/app/api/admin/companies/[id]/fetch-relations/route.ts
@@ -15,11 +15,15 @@ export async function POST(
 ) {
   const { id } = await params
   const force = request.nextUrl.searchParams.get('force')
-  const qs = force === 'true' ? '?force=true' : ''
+  const cacheOnly = request.nextUrl.searchParams.get('cache_only')
+  const qs = new URLSearchParams()
+  if (force === 'true') qs.set('force', 'true')
+  if (cacheOnly === 'true') qs.set('cache_only', 'true')
+  const query = qs.toString() ? `?${qs.toString()}` : ''
   try {
-    const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-relations${qs}`, {
+    const result = await proxyAdminBackend('POST', `/api/admin/companies/${id}/fetch-relations${query}`, {
       headers: adminProxyHeaders(request.headers),
-      timeoutMs: 180_000,
+      timeoutMs: 120_000,
     })
     return jsonFromProxyResult(result)
   } catch (err) {

--- a/frontend/app/api/admin/companies/fetch-missing-batch/route.ts
+++ b/frontend/app/api/admin/companies/fetch-missing-batch/route.ts
@@ -1,9 +1,10 @@
-import http from 'node:http'
-import https from 'node:https'
-import { URL } from 'node:url'
 import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 /** Backend がレスポンスを返すまで最大15分待つ（global fetch / undici 既定の HeadersTimeout=5分を回避） */
 const BATCH_TIMEOUT_MS = 900_000
@@ -11,81 +12,27 @@ const BATCH_TIMEOUT_MS = 900_000
 export const dynamic = 'force-dynamic'
 export const maxDuration = 900
 
-function postWithLongTimeout(
-  url: string,
-  headers: Record<string, string>,
-  body: string,
-): Promise<{ status: number; text: string }> {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url)
-    const lib = parsed.protocol === 'https:' ? https : http
-    const req = lib.request(
-      {
-        protocol: parsed.protocol,
-        hostname: parsed.hostname,
-        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
-        path: `${parsed.pathname}${parsed.search}`,
-        method: 'POST',
-        headers: {
-          ...headers,
-          'Content-Length': Buffer.byteLength(body),
-        },
-        timeout: BATCH_TIMEOUT_MS,
-      },
-      (res) => {
-        const chunks: Buffer[] = []
-        res.on('data', (chunk: Buffer) => chunks.push(chunk))
-        res.on('end', () => {
-          resolve({
-            status: res.statusCode ?? 502,
-            text: Buffer.concat(chunks).toString('utf8'),
-          })
-        })
-      },
-    )
-    req.setTimeout(BATCH_TIMEOUT_MS, () => {
-      req.destroy(new Error('Headers/body timeout'))
-    })
-    req.on('timeout', () => {
-      req.destroy(new Error('Request timeout'))
-    })
-    req.on('error', reject)
-    req.write(body)
-    req.end()
-  })
-}
-
 export async function POST(request: NextRequest) {
   const body = (await request.text()) || '{}'
   try {
-    const { status, text } = await postWithLongTimeout(
-      `${BACKEND_URL}/api/admin/companies/fetch-missing-batch`,
-      {
-        'Content-Type': 'application/json',
-        'X-Admin-Email': request.headers.get('x-admin-email') || '',
-        'X-Admin-Token': request.headers.get('x-admin-token') || '',
-      },
+    const result = await proxyAdminBackend('POST', '/api/admin/companies/fetch-missing-batch', {
+      headers: adminProxyHeaders(request.headers),
       body,
-    )
-    let data: Record<string, unknown> = {}
-    if (text) {
-      try {
-        data = JSON.parse(text) as Record<string, unknown>
-      } catch {
-        data = status < 400 ? { message: text } : { error: text }
-      }
-    }
-    return NextResponse.json(data, { status })
-  } catch (err: unknown) {
+      timeoutMs: BATCH_TIMEOUT_MS,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     const timedOut = /timeout/i.test(message)
-    return NextResponse.json(
-      {
-        error: timedOut
-          ? 'まとめて取得がタイムアウトしました。件数を減らすか、時間をおいて再度お試しください。'
-          : `バックエンドに接続できません: ${message}`,
-      },
-      { status: timedOut ? 504 : 503 },
-    )
+    if (timedOut) {
+      return NextResponse.json(
+        {
+          error:
+            'まとめて取得がタイムアウトしました。件数を減らすか、時間をおいて再度お試しください。',
+        },
+        { status: 504 },
+      )
+    }
+    return proxyErrorResponse(err)
   }
 }

--- a/frontend/app/api/admin/companies/fetch-missing-batch/route.ts
+++ b/frontend/app/api/admin/companies/fetch-missing-batch/route.ts
@@ -1,30 +1,91 @@
+import http from 'node:http'
+import https from 'node:https'
+import { URL } from 'node:url'
 import { NextRequest, NextResponse } from 'next/server'
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
 
+/** Backend がレスポンスを返すまで最大15分待つ（global fetch / undici 既定の HeadersTimeout=5分を回避） */
+const BATCH_TIMEOUT_MS = 900_000
+
 export const dynamic = 'force-dynamic'
+export const maxDuration = 900
+
+function postWithLongTimeout(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+): Promise<{ status: number; text: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const lib = parsed.protocol === 'https:' ? https : http
+    const req = lib.request(
+      {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: `${parsed.pathname}${parsed.search}`,
+        method: 'POST',
+        headers: {
+          ...headers,
+          'Content-Length': Buffer.byteLength(body),
+        },
+        timeout: BATCH_TIMEOUT_MS,
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 502,
+            text: Buffer.concat(chunks).toString('utf8'),
+          })
+        })
+      },
+    )
+    req.setTimeout(BATCH_TIMEOUT_MS, () => {
+      req.destroy(new Error('Headers/body timeout'))
+    })
+    req.on('timeout', () => {
+      req.destroy(new Error('Request timeout'))
+    })
+    req.on('error', reject)
+    req.write(body)
+    req.end()
+  })
+}
 
 export async function POST(request: NextRequest) {
-  const body = await request.text()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/fetch-missing-batch`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    body: body || '{}',
-    // 最大50社 × 複数取得のため長め
-    signal: AbortSignal.timeout(600_000),
-  })
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
+  const body = (await request.text()) || '{}'
+  try {
+    const { status, text } = await postWithLongTimeout(
+      `${BACKEND_URL}/api/admin/companies/fetch-missing-batch`,
+      {
+        'Content-Type': 'application/json',
+        'X-Admin-Email': request.headers.get('x-admin-email') || '',
+        'X-Admin-Token': request.headers.get('x-admin-token') || '',
+      },
+      body,
+    )
+    let data: Record<string, unknown> = {}
+    if (text) {
+      try {
+        data = JSON.parse(text) as Record<string, unknown>
+      } catch {
+        data = status < 400 ? { message: text } : { error: text }
+      }
     }
+    return NextResponse.json(data, { status })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    const timedOut = /timeout/i.test(message)
+    return NextResponse.json(
+      {
+        error: timedOut
+          ? 'まとめて取得がタイムアウトしました。件数を減らすか、時間をおいて再度お試しください。'
+          : `バックエンドに接続できません: ${message}`,
+      },
+      { status: timedOut ? 504 : 503 },
+    )
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/industries/route.ts
+++ b/frontend/app/api/admin/companies/industries/route.ts
@@ -1,25 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 30
 
 export async function GET(request: NextRequest) {
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/industries`, {
-    headers: {
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    cache: 'no-store',
-  })
-  const raw = await response.text()
-  let data: unknown = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('GET', '/api/admin/companies/industries', {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 15_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/industries/route.ts
+++ b/frontend/app/api/admin/companies/industries/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const response = await fetch(`${BACKEND_URL}/api/admin/companies/industries`, {
+    headers: {
+      'X-Admin-Email': request.headers.get('x-admin-email') || '',
+      'X-Admin-Token': request.headers.get('x-admin-token') || '',
+    },
+    cache: 'no-store',
+  })
+  const raw = await response.text()
+  let data: unknown = {}
+  if (raw) {
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      data = response.ok ? { message: raw } : { error: raw }
+    }
+  }
+  return NextResponse.json(data, { status: response.status })
+}

--- a/frontend/app/api/admin/companies/web-search-relations/route.ts
+++ b/frontend/app/api/admin/companies/web-search-relations/route.ts
@@ -1,29 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 180
 
 export async function POST(request: NextRequest) {
   const body = await request.text()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/web-search-relations`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    body,
-    signal: AbortSignal.timeout(120_000),
-  })
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('POST', '/api/admin/companies/web-search-relations', {
+      headers: adminProxyHeaders(request.headers),
+      body,
+      timeoutMs: 180_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/web-search-relations/route.ts
+++ b/frontend/app/api/admin/companies/web-search-relations/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
     const result = await proxyAdminBackend('POST', '/api/admin/companies/web-search-relations', {
       headers: adminProxyHeaders(request.headers),
       body,
-      timeoutMs: 180_000,
+      timeoutMs: 120_000,
     })
     return jsonFromProxyResult(result)
   } catch (err) {

--- a/frontend/app/api/admin/companies/web-search/route.ts
+++ b/frontend/app/api/admin/companies/web-search/route.ts
@@ -1,28 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  adminProxyHeaders,
+  jsonFromProxyResult,
+  proxyAdminBackend,
+  proxyErrorResponse,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+export const maxDuration = 180
 
 export async function POST(request: NextRequest) {
   const body = await request.text()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/web-search`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    body,
-  })
-  const raw = await response.text()
-  let data: Record<string, unknown> = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('POST', '/api/admin/companies/web-search', {
+      headers: adminProxyHeaders(request.headers),
+      body,
+      timeoutMs: 180_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }

--- a/frontend/app/api/admin/companies/web-search/route.ts
+++ b/frontend/app/api/admin/companies/web-search/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
     const result = await proxyAdminBackend('POST', '/api/admin/companies/web-search', {
       headers: adminProxyHeaders(request.headers),
       body,
-      timeoutMs: 180_000,
+      timeoutMs: 120_000,
     })
     return jsonFromProxyResult(result)
   } catch (err) {

--- a/frontend/components/admin/CompanyAspectTabs.tsx
+++ b/frontend/components/admin/CompanyAspectTabs.tsx
@@ -2,31 +2,43 @@
 
 import Link from 'next/link'
 import { Button, Stack } from '@mui/material'
+import { resolveIndustryFieldProfile } from '@/lib/admin-company-field-profile'
 
 export type CompanyAspect = 'info' | 'tech' | 'relations'
 
-const ASPECTS: { key: CompanyAspect; label: string; path: (id: string | number) => string }[] = [
-  { key: 'info', label: '会社概要', path: (id) => `/admin/companies/${id}/info` },
-  { key: 'tech', label: '技術情報', path: (id) => `/admin/companies/${id}/edit` },
-  { key: 'relations', label: '関連企業', path: (id) => `/admin/companies/${id}/relations` },
-]
+const ASPECT_PATHS: Record<CompanyAspect, (id: string | number) => string> = {
+  info: (id) => `/admin/companies/${id}/info`,
+  tech: (id) => `/admin/companies/${id}/edit`,
+  relations: (id) => `/admin/companies/${id}/relations`,
+}
 
 type CompanyAspectTabsProps = {
   companyId: string | number
   active: CompanyAspect
+  /** 業界名。省略時は技術タブも表示（従来互換） */
+  industry?: string | null
 }
 
-/** 企業詳細の3画面切替（会社概要 / 技術情報 / 関連企業）。 */
-export function CompanyAspectTabs({ companyId, active }: CompanyAspectTabsProps) {
+/** 企業詳細の画面切替（会社概要 / 技術・設備 / 関連企業）。業界により技術タブの表示・ラベルが変わる。 */
+export function CompanyAspectTabs({ companyId, active, industry }: CompanyAspectTabsProps) {
+  const profile = resolveIndustryFieldProfile(industry)
+  const aspects: { key: CompanyAspect; label: string }[] = [
+    { key: 'info', label: '会社概要' },
+  ]
+  if (profile.techAspectEnabled) {
+    aspects.push({ key: 'tech', label: profile.techAspectLabel })
+  }
+  aspects.push({ key: 'relations', label: '関連企業' })
+
   return (
     <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
-      {ASPECTS.map((aspect) => {
+      {aspects.map((aspect) => {
         const selected = aspect.key === active
         return (
           <Button
             key={aspect.key}
             component={Link}
-            href={aspect.path(companyId)}
+            href={ASPECT_PATHS[aspect.key](companyId)}
             size="small"
             variant={selected ? 'contained' : 'outlined'}
             color={selected ? 'primary' : 'inherit'}
@@ -42,6 +54,5 @@ export function CompanyAspectTabs({ companyId, active }: CompanyAspectTabsProps)
 }
 
 export function companyAspectHref(companyId: string | number, aspect: CompanyAspect): string {
-  const found = ASPECTS.find((a) => a.key === aspect)
-  return found ? found.path(companyId) : `/admin/companies/${companyId}/info`
+  return ASPECT_PATHS[aspect](companyId)
 }

--- a/frontend/components/admin/CompanyAspectTabs.tsx
+++ b/frontend/components/admin/CompanyAspectTabs.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { Button, Stack } from '@mui/material'
+
+export type CompanyAspect = 'info' | 'tech' | 'relations'
+
+const ASPECTS: { key: CompanyAspect; label: string; path: (id: string | number) => string }[] = [
+  { key: 'info', label: '会社概要', path: (id) => `/admin/companies/${id}/info` },
+  { key: 'tech', label: '技術情報', path: (id) => `/admin/companies/${id}/edit` },
+  { key: 'relations', label: '関連企業', path: (id) => `/admin/companies/${id}/relations` },
+]
+
+type CompanyAspectTabsProps = {
+  companyId: string | number
+  active: CompanyAspect
+}
+
+/** 企業詳細の3画面切替（会社概要 / 技術情報 / 関連企業）。 */
+export function CompanyAspectTabs({ companyId, active }: CompanyAspectTabsProps) {
+  return (
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
+      {ASPECTS.map((aspect) => {
+        const selected = aspect.key === active
+        return (
+          <Button
+            key={aspect.key}
+            component={Link}
+            href={aspect.path(companyId)}
+            size="small"
+            variant={selected ? 'contained' : 'outlined'}
+            color={selected ? 'primary' : 'inherit'}
+            disableElevation
+            sx={{ textTransform: 'none' }}
+          >
+            {aspect.label}
+          </Button>
+        )
+      })}
+    </Stack>
+  )
+}
+
+export function companyAspectHref(companyId: string | number, aspect: CompanyAspect): string {
+  const found = ASPECTS.find((a) => a.key === aspect)
+  return found ? found.path(companyId) : `/admin/companies/${companyId}/info`
+}

--- a/frontend/components/admin/CompanyRelationGraph.tsx
+++ b/frontend/components/admin/CompanyRelationGraph.tsx
@@ -55,10 +55,18 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
   }, [companyId])
 
   const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
-    if (!graph || graph.nodes.length === 0) return { nodes: [], edges: [] }
-    const positions = layoutCapitalGraph(graph)
+    if (!graph) return { nodes: [], edges: [] }
+    const graphNodes = graph.nodes ?? []
+    const capitalEdges = graph.capital_edges ?? []
+    if (graphNodes.length === 0) return { nodes: [], edges: [] }
 
-    const flowNodes: Node[] = graph.nodes.map((n) => {
+    const positions = layoutCapitalGraph({
+      company_id: graph.company_id,
+      nodes: graphNodes,
+      capital_edges: capitalEdges,
+    })
+
+    const flowNodes: Node[] = graphNodes.map((n) => {
       const pos = positions.get(n.id) ?? { x: 0, y: 0, level: 0, column: 0 }
       const marketType = (n.market_type || 'unlisted') as MarketType
       return {
@@ -89,7 +97,7 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
       }
     })
 
-    const flowEdges: Edge[] = graph.capital_edges.map((e, idx) => ({
+    const flowEdges: Edge[] = capitalEdges.map((e, idx) => ({
       id: `capital-${idx}`,
       source: String(e.parent_id),
       target: String(e.child_id),
@@ -118,7 +126,10 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
     return <Alert severity="error">{error}</Alert>
   }
 
-  if (!graph || graph.nodes.length <= 1) {
+  const graphNodes = graph?.nodes ?? []
+  const businessRelations = graph?.business_relations ?? []
+
+  if (!graph || graphNodes.length <= 1) {
     return (
       <Typography variant="body2" color="text.secondary">
         保存済みの資本関係データがありません。関係を確定保存すると相関図が表示されます。
@@ -137,11 +148,11 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
           <Controls />
         </ReactFlow>
       </Box>
-      {graph.business_relations.length > 0 && (
+      {businessRelations.length > 0 && (
         <Box>
           <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>取引関係</Typography>
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            {graph.business_relations.map((rel) => (
+            {businessRelations.map((rel) => (
               <Chip
                 key={`${rel.company_id}-${rel.relation_type}`}
                 size="small"

--- a/frontend/components/admin/CompanyRelationGraph.tsx
+++ b/frontend/components/admin/CompanyRelationGraph.tsx
@@ -13,6 +13,7 @@ import { Alert, Box, Chip, CircularProgress, Stack, Typography } from '@mui/mate
 import { authService } from '@/lib/auth'
 import { marketColors, marketLabels, type MarketType } from '@/lib/company-data'
 import { layoutCapitalGraph, type CompanyRelationGraph as RelationGraphData } from '@/lib/relation-graph'
+import { sanitizeRelationDescription, displayRelationDescription, isRelationDescriptionFallback } from '@/lib/relation-labels'
 
 interface CompanyRelationGraphProps {
   companyId: number
@@ -142,7 +143,17 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
       {graph.truncated && (
         <Alert severity="warning">関係の件数が多いため一部を省略して表示しています。</Alert>
       )}
-      <Box sx={{ width: '100%', height: 420, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+      <Box
+        sx={{
+          width: '100%',
+          height: { xs: 480, sm: 560, md: 'min(72vh, 720px)' },
+          minHeight: 420,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          bgcolor: 'grey.50',
+        }}
+      >
         <ReactFlow nodes={nodes} edges={edges} fitView minZoom={0.1} maxZoom={2} nodesDraggable nodesConnectable={false}>
           <Background />
           <Controls />
@@ -150,15 +161,39 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
       </Box>
       {businessRelations.length > 0 && (
         <Box>
-          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 0.5 }}>取引関係</Typography>
-          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            {businessRelations.map((rel) => (
-              <Chip
-                key={`${rel.company_id}-${rel.relation_type}`}
-                size="small"
-                label={`${rel.name}（${RELATION_TYPE_LABELS[rel.relation_type] || rel.relation_type}）`}
-              />
-            ))}
+          <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1 }}>
+            取引関係
+          </Typography>
+          <Stack spacing={1}>
+            {businessRelations.map((rel) => {
+              const detail = displayRelationDescription(rel.description || '', rel.relation_type)
+              const isFallback = isRelationDescriptionFallback(rel.description || '')
+              const typeLabel = RELATION_TYPE_LABELS[rel.relation_type] || rel.relation_type
+              return (
+                <Box
+                  key={`${rel.company_id}-${rel.relation_type}-${rel.name}`}
+                  sx={{
+                    px: 1.5,
+                    py: 1,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: '8px',
+                    bgcolor: 'background.paper',
+                  }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                    <Typography variant="body2" fontWeight={700}>
+                      {rel.name}
+                    </Typography>
+                    <Chip size="small" label={typeLabel} />
+                    {isFallback && <Chip size="small" variant="outlined" label="内容未特定" />}
+                  </Stack>
+                  <Typography variant="body2" color={isFallback ? 'text.secondary' : 'text.primary'} sx={{ mt: 0.5 }}>
+                    {detail}
+                  </Typography>
+                </Box>
+              )
+            })}
           </Stack>
         </Box>
       )}

--- a/frontend/components/admin/CompanyRelationGraph.tsx
+++ b/frontend/components/admin/CompanyRelationGraph.tsx
@@ -129,11 +129,13 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
 
   const graphNodes = graph?.nodes ?? []
   const businessRelations = graph?.business_relations ?? []
+  const hasCapitalGraph = graphNodes.length > 1
+  const hasBusinessRelations = businessRelations.length > 0
 
-  if (!graph || graphNodes.length <= 1) {
+  if (!graph || (!hasCapitalGraph && !hasBusinessRelations)) {
     return (
       <Typography variant="body2" color="text.secondary">
-        保存済みの資本関係データがありません。関係を確定保存すると相関図が表示されます。
+        保存済みの関係データがありません。関係を確定保存すると相関図・取引関係が表示されます。
       </Typography>
     )
   }
@@ -143,23 +145,30 @@ export default function CompanyRelationGraph({ companyId }: CompanyRelationGraph
       {graph.truncated && (
         <Alert severity="warning">関係の件数が多いため一部を省略して表示しています。</Alert>
       )}
-      <Box
-        sx={{
-          width: '100%',
-          height: { xs: 480, sm: 560, md: 'min(72vh, 720px)' },
-          minHeight: 420,
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: 1,
-          bgcolor: 'grey.50',
-        }}
-      >
-        <ReactFlow nodes={nodes} edges={edges} fitView minZoom={0.1} maxZoom={2} nodesDraggable nodesConnectable={false}>
-          <Background />
-          <Controls />
-        </ReactFlow>
-      </Box>
-      {businessRelations.length > 0 && (
+      {hasCapitalGraph && (
+        <Box
+          sx={{
+            width: '100%',
+            height: { xs: 480, sm: 560, md: 'min(72vh, 720px)' },
+            minHeight: 420,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            bgcolor: 'grey.50',
+          }}
+        >
+          <ReactFlow nodes={nodes} edges={edges} fitView minZoom={0.1} maxZoom={2} nodesDraggable nodesConnectable={false}>
+            <Background />
+            <Controls />
+          </ReactFlow>
+        </Box>
+      )}
+      {!hasCapitalGraph && hasBusinessRelations && (
+        <Typography variant="body2" color="text.secondary">
+          資本関係データはありません。取引関係のみ表示しています。
+        </Typography>
+      )}
+      {hasBusinessRelations && (
         <Box>
           <Typography variant="subtitle2" fontWeight="bold" sx={{ mb: 1 }}>
             取引関係

--- a/frontend/components/admin/PageContainer.tsx
+++ b/frontend/components/admin/PageContainer.tsx
@@ -9,6 +9,8 @@ export const ADMIN_PAGE_WIDTH = {
   form: 720,
   standard: 1100,
   wide: 1200,
+  /** 相関図など横に広い可視化向け */
+  full: 1600,
 } as const
 
 export function PageContainer({

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -43,13 +43,13 @@ test.describe('管理者ダッシュボードフロー', () => {
   test('管理者ダッシュボードが表示される', async ({ page }) => {
     await page.goto('/admin')
     await page.waitForLoadState('networkidle')
-    await expect(page.getByText('管理者ダッシュボード')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByText('管理メニュー')).toBeVisible({ timeout: 8000 })
   })
 
   test('管理者ダッシュボードにメニューカードが表示される', async ({ page }) => {
     await page.goto('/admin')
     await page.waitForLoadState('networkidle')
-    await expect(page.getByRole('heading', { name: '企業データ' })).toBeVisible({ timeout: 8000 })
+    await expect(page.getByRole('heading', { name: '企業情報' })).toBeVisible({ timeout: 8000 })
     await expect(page.getByRole('heading', { name: 'スコアダッシュボード' })).toBeVisible({ timeout: 8000 })
     await expect(page.getByRole('heading', { name: 'スコア精度検証' })).toBeVisible({ timeout: 8000 })
   })

--- a/frontend/lib/admin-backend-proxy.ts
+++ b/frontend/lib/admin-backend-proxy.ts
@@ -1,0 +1,133 @@
+import http from 'node:http'
+import https from 'node:https'
+import { URL } from 'node:url'
+import { NextResponse } from 'next/server'
+
+export const ADMIN_BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+type ProxyResult = { status: number; text: string }
+
+function isTransientSocketError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const msg = err.message.toLowerCase()
+  const code =
+    typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: string }).code || '')
+      : ''
+  return (
+    code === 'UND_ERR_SOCKET' ||
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    msg.includes('other side closed') ||
+    msg.includes('socket hang up') ||
+    msg.includes('econnreset') ||
+    msg.includes('econnrefused')
+  )
+}
+
+function requestOnce(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body: string | undefined,
+  timeoutMs: number,
+): Promise<ProxyResult> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const lib = parsed.protocol === 'https:' ? https : http
+    const req = lib.request(
+      {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: `${parsed.pathname}${parsed.search}`,
+        method,
+        headers: {
+          ...headers,
+          ...(body != null ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 502,
+            text: Buffer.concat(chunks).toString('utf8'),
+          })
+        })
+      },
+    )
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error('Request timeout'))
+    })
+    req.on('timeout', () => {
+      req.destroy(new Error('Request timeout'))
+    })
+    req.on('error', reject)
+    if (body != null) req.write(body)
+    req.end()
+  })
+}
+
+/** Backend への転送。再起動中の切断は1回だけリトライする。 */
+export async function proxyAdminBackend(
+  method: string,
+  path: string,
+  options: {
+    headers?: Record<string, string>
+    body?: string
+    timeoutMs?: number
+  } = {},
+): Promise<ProxyResult> {
+  const timeoutMs = options.timeoutMs ?? 180_000
+  const url = `${ADMIN_BACKEND_URL}${path}`
+  const headers = options.headers ?? {}
+  try {
+    return await requestOnce(method, url, headers, options.body, timeoutMs)
+  } catch (err) {
+    if (!isTransientSocketError(err)) throw err
+    // air 再起動などで接続が切れた場合、少し待って再試行
+    await new Promise((r) => setTimeout(r, 800))
+    return requestOnce(method, url, headers, options.body, timeoutMs)
+  }
+}
+
+export function jsonFromProxyResult(result: ProxyResult): NextResponse {
+  let data: Record<string, unknown> = {}
+  if (result.text) {
+    try {
+      data = JSON.parse(result.text) as Record<string, unknown>
+    } catch {
+      data = result.status < 400 ? { message: result.text } : { error: result.text }
+    }
+  } else if (result.status >= 400) {
+    data = { error: 'バックエンドから空の応答が返りました' }
+  }
+  return NextResponse.json(data, { status: result.status })
+}
+
+export function proxyErrorResponse(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : String(err)
+  const timedOut = /timeout/i.test(message)
+  const transient = isTransientSocketError(err)
+  return NextResponse.json(
+    {
+      error: timedOut
+        ? '処理がタイムアウトしました。時間をおいて再度お試しください。'
+        : transient
+          ? 'サーバーが再起動中か一時的に接続できませんでした。数秒待って再度お試しください。'
+          : `バックエンドに接続できません: ${message}`,
+    },
+    { status: timedOut ? 504 : 503 },
+  )
+}
+
+export function adminProxyHeaders(requestHeaders: Headers): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Email': requestHeaders.get('x-admin-email') || '',
+    'X-Admin-Token': requestHeaders.get('x-admin-token') || '',
+  }
+}

--- a/frontend/lib/admin-backend-proxy.ts
+++ b/frontend/lib/admin-backend-proxy.ts
@@ -51,6 +51,7 @@ function requestOnce(
       (res) => {
         const chunks: Buffer[] = []
         res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('error', reject)
         res.on('end', () => {
           resolve({
             status: res.statusCode ?? 502,
@@ -71,7 +72,23 @@ function requestOnce(
   })
 }
 
-/** Backend への転送。再起動中の切断は1回だけリトライする。 */
+function isPreConnectTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const code =
+    typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: string }).code || '')
+      : ''
+  const msg = err.message.toLowerCase()
+  // 接続確立前の拒否のみ再試行（送信済み POST の二重実行を避ける）
+  return code === 'ECONNREFUSED' || msg.includes('econnrefused')
+}
+
+function isIdempotentMethod(method: string): boolean {
+  const m = method.toUpperCase()
+  return m === 'GET' || m === 'HEAD' || m === 'OPTIONS'
+}
+
+/** Backend への転送。再起動中の切断は安全な場合のみ1回リトライする。 */
 export async function proxyAdminBackend(
   method: string,
   path: string,
@@ -87,7 +104,10 @@ export async function proxyAdminBackend(
   try {
     return await requestOnce(method, url, headers, options.body, timeoutMs)
   } catch (err) {
-    if (!isTransientSocketError(err)) throw err
+    const canRetry =
+      isTransientSocketError(err) &&
+      (isIdempotentMethod(method) || isPreConnectTransientError(err))
+    if (!canRetry) throw err
     // air 再起動などで接続が切れた場合、少し待って再試行
     await new Promise((r) => setTimeout(r, 800))
     return requestOnce(method, url, headers, options.body, timeoutMs)

--- a/frontend/lib/admin-company-fetch.ts
+++ b/frontend/lib/admin-company-fetch.ts
@@ -72,9 +72,27 @@ function stepLabel(step: FetchPrimaryStep | undefined, label: string): string | 
   if (step.status === 'fetched') {
     return step.count != null ? `${label}取得(${step.count})` : `${label}取得`
   }
-  if (step.status === 'skipped') return `${label}スキップ`
+  if (step.status === 'skipped') {
+    const reason =
+      step.detail === 'ttl' || step.detail === 'ttl_fresh'
+        ? '取得済み'
+        : step.detail === 'budget'
+          ? '予算超過'
+          : step.detail === 'fetcher unavailable'
+            ? '取得器なし'
+            : step.detail || ''
+    return reason ? `${label}スキップ(${reason})` : `${label}スキップ`
+  }
   if (step.status === 'empty') return `${label}取得ゼロ`
-  if (step.status === 'error') return `${label}失敗`
+  if (step.status === 'error') {
+    const reason =
+      step.detail === 'budget'
+        ? '予算超過'
+        : step.detail
+          ? `(${step.detail})`
+          : ''
+    return `${label}失敗${reason}`
+  }
   return `${label}${step.status}`
 }
 

--- a/frontend/lib/admin-company-fetch.ts
+++ b/frontend/lib/admin-company-fetch.ts
@@ -3,6 +3,8 @@
  * Backend 専用 API POST /api/admin/companies/:id/fetch-primary を呼ぶ。
  */
 
+import { resolveIndustryFieldProfile } from '@/lib/admin-company-field-profile'
+
 export type FetchPrimaryStep = {
   status?: string
   detail?: string
@@ -67,23 +69,56 @@ function parseFetchPrimaryResponse(value: unknown): FetchPrimaryResponse {
   }
 }
 
+function industryFromResponse(data: FetchPrimaryResponse, fallbackIndustry?: string | null): string {
+  const fromCompany = data.company?.industry
+  if (typeof fromCompany === 'string' && fromCompany.trim()) return fromCompany
+  return fallbackIndustry?.trim() || ''
+}
+
+function techLabelForIndustry(industry?: string | null): string {
+  return resolveIndustryFieldProfile(industry).techAspectLabel
+}
+
+function skipReasonLabel(detail?: string): string {
+  switch (detail) {
+    case 'ttl':
+    case 'ttl_fresh':
+      return '取得済み'
+    case 'budget':
+      return '予算超過'
+    case 'fetcher unavailable':
+      return '取得器なし'
+    case 'industry_not_applicable':
+      return '業種対象外'
+    case 'optional_empty':
+      return '任意・未特定'
+    case 'public_info_sparse':
+      return '公開情報限定'
+    case 'confirmed_unlisted':
+      return '非上場・関係なし'
+    default:
+      return detail || ''
+  }
+}
+
 function stepLabel(step: FetchPrimaryStep | undefined, label: string): string | null {
   if (!step?.status) return null
   if (step.status === 'fetched') {
+    if (step.detail === 'confirmed_unlisted') {
+      return `${label}確認済(非上場・関係なし)`
+    }
     return step.count != null ? `${label}取得(${step.count})` : `${label}取得`
   }
   if (step.status === 'skipped') {
-    const reason =
-      step.detail === 'ttl' || step.detail === 'ttl_fresh'
-        ? '取得済み'
-        : step.detail === 'budget'
-          ? '予算超過'
-          : step.detail === 'fetcher unavailable'
-            ? '取得器なし'
-            : step.detail || ''
+    const reason = skipReasonLabel(step.detail)
     return reason ? `${label}スキップ(${reason})` : `${label}スキップ`
   }
-  if (step.status === 'empty') return `${label}取得ゼロ`
+  if (step.status === 'empty') {
+    if (step.detail === 'public_info_sparse') {
+      return `${label}確認済(概要未特定)`
+    }
+    return `${label}取得ゼロ`
+  }
   if (step.status === 'error') {
     const reason =
       step.detail === 'budget'
@@ -96,14 +131,62 @@ function stepLabel(step: FetchPrimaryStep | undefined, label: string): string | 
   return `${label}${step.status}`
 }
 
-export function formatFetchPrimarySummary(data: FetchPrimaryResponse): string {
+/** 業界制約を踏まえ、警告対象の empty ステップか。 */
+export function isActionableEmptyStep(
+  step: FetchPrimaryStep | undefined,
+  aspect: 'info' | 'tech' | 'relations',
+  industry?: string | null,
+): boolean {
+  if (step?.status !== 'empty') return false
+  // 公開情報から概要が取れなかった確認済みは、手入力検討のソフト警告対象
+  if (aspect === 'info' && step.detail === 'public_info_sparse') return true
+  if (aspect === 'tech') {
+    return resolveIndustryFieldProfile(industry).requireTechForPublish
+  }
+  return true
+}
+
+export function hasActionableSoftEmpty(
+  data: FetchPrimaryResponse,
+  fallbackIndustry?: string | null,
+): boolean {
+  const industry = industryFromResponse(data, fallbackIndustry)
+  return (
+    isActionableEmptyStep(data.info_step, 'info', industry) ||
+    isActionableEmptyStep(data.tech_step, 'tech', industry) ||
+    isActionableEmptyStep(data.relations_step, 'relations', industry)
+  )
+}
+
+export function formatFetchPrimarySummary(
+  data: FetchPrimaryResponse,
+  fallbackIndustry?: string | null,
+): string {
+  const industry = industryFromResponse(data, fallbackIndustry)
+  const techLabel = techLabelForIndustry(industry)
   return [
     stepLabel(data.info_step, '基本'),
-    stepLabel(data.tech_step, '技術'),
+    stepLabel(data.tech_step, techLabel),
     stepLabel(data.relations_step, '関係'),
   ]
     .filter(Boolean)
     .join(' / ')
+}
+
+/** empty になった項目だけを短く列挙（警告文用）。 */
+export function formatFetchPrimaryEmptyAspects(
+  data: FetchPrimaryResponse,
+  fallbackIndustry?: string | null,
+): string {
+  const industry = industryFromResponse(data, fallbackIndustry)
+  const techLabel = techLabelForIndustry(industry)
+  const parts: string[] = []
+  if (isActionableEmptyStep(data.info_step, 'info', industry)) {
+    parts.push(data.info_step?.detail === 'public_info_sparse' ? '会社概要（公開情報から未特定）' : '会社概要')
+  }
+  if (isActionableEmptyStep(data.tech_step, 'tech', industry)) parts.push(techLabel)
+  if (isActionableEmptyStep(data.relations_step, 'relations', industry)) parts.push('関連企業')
+  return parts.join('・')
 }
 
 /** 主3種を1 API で取得する。 */

--- a/frontend/lib/admin-company-field-profile.ts
+++ b/frontend/lib/admin-company-field-profile.ts
@@ -1,0 +1,221 @@
+/**
+ * 業界ごとに入力・表示する企業フィールドの定義。
+ * Backend/internal/companyfields/profile.go と対応を揃えること。
+ */
+
+export type IndustryProfileId =
+  | 'it'
+  | 'manufacturing'
+  | 'finance'
+  | 'consulting'
+  | 'education'
+  | 'healthcare'
+  | 'general'
+
+export type InfoFieldKey =
+  | 'description'
+  | 'industry'
+  | 'location'
+  | 'website_url'
+  | 'founded_year'
+  | 'employee_count'
+  | 'main_business'
+  | 'culture'
+  | 'work_style'
+  | 'welfare_details'
+  | 'tech_stack'
+
+export type TechFieldKey = 'tech_stack' | 'infra_stack' | 'cicd_tools' | 'development_style'
+
+export type TechFieldSpec = {
+  key: TechFieldKey
+  label: string
+  placeholder?: string
+  /** development_style 用の選択肢。未指定時は IT 向け既定を使う */
+  options?: string[]
+}
+
+export type IndustryFieldProfile = {
+  id: IndustryProfileId
+  label: string
+  matchKeywords: string[]
+  infoFields: InfoFieldKey[]
+  techAspectEnabled: boolean
+  /** タブ表示名（技術情報 / 設備・技術 など） */
+  techAspectLabel: string
+  techFields: TechFieldSpec[]
+  requireTechForPublish: boolean
+  /** 技術タブが無いときの案内文 */
+  techDisabledMessage?: string
+}
+
+const COMMON_INFO_FIELDS: InfoFieldKey[] = [
+  'description',
+  'industry',
+  'location',
+  'website_url',
+  'founded_year',
+  'employee_count',
+  'main_business',
+  'culture',
+  'work_style',
+  'welfare_details',
+]
+
+const IT_DEV_STYLES = ['スクラム', 'ウォーターフォール', 'カンバン', 'アジャイル', 'その他']
+const MFG_DEV_STYLES = ['セル生産', 'ライン生産', '受注生産', '見込み生産', 'その他']
+
+/**
+ * マッチ優先順。キーワードが industry に含まれたらそのプロファイルを採用。
+ * 末尾の general がフォールバック。
+ */
+export const INDUSTRY_FIELD_PROFILES: IndustryFieldProfile[] = [
+  {
+    id: 'it',
+    label: 'IT・ソフトウェア',
+    matchKeywords: [
+      'it',
+      'ｉｔ',
+      '情報',
+      'ソフト',
+      'software',
+      'web',
+      'ウェブ',
+      'saas',
+      'システム開発',
+      '通信',
+      'インターネット',
+      'ゲーム',
+    ],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: true,
+    techAspectLabel: '技術情報',
+    techFields: [
+      {
+        key: 'tech_stack',
+        label: '言語・フレームワーク',
+        placeholder: '例: Go, React, TypeScript',
+      },
+      {
+        key: 'infra_stack',
+        label: 'インフラ',
+        placeholder: '例: AWS, GCP, Azure, オンプレ',
+      },
+      {
+        key: 'cicd_tools',
+        label: 'CI/CDツール',
+        placeholder: '例: GitHub Actions, Jenkins, CircleCI',
+      },
+      {
+        key: 'development_style',
+        label: '開発手法',
+        options: IT_DEV_STYLES,
+      },
+    ],
+    requireTechForPublish: true,
+  },
+  {
+    id: 'manufacturing',
+    label: '製造業',
+    matchKeywords: ['製造', 'メーカー', '自動車', '機械', '電機', '電子', 'ものづくり', '工場'],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: true,
+    techAspectLabel: '設備・技術',
+    techFields: [
+      {
+        key: 'tech_stack',
+        label: '主要技術・製品技術',
+        placeholder: '例: 精密加工, 車載センサー, CAD/CAM',
+      },
+      {
+        key: 'infra_stack',
+        label: '生産設備・拠点',
+        placeholder: '例: 国内工場, SMTライン, クリーンルーム',
+      },
+      {
+        key: 'development_style',
+        label: '生産・開発の進め方',
+        options: MFG_DEV_STYLES,
+      },
+    ],
+    requireTechForPublish: false,
+  },
+  {
+    id: 'finance',
+    label: '金融・保険',
+    matchKeywords: ['金融', '銀行', '保険', '証券', 'クレジット'],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: false,
+    techAspectLabel: '技術情報',
+    techFields: [],
+    requireTechForPublish: false,
+    techDisabledMessage: '金融・保険業では、プログラミング技術スタックの登録は不要です。会社概要と関連企業を確認してください。',
+  },
+  {
+    id: 'consulting',
+    label: 'コンサルティング',
+    matchKeywords: ['コンサル'],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: false,
+    techAspectLabel: '技術情報',
+    techFields: [],
+    requireTechForPublish: false,
+    techDisabledMessage: 'コンサルティング業では技術スタックの登録は必須ではありません。会社概要と関連企業を確認してください。',
+  },
+  {
+    id: 'education',
+    label: '教育',
+    matchKeywords: ['教育', '学校', '学習', '大学', '塾'],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: false,
+    techAspectLabel: '技術情報',
+    techFields: [],
+    requireTechForPublish: false,
+    techDisabledMessage: '教育業界では技術スタックの登録は不要です。会社概要と関連企業を確認してください。',
+  },
+  {
+    id: 'healthcare',
+    label: '医療・福祉',
+    matchKeywords: ['医療', '福祉', '病院', 'ヘルスケア', '介護'],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: false,
+    techAspectLabel: '技術情報',
+    techFields: [],
+    requireTechForPublish: false,
+    techDisabledMessage: '医療・福祉では技術スタックの登録は不要です。会社概要と関連企業を確認してください。',
+  },
+  {
+    id: 'general',
+    label: 'その他',
+    matchKeywords: [],
+    infoFields: COMMON_INFO_FIELDS,
+    techAspectEnabled: false,
+    techAspectLabel: '技術情報',
+    techFields: [],
+    requireTechForPublish: false,
+    techDisabledMessage:
+      'この業界では技術スタックの登録は必須ではありません。必要な場合は業種を IT・ソフトウェアや製造業に近い名称へ変更してください。',
+  },
+]
+
+export function resolveIndustryFieldProfile(industry?: string | null): IndustryFieldProfile {
+  const normalized = (industry || '').trim().toLowerCase()
+  if (!normalized) {
+    return INDUSTRY_FIELD_PROFILES[INDUSTRY_FIELD_PROFILES.length - 1]
+  }
+  for (const profile of INDUSTRY_FIELD_PROFILES) {
+    if (profile.id === 'general') continue
+    if (profile.matchKeywords.some((kw) => normalized.includes(kw.toLowerCase()))) {
+      return profile
+    }
+  }
+  return INDUSTRY_FIELD_PROFILES[INDUSTRY_FIELD_PROFILES.length - 1]
+}
+
+export function infoFieldEnabled(profile: IndustryFieldProfile, key: InfoFieldKey): boolean {
+  return profile.infoFields.includes(key)
+}
+
+export function techFieldSpec(profile: IndustryFieldProfile, key: TechFieldKey): TechFieldSpec | undefined {
+  return profile.techFields.find((f) => f.key === key)
+}

--- a/frontend/lib/relation-graph.ts
+++ b/frontend/lib/relation-graph.ts
@@ -98,7 +98,8 @@ export interface CompanyRelationGraph {
   company_id: number
   nodes: RelationGraphNode[]
   capital_edges: RelationGraphCapitalEdge[]
-  business_relations: RelationGraphBusinessEntry[]
+  /** API は未設定時に null を返すことがある */
+  business_relations?: RelationGraphBusinessEntry[] | null
   truncated?: boolean
 }
 
@@ -125,7 +126,7 @@ export function layoutCapitalGraph(graph: Pick<CompanyRelationGraph, 'company_id
     if (!neighborDeltas.has(from)) neighborDeltas.set(from, [])
     neighborDeltas.get(from)!.push({ id: to, delta })
   }
-  for (const edge of graph.capital_edges) {
+  for (const edge of graph.capital_edges ?? []) {
     // parent -> child は子方向なので +1、child -> parent は親方向なので -1
     addNeighbor(edge.parent_id, edge.child_id, 1)
     addNeighbor(edge.child_id, edge.parent_id, -1)
@@ -145,7 +146,7 @@ export function layoutCapitalGraph(graph: Pick<CompanyRelationGraph, 'company_id
   }
 
   const nodesByLevel = new Map<number, number[]>()
-  for (const node of graph.nodes) {
+  for (const node of graph.nodes ?? []) {
     const level = levelById.get(node.id) ?? 0
     if (!nodesByLevel.has(level)) nodesByLevel.set(level, [])
     nodesByLevel.get(level)!.push(node.id)

--- a/frontend/lib/relation-labels.ts
+++ b/frontend/lib/relation-labels.ts
@@ -18,6 +18,20 @@ const RELATION_TYPE_LABELS: Record<string, string> = {
   business_subsidy: '補助金連携',
 }
 
+const GENERIC_RELATION_LABELS = new Set([
+  '子会社',
+  '関連会社',
+  '主要取引先',
+  '取引先',
+  '調達・契約',
+  '補助金連携',
+  'ビジネス関係',
+  '資本関係',
+  '関連',
+  '調達（gBiz）',
+  '補助金（gBiz）',
+])
+
 /** 取得元タグのプレースホルダ説明か（例: web_search:企業名） */
 export function isSourceTagDescription(description: string): boolean {
   const trimmed = description.trim()
@@ -28,6 +42,23 @@ export function isSourceTagDescription(description: string): boolean {
   return (SOURCE_TAG_PREFIXES as readonly string[]).includes(tag)
 }
 
+/** 関係種別ラベルだけで、取引内容ではないか */
+export function isGenericRelationLabel(description: string): boolean {
+  return GENERIC_RELATION_LABELS.has(description.trim())
+}
+
+/**
+ * 編集フォーム／保存用: 実取引内容だけを残す。
+ * 種別ラベルや取得元タグは空にする（「主要取引先」を説明欄に入れない）。
+ */
+export function sanitizeRelationDescription(description: string): string {
+  const trimmed = description.trim()
+  if (!trimmed || isSourceTagDescription(trimmed) || isGenericRelationLabel(trimmed)) {
+    return ''
+  }
+  return trimmed
+}
+
 const RELATION_TYPE_LABELS_SHORT: Record<string, string> = {
   capital_subsidiary: '子会社',
   capital_affiliate: '関連',
@@ -36,12 +67,10 @@ const RELATION_TYPE_LABELS_SHORT: Record<string, string> = {
   business_subsidy: '補助',
 }
 
-/** 図・一覧向けの関係ラベル */
+/** 図・一覧向けの関係ラベル（実内容優先、無ければ種別） */
 export function formatRelationLabel(description: string, relationType: string): string {
-  const trimmed = description.trim()
-  if (trimmed && !isSourceTagDescription(trimmed)) {
-    return trimmed
-  }
+  const real = sanitizeRelationDescription(description)
+  if (real) return real
   if (RELATION_TYPE_LABELS[relationType]) {
     return RELATION_TYPE_LABELS[relationType]
   }
@@ -50,11 +79,69 @@ export function formatRelationLabel(description: string, relationType: string): 
   return relationType || '関連'
 }
 
+/**
+ * 取引内容の表示用。具体内容が無ければフォールバックとして種別ラベル（取引先は「主要取引先」）。
+ */
+export function displayRelationDescription(description: string, relationType: string): string {
+  return formatRelationLabel(description, relationType)
+}
+
+/** 具体的な取引内容が無く、種別フォールバック表示になるか */
+export function isRelationDescriptionFallback(description: string): boolean {
+  return sanitizeRelationDescription(description) === ''
+}
+
+/** 関係先として保存してよい、はっきりした組織名か */
+export function isClearOrganizationName(name: string): boolean {
+  const n = name.trim()
+  if (!n) return false
+  const unclearExact = new Set([
+    '不明',
+    '未定',
+    'その他',
+    'なし',
+    '無し',
+    '該当なし',
+    'n/a',
+    'na',
+    '-',
+    '—',
+    '－',
+    '複数社',
+    '各社',
+    '関係会社',
+    'グループ会社',
+    'グループ',
+    '共同企業体',
+    '特定共同企業体',
+    'コンソーシアム',
+    'jv',
+    'ｊｖ',
+    '株式会社',
+    '有限会社',
+    '合同会社',
+    '主要取引先',
+    '取引先',
+  ])
+  if (unclearExact.has(n) || unclearExact.has(n.toLowerCase())) return false
+  if (/不明|未定|その他多数|ほか数社|他数社|等数社|共同企業体|特定共同企業体/.test(n)) {
+    return false
+  }
+  const core = n
+    .replace(/^(株式会社|有限会社|合同会社|合資会社|合名会社|一般社団法人|一般財団法人|公益社団法人|公益財団法人)\s*/u, '')
+    .replace(/\s*(株式会社|有限会社|合同会社|合資会社|合名会社|Inc\.?|Ltd\.?|LLC|Corp\.?)$/iu, '')
+    .trim()
+  if (!core || unclearExact.has(core.toLowerCase())) return false
+  if ([...core].length < 2) return false
+  return true
+}
+
+
 /** 関連図エッジ向けの短いラベル（重なり防止） */
 export function formatRelationLabelShort(description: string, relationType: string): string {
-  const trimmed = description.trim()
-  if (!trimmed || isSourceTagDescription(trimmed)) {
+  const real = sanitizeRelationDescription(description)
+  if (!real) {
     return RELATION_TYPE_LABELS_SHORT[relationType] || formatRelationLabel(description, relationType)
   }
-  return trimmed.length > 12 ? `${trimmed.slice(0, 12)}…` : trimmed
+  return real.length > 12 ? `${real.slice(0, 12)}…` : real
 }

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,10 @@
 {
-  "status": "passed",
-  "failedTests": []
+  "status": "failed",
+  "failedTests": [
+    "d4043a9dd1ab94463227-8393955dd578eda2e46e",
+    "d4043a9dd1ab94463227-87bf3e8cab65f5601bdf",
+    "d4043a9dd1ab94463227-c39136eac66d9d61b275",
+    "d4043a9dd1ab94463227-1784c5152923b4558272",
+    "d4043a9dd1ab94463227-57390bfff99bf63f4fa3"
+  ]
 }

--- a/frontend/tests/lib/admin-company-fetch.test.ts
+++ b/frontend/tests/lib/admin-company-fetch.test.ts
@@ -1,0 +1,115 @@
+import {
+  formatFetchPrimaryEmptyAspects,
+  formatFetchPrimarySummary,
+  hasActionableSoftEmpty,
+  isActionableEmptyStep,
+  type FetchPrimaryResponse,
+} from '@/lib/admin-company-fetch'
+
+describe('admin-company-fetch', () => {
+  const base: FetchPrimaryResponse = {
+    info_step: { status: 'fetched', detail: 'ok' },
+    tech_step: { status: 'empty', detail: 'no_tech_stack' },
+    relations_step: { status: 'fetched', detail: 'ok', count: 2 },
+  }
+
+  describe('isActionableEmptyStep / hasActionableSoftEmpty', () => {
+    it('treats tech empty as actionable for IT', () => {
+      expect(isActionableEmptyStep(base.tech_step, 'tech', 'IT・ソフトウェア')).toBe(true)
+      expect(hasActionableSoftEmpty(base, 'IT・ソフトウェア')).toBe(true)
+    })
+
+    it('ignores tech empty for manufacturing and finance', () => {
+      expect(isActionableEmptyStep(base.tech_step, 'tech', '製造業')).toBe(false)
+      expect(hasActionableSoftEmpty(base, '製造業')).toBe(false)
+      expect(hasActionableSoftEmpty(base, '金融・保険業')).toBe(false)
+    })
+
+    it('uses company.industry from response when fallback is empty', () => {
+      const data: FetchPrimaryResponse = {
+        ...base,
+        company: { industry: '製造業' },
+      }
+      expect(hasActionableSoftEmpty(data, '')).toBe(false)
+    })
+
+    it('still warns when info is empty regardless of industry', () => {
+      const data: FetchPrimaryResponse = {
+        info_step: { status: 'empty', detail: 'no_basic_info' },
+        tech_step: { status: 'skipped', detail: 'industry_not_applicable' },
+        relations_step: { status: 'fetched' },
+      }
+      expect(hasActionableSoftEmpty(data, '金融・保険業')).toBe(true)
+    })
+
+    it('treats public_info_sparse as soft-warn info empty', () => {
+      const data: FetchPrimaryResponse = {
+        info_step: { status: 'empty', detail: 'public_info_sparse' },
+        tech_step: { status: 'skipped', detail: 'industry_not_applicable' },
+        relations_step: { status: 'fetched', detail: 'confirmed_unlisted', count: 1 },
+      }
+      expect(hasActionableSoftEmpty(data, '金融・保険業')).toBe(true)
+      expect(formatFetchPrimaryEmptyAspects(data, '金融・保険業')).toContain('公開情報から未特定')
+    })
+  })
+
+  describe('formatFetchPrimarySummary', () => {
+    it('labels tech aspect by industry profile', () => {
+      const itSummary = formatFetchPrimarySummary(base, 'IT・ソフトウェア')
+      expect(itSummary).toContain('基本取得')
+      expect(itSummary).toContain('技術情報取得ゼロ')
+      expect(itSummary).toContain('関係取得(2)')
+
+      const mfgSummary = formatFetchPrimarySummary(
+        {
+          ...base,
+          tech_step: { status: 'skipped', detail: 'optional_empty' },
+        },
+        '製造業',
+      )
+      expect(mfgSummary).toContain('設備・技術スキップ(任意・未特定)')
+    })
+
+    it('explains industry_not_applicable skip reason', () => {
+      const summary = formatFetchPrimarySummary(
+        {
+          info_step: { status: 'fetched' },
+          tech_step: { status: 'skipped', detail: 'industry_not_applicable' },
+          relations_step: { status: 'fetched' },
+        },
+        '金融・保険業',
+      )
+      expect(summary).toContain('技術情報スキップ(業種対象外)')
+    })
+
+    it('labels confirmed sparse / unlisted outcomes', () => {
+      const summary = formatFetchPrimarySummary(
+        {
+          info_step: { status: 'empty', detail: 'public_info_sparse' },
+          tech_step: { status: 'skipped', detail: 'industry_not_applicable' },
+          relations_step: { status: 'fetched', detail: 'confirmed_unlisted', count: 1 },
+        },
+        '金融・保険業',
+      )
+      expect(summary).toContain('基本確認済(概要未特定)')
+      expect(summary).toContain('関係確認済(非上場・関係なし)')
+    })
+  })
+
+  describe('formatFetchPrimaryEmptyAspects', () => {
+    it('lists only actionable empty aspects', () => {
+      expect(formatFetchPrimaryEmptyAspects(base, 'IT・ソフトウェア')).toBe('技術情報')
+      expect(formatFetchPrimaryEmptyAspects(base, '製造業')).toBe('')
+      expect(
+        formatFetchPrimaryEmptyAspects(
+          {
+            info_step: { status: 'empty' },
+            tech_step: { status: 'empty' },
+            relations_step: { status: 'empty' },
+          },
+          'IT・ソフトウェア',
+        ),
+      ).toBe('会社概要・技術情報・関連企業')
+    })
+  })
+})

--- a/frontend/tests/lib/admin-company-field-profile.test.ts
+++ b/frontend/tests/lib/admin-company-field-profile.test.ts
@@ -1,0 +1,52 @@
+import {
+  infoFieldEnabled,
+  resolveIndustryFieldProfile,
+  techFieldSpec,
+} from '@/lib/admin-company-field-profile'
+
+describe('admin-company-field-profile', () => {
+  describe('resolveIndustryFieldProfile', () => {
+    it('resolves IT industries and requires tech for publish', () => {
+      const profile = resolveIndustryFieldProfile('IT・ソフトウェア')
+      expect(profile.id).toBe('it')
+      expect(profile.techAspectEnabled).toBe(true)
+      expect(profile.requireTechForPublish).toBe(true)
+      expect(profile.techAspectLabel).toBe('技術情報')
+      expect(techFieldSpec(profile, 'cicd_tools')).toBeDefined()
+    })
+
+    it('resolves manufacturing with optional equipment fields', () => {
+      const profile = resolveIndustryFieldProfile('自動車製造')
+      expect(profile.id).toBe('manufacturing')
+      expect(profile.techAspectEnabled).toBe(true)
+      expect(profile.requireTechForPublish).toBe(false)
+      expect(profile.techAspectLabel).toBe('設備・技術')
+      expect(techFieldSpec(profile, 'cicd_tools')).toBeUndefined()
+      expect(techFieldSpec(profile, 'infra_stack')?.label).toContain('生産設備')
+    })
+
+    it('hides tech aspect for finance/education/healthcare', () => {
+      for (const industry of ['金融・保険業', '教育・学習支援業', '医療・福祉', 'コンサルティング']) {
+        const profile = resolveIndustryFieldProfile(industry)
+        expect(profile.techAspectEnabled).toBe(false)
+        expect(profile.requireTechForPublish).toBe(false)
+        expect(profile.techFields).toHaveLength(0)
+      }
+    })
+
+    it('falls back to general for unknown or empty industry', () => {
+      expect(resolveIndustryFieldProfile('').id).toBe('general')
+      expect(resolveIndustryFieldProfile('小売業').id).toBe('general')
+      expect(resolveIndustryFieldProfile(null).techAspectEnabled).toBe(false)
+    })
+  })
+
+  describe('infoFieldEnabled', () => {
+    it('does not expose tech_stack on info form by default', () => {
+      const profile = resolveIndustryFieldProfile('IT・ソフトウェア')
+      expect(infoFieldEnabled(profile, 'description')).toBe(true)
+      expect(infoFieldEnabled(profile, 'industry')).toBe(true)
+      expect(infoFieldEnabled(profile, 'tech_stack')).toBe(false)
+    })
+  })
+})

--- a/frontend/tests/lib/relation-labels.test.ts
+++ b/frontend/tests/lib/relation-labels.test.ts
@@ -1,4 +1,12 @@
-import { formatRelationLabel, isSourceTagDescription } from '@/lib/relation-labels'
+import {
+  displayRelationDescription,
+  formatRelationLabel,
+  isClearOrganizationName,
+  isGenericRelationLabel,
+  isRelationDescriptionFallback,
+  isSourceTagDescription,
+  sanitizeRelationDescription,
+} from '@/lib/relation-labels'
 
 describe('relation-labels', () => {
   it('取得元タグのプレースホルダを検出する', () => {
@@ -7,9 +15,39 @@ describe('relation-labels', () => {
     expect(isSourceTagDescription('決済代行')).toBe(false)
   })
 
-  it('関係タイプから表示ラベルを返す', () => {
+  it('種別ラベルだけの説明を検出する', () => {
+    expect(isGenericRelationLabel('主要取引先')).toBe(true)
+    expect(isGenericRelationLabel('取引先')).toBe(true)
+    expect(isGenericRelationLabel('決済代行')).toBe(false)
+  })
+
+  it('編集用に種別ラベルを落とす', () => {
+    expect(sanitizeRelationDescription('主要取引先')).toBe('')
+    expect(sanitizeRelationDescription('web_search:sky株式会社')).toBe('')
+    expect(sanitizeRelationDescription('決済代行')).toBe('決済代行')
+  })
+
+  it('図表示では実内容を優先し、無ければ種別ラベル', () => {
     expect(formatRelationLabel('web_search:sky株式会社', 'business_partner')).toBe('主要取引先')
+    expect(formatRelationLabel('主要取引先', 'business_partner')).toBe('主要取引先')
     expect(formatRelationLabel('', 'business_procurement')).toBe('調達・契約')
     expect(formatRelationLabel('クラウド基盤共同開発', 'business_partner')).toBe('クラウド基盤共同開発')
+  })
+
+  it('弱いフォールバックは主要取引先表示', () => {
+    expect(isRelationDescriptionFallback('')).toBe(true)
+    expect(isRelationDescriptionFallback('主要取引先')).toBe(true)
+    expect(isRelationDescriptionFallback('決済代行')).toBe(false)
+    expect(displayRelationDescription('', 'business_partner')).toBe('主要取引先')
+    expect(displayRelationDescription('決済代行', 'business_partner')).toBe('決済代行')
+  })
+
+  it('曖昧な組織名を弾く', () => {
+    expect(isClearOrganizationName('デジタル庁')).toBe(true)
+    expect(isClearOrganizationName('株式会社パートナーA')).toBe(true)
+    expect(isClearOrganizationName('共同企業体')).toBe(false)
+    expect(isClearOrganizationName('その他')).toBe(false)
+    expect(isClearOrganizationName('株式会社')).toBe(false)
+    expect(isClearOrganizationName('')).toBe(false)
   })
 })

--- a/rag/constraints.txt
+++ b/rag/constraints.txt
@@ -12,11 +12,11 @@
 
 # --- LangChain エコシステム ---
 # crewai は依存衝突のため requirements.txt から除外済み（langchain 上限は crewai 制約によらない）。
-# 2026-03 に 0.3.x 系列へ移行（#135）。0.4.0 以降は破壊的変更のリスクがあるため上限を設定。
-langchain>=0.2.16,<0.4.0
-langchain-community>=0.4.2,<0.5.0
+# 2026-03 に 0.3.x 系列へ移行（#135）。
+# 注意: langchain-community 0.4+ は langchain-core 1.x を要求するため、0.3.x に揃える。
+langchain>=0.3.0,<0.4.0
+langchain-community>=0.3.0,<0.4.0
 langchain-core>=0.3.86,<0.4.0
-# langchain-openai 0.3.x が langchain 0.3.x + openai 2.x に対応するバージョン系列
 langchain-openai>=0.3.0,<0.4.0
 langchain-text-splitters>=0.3.11,<0.4.0
 

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -1,9 +1,17 @@
 # RAG サービス 直接依存パッケージ
 # バージョン制約の詳細は constraints.txt を参照。
+# インストール: pip install -r requirements.txt -c constraints.txt
 chromadb>=0.6.3,<0.7.0
 # crewai omitted due to dependency conflicts (embedchain/langchain). See Issue #273
 fastapi==0.140.0
-openai==1.109.1
+# LangChain（埋め込み・検索・今後のチェーン化）。0.3.x 系に固定（constraints.txt 参照）。
+langchain>=0.3.0,<0.4.0
+langchain-community>=0.3.0,<0.4.0
+langchain-core>=0.3.86,<0.4.0
+langchain-openai>=0.3.0,<0.4.0
+langchain-text-splitters>=0.3.11,<0.4.0
+# langchain-openai 0.3 / litellm との両立のため 1.x〜2.x を許容
+openai>=1.109.1,<3.0
 pydantic==2.13.4
 pytest==8.4.2
 tiktoken==0.13.0

--- a/rag/services/embed.py
+++ b/rag/services/embed.py
@@ -1,7 +1,8 @@
 """埋め込み・類似度・ドキュメント取得。
 
-patch("main.OpenAI") / patch("main.EMBED_MAX_RETRIES") / patch("main.embed_texts")
-との互換のため、実行時に main モジュール上のシンボルを参照する。
+埋め込みは LangChain（langchain-openai.OpenAIEmbeddings）経由。
+patch("main.embed_texts") / patch("main.EMBED_MAX_RETRIES") 互換のため、
+実行時に main モジュール上のシンボルも参照する。
 """
 from __future__ import annotations
 
@@ -13,6 +14,9 @@ from typing import List
 
 import tiktoken
 from fastapi import HTTPException
+from langchain_core.documents import Document
+
+from services.langchain_runtime import get_embeddings
 
 logger = logging.getLogger("main")
 
@@ -33,7 +37,7 @@ def _truncate_text(text: str, model: str) -> str:
             m.MAX_EMBED_TOKENS,
             model,
         )
-        return enc.decode(tokens[:m.MAX_EMBED_TOKENS])
+        return enc.decode(tokens[: m.MAX_EMBED_TOKENS])
     return text
 
 
@@ -45,16 +49,15 @@ def embed_texts(texts: List[str]) -> List[List[float]]:
         raise HTTPException(status_code=500, detail="OPENAI_API_KEY is required")
 
     embedding_model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
-    client = m.OpenAI(api_key=api_key)
-
-    # トークン上限チェック
     texts = [_truncate_text(t, embedding_model) for t in texts]
+
+    # get_embeddings は api_key 欠如で ValueError。上で既にチェック済み。
+    embeddings = get_embeddings(embedding_model)
 
     last_err: Exception = RuntimeError("embed_texts: no attempts made")
     for attempt in range(1, m.EMBED_MAX_RETRIES + 1):
         try:
-            response = client.embeddings.create(model=embedding_model, input=texts)
-            return [item.embedding for item in response.data]
+            return embeddings.embed_documents(texts)
         except Exception as exc:
             last_err = exc
             if attempt < m.EMBED_MAX_RETRIES:
@@ -83,17 +86,20 @@ def cosine_similarity(a: List[float], b: List[float]) -> float:
 
 
 def retrieve_docs(docs: List[str], query: str) -> List[str]:
+    """クエリに近いドキュメント上位を返す（LangChain Document + 埋め込み類似度）。"""
     import main as m
 
     if not docs:
         return []
-    embeddings = m.embed_texts(docs + [query])
+
+    # Document 化して LC 上の単位を揃える（本文は page_content）
+    documents = [Document(page_content=doc) for doc in docs]
+    embeddings = m.embed_texts([d.page_content for d in documents] + [query])
     doc_embeddings = embeddings[:-1]
     query_embedding = embeddings[-1]
 
-    scored = []
-    for doc, emb in zip(docs, doc_embeddings):
-        scored.append((m.cosine_similarity(query_embedding, emb), doc))
+    scored: list[tuple[float, str]] = []
+    for doc, emb in zip(documents, doc_embeddings):
+        scored.append((m.cosine_similarity(query_embedding, emb), doc.page_content))
     scored.sort(key=lambda item: item[0], reverse=True)
-    top_docs = [doc for _, doc in scored[: min(5, len(scored))]]
-    return top_docs
+    return [doc for _, doc in scored[: min(5, len(scored))]]

--- a/rag/services/langchain_runtime.py
+++ b/rag/services/langchain_runtime.py
@@ -1,0 +1,42 @@
+"""LangChain ランタイム（埋め込み・今後の Chat / Retriever 共通入口）。
+
+FastAPI エンドポイントはそのままに、LLM/埋め込み実装を LangChain へ寄せるための薄いファサード。
+"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+
+def embedding_model_name() -> str:
+    return os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+
+
+def chat_model_name() -> str:
+    return os.getenv("OPENAI_CHAT_MODEL", os.getenv("OPENAI_MODEL", "gpt-4o-mini"))
+
+
+@lru_cache(maxsize=4)
+def get_embeddings(model: str | None = None) -> OpenAIEmbeddings:
+    """OpenAI Embeddings（LangChain）。API キーは環境変数 OPENAI_API_KEY。"""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY is required")
+    return OpenAIEmbeddings(
+        model=model or embedding_model_name(),
+        api_key=api_key,
+    )
+
+
+def get_chat_model(model: str | None = None, temperature: float = 0.2) -> ChatOpenAI:
+    """Chat モデル（LangChain）。段階的に research / review へ適用する。"""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY is required")
+    return ChatOpenAI(
+        model=model or chat_model_name(),
+        api_key=api_key,
+        temperature=temperature,
+    )

--- a/rag/services/langchain_runtime.py
+++ b/rag/services/langchain_runtime.py
@@ -1,6 +1,7 @@
 """LangChain ランタイム（埋め込み・今後の Chat / Retriever 共通入口）。
 
 FastAPI エンドポイントはそのままに、LLM/埋め込み実装を LangChain へ寄せるための薄いファサード。
+再試行は外側（embed_texts の EMBED_MAX_RETRIES）に集約し、LangChain 側は max_retries=0。
 """
 from __future__ import annotations
 
@@ -8,6 +9,9 @@ import os
 from functools import lru_cache
 
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+
+# 外側リトライと二重にしない。タイムアウトはハング防止用。
+_DEFAULT_REQUEST_TIMEOUT_SEC = float(os.getenv("RAG_OPENAI_TIMEOUT_SEC", "60"))
 
 
 def embedding_model_name() -> str:
@@ -27,6 +31,8 @@ def get_embeddings(model: str | None = None) -> OpenAIEmbeddings:
     return OpenAIEmbeddings(
         model=model or embedding_model_name(),
         api_key=api_key,
+        max_retries=0,
+        request_timeout=_DEFAULT_REQUEST_TIMEOUT_SEC,
     )
 
 
@@ -39,4 +45,6 @@ def get_chat_model(model: str | None = None, temperature: float = 0.2) -> ChatOp
         model=model or chat_model_name(),
         api_key=api_key,
         temperature=temperature,
+        max_retries=0,
+        request_timeout=_DEFAULT_REQUEST_TIMEOUT_SEC,
     )

--- a/rag/tests/test_dependency_constraints.py
+++ b/rag/tests/test_dependency_constraints.py
@@ -165,6 +165,24 @@ class TestConstraintsCommentConsistency:
                 )
 
 
+# ── LangChain が requirements に載っていること ───────────────────────────────
+
+class TestLangchainInRequirements:
+    def test_langchain_packages_listed_in_requirements(self):
+        required = [
+            "langchain",
+            "langchain-core",
+            "langchain-openai",
+            "langchain-community",
+            "langchain-text-splitters",
+        ]
+        for pkg in required:
+            spec = _parse_version_spec(_REQUIREMENTS_TXT, pkg)
+            assert spec is not None, f"requirements.txt に {pkg} が無い。LangChain 導入を反映すること。"
+            con = _parse_version_spec(_CONSTRAINTS_TXT, pkg)
+            assert con is not None, f"constraints.txt に {pkg} が無い"
+
+
 # ── Frontend: package.json バージョン整合性 ────────────────────────────────
 
 class TestFrontendReactVersionConsistency:

--- a/rag/tests/test_extra.py
+++ b/rag/tests/test_extra.py
@@ -15,21 +15,20 @@ class TestEmbedTextsRetry429:
         class RateLimitError(Exception):
             pass
 
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.data = [MagicMock(embedding=[0.9])]
-
-        # 1回目は 429 相当の例外、2回目で成功
-        mock_client.embeddings.create.side_effect = [RateLimitError("429 Too Many Requests"), mock_response]
+        mock_emb = MagicMock()
+        mock_emb.embed_documents.side_effect = [
+            RateLimitError("429 Too Many Requests"),
+            [[0.9]],
+        ]
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            with patch("main.OpenAI", return_value=mock_client):
+            with patch("services.embed.get_embeddings", return_value=mock_emb):
                 with patch("main.EMBED_MAX_RETRIES", 2):
                     with patch("time.sleep"):
                         result = main.embed_texts(["hello"])
 
         assert result == [[0.9]]
-        assert mock_client.embeddings.create.call_count == 2
+        assert mock_emb.embed_documents.call_count == 2
 
 
 class TestCacheBehavior:

--- a/rag/tests/test_langchain_runtime.py
+++ b/rag/tests/test_langchain_runtime.py
@@ -39,4 +39,19 @@ def test_langchain_runtime_get_embeddings_cached(monkeypatch):
         b = runtime.get_embeddings("text-embedding-3-small")
         assert a is b
         assert mock_cls.call_count == 1
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["max_retries"] == 0
+        assert kwargs["request_timeout"] == runtime._DEFAULT_REQUEST_TIMEOUT_SEC
     runtime.get_embeddings.cache_clear()
+
+
+def test_langchain_runtime_get_chat_model_disables_inner_retries(monkeypatch):
+    from services import langchain_runtime as runtime
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with patch("services.langchain_runtime.ChatOpenAI") as mock_cls:
+        mock_cls.return_value = MagicMock(name="chat")
+        runtime.get_chat_model("gpt-4o-mini")
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["max_retries"] == 0
+        assert kwargs["request_timeout"] == runtime._DEFAULT_REQUEST_TIMEOUT_SEC

--- a/rag/tests/test_langchain_runtime.py
+++ b/rag/tests/test_langchain_runtime.py
@@ -1,0 +1,42 @@
+"""LangChain 導入のスモークテスト。"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_langchain_packages_importable():
+    import langchain
+    import langchain_core
+    import langchain_openai
+    from langchain_core.documents import Document
+
+    assert langchain.__name__ == "langchain"
+    assert langchain_core.__name__ == "langchain_core"
+    assert langchain_openai.__name__ == "langchain_openai"
+    assert Document(page_content="x").page_content == "x"
+
+
+def test_langchain_runtime_get_embeddings_requires_api_key():
+    from services import langchain_runtime as runtime
+
+    runtime.get_embeddings.cache_clear()
+    env = {k: v for k, v in __import__("os").environ.items() if k != "OPENAI_API_KEY"}
+    with patch.dict("os.environ", env, clear=True):
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            runtime.get_embeddings()
+
+
+def test_langchain_runtime_get_embeddings_cached(monkeypatch):
+    from services import langchain_runtime as runtime
+
+    runtime.get_embeddings.cache_clear()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with patch("services.langchain_runtime.OpenAIEmbeddings") as mock_cls:
+        mock_cls.return_value = MagicMock(name="embeddings")
+        a = runtime.get_embeddings("text-embedding-3-small")
+        b = runtime.get_embeddings("text-embedding-3-small")
+        assert a is b
+        assert mock_cls.call_count == 1
+    runtime.get_embeddings.cache_clear()

--- a/rag/tests/test_rag.py
+++ b/rag/tests/test_rag.py
@@ -56,58 +56,58 @@ class TestSanitizeCollectionName:
         assert 3 <= len(name) <= 63
 
 
-# ── embed_texts テスト（OpenAI モック） ─────────────────────────────────────
+# ── embed_texts テスト（LangChain OpenAIEmbeddings モック） ─────────────────
 
 class TestEmbedTexts:
-    def _make_mock_client(self, embeddings: list):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.data = [MagicMock(embedding=emb) for emb in embeddings]
-        mock_client.embeddings.create.return_value = mock_response
-        return mock_client
+    def _patch_embeddings(self, embed_documents_side_effect=None, return_value=None):
+        mock_emb = MagicMock()
+        if embed_documents_side_effect is not None:
+            mock_emb.embed_documents.side_effect = embed_documents_side_effect
+        else:
+            mock_emb.embed_documents.return_value = return_value
+        return patch("services.embed.get_embeddings", return_value=mock_emb), mock_emb
 
     def test_returns_embeddings(self):
-        mock_client = self._make_mock_client([[0.1, 0.2, 0.3]])
+        p, mock_emb = self._patch_embeddings(return_value=[[0.1, 0.2, 0.3]])
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            with patch("main.OpenAI", return_value=mock_client):
+            with p:
                 result = main.embed_texts(["hello world"])
         assert result == [[0.1, 0.2, 0.3]]
-        mock_client.embeddings.create.assert_called_once()
+        mock_emb.embed_documents.assert_called_once()
 
     def test_multiple_texts(self):
-        mock_client = self._make_mock_client([[0.1], [0.2]])
+        p, mock_emb = self._patch_embeddings(return_value=[[0.1], [0.2]])
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            with patch("main.OpenAI", return_value=mock_client):
+            with p:
                 result = main.embed_texts(["text1", "text2"])
         assert len(result) == 2
+        mock_emb.embed_documents.assert_called_once()
 
     def test_retries_on_failure_then_succeeds(self):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.data = [MagicMock(embedding=[0.5])]
-        mock_client.embeddings.create.side_effect = [Exception("timeout"), mock_response]
-
+        p, mock_emb = self._patch_embeddings(
+            embed_documents_side_effect=[Exception("timeout"), [[0.5]]],
+        )
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            with patch("main.OpenAI", return_value=mock_client):
+            with p:
                 with patch("main.EMBED_MAX_RETRIES", 2):
                     with patch("time.sleep"):
                         result = main.embed_texts(["test"])
 
         assert result == [[0.5]]
-        assert mock_client.embeddings.create.call_count == 2
+        assert mock_emb.embed_documents.call_count == 2
 
     def test_raises_after_max_retries(self):
-        mock_client = MagicMock()
-        mock_client.embeddings.create.side_effect = Exception("persistent error")
-
+        p, mock_emb = self._patch_embeddings(
+            embed_documents_side_effect=Exception("persistent error"),
+        )
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            with patch("main.OpenAI", return_value=mock_client):
+            with p:
                 with patch("main.EMBED_MAX_RETRIES", 2):
                     with patch("time.sleep"):
                         with pytest.raises(Exception, match="persistent error"):
                             main.embed_texts(["test"])
 
-        assert mock_client.embeddings.create.call_count == 2
+        assert mock_emb.embed_documents.call_count == 2
 
     def test_raises_without_api_key(self):
         from fastapi import HTTPException


### PR DESCRIPTION
## Summary
- 非上場企業でも関係・基本情報を「確認済み」として扱えるよう成功判定を見直し、AI失敗の握りつぶしを解消
- 関係の取引内容をAIで取得（推定可／弱い場合は「主要取引先」表示）。曖昧な社名は除外し、入札・調達は省庁名を記載
- 業種別フィールドプロファイル（技術必須の出し分け）と管理画面UI（フィルタ・関係/技術レイアウト）を改善
- RAG埋め込みを LangChain（`langchain-openai` 0.3系）経由に切り替え、依存とテストを追加

## Test plan
- [ ] `cd Backend && go test ./internal/companyfetch/ ./internal/services/ ./test/services/`
- [ ] `cd rag && pytest tests/ -q`（LangChain導入・埋め込み）
- [ ] `cd frontend && npx jest tests/lib/admin-company-fetch.test.ts tests/lib/relation-labels.test.ts --watchAll=false`
- [ ] 管理画面で非上場企業の主3種取得 → 関係が「確認済(非上場)」になること
- [ ] 関係ページで取引内容が表示／空なら「主要取引先」になること
- [ ] RAG `/health` と実埋め込み（OpenAI）が通ること
- [ ] 業種フィルタ・技術タブの出し分けが意図どおりであること

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core admin company fetch, TTL/stamping rules, parallel batch jobs, and relation persistence (including gBiz mapping), so regressions could leave companies stuck as missing or write bad graph data. AI retry and force-fetch paths also increase external API load and cost exposure.
> 
> **Overview**
> **企業データの取得・充足判定と管理画面**を、業種と「主3種（基本・技術・関係）」の考え方に合わせて大きく見直します。
> 
> **Backend**では `companyfields` を追加し、業界ごとに技術タブの要否・公開必須・充足 SQL を切り替えます。基本情報は `HasBasicInfoFootprint` で疎データでも TTL スタンプ可能にし、非上場確定を関係取得の成功扱いに変更します。IT 向け技術充足は `tech_stack` 必須に厳格化し、製造業は別スキーマ／プロンプトで取得します。関係は `SanitizeRelationDescription` と `IsClearOrganizationName` で曖昧名・種別ラベルの DB 保存を止め、gBiz 調達・補助金は共同署名ではなく省庁名ベースに変更。関係 AI は取引内容の追撃補完と `cache_only` / `LoadSaved` を追加。企業一覧は業界・readiness・並び順フィルタと `GET /companies/industries` を追加。不足一括取得は `primary_only`・並列 `concurrency`・不足項目の `force=true` とキャッシュ空判定の厳格化を入れます。`fetch-primary` ステップも業種・キャッシュ中身で成功／エラーを分けます。
> 
> **Frontend**は会社概要・技術・関連企業を `CompanyAspectTabs` で統一し、一覧側の業界／充足フィルタと業種プロファイル連動の入力項目に寄せます。関係画面は保存済みの `cache_only` 読み込み、取引内容フィールド、曖昧社名の保存除外を反映します。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2728968ef3c00e4f54c5c35d80c2b9eeb47d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 業種に応じて企業情報・技術情報の入力項目や表示内容を最適化しました。
  * 企業一覧で業種、情報充足度、並び順による絞り込みが可能になりました。
  * 複数企業の一括公開と、情報不足データの並列取得に対応しました。
  * 企業詳細画面に情報・技術・関連企業のタブを追加しました。
  * 関連企業の説明表示を改善し、相関図を見やすくしました。

* **改善**
  * 取得結果やキャッシュ不足時の状態表示を明確化しました。
  * AI検索の一時的な失敗時に自動再試行するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->