### PR TITLE
fix: Company/CompanyJobPosition/CompanyReviewのDeletedAtをgorm.DeletedAtに修正

### DIFF
--- a/Backend/internal/models/company.go
+++ b/Backend/internal/models/company.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // Company 企業情報
 type Company struct {
@@ -54,7 +58,7 @@ type Company struct {
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
-	DeletedAt *time.Time `gorm:"index"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 }
 
 // CompanyJobPosition 企業の募集職種
@@ -88,7 +92,7 @@ type CompanyJobPosition struct {
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
-	DeletedAt *time.Time `gorm:"index" json:"-"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 }
 
 // CompanyWeightProfile 企業の適性プロファイル（10カテゴリの重視度）
@@ -231,7 +235,7 @@ type CompanyReview struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	DeletedAt *time.Time `gorm:"index"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
 }
 
 // CompanyBenefit 企業の福利厚生


### PR DESCRIPTION
## Summary
- `Company`, `CompanyJobPosition`, `CompanyReview` の `DeletedAt` フィールドが `*time.Time` 型だったため、GORMのソフトデリート自動フィルタが機能していなかった
- `gorm.DeletedAt` 型に統一し、`CompanyRelation` と整合性を確保
- DBカラム型（datetime）は同一のためマイグレーション不要

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/... ./migrations/...` 全テスト通過
- [ ] CI通過確認

closes #727

Made with [Cursor](https://cursor.com)