### PR TITLE
fix: バリデーションキャッシュの定期パージ追加・デッドコード除去

### DIFF
--- a/Backend/internal/controllers/admin_company_controller.go
+++ b/Backend/internal/controllers/admin_company_controller.go
@@ -54,11 +54,7 @@ func NewAdminCompanyController(repo repository.CompanyRepository, audit ifaces.A
 func (c *AdminCompanyController) SetRelationsFetcher(fetcher *services.CompanyRelationsFetcher) {
 	if c != nil {
 		c.relationsFetcher = fetcher
-		if c.missingBatch != nil {
-			c.missingBatch = services.NewCompanyMissingBatchService(
-				c.repo, c.infoFetcher, c.jobFetcher, c.techFetcher, fetcher,
-			)
-		} else if c.infoFetcher != nil {
+		if c.missingBatch != nil || c.infoFetcher != nil {
 			c.missingBatch = services.NewCompanyMissingBatchService(
 				c.repo, c.infoFetcher, c.jobFetcher, c.techFetcher, fetcher,
 			)

--- a/Backend/internal/controllers/company_relation_controller.go
+++ b/Backend/internal/controllers/company_relation_controller.go
@@ -295,30 +295,3 @@ func (ctrl *CompanyRelationController) searchCompaniesWithOpenAI(ctx context.Con
 	return parsed.Results
 }
 
-// splitPath はURLパスを "/" で分割してスラッシュを除去した要素のスライスを返す（後方互換性のため残存）
-func splitPath(path string) []string {
-	result := []string{}
-	start := 0
-	for i := 0; i <= len(path); i++ {
-		if i == len(path) || path[i] == '/' {
-			if i > start {
-				result = append(result, path[start:i])
-			}
-			start = i + 1
-		}
-	}
-	return result
-}
-
-// trimSpace は文字列の先頭と末尾の空白を除去する
-func trimSpace(s string) string {
-	start := 0
-	end := len(s)
-	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
-		start++
-	}
-	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
-		end--
-	}
-	return s[start:end]
-}

--- a/Backend/internal/services/company_validation_service.go
+++ b/Backend/internal/services/company_validation_service.go
@@ -56,11 +56,13 @@ type CompanyValidationService struct {
 }
 
 func NewCompanyValidationService(companyRepo companyLookup, client *openai.Client) *CompanyValidationService {
-	return &CompanyValidationService{
+	s := &CompanyValidationService{
 		companyRepo:  companyRepo,
 		openaiClient: client,
 		cache:        make(map[string]companyValidationCacheEntry),
 	}
+	go s.purgeLoop()
+	return s
 }
 
 // SetSearchBudget は月次 Search 予算ガードを注入する。
@@ -313,6 +315,25 @@ func (s *CompanyValidationService) getCache(key string) (CompanyValidationResult
 		return CompanyValidationResult{}, false
 	}
 	return entry.result, true
+}
+
+func (s *CompanyValidationService) purgeLoop() {
+	ticker := time.NewTicker(companyValidationCacheTTL)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.purgeExpired()
+	}
+}
+
+func (s *CompanyValidationService) purgeExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, v := range s.cache {
+		if now.After(v.expiresAt) {
+			delete(s.cache, k)
+		}
+	}
 }
 
 func (s *CompanyValidationService) putCache(key string, result CompanyValidationResult) {


### PR DESCRIPTION
## Summary
- `CompanyValidationService` のインメモリキャッシュに定期パージ goroutine を追加し、期限切れエントリによるメモリリークを解消
- `company_relation_controller.go` の未使用関数 `splitPath`, `trimSpace` を削除
- `SetRelationsFetcher` 内の到達不能 `else if` ブランチを条件統合で修正

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/... ./migrations/...` 全テスト通過
- [ ] CI通過確認

closes #732

Made with [Cursor](https://cursor.com)