### PR TITLE
fix: 企業管理APIルートをproxyAdminBackendに統一し型安全性を向上

### DIFF
--- a/frontend/app/admin/companies/[id]/interview-questions/page.tsx
+++ b/frontend/app/admin/companies/[id]/interview-questions/page.tsx
@@ -164,8 +164,8 @@ export default function AdminInterviewQuestionsPage() {
       setSuccess(editingId ? '質問を更新しました' : '質問を追加しました')
       setDialogOpen(false)
       fetchQuestions()
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     } finally {
       setSaving(false)
     }
@@ -185,8 +185,8 @@ export default function AdminInterviewQuestionsPage() {
       setGeneratedQuestions(qs)
       setSelectedIndices(new Set(qs.map((_, i) => i)))
       setGenerateDialogOpen(true)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     } finally {
       setGenerating(false)
     }
@@ -235,8 +235,8 @@ export default function AdminInterviewQuestionsPage() {
       setSuccess('質問を削除しました')
       setDeleteConfirmId(null)
       fetchQuestions()
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     }
   }
 

--- a/frontend/app/api/admin/companies/[id]/route.ts
+++ b/frontend/app/api/admin/companies/[id]/route.ts
@@ -1,28 +1,35 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  proxyAdminBackend,
+  jsonFromProxyResult,
+  proxyErrorResponse,
+  adminProxyHeaders,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
+
+function parseCompanyId(id: string): number | null {
+  const n = Number(id)
+  return Number.isInteger(n) && n > 0 ? n : null
+}
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
-  })
-  const raw = await response.text()
-  let data: any = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  if (!parseCompanyId(id)) {
+    return Response.json({ error: 'invalid company id' }, { status: 400 })
   }
-  return NextResponse.json(data, { status: response.status })
+  try {
+    const result = await proxyAdminBackend('GET', `/api/admin/companies/${id}`, {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 15_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
+  }
 }
 
 export async function PUT(
@@ -30,21 +37,18 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params
-  const body = await request.text()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json', 'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
-    body,
-  })
-  const raw = await response.text()
-  let data: any = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  if (!parseCompanyId(id)) {
+    return Response.json({ error: 'invalid company id' }, { status: 400 })
   }
-  return NextResponse.json(data, { status: response.status })
+  const body = await request.text()
+  try {
+    const result = await proxyAdminBackend('PUT', `/api/admin/companies/${id}`, {
+      headers: adminProxyHeaders(request.headers),
+      body,
+      timeoutMs: 30_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
+  }
 }

--- a/frontend/app/api/admin/companies/route.ts
+++ b/frontend/app/api/admin/companies/route.ts
@@ -1,46 +1,37 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+import { NextRequest } from 'next/server'
+import {
+  proxyAdminBackend,
+  jsonFromProxyResult,
+  proxyErrorResponse,
+  adminProxyHeaders,
+} from '@/lib/admin-backend-proxy'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.toString()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies${query ? `?${query}` : ''}`, {
-    headers: { 'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '' },
-  })
-  const raw = await response.text()
-  let data: any = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  const path = `/api/admin/companies${query ? `?${query}` : ''}`
+  try {
+    const result = await proxyAdminBackend('GET', path, {
+      headers: adminProxyHeaders(request.headers),
+      timeoutMs: 15_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }
 
 export async function POST(request: NextRequest) {
   const body = await request.text()
-  const response = await fetch(`${BACKEND_URL}/api/admin/companies`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Admin-Email': request.headers.get('x-admin-email') || '',
-      'X-Admin-Token': request.headers.get('x-admin-token') || '',
-    },
-    body,
-  })
-  const raw = await response.text()
-  let data: any = {}
-  if (raw) {
-    try {
-      data = JSON.parse(raw)
-    } catch {
-      data = response.ok ? { message: raw } : { error: raw }
-    }
+  try {
+    const result = await proxyAdminBackend('POST', '/api/admin/companies', {
+      headers: adminProxyHeaders(request.headers),
+      body,
+      timeoutMs: 30_000,
+    })
+    return jsonFromProxyResult(result)
+  } catch (err) {
+    return proxyErrorResponse(err)
   }
-  return NextResponse.json(data, { status: response.status })
 }


### PR DESCRIPTION
## Summary
- `companies/route.ts` と `companies/[id]/route.ts` を raw fetch から `proxyAdminBackend` に移行
- `any` 型を除去し、タイムアウト・リトライ・エラーフォーマットを統一
- `params.id` の数値バリデーションを追加（非数値IDは400エラー）
- `interview-questions/page.tsx` の `catch (e: any)` を型安全な形に修正

## Test plan
- [x] `npx tsc --noEmit` 成功
- [ ] CI通過確認

closes #728

Made with [Cursor](https://cursor.com)