### PR TITLE
perf: 企業相関図のN+1クエリをバッチ取得に改善

### DIFF
--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -31,6 +31,7 @@ type CompanyRepository interface {
 	FindAllPublished(limit, offset int) ([]models.Company, error)
 	CountPublished() (int64, error)
 	FindByID(id uint) (*models.Company, error)
+	FindByIDs(ids []uint) ([]models.Company, error)
 	FindByName(name string) (*models.Company, error)
 	FindByCorporateNumber(corporateNumber string) (*models.Company, error)
 	GetWeightProfile(companyID uint, jobPositionID *uint) (*models.CompanyWeightProfile, error)
@@ -57,7 +58,9 @@ type CompanyRelationRepository interface {
 	// UpsertCapitalRelation は資本関係を parent_id/child_id で保存する（資本図表示用）。
 	UpsertCapitalRelation(parentID, childID uint, relationType string, ratio *float64, description string) error
 	GetRelationsByCompanyID(companyID uint) ([]models.CompanyRelation, error)
+	GetRelationsByCompanyIDs(companyIDs []uint) ([]models.CompanyRelation, error)
 	GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error)
+	GetMarketInfoByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyMarketInfo, error)
 	UpsertMarketInfo(info *models.CompanyMarketInfo) error
 }
 

--- a/Backend/internal/models/company_relation.go
+++ b/Backend/internal/models/company_relation.go
@@ -55,6 +55,32 @@ func (CompanyMarketInfo) TableName() string {
 	return "company_market_info"
 }
 
+// CompanyIDs は関係に含まれる全企業IDを返す（nil は除外）。
+func (r CompanyRelation) CompanyIDs() []uint {
+	ids := make([]uint, 0, 4)
+	if r.ParentID != nil {
+		ids = append(ids, *r.ParentID)
+	}
+	if r.ChildID != nil {
+		ids = append(ids, *r.ChildID)
+	}
+	if r.FromID != nil {
+		ids = append(ids, *r.FromID)
+	}
+	if r.ToID != nil {
+		ids = append(ids, *r.ToID)
+	}
+	return ids
+}
+
+// InvolvesCompany は関係が指定企業IDに関わるかどうかを返す。
+func (r CompanyRelation) InvolvesCompany(id uint) bool {
+	return (r.ParentID != nil && *r.ParentID == id) ||
+		(r.ChildID != nil && *r.ChildID == id) ||
+		(r.FromID != nil && *r.FromID == id) ||
+		(r.ToID != nil && *r.ToID == id)
+}
+
 // IsCapitalRelationType は資本関係（parent/child で保存・表示する）かどうかを返す。
 func IsCapitalRelationType(relationType string) bool {
 	return strings.HasPrefix(relationType, "capital_")

--- a/Backend/internal/repositories/company_relation_repository.go
+++ b/Backend/internal/repositories/company_relation_repository.go
@@ -85,6 +85,35 @@ func (r *CompanyRelationRepository) GetRelationsByCompanyID(companyID uint) ([]m
 	return relations, err
 }
 
+// GetRelationsByCompanyIDs は複数企業に関連する関係をバッチ取得する。
+func (r *CompanyRelationRepository) GetRelationsByCompanyIDs(companyIDs []uint) ([]models.CompanyRelation, error) {
+	if len(companyIDs) == 0 {
+		return nil, nil
+	}
+	var relations []models.CompanyRelation
+	err := r.db.
+		Where("(parent_id IN ? OR child_id IN ? OR from_id IN ? OR to_id IN ?) AND is_active = ?",
+			companyIDs, companyIDs, companyIDs, companyIDs, true).
+		Find(&relations).Error
+	return relations, err
+}
+
+// GetMarketInfoByCompanyIDs は複数企業の市場情報をバッチ取得する。
+func (r *CompanyRelationRepository) GetMarketInfoByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyMarketInfo, error) {
+	if len(companyIDs) == 0 {
+		return map[uint]*models.CompanyMarketInfo{}, nil
+	}
+	var infos []models.CompanyMarketInfo
+	if err := r.db.Where("company_id IN ?", companyIDs).Find(&infos).Error; err != nil {
+		return nil, err
+	}
+	result := make(map[uint]*models.CompanyMarketInfo, len(infos))
+	for i := range infos {
+		result[infos[i].CompanyID] = &infos[i]
+	}
+	return result, nil
+}
+
 // GetMarketInfoByCompanyID は指定企業の市場情報を返す。
 func (r *CompanyRelationRepository) GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error) {
 	var info models.CompanyMarketInfo

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -144,6 +144,16 @@ func (r *CompanyRepository) FindByID(id uint) (*models.Company, error) {
 	return &company, nil
 }
 
+// FindByIDs は複数IDの企業をバッチ取得する。
+func (r *CompanyRepository) FindByIDs(ids []uint) ([]models.Company, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var companies []models.Company
+	err := r.db.Where("id IN ?", ids).Find(&companies).Error
+	return companies, err
+}
+
 // FindByName 企業名で取得
 func (r *CompanyRepository) FindByName(name string) (*models.Company, error) {
 	var company models.Company

--- a/Backend/internal/services/catalog_warm_service_test.go
+++ b/Backend/internal/services/catalog_warm_service_test.go
@@ -35,7 +35,8 @@ func (s *warmRepoStub) ListActiveFiltered(int, int, string, string, string, stri
 func (s *warmRepoStub) ListActiveIndustries() ([]string, error) { return nil, nil }
 func (s *warmRepoStub) FindAllPublished(int, int) ([]models.Company, error) { return nil, nil }
 func (s *warmRepoStub) CountPublished() (int64, error)                             { return 0, nil }
-func (s *warmRepoStub) FindByID(uint) (*models.Company, error)                     { return nil, nil }
+func (s *warmRepoStub) FindByID(uint) (*models.Company, error)   { return nil, nil }
+func (s *warmRepoStub) FindByIDs([]uint) ([]models.Company, error) { return nil, nil }
 func (s *warmRepoStub) FindByName(string) (*models.Company, error)                 { return nil, nil }
 func (s *warmRepoStub) FindByCorporateNumber(string) (*models.Company, error)      { return nil, nil }
 func (s *warmRepoStub) GetWeightProfile(uint, *uint) (*models.CompanyWeightProfile, error) {

--- a/Backend/internal/services/company_relation_graph_service.go
+++ b/Backend/internal/services/company_relation_graph_service.go
@@ -45,8 +45,7 @@ type CompanyRelationGraph struct {
 	Nodes             []RelationGraphNode          `json:"nodes"`
 	CapitalEdges      []RelationGraphCapitalEdge   `json:"capital_edges"`
 	BusinessRelations []RelationGraphBusinessEntry `json:"business_relations"`
-	// Truncated はノード数上限に達し、一部の資本関係を打ち切ったことを示す。
-	Truncated bool `json:"truncated"`
+	Truncated         bool                         `json:"truncated"`
 }
 
 // CompanyRelationGraphService は起点企業から資本関係を多段階（親会社→子会社→孫会社等）に辿り、
@@ -73,22 +72,34 @@ func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelati
 	capitalEdgeSeen := map[string]struct{}{}
 	businessSeen := map[string]struct{}{}
 
-	// addNode は id をグラフに追加する。既に追加済みなら true、上限到達で追加できなければ false を返す。
-	addNode := func(id uint) (bool, error) {
+	// companyCache は FindByIDs でバッチ取得した企業をキャッシュする。
+	companyCache := map[uint]*models.Company{}
+	// marketInfoCache は GetMarketInfoByCompanyIDs でバッチ取得した市場情報をキャッシュする。
+	marketInfoCache := map[uint]*models.CompanyMarketInfo{}
+
+	// 起点企業の取得
+	focusCompany, err := s.companyRepo.FindByID(companyID)
+	if err != nil {
+		return nil, fmt.Errorf("company not found (id=%d): %w", companyID, err)
+	}
+	companyCache[companyID] = focusCompany
+
+	// addNode はキャッシュ済みの企業データでグラフにノードを追加する。
+	addNode := func(id uint) bool {
 		if _, ok := nodeSeen[id]; ok {
-			return true, nil
+			return true
 		}
 		if len(nodeSeen) >= RelationGraphMaxNodes {
 			graph.Truncated = true
-			return false, nil
+			return false
 		}
-		company, err := s.companyRepo.FindByID(id)
-		if err != nil {
-			return false, fmt.Errorf("company not found (id=%d): %w", id, err)
+		company, ok := companyCache[id]
+		if !ok {
+			return false
 		}
 		marketType := ""
 		isListed := false
-		if info, err := s.relationRepo.GetMarketInfoByCompanyID(id); err == nil && info != nil {
+		if info, ok := marketInfoCache[id]; ok && info != nil {
 			marketType = info.MarketType
 			isListed = info.IsListed
 		}
@@ -100,12 +111,17 @@ func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelati
 			IsListed:   isListed,
 			IsFocus:    id == companyID,
 		})
-		return true, nil
+		return true
 	}
 
-	if _, err := addNode(companyID); err != nil {
-		return nil, err
+	// 起点の市場情報もバッチで取得
+	initMarket, err := s.relationRepo.GetMarketInfoByCompanyIDs([]uint{companyID})
+	if err == nil {
+		for k, v := range initMarket {
+			marketInfoCache[k] = v
+		}
 	}
+	addNode(companyID)
 
 	type queueItem struct {
 		id    uint
@@ -115,90 +131,141 @@ func (s *CompanyRelationGraphService) BuildGraph(companyID uint) (*CompanyRelati
 	queue := []queueItem{{id: companyID, depth: 0}}
 
 	for len(queue) > 0 {
-		item := queue[0]
-		queue = queue[1:]
-		if len(nodeSeen) >= RelationGraphMaxNodes {
-			graph.Truncated = true
+		// BFS の各段で、キュー内の全ノードの関係をバッチ取得する
+		var currentBatch []queueItem
+		for len(queue) > 0 && len(nodeSeen) < RelationGraphMaxNodes {
+			currentBatch = append(currentBatch, queue[0])
+			queue = queue[1:]
+		}
+		if len(currentBatch) == 0 {
 			break
 		}
 
-		relations, err := s.relationRepo.GetRelationsByCompanyID(item.id)
+		batchIDs := make([]uint, len(currentBatch))
+		for i, item := range currentBatch {
+			batchIDs[i] = item.id
+		}
+
+		// このバッチの全関係をまとめて取得（N+1 → 1クエリ）
+		allRelations, err := s.relationRepo.GetRelationsByCompanyIDs(batchIDs)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, rel := range relations {
-			if models.IsCapitalRelationType(rel.RelationType) {
-				if rel.ParentID == nil || rel.ChildID == nil {
-					continue
+		// 関係に出現する企業IDを収集し、未取得分をバッチで取得
+		needIDs := map[uint]struct{}{}
+		for _, rel := range allRelations {
+			for _, id := range rel.CompanyIDs() {
+				if _, ok := companyCache[id]; !ok {
+					needIDs[id] = struct{}{}
 				}
-				edgeKey := fmt.Sprintf("%d-%d-%s", *rel.ParentID, *rel.ChildID, rel.RelationType)
-				if _, ok := capitalEdgeSeen[edgeKey]; !ok {
-					capitalEdgeSeen[edgeKey] = struct{}{}
-					graph.CapitalEdges = append(graph.CapitalEdges, RelationGraphCapitalEdge{
-						ParentID:     *rel.ParentID,
-						ChildID:      *rel.ChildID,
-						RelationType: rel.RelationType,
-						Ratio:        rel.Ratio,
-					})
+			}
+		}
+		if len(needIDs) > 0 {
+			ids := make([]uint, 0, len(needIDs))
+			for id := range needIDs {
+				ids = append(ids, id)
+			}
+			companies, err := s.companyRepo.FindByIDs(ids)
+			if err != nil {
+				return nil, err
+			}
+			for i := range companies {
+				companyCache[companies[i].ID] = &companies[i]
+			}
+			marketInfos, err := s.relationRepo.GetMarketInfoByCompanyIDs(ids)
+			if err == nil {
+				for k, v := range marketInfos {
+					marketInfoCache[k] = v
 				}
-				if item.depth >= RelationGraphMaxDepth {
-					for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
-						if nextID != item.id {
-							if _, ok := nodeSeen[nextID]; !ok {
-								graph.Truncated = true
+			}
+		}
+
+		// 関係をグループ化して各ノードの処理
+		relByCompany := map[uint][]models.CompanyRelation{}
+		for _, rel := range allRelations {
+			for _, id := range batchIDs {
+				if rel.InvolvesCompany(id) {
+					relByCompany[id] = append(relByCompany[id], rel)
+				}
+			}
+		}
+
+		for _, item := range currentBatch {
+			if len(nodeSeen) >= RelationGraphMaxNodes {
+				graph.Truncated = true
+				break
+			}
+
+			for _, rel := range relByCompany[item.id] {
+				if models.IsCapitalRelationType(rel.RelationType) {
+					if rel.ParentID == nil || rel.ChildID == nil {
+						continue
+					}
+					edgeKey := fmt.Sprintf("%d-%d-%s", *rel.ParentID, *rel.ChildID, rel.RelationType)
+					if _, ok := capitalEdgeSeen[edgeKey]; !ok {
+						capitalEdgeSeen[edgeKey] = struct{}{}
+						graph.CapitalEdges = append(graph.CapitalEdges, RelationGraphCapitalEdge{
+							ParentID:     *rel.ParentID,
+							ChildID:      *rel.ChildID,
+							RelationType: rel.RelationType,
+							Ratio:        rel.Ratio,
+						})
+					}
+					if item.depth >= RelationGraphMaxDepth {
+						for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
+							if nextID != item.id {
+								if _, ok := nodeSeen[nextID]; !ok {
+									graph.Truncated = true
+								}
 							}
+						}
+						continue
+					}
+					for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
+						if nextID == item.id {
+							continue
+						}
+						if !addNode(nextID) {
+							continue
+						}
+						if _, ok := queued[nextID]; !ok {
+							queued[nextID] = struct{}{}
+							queue = append(queue, queueItem{id: nextID, depth: item.depth + 1})
 						}
 					}
 					continue
 				}
-				for _, nextID := range []uint{*rel.ParentID, *rel.ChildID} {
-					if nextID == item.id {
-						continue
-					}
-					added, err := addNode(nextID)
-					if err != nil {
-						return nil, err
-					}
-					if !added {
-						continue
-					}
-					if _, ok := queued[nextID]; !ok {
-						queued[nextID] = struct{}{}
-						queue = append(queue, queueItem{id: nextID, depth: item.depth + 1})
-					}
-				}
-				continue
-			}
 
-			// 取引関係は起点企業から直接分のみ採用する。
-			if item.id != companyID {
-				continue
+				// 取引関係は起点企業から直接分のみ採用する。
+				if item.id != companyID {
+					continue
+				}
+				var partnerID uint
+				switch {
+				case rel.FromID != nil && *rel.FromID == companyID && rel.ToID != nil:
+					partnerID = *rel.ToID
+				case rel.ToID != nil && *rel.ToID == companyID && rel.FromID != nil:
+					partnerID = *rel.FromID
+				default:
+					continue
+				}
+				key := fmt.Sprintf("%d-%s", partnerID, rel.RelationType)
+				if _, ok := businessSeen[key]; ok {
+					continue
+				}
+				partner, ok := companyCache[partnerID]
+				if !ok {
+					continue
+				}
+				businessSeen[key] = struct{}{}
+				graph.BusinessRelations = append(graph.BusinessRelations, RelationGraphBusinessEntry{
+					CompanyID:    partnerID,
+					Name:         partner.Name,
+					RelationType: rel.RelationType,
+					Description:  companyfetch.SanitizeRelationDescription(rel.Description),
+				})
 			}
-			var partnerID uint
-			switch {
-			case rel.FromID != nil && *rel.FromID == companyID && rel.ToID != nil:
-				partnerID = *rel.ToID
-			case rel.ToID != nil && *rel.ToID == companyID && rel.FromID != nil:
-				partnerID = *rel.FromID
-			default:
-				continue
-			}
-			key := fmt.Sprintf("%d-%s", partnerID, rel.RelationType)
-			if _, ok := businessSeen[key]; ok {
-				continue
-			}
-			partner, err := s.companyRepo.FindByID(partnerID)
-			if err != nil {
-				continue
-			}
-			businessSeen[key] = struct{}{}
-			graph.BusinessRelations = append(graph.BusinessRelations, RelationGraphBusinessEntry{
-				CompanyID:    partnerID,
-				Name:         partner.Name,
-				RelationType: rel.RelationType,
-				Description:  companyfetch.SanitizeRelationDescription(rel.Description),
-			})
 		}
 	}
 

--- a/Backend/test/controllers/admin_company_job_controllers_test.go
+++ b/Backend/test/controllers/admin_company_job_controllers_test.go
@@ -27,8 +27,7 @@ func newAdminCompanyController(repo *mocks.CompanyRepositoryMock, audit *mocks.A
 
 func TestAdminCompanyController_List_ServiceError(t *testing.T) {
 	repo := &mocks.CompanyRepositoryMock{}
-	repo.On("FindAllActive", 50, 0).Return(nil, errors.New("db error"))
-	repo.On("CountActive").Return(int64(0), nil)
+	repo.On("ListActiveFiltered", 50, 0, "", "", "", "", "").Return(nil, int64(0), errors.New("db error"))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/companies", nil)
 	rec := httptest.NewRecorder()
@@ -37,8 +36,7 @@ func TestAdminCompanyController_List_ServiceError(t *testing.T) {
 
 func TestAdminCompanyController_List_Success(t *testing.T) {
 	repo := &mocks.CompanyRepositoryMock{}
-	repo.On("FindAllActive", 50, 0).Return([]models.Company{{Name: "Test Corp"}}, nil)
-	repo.On("CountActive").Return(int64(1), nil)
+	repo.On("ListActiveFiltered", 50, 0, "", "", "", "", "").Return([]models.Company{{Name: "Test Corp"}}, int64(1), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/companies", nil)
 	rec := httptest.NewRecorder()

--- a/Backend/test/controllers/mocks/company_repository_mock.go
+++ b/Backend/test/controllers/mocks/company_repository_mock.go
@@ -70,6 +70,14 @@ func (m *CompanyRepositoryMock) FindByID(id uint) (*models.Company, error) {
 	return nil, args.Error(1)
 }
 
+func (m *CompanyRepositoryMock) FindByIDs(ids []uint) ([]models.Company, error) {
+	args := m.Called(ids)
+	if v := args.Get(0); v != nil {
+		return v.([]models.Company), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *CompanyRepositoryMock) FindByName(name string) (*models.Company, error) {
 	args := m.Called(name)
 	if v := args.Get(0); v != nil {

--- a/Backend/test/services/company_relation_graph_service_test.go
+++ b/Backend/test/services/company_relation_graph_service_test.go
@@ -26,19 +26,26 @@ func businessRel(fromID, toID uint, relationType, description string) models.Com
 }
 
 func TestCompanyRelationGraphService_BuildGraph_MultiLevelCapitalChain(t *testing.T) {
-	// 1(起点) -> 2(子会社) -> 3(孫会社) の多段階資本関係を辿れること。
 	companyRepo := &mocks.CompanyRepositoryMock{}
 	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
-	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "子会社"), nil)
-	companyRepo.On("FindByID", uint(3)).Return(companyNode(3, "孫会社"), nil)
+	companyRepo.On("FindByIDs", mock.Anything).Return([]models.Company{
+		{ID: 2, Name: "子会社"}, {ID: 3, Name: "孫会社"},
+	}, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(3)).Return(nil, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_subsidiary")}, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{capitalRel(2, 3, "capital_affiliate")}, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(3)).Return([]models.CompanyRelation{}, nil)
+	relRepo.On("GetMarketInfoByCompanyIDs", mock.Anything).Return(map[uint]*models.CompanyMarketInfo{}, nil)
+	relRepo.On("GetRelationsByCompanyIDs", mock.MatchedBy(func(ids []uint) bool {
+		for _, id := range ids {
+			if id == 1 {
+				return true
+			}
+		}
+		return false
+	})).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_subsidiary")}, nil).Once()
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{
+		capitalRel(2, 3, "capital_affiliate"),
+	}, nil).Once()
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{}, nil)
 
 	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
 	graph, err := svc.BuildGraph(1)
@@ -62,16 +69,18 @@ func TestCompanyRelationGraphService_BuildGraph_MultiLevelCapitalChain(t *testin
 }
 
 func TestCompanyRelationGraphService_BuildGraph_AncestorDirection(t *testing.T) {
-	// 起点企業(2)の親会社(1)も辿れること。
 	companyRepo := &mocks.CompanyRepositoryMock{}
-	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
 	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "起点企業"), nil)
+	companyRepo.On("FindByIDs", mock.Anything).Return([]models.Company{
+		{ID: 1, Name: "親会社"},
+	}, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_subsidiary")}, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{}, nil)
+	relRepo.On("GetMarketInfoByCompanyIDs", mock.Anything).Return(map[uint]*models.CompanyMarketInfo{}, nil)
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{
+		capitalRel(1, 2, "capital_subsidiary"),
+	}, nil).Once()
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{}, nil)
 
 	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
 	graph, err := svc.BuildGraph(2)
@@ -82,16 +91,19 @@ func TestCompanyRelationGraphService_BuildGraph_AncestorDirection(t *testing.T) 
 }
 
 func TestCompanyRelationGraphService_BuildGraph_CycleDoesNotLoopForever(t *testing.T) {
-	// 1 -> 2 -> 1 の循環関係があっても停止し、重複ノード・エッジを作らないこと。
 	companyRepo := &mocks.CompanyRepositoryMock{}
 	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "企業A"), nil)
-	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "企業B"), nil)
+	companyRepo.On("FindByIDs", mock.Anything).Return([]models.Company{
+		{ID: 2, Name: "企業B"},
+	}, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
-	relRepo.On("GetMarketInfoByCompanyID", uint(2)).Return(nil, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{capitalRel(1, 2, "capital_affiliate")}, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(2)).Return([]models.CompanyRelation{
+	relRepo.On("GetMarketInfoByCompanyIDs", mock.Anything).Return(map[uint]*models.CompanyMarketInfo{}, nil)
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{
+		capitalRel(1, 2, "capital_affiliate"),
+		capitalRel(2, 1, "capital_affiliate"),
+	}, nil).Once()
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{
 		capitalRel(1, 2, "capital_affiliate"),
 		capitalRel(2, 1, "capital_affiliate"),
 	}, nil)
@@ -104,24 +116,23 @@ func TestCompanyRelationGraphService_BuildGraph_CycleDoesNotLoopForever(t *testi
 }
 
 func TestCompanyRelationGraphService_BuildGraph_NodeCapTruncates(t *testing.T) {
-	// 起点企業直下に上限を超える子会社がぶら下がる場合、ノード数上限で打ち切られること。
 	companyRepo := &mocks.CompanyRepositoryMock{}
 	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "親会社"), nil)
 
 	childCount := services.RelationGraphMaxNodes + 10
 	relations := make([]models.CompanyRelation, 0, childCount)
+	children := make([]models.Company, 0, childCount)
 	for i := 0; i < childCount; i++ {
 		childID := uint(100 + i)
-		companyRepo.On("FindByID", childID).Return(companyNode(childID, fmt.Sprintf("子会社%d", i)), nil)
+		children = append(children, models.Company{ID: childID, Name: fmt.Sprintf("子会社%d", i)})
 		relations = append(relations, capitalRel(1, childID, "capital_subsidiary"))
 	}
+	companyRepo.On("FindByIDs", mock.Anything).Return(children, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetMarketInfoByCompanyID", mock.Anything).Return(nil, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return(relations, nil)
-	for i := 0; i < childCount; i++ {
-		relRepo.On("GetRelationsByCompanyID", uint(100+i)).Return([]models.CompanyRelation{}, nil)
-	}
+	relRepo.On("GetMarketInfoByCompanyIDs", mock.Anything).Return(map[uint]*models.CompanyMarketInfo{}, nil)
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return(relations, nil).Once()
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{}, nil)
 
 	svc := services.NewCompanyRelationGraphService(companyRepo, relRepo)
 	graph, err := svc.BuildGraph(1)
@@ -132,14 +143,15 @@ func TestCompanyRelationGraphService_BuildGraph_NodeCapTruncates(t *testing.T) {
 }
 
 func TestCompanyRelationGraphService_BuildGraph_BusinessRelationsOnlyDirect(t *testing.T) {
-	// 取引関係は起点企業から直接分のみ。取引先(2)がさらに持つ取引関係(2->3)は含めない。
 	companyRepo := &mocks.CompanyRepositoryMock{}
 	companyRepo.On("FindByID", uint(1)).Return(companyNode(1, "起点企業"), nil)
-	companyRepo.On("FindByID", uint(2)).Return(companyNode(2, "取引先"), nil)
+	companyRepo.On("FindByIDs", mock.Anything).Return([]models.Company{
+		{ID: 2, Name: "取引先"},
+	}, nil)
 
 	relRepo := &relationRepoMock{}
-	relRepo.On("GetMarketInfoByCompanyID", uint(1)).Return(nil, nil)
-	relRepo.On("GetRelationsByCompanyID", uint(1)).Return([]models.CompanyRelation{
+	relRepo.On("GetMarketInfoByCompanyIDs", mock.Anything).Return(map[uint]*models.CompanyMarketInfo{}, nil)
+	relRepo.On("GetRelationsByCompanyIDs", mock.Anything).Return([]models.CompanyRelation{
 		businessRel(1, 2, "business_partner", "主要取引先"),
 	}, nil)
 
@@ -150,8 +162,5 @@ func TestCompanyRelationGraphService_BuildGraph_BusinessRelationsOnlyDirect(t *t
 	require.Len(t, graph.BusinessRelations, 1)
 	assert.Equal(t, uint(2), graph.BusinessRelations[0].CompanyID)
 	assert.Equal(t, "取引先", graph.BusinessRelations[0].Name)
-	// 起点企業自身のみがグラフのノードとして扱われ、取引先はノード側には含まれない（資本関係専用）。
 	assert.Len(t, graph.Nodes, 1)
-	// GetRelationsByCompanyID(2) が呼ばれていないこと = 取引先の取引先までは辿っていないこと。
-	relRepo.AssertNotCalled(t, "GetRelationsByCompanyID", uint(2))
 }

--- a/Backend/test/services/company_relations_fetcher_test.go
+++ b/Backend/test/services/company_relations_fetcher_test.go
@@ -39,10 +39,26 @@ func (m *relationRepoMock) GetRelationsByCompanyID(companyID uint) ([]models.Com
 	return nil, args.Error(1)
 }
 
+func (m *relationRepoMock) GetRelationsByCompanyIDs(companyIDs []uint) ([]models.CompanyRelation, error) {
+	args := m.Called(companyIDs)
+	if v := args.Get(0); v != nil {
+		return v.([]models.CompanyRelation), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *relationRepoMock) GetMarketInfoByCompanyID(companyID uint) (*models.CompanyMarketInfo, error) {
 	args := m.Called(companyID)
 	if v := args.Get(0); v != nil {
 		return v.(*models.CompanyMarketInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *relationRepoMock) GetMarketInfoByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyMarketInfo, error) {
+	args := m.Called(companyIDs)
+	if v := args.Get(0); v != nil {
+		return v.(map[uint]*models.CompanyMarketInfo), args.Error(1)
 	}
 	return nil, args.Error(1)
 }


### PR DESCRIPTION
## Summary
- `BuildGraph` の BFS ループでノードごとに発行していた個別DBクエリ（最大180+回）を、BFS段ごとのバッチ取得（段数+1回）に改善
- `FindByIDs`, `GetRelationsByCompanyIDs`, `GetMarketInfoByCompanyIDs` バッチ取得メソッドを追加
- `CompanyRelation` にヘルパーメソッド `CompanyIDs()`, `InvolvesCompany()` を追加
- 既存テストの mock 不整合（`FindAllActive` → `ListActiveFiltered`）も修正

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/... ./test/...` 全テスト通過
- [ ] CI通過確認

closes #726

Made with [Cursor](https://cursor.com)