### PR TITLE
fix: 企業管理のハードコード値を環境変数で設定可能にする

### DIFF
--- a/Backend/internal/companyfetch/text.go
+++ b/Backend/internal/companyfetch/text.go
@@ -2,6 +2,7 @@ package companyfetch
 
 import (
 	"Backend/internal/companyfields"
+	"Backend/internal/config"
 	"context"
 	"fmt"
 	"html"
@@ -15,11 +16,21 @@ import (
 	"unicode/utf8"
 )
 
+var (
+	TTLInfo      = 90 * 24 * time.Hour
+	TTLJobs      = 7 * 24 * time.Hour
+	TTLTech      = 30 * 24 * time.Hour
+	TTLRelations = 60 * 24 * time.Hour
+)
+
+func init() {
+	TTLInfo = time.Duration(config.CompanyTTLInfoDays()) * 24 * time.Hour
+	TTLJobs = time.Duration(config.CompanyTTLJobsDays()) * 24 * time.Hour
+	TTLTech = time.Duration(config.CompanyTTLTechDays()) * 24 * time.Hour
+	TTLRelations = time.Duration(config.CompanyTTLRelationsDays()) * 24 * time.Hour
+}
+
 const (
-	TTLInfo       = 90 * 24 * time.Hour
-	TTLJobs       = 7 * 24 * time.Hour
-	TTLTech       = 30 * 24 * time.Hour
-	TTLRelations  = 60 * 24 * time.Hour
 
 	ConfidenceHigh   = "high"
 	ConfidenceMedium = "medium"

--- a/Backend/internal/config/constants.go
+++ b/Backend/internal/config/constants.go
@@ -45,6 +45,36 @@ func CompanyGraphThreshold() float64 {
 	return value
 }
 
+// --- 企業管理系定数 ---
+
+func CompanyTTLInfoDays() int       { return getIntOrDefault("COMPANY_TTL_INFO_DAYS", 90) }
+func CompanyTTLJobsDays() int       { return getIntOrDefault("COMPANY_TTL_JOBS_DAYS", 7) }
+func CompanyTTLTechDays() int       { return getIntOrDefault("COMPANY_TTL_TECH_DAYS", 30) }
+func CompanyTTLRelationsDays() int  { return getIntOrDefault("COMPANY_TTL_RELATIONS_DAYS", 60) }
+
+func MissingBatchDefaultLimit() int { return getIntOrDefault("MISSING_BATCH_DEFAULT_LIMIT", 20) }
+func MissingBatchMaxLimit() int     { return getIntOrDefault("MISSING_BATCH_MAX_LIMIT", 50) }
+func MissingBatchMaxConcurrency() int { return getIntOrDefault("MISSING_BATCH_MAX_CONCURRENCY", 8) }
+
+func RelationGraphMaxDepth() int { return getIntOrDefault("RELATION_GRAPH_MAX_DEPTH", 4) }
+func RelationGraphMaxNodes() int { return getIntOrDefault("RELATION_GRAPH_MAX_NODES", 60) }
+
+func RelationEnrichMaxTargets() int { return getIntOrDefault("RELATION_ENRICH_MAX_TARGETS", 12) }
+
+func ValidationCacheTTLMinutes() int { return getIntOrDefault("VALIDATION_CACHE_TTL_MINUTES", 30) }
+
+func getIntOrDefault(key string, def int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
+}
+
 func DevAllowedOrigins() []string {
 	return []string{
 		"http://localhost:3000",

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -4,6 +4,7 @@ import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
 	"Backend/internal/companyfields"
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"context"
 	"fmt"
@@ -14,10 +15,7 @@ import (
 )
 
 const (
-	defaultMissingBatchLimit       = 20
-	maxMissingBatchLimit           = 50
 	defaultMissingBatchConcurrency = 4
-	maxMissingBatchConcurrency     = 8
 )
 
 // MissingBatchOptions は企業管理全体の不足データ一括取得オプション。
@@ -92,8 +90,8 @@ func clampMissingBatchConcurrency(n int) int {
 	if n <= 0 {
 		return defaultMissingBatchConcurrency
 	}
-	if n > maxMissingBatchConcurrency {
-		return maxMissingBatchConcurrency
+	if maxC := config.MissingBatchMaxConcurrency(); n > maxC {
+		return maxC
 	}
 	return n
 }
@@ -102,10 +100,10 @@ func clampMissingBatchConcurrency(n int) int {
 // 1社内の主3種は依存があるため直列、企業間は Concurrency 上限で並列化する。
 func (s *CompanyMissingBatchService) Run(ctx context.Context, opts MissingBatchOptions) (*MissingBatchResult, error) {
 	if opts.Limit <= 0 {
-		opts.Limit = defaultMissingBatchLimit
+		opts.Limit = config.MissingBatchDefaultLimit()
 	}
-	if opts.Limit > maxMissingBatchLimit {
-		opts.Limit = maxMissingBatchLimit
+	if maxL := config.MissingBatchMaxLimit(); opts.Limit > maxL {
+		opts.Limit = maxL
 	}
 	concurrency := clampMissingBatchConcurrency(opts.Concurrency)
 

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"context"
 	"testing"
@@ -132,7 +133,7 @@ func TestClampMissingBatchConcurrency(t *testing.T) {
 	}{
 		{"未指定はデフォルト", 0, defaultMissingBatchConcurrency},
 		{"範囲内はそのまま", 3, 3},
-		{"上限でクランプ", 100, maxMissingBatchConcurrency},
+		{"上限でクランプ", 100, config.MissingBatchMaxConcurrency()},
 		{"負数はデフォルト", -1, defaultMissingBatchConcurrency},
 	}
 	for _, tt := range tests {

--- a/Backend/internal/services/company_relation_graph_service.go
+++ b/Backend/internal/services/company_relation_graph_service.go
@@ -3,16 +3,21 @@ package services
 import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"fmt"
 )
 
-// 親会社→子会社→孫会社のように資本関係を辿る際の安全弁。
-// 深さ・ノード数のどちらかに達したら打ち切り、無限ループや巨大レスポンスを防ぐ。
-const (
+// RelationGraphMaxDepth/MaxNodes はデフォルト値。環境変数で上書き可能。
+var (
 	RelationGraphMaxDepth = 4
 	RelationGraphMaxNodes = 60
 )
+
+func init() {
+	RelationGraphMaxDepth = config.RelationGraphMaxDepth()
+	RelationGraphMaxNodes = config.RelationGraphMaxNodes()
+}
 
 // RelationGraphNode はグラフ上の1企業ノード。
 type RelationGraphNode struct {

--- a/Backend/internal/services/company_relations_fetcher.go
+++ b/Backend/internal/services/company_relations_fetcher.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Backend/domain/repository"
 	"Backend/internal/companyfetch"
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"Backend/internal/openai"
 	"context"
@@ -363,7 +364,7 @@ func (f *CompanyRelationsFetcher) enrichTransactionDescriptions(
 			continue
 		}
 		targets = append(targets, name)
-		if len(targets) >= 12 {
+		if len(targets) >= config.RelationEnrichMaxTargets() {
 			break
 		}
 	}

--- a/Backend/internal/services/company_validation_service.go
+++ b/Backend/internal/services/company_validation_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"Backend/internal/companyfetch"
+	"Backend/internal/config"
 	"Backend/internal/models"
 	"Backend/internal/openai"
 	"context"
@@ -15,10 +16,13 @@ import (
 	"unicode"
 )
 
-const (
-	companyValidationCacheTTL = 30 * time.Minute
-	companyValidationMaxTok   = 200
-)
+var companyValidationCacheTTL = 30 * time.Minute
+
+const companyValidationMaxTok = 200
+
+func init() {
+	companyValidationCacheTTL = time.Duration(config.ValidationCacheTTLMinutes()) * time.Minute
+}
 
 // companyLookup は企業実在確認に必要な最小の参照インターフェース。
 type companyLookup interface {


### PR DESCRIPTION
## Summary
- `config/constants.go` に企業管理系の設定ヘルパー関数を追加
- TTL、バッチ制限、グラフ制限、キャッシュTTL等を環境変数から上書き可能に
- 未設定時は従来のデフォルト値にフォールバック

### 設定可能な環境変数
| 環境変数 | デフォルト | 用途 |
|---|---|---|
| `COMPANY_TTL_INFO_DAYS` | 90 | 基本情報TTL(日) |
| `COMPANY_TTL_JOBS_DAYS` | 7 | 求人TTL(日) |
| `COMPANY_TTL_TECH_DAYS` | 30 | 技術情報TTL(日) |
| `COMPANY_TTL_RELATIONS_DAYS` | 60 | 関係情報TTL(日) |
| `MISSING_BATCH_DEFAULT_LIMIT` | 20 | バッチデフォルト件数 |
| `MISSING_BATCH_MAX_LIMIT` | 50 | バッチ最大件数 |
| `MISSING_BATCH_MAX_CONCURRENCY` | 8 | バッチ最大並行数 |
| `RELATION_GRAPH_MAX_DEPTH` | 4 | グラフBFS最大深度 |
| `RELATION_GRAPH_MAX_NODES` | 60 | グラフ最大ノード数 |
| `RELATION_ENRICH_MAX_TARGETS` | 12 | エンリッチ最大対象数 |
| `VALIDATION_CACHE_TTL_MINUTES` | 30 | バリデーションキャッシュTTL(分) |

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/... ./test/services/...` 全テスト通過
- [ ] CI通過確認

closes #730

Made with [Cursor](https://cursor.com)