### PR TITLE
refactor: 企業管理FEのapplyInfoPayloadと勤務形態オプションを共通化

### DIFF
--- a/frontend/app/admin/companies/[id]/info/page.tsx
+++ b/frontend/app/admin/companies/[id]/info/page.tsx
@@ -17,6 +17,7 @@ import { infoFieldEnabled, resolveIndustryFieldProfile } from '@/lib/admin-compa
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { CompanyAspectTabs } from '@/components/admin/CompanyAspectTabs'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { applyInfoPayload, WORK_STYLE_OPTIONS } from '@/lib/admin-company-form'
 
 export default function AdminCompanyInfoEditPage() {
   const params = useParams()
@@ -94,22 +95,11 @@ export default function AdminCompanyInfoEditPage() {
     loadCompany()
   }, [id])
 
-  const applyInfoPayload = (data: Record<string, unknown>) => {
-    if (typeof data.description === 'string' && data.description) setDescription(data.description)
-    if (typeof data.industry === 'string' && data.industry) setIndustry(data.industry)
-    if (typeof data.location === 'string' && data.location) setLocation(data.location)
-    if (typeof data.website_url === 'string' && data.website_url) setWebsiteUrl(data.website_url)
-    if (typeof data.founded_year === 'number' && data.founded_year) setFoundedYear(String(data.founded_year))
-    if (typeof data.employee_count === 'number' && data.employee_count) setEmployeeCount(String(data.employee_count))
-    if (typeof data.main_business === 'string' && data.main_business) setMainBusiness(data.main_business)
-    if (typeof data.culture === 'string' && data.culture) setCulture(data.culture)
-    if (typeof data.work_style === 'string' && data.work_style) setWorkStyle(data.work_style)
-    if (typeof data.tech_stack === 'string' && data.tech_stack) setTechStack(data.tech_stack)
-    if (typeof data.welfare_details === 'string' && data.welfare_details) setWelfareDetails(data.welfare_details)
-    if (typeof data.source === 'string' && data.source) setSourceType(data.source)
-    if (typeof data.source_url === 'string' && data.source_url) setSourceUrl(data.source_url)
-    if (typeof data.model_used === 'string' && data.model_used) setLastModelUsed(data.model_used)
-    if (typeof data.confidence === 'string' && data.confidence) setLastFetchConfidence(data.confidence)
+  const infoSetters = {
+    setDescription, setIndustry, setLocation, setWebsiteUrl,
+    setFoundedYear, setEmployeeCount, setMainBusiness, setCulture,
+    setWorkStyle, setTechStack, setWelfareDetails, setSourceType,
+    setSourceUrl, setLastModelUsed, setLastFetchConfidence,
   }
 
   const handleAiFetch = async () => {
@@ -134,7 +124,7 @@ export default function AdminCompanyInfoEditPage() {
         )
         return
       }
-      applyInfoPayload(data)
+      applyInfoPayload(data, infoSetters)
       setPreviewPending(true)
       setSuccess('プレビュー取得が完了しました。内容を確認・修正してから「確定して保存」してください。')
     } catch {
@@ -161,7 +151,7 @@ export default function AdminCompanyInfoEditPage() {
         )
         return
       }
-      applyInfoPayload(data)
+      applyInfoPayload(data, infoSetters)
       loadCompany()
       if (data.budget_exceeded) {
         setSuccess('月次 Search 予算超過のため、既存キャッシュのみ返却しました（新規 Search なし）。コスト画面を確認してください。')
@@ -214,7 +204,7 @@ export default function AdminCompanyInfoEditPage() {
         )
         return
       }
-      applyInfoPayload(data)
+      applyInfoPayload(data, infoSetters)
       loadCompany()
       setSuccess('プレビュー内容を確定して保存しました。')
     } catch {
@@ -420,9 +410,9 @@ export default function AdminCompanyInfoEditPage() {
             onChange={(e) => setWorkStyle(e.target.value)}
           >
             <MenuItem value="">未設定</MenuItem>
-            <MenuItem value="リモート">リモート</MenuItem>
-            <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
-            <MenuItem value="オフィス">オフィス</MenuItem>
+            {WORK_STYLE_OPTIONS.map((opt) => (
+              <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+            ))}
           </TextField>
         )}
         {show('tech_stack') && (

--- a/frontend/app/admin/companies/new/page.tsx
+++ b/frontend/app/admin/companies/new/page.tsx
@@ -15,6 +15,7 @@ import {
 import { authService } from '@/lib/auth'
 import { AdminFormContainer } from '@/components/admin/AdminFormContainer'
 import { ErrorAlert } from '@/components/common/ErrorAlert'
+import { applyInfoPayload, WORK_STYLE_OPTIONS } from '@/lib/admin-company-form'
 
 export default function AdminCompanyNewPage() {
   const router = useRouter()
@@ -50,22 +51,11 @@ export default function AdminCompanyNewPage() {
   const [lastModelUsed, setLastModelUsed] = useState('')
   const [lastFetchConfidence, setLastFetchConfidence] = useState('')
 
-  const applyInfoPayload = (data: Record<string, unknown>) => {
-    if (typeof data.description === 'string' && data.description) setDescription(data.description)
-    if (typeof data.industry === 'string' && data.industry) setIndustry(data.industry)
-    if (typeof data.location === 'string' && data.location) setLocation(data.location)
-    if (typeof data.website_url === 'string' && data.website_url) setWebsiteUrl(data.website_url)
-    if (typeof data.founded_year === 'number' && data.founded_year) setFoundedYear(String(data.founded_year))
-    if (typeof data.employee_count === 'number' && data.employee_count) setEmployeeCount(String(data.employee_count))
-    if (typeof data.main_business === 'string' && data.main_business) setMainBusiness(data.main_business)
-    if (typeof data.culture === 'string' && data.culture) setCulture(data.culture)
-    if (typeof data.work_style === 'string' && data.work_style) setWorkStyle(data.work_style)
-    if (typeof data.tech_stack === 'string' && data.tech_stack) setTechStack(data.tech_stack)
-    if (typeof data.welfare_details === 'string' && data.welfare_details) setWelfareDetails(data.welfare_details)
-    if (typeof data.source === 'string' && data.source) setSourceType(data.source)
-    if (typeof data.source_url === 'string' && data.source_url) setSourceUrl(data.source_url)
-    if (typeof data.model_used === 'string' && data.model_used) setLastModelUsed(data.model_used)
-    if (typeof data.confidence === 'string' && data.confidence) setLastFetchConfidence(data.confidence)
+  const infoSetters = {
+    setDescription, setIndustry, setLocation, setWebsiteUrl,
+    setFoundedYear, setEmployeeCount, setMainBusiness, setCulture,
+    setWorkStyle, setTechStack, setWelfareDetails, setSourceType,
+    setSourceUrl, setLastModelUsed, setLastFetchConfidence,
   }
 
   const handleAiFetch = async () => {
@@ -87,7 +77,7 @@ export default function AdminCompanyNewPage() {
         setError(data?.error || '企業情報取得に失敗しました')
         return
       }
-      applyInfoPayload(data)
+      applyInfoPayload(data, infoSetters)
       setSuccess('プレビュー取得が完了しました。内容を確認・修正してから「追加する」を押してください。')
     } finally {
       setAiLoading(false)
@@ -219,9 +209,9 @@ export default function AdminCompanyNewPage() {
           onChange={(e) => setWorkStyle(e.target.value)}
         >
           <MenuItem value="">未設定</MenuItem>
-          <MenuItem value="リモート">リモート</MenuItem>
-          <MenuItem value="ハイブリッド">ハイブリッド</MenuItem>
-          <MenuItem value="オフィス">オフィス</MenuItem>
+          {WORK_STYLE_OPTIONS.map((opt) => (
+            <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+          ))}
         </TextField>
         <TextField
           label="技術スタック"

--- a/frontend/lib/admin-company-form.ts
+++ b/frontend/lib/admin-company-form.ts
@@ -1,0 +1,53 @@
+/** 企業管理フォームの共通ロジック */
+
+export const WORK_STYLE_OPTIONS = ['リモート', 'ハイブリッド', 'オフィス'] as const
+
+export type CompanyInfoSetters = {
+  setDescription: (v: string) => void
+  setIndustry: (v: string) => void
+  setLocation: (v: string) => void
+  setWebsiteUrl: (v: string) => void
+  setFoundedYear: (v: string) => void
+  setEmployeeCount: (v: string) => void
+  setMainBusiness: (v: string) => void
+  setCulture: (v: string) => void
+  setWorkStyle: (v: string) => void
+  setTechStack: (v: string) => void
+  setWelfareDetails: (v: string) => void
+  setSourceType: (v: string) => void
+  setSourceUrl: (v: string) => void
+  setLastModelUsed: (v: string) => void
+  setLastFetchConfidence: (v: string) => void
+}
+
+/**
+ * AI取得結果やAPI応答のペイロードをフォームのstateに反映する。
+ * 空文字列・ゼロ値のフィールドは上書きしない。
+ */
+export function applyInfoPayload(
+  data: Record<string, unknown>,
+  setters: CompanyInfoSetters,
+) {
+  const s = (key: string, setter: (v: string) => void) => {
+    if (typeof data[key] === 'string' && data[key]) setter(data[key] as string)
+  }
+  const n = (key: string, setter: (v: string) => void) => {
+    if (typeof data[key] === 'number' && data[key]) setter(String(data[key]))
+  }
+
+  s('description', setters.setDescription)
+  s('industry', setters.setIndustry)
+  s('location', setters.setLocation)
+  s('website_url', setters.setWebsiteUrl)
+  n('founded_year', setters.setFoundedYear)
+  n('employee_count', setters.setEmployeeCount)
+  s('main_business', setters.setMainBusiness)
+  s('culture', setters.setCulture)
+  s('work_style', setters.setWorkStyle)
+  s('tech_stack', setters.setTechStack)
+  s('welfare_details', setters.setWelfareDetails)
+  s('source', setters.setSourceType)
+  s('source_url', setters.setSourceUrl)
+  s('model_used', setters.setLastModelUsed)
+  s('confidence', setters.setLastFetchConfidence)
+}


### PR DESCRIPTION
## Summary
- `lib/admin-company-form.ts` に `applyInfoPayload` 関数と `WORK_STYLE_OPTIONS` 定数を共通モジュールとして抽出
- `new/page.tsx` と `[id]/info/page.tsx` のインライン実装を共通関数に置換
- 勤務形態オプション（リモート/ハイブリッド/オフィス）の重複定義を解消

## Test plan
- [x] `npx tsc --noEmit` 成功
- [ ] CI通過確認

closes #733

Made with [Cursor](https://cursor.com)