### PR TITLE
test: 企業管理サービスのヘルパー関数カバレッジを向上

### DIFF
--- a/Backend/internal/services/company_info_fetcher_helpers_test.go
+++ b/Backend/internal/services/company_info_fetcher_helpers_test.go
@@ -47,34 +47,119 @@ func TestGbizResultUseful(t *testing.T) {
 }
 
 func TestMergeCompanyInfoGaps(t *testing.T) {
-	base := &CompanyInfoResult{
-		Description: "既存概要",
-		Industry:    "",
-		Location:    "東京",
-		FoundedYear: 0,
+	tests := []struct {
+		name string
+		base *CompanyInfoResult
+		ai   *CompanyInfoResult
+		want *CompanyInfoResult
+	}{
+		{
+			name: "既存値保持と空欄補完",
+			base: &CompanyInfoResult{
+				Description: "既存概要",
+				Industry:    "",
+				Location:    "東京",
+				FoundedYear: 0,
+			},
+			ai: &CompanyInfoResult{
+				Description:  "AI概要",
+				Industry:     "IT",
+				Location:     "大阪",
+				FoundedYear:  1990,
+				MainBusiness: "ソフトウェア開発",
+			},
+			want: &CompanyInfoResult{
+				Description:  "既存概要",
+				Industry:     "IT",
+				Location:     "東京",
+				FoundedYear:  1990,
+				MainBusiness: "ソフトウェア開発",
+			},
+		},
+		{
+			name: "補完元が空",
+			base: &CompanyInfoResult{
+				Description: "既存概要",
+				Location:    "東京",
+			},
+			ai: &CompanyInfoResult{},
+			want: &CompanyInfoResult{
+				Description: "既存概要",
+				Location:    "東京",
+			},
+		},
+		{
+			name: "baseが全て空でAIから埋まる",
+			base: &CompanyInfoResult{},
+			ai: &CompanyInfoResult{
+				Description:   "AI概要",
+				Industry:      "IT",
+				Location:      "大阪",
+				WebsiteURL:    "https://example.com",
+				FoundedYear:   2000,
+				EmployeeCount: 50,
+				MainBusiness:  "開発",
+				Culture:       "フラット",
+				WorkStyle:     "リモート",
+				TechStack:     "Go",
+				WelfareDetails: "住宅手当",
+			},
+			want: &CompanyInfoResult{
+				Description:   "AI概要",
+				Industry:      "IT",
+				Location:      "大阪",
+				WebsiteURL:    "https://example.com",
+				FoundedYear:   2000,
+				EmployeeCount: 50,
+				MainBusiness:  "開発",
+				Culture:       "フラット",
+				WorkStyle:     "リモート",
+				TechStack:     "Go",
+				WelfareDetails: "住宅手当",
+			},
+		},
 	}
-	ai := &CompanyInfoResult{
-		Description: "AI概要",
-		Industry:    "IT",
-		Location:    "大阪",
-		FoundedYear: 1990,
-		MainBusiness: "ソフトウェア開発",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeCompanyInfoGaps(tt.base, tt.ai)
+			assertCompanyInfoResult(t, tt.base, tt.want)
+		})
 	}
-	mergeCompanyInfoGaps(base, ai)
+}
 
-	if base.Description != "既存概要" {
-		t.Errorf("既存フィールドが上書きされた: %q", base.Description)
+func assertCompanyInfoResult(t *testing.T, got, want *CompanyInfoResult) {
+	t.Helper()
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
 	}
-	if base.Industry != "IT" {
-		t.Errorf("空欄が埋められなかった: Industry=%q", base.Industry)
+	if got.Industry != want.Industry {
+		t.Errorf("Industry = %q, want %q", got.Industry, want.Industry)
 	}
-	if base.Location != "東京" {
-		t.Errorf("既存Locationが上書きされた: %q", base.Location)
+	if got.Location != want.Location {
+		t.Errorf("Location = %q, want %q", got.Location, want.Location)
 	}
-	if base.FoundedYear != 1990 {
-		t.Errorf("FoundedYearが埋められなかった: %d", base.FoundedYear)
+	if got.WebsiteURL != want.WebsiteURL {
+		t.Errorf("WebsiteURL = %q, want %q", got.WebsiteURL, want.WebsiteURL)
 	}
-	if base.MainBusiness != "ソフトウェア開発" {
-		t.Errorf("MainBusinessが埋められなかった: %q", base.MainBusiness)
+	if got.FoundedYear != want.FoundedYear {
+		t.Errorf("FoundedYear = %d, want %d", got.FoundedYear, want.FoundedYear)
+	}
+	if got.EmployeeCount != want.EmployeeCount {
+		t.Errorf("EmployeeCount = %d, want %d", got.EmployeeCount, want.EmployeeCount)
+	}
+	if got.MainBusiness != want.MainBusiness {
+		t.Errorf("MainBusiness = %q, want %q", got.MainBusiness, want.MainBusiness)
+	}
+	if got.Culture != want.Culture {
+		t.Errorf("Culture = %q, want %q", got.Culture, want.Culture)
+	}
+	if got.WorkStyle != want.WorkStyle {
+		t.Errorf("WorkStyle = %q, want %q", got.WorkStyle, want.WorkStyle)
+	}
+	if got.TechStack != want.TechStack {
+		t.Errorf("TechStack = %q, want %q", got.TechStack, want.TechStack)
+	}
+	if got.WelfareDetails != want.WelfareDetails {
+		t.Errorf("WelfareDetails = %q, want %q", got.WelfareDetails, want.WelfareDetails)
 	}
 }

--- a/Backend/internal/services/company_info_fetcher_helpers_test.go
+++ b/Backend/internal/services/company_info_fetcher_helpers_test.go
@@ -1,0 +1,80 @@
+package services
+
+import "testing"
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{"全て空", []string{"", "  ", ""}, ""},
+		{"最初が有効", []string{"a", "b"}, "a"},
+		{"2番目が有効", []string{"", "b"}, "b"},
+		{"空白スキップ", []string{"  ", "c"}, "c"},
+		{"引数なし", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstNonEmpty(tt.values...); got != tt.want {
+				t.Errorf("firstNonEmpty(%v) = %q, want %q", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGbizResultUseful(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *CompanyInfoResult
+		want bool
+	}{
+		{"nil", nil, false},
+		{"空結果", &CompanyInfoResult{}, false},
+		{"Locationあり", &CompanyInfoResult{Location: "東京"}, true},
+		{"WebsiteURLあり", &CompanyInfoResult{WebsiteURL: "https://example.com"}, true},
+		{"EmployeeCountあり", &CompanyInfoResult{EmployeeCount: 100}, true},
+		{"FoundedYearあり", &CompanyInfoResult{FoundedYear: 2000}, true},
+		{"Descriptionあり", &CompanyInfoResult{Description: "概要"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gbizResultUseful(tt.r); got != tt.want {
+				t.Errorf("gbizResultUseful() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeCompanyInfoGaps(t *testing.T) {
+	base := &CompanyInfoResult{
+		Description: "既存概要",
+		Industry:    "",
+		Location:    "東京",
+		FoundedYear: 0,
+	}
+	ai := &CompanyInfoResult{
+		Description: "AI概要",
+		Industry:    "IT",
+		Location:    "大阪",
+		FoundedYear: 1990,
+		MainBusiness: "ソフトウェア開発",
+	}
+	mergeCompanyInfoGaps(base, ai)
+
+	if base.Description != "既存概要" {
+		t.Errorf("既存フィールドが上書きされた: %q", base.Description)
+	}
+	if base.Industry != "IT" {
+		t.Errorf("空欄が埋められなかった: Industry=%q", base.Industry)
+	}
+	if base.Location != "東京" {
+		t.Errorf("既存Locationが上書きされた: %q", base.Location)
+	}
+	if base.FoundedYear != 1990 {
+		t.Errorf("FoundedYearが埋められなかった: %d", base.FoundedYear)
+	}
+	if base.MainBusiness != "ソフトウェア開発" {
+		t.Errorf("MainBusinessが埋められなかった: %q", base.MainBusiness)
+	}
+}

--- a/Backend/internal/services/company_validation_helpers_test.go
+++ b/Backend/internal/services/company_validation_helpers_test.go
@@ -1,0 +1,93 @@
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeCompanyKey_Extended(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"通常", "株式会社テスト", "テスト"},
+		{"(株)除去", "(株)サンプル", "サンプル"},
+		{"全角(株)除去", "（株）サンプル", "サンプル"},
+		{"空白除去", " テ ス ト ", "テスト"},
+		{"全角スペース除去", "テスト　カンパニー", "テストカンパニー"},
+		{"小文字化", "ABC Corp", "abccorp"},
+		{"空文字", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCompanyKey(tt.in); got != tt.want {
+				t.Errorf("normalizeCompanyKey(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNonEmptyURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"空文字", "", 0},
+		{"空白のみ", "  ", 0},
+		{"有効URL", "https://example.com", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nonEmptyURLs(tt.url)
+			if len(got) != tt.want {
+				t.Errorf("nonEmptyURLs(%q) len = %d, want %d", tt.url, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		max  int
+		want string
+	}{
+		{"短い文字列", "abc", 5, "abc"},
+		{"ちょうど", "abcde", 5, "abcde"},
+		{"切り詰め", "abcdef", 5, "abcde…"},
+		{"日本語", "あいうえお", 3, "あいう…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateRunes(tt.s, tt.max); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.s, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPurgeExpired(t *testing.T) {
+	s := &CompanyValidationService{
+		cache: map[string]companyValidationCacheEntry{
+			"expired": {
+				result:    CompanyValidationResult{CanonicalName: "old"},
+				expiresAt: time.Now().Add(-1 * time.Hour),
+			},
+			"valid": {
+				result:    CompanyValidationResult{CanonicalName: "new"},
+				expiresAt: time.Now().Add(1 * time.Hour),
+			},
+		},
+	}
+	s.purgeExpired()
+
+	if _, ok := s.cache["expired"]; ok {
+		t.Error("expired entry should have been purged")
+	}
+	if _, ok := s.cache["valid"]; !ok {
+		t.Error("valid entry should not have been purged")
+	}
+}

--- a/Backend/internal/services/company_validation_helpers_test.go
+++ b/Backend/internal/services/company_validation_helpers_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -32,17 +33,18 @@ func TestNonEmptyURLs(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
-		want int
+		want []string
 	}{
-		{"空文字", "", 0},
-		{"空白のみ", "  ", 0},
-		{"有効URL", "https://example.com", 1},
+		{"空文字", "", []string{}},
+		{"空白のみ", "  ", []string{}},
+		{"有効URL", "https://example.com", []string{"https://example.com"}},
+		{"前後空白付きURL", "  https://example.com  ", []string{"https://example.com"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := nonEmptyURLs(tt.url)
-			if len(got) != tt.want {
-				t.Errorf("nonEmptyURLs(%q) len = %d, want %d", tt.url, len(got), tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nonEmptyURLs(%q) = %v, want %v", tt.url, got, tt.want)
 			}
 		})
 	}
@@ -70,24 +72,72 @@ func TestTruncateRunes(t *testing.T) {
 }
 
 func TestPurgeExpired(t *testing.T) {
-	s := &CompanyValidationService{
-		cache: map[string]companyValidationCacheEntry{
-			"expired": {
-				result:    CompanyValidationResult{CanonicalName: "old"},
-				expiresAt: time.Now().Add(-1 * time.Hour),
+	now := time.Now()
+	tests := []struct {
+		name         string
+		cache        map[string]companyValidationCacheEntry
+		wantRemaining []string
+	}{
+		{
+			name: "期限切れと有効が混在",
+			cache: map[string]companyValidationCacheEntry{
+				"expired": {
+					result:    CompanyValidationResult{CanonicalName: "old"},
+					expiresAt: now.Add(-1 * time.Hour),
+				},
+				"valid": {
+					result:    CompanyValidationResult{CanonicalName: "new"},
+					expiresAt: now.Add(1 * time.Hour),
+				},
 			},
-			"valid": {
-				result:    CompanyValidationResult{CanonicalName: "new"},
-				expiresAt: time.Now().Add(1 * time.Hour),
+			wantRemaining: []string{"valid"},
+		},
+		{
+			name: "複数期限切れ",
+			cache: map[string]companyValidationCacheEntry{
+				"expired1": {
+					result:    CompanyValidationResult{CanonicalName: "a"},
+					expiresAt: now.Add(-2 * time.Hour),
+				},
+				"expired2": {
+					result:    CompanyValidationResult{CanonicalName: "b"},
+					expiresAt: now.Add(-30 * time.Minute),
+				},
+				"valid": {
+					result:    CompanyValidationResult{CanonicalName: "c"},
+					expiresAt: now.Add(1 * time.Hour),
+				},
 			},
+			wantRemaining: []string{"valid"},
+		},
+		{
+			name: "全て有効",
+			cache: map[string]companyValidationCacheEntry{
+				"a": {
+					result:    CompanyValidationResult{CanonicalName: "a"},
+					expiresAt: now.Add(1 * time.Hour),
+				},
+				"b": {
+					result:    CompanyValidationResult{CanonicalName: "b"},
+					expiresAt: now.Add(2 * time.Hour),
+				},
+			},
+			wantRemaining: []string{"a", "b"},
 		},
 	}
-	s.purgeExpired()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CompanyValidationService{cache: tt.cache}
+			s.purgeExpired()
 
-	if _, ok := s.cache["expired"]; ok {
-		t.Error("expired entry should have been purged")
-	}
-	if _, ok := s.cache["valid"]; !ok {
-		t.Error("valid entry should not have been purged")
+			if len(s.cache) != len(tt.wantRemaining) {
+				t.Fatalf("remaining count = %d, want %d; cache=%v", len(s.cache), len(tt.wantRemaining), s.cache)
+			}
+			for _, key := range tt.wantRemaining {
+				if _, ok := s.cache[key]; !ok {
+					t.Errorf("expected key %q to remain", key)
+				}
+			}
+		})
 	}
 }

--- a/Backend/internal/services/gbizinfo_helpers_test.go
+++ b/Backend/internal/services/gbizinfo_helpers_test.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestSplitClearAgencyNames(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"空文字", "", nil},
+		{"空白のみ", "   ", nil},
+		{"単一名", "株式会社テスト商事", []string{"株式会社テスト商事"}},
+		{"スラッシュ区切り", "株式会社テスト商事／株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
+		{"カンマ区切り", "株式会社テスト商事、株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
+		{"重複除去", "株式会社テスト商事/株式会社テスト商事", []string{"株式会社テスト商事"}},
+		{"不明瞭な名前は除外", "A/株式会社テスト商事", []string{"株式会社テスト商事"}},
+		{"パイプ区切り", "株式会社テスト商事｜株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
+		{"セミコロン区切り", "株式会社テスト商事；株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitClearAgencyNames(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitClearAgencyNames(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseJointSignatures(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"空文字", "", nil},
+		{"空白のみ", "  ", nil},
+		{"有効なJSON配列", `["Alice","Bob"]`, []string{"Alice", "Bob"}},
+		{"不正なJSON", "not json", []string{}},
+		{"空配列", "[]", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseJointSignatures(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseJointSignatures(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMarshalJointSignatures(t *testing.T) {
+	tests := []struct {
+		name  string
+		names []string
+		want  string
+	}{
+		{"nilスライス", nil, ""},
+		{"空スライス", []string{}, ""},
+		{"空白のみ含むスライス", []string{"  ", ""}, ""},
+		{"有効な名前", []string{"Alice", "Bob"}, `["Alice","Bob"]`},
+		{"空白混在", []string{" Alice ", "", "Bob"}, `["Alice","Bob"]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := marshalJointSignatures(tt.names)
+			if got != tt.want {
+				t.Errorf("marshalJointSignatures(%v) = %q, want %q", tt.names, got, tt.want)
+			}
+		})
+	}
+}

--- a/Backend/internal/services/gbizinfo_helpers_test.go
+++ b/Backend/internal/services/gbizinfo_helpers_test.go
@@ -16,6 +16,7 @@ func TestSplitClearAgencyNames(t *testing.T) {
 		{"スラッシュ区切り", "株式会社テスト商事／株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
 		{"カンマ区切り", "株式会社テスト商事、株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
 		{"重複除去", "株式会社テスト商事/株式会社テスト商事", []string{"株式会社テスト商事"}},
+		{"大小文字違いの重複除去", "株式会社ABC/株式会社abc", []string{"株式会社ABC"}},
 		{"不明瞭な名前は除外", "A/株式会社テスト商事", []string{"株式会社テスト商事"}},
 		{"パイプ区切り", "株式会社テスト商事｜株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
 		{"セミコロン区切り", "株式会社テスト商事；株式会社サンプル技研", []string{"株式会社テスト商事", "株式会社サンプル技研"}},
@@ -23,6 +24,9 @@ func TestSplitClearAgencyNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := splitClearAgencyNames(tt.raw)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("splitClearAgencyNames(%q) nil-ness mismatch: got %v, want %v", tt.raw, got, tt.want)
+			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("splitClearAgencyNames(%q) = %v, want %v", tt.raw, got, tt.want)
 			}
@@ -50,6 +54,9 @@ func TestParseJointSignatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseJointSignatures(tt.raw)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("parseJointSignatures(%q) nil-ness mismatch: got %v, want %v", tt.raw, got, tt.want)
+			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("parseJointSignatures(%q) = %v, want %v", tt.raw, got, tt.want)
 			}


### PR DESCRIPTION
## Summary
- 企業管理関連サービスの未テスト純粋関数にテーブル駆動テストを追加
  - **gbizinfo**: `splitClearAgencyNames`, `parseJointSignatures`, `marshalJointSignatures`
  - **validation**: `normalizeCompanyKey`, `nonEmptyURLs`, `truncateRunes`, `purgeExpired`
  - **info_fetcher**: `firstNonEmpty`, `gbizResultUseful`, `mergeCompanyInfoGaps`

## Test plan
- [x] 追加した全テスト通過
- [ ] CI通過確認

closes #729

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 企業情報の統合・補完ロジックに対するテストを追加しました。
  * 企業キーの正規化、URL filtering、文字列の切り詰め、期限切れキャッシュの削除を検証します。
  * 企業情報由来の名称分割や署名データの変換処理を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->