### PR TITLE
fix: 企業「情報を取得」で概要不足でもTTLスキップしない

### DIFF
--- a/Backend/internal/controllers/admin_company_fetch_controller.go
+++ b/Backend/internal/controllers/admin_company_fetch_controller.go
@@ -422,7 +422,10 @@ func (c *AdminCompanyController) runPrimaryAspectFetches(
 	// 1) 基本情報
 	infoStep := fetchStepResult{Status: "skipped", Skipped: true, Detail: "fetcher unavailable"}
 	if c.infoFetcher != nil {
-		needInfo := forceRefresh || !companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo)
+		// FE missingAspects（概要+公式URL）と揃え、スタンプ済みでも中身不足なら再取得する。
+		needInfo := forceRefresh ||
+			!companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) ||
+			!companyfetch.HasBasicInfo(company.Description, company.WebsiteURL)
 		if !needInfo {
 			infoStep = fetchStepResult{Status: "skipped", Skipped: true, Detail: "ttl_fresh"}
 		} else {

--- a/Backend/internal/services/company_info_fetcher.go
+++ b/Backend/internal/services/company_info_fetcher.go
@@ -93,8 +93,10 @@ func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint, f
 		return nil, fmt.Errorf("company not found: %w", err)
 	}
 
-	// スタンプ済み（公開情報限定の確認済み含む）なら TTL 内は再取得しない。強制更新は force。
-	if !forceRefresh && companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) {
+	// TTL 内でも概要+公式URLが揃っていなければ再取得する（スタンプだけ進んだ残骸・FE不足表示との整合）。
+	// 技術取得と同様。強制更新は force。
+	if !forceRefresh && companyfetch.IsFresh(company.InfoFetchedAt, companyfetch.TTLInfo) &&
+		companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
 		return markInfoCacheSkip(companyInfoFromModel(company), "ttl", false), nil
 	}
 
@@ -129,7 +131,8 @@ func (f *CompanyInfoFetcher) FetchAndSave(ctx context.Context, companyID uint, f
 	company.SourceURL = result.SourceURL
 	company.SourceFetchedAt = &now
 	// 更新後の company（今回の取得結果＋既存の URL/所在地など）で判定する。
-	// 手がかりが残っていれば疎データでもスタンプし、TTL 内の無駄な再取得を避ける。
+	// 手がかりがあれば疎データでもスタンプする（取得試行の記録）。
+	// ただし再取得スキップは HasBasicInfo（概要+公式URL）揃い時のみ（FetchAndSave 先頭参照）。
 	if companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
 		company.InfoFetchedAt = &now
 	}

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -316,13 +316,14 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 }
 
 // MissingNeedsFromCompany は不足判定ヘルパ（基本情報・技術・ビジネス関係・求人）。
-// InfoFetchedAt / RelationsFetchedAt が TTL 内なら、公開情報限定の確認済みも含め再取得不要。
+// 基本情報は TTL 切れ、または概要+公式URLが揃っていない場合に不足（FE missingAspects と揃える）。
 // 技術は中身が空なら不足とみなす。関係の DB 実体欠落は Run() 側で HasStoredData により追加判定する。
 func MissingNeedsFromCompany(c *models.Company) (needInfo, needJobs, needTech, needRelations bool) {
 	if c == nil {
 		return false, false, false, false
 	}
-	needInfo = !companyfetch.IsFresh(c.InfoFetchedAt, companyfetch.TTLInfo)
+	needInfo = !companyfetch.IsFresh(c.InfoFetchedAt, companyfetch.TTLInfo) ||
+		!companyfetch.HasBasicInfo(c.Description, c.WebsiteURL)
 	needJobs = !companyfetch.IsFresh(c.JobsFetchedAt, companyfetch.TTLJobs)
 	needTech = companyfields.RequiresTech(c.Industry) &&
 		(!companyfetch.IsFresh(c.TechFetchedAt, companyfetch.TTLTech) ||

--- a/Backend/internal/services/company_missing_batch_service.go
+++ b/Backend/internal/services/company_missing_batch_service.go
@@ -202,20 +202,13 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 			inc(func() { result.Errors++ })
 		} else if res != nil && res.FromCache {
 			company, _ := s.repo.FindByID(item.CompanyID)
-			if company != nil && companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
-				item.InfoStatus = "skipped_cache"
-				inc(func() { result.Skipped++ })
-			} else if company != nil && companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
-				item.InfoStatus = "empty"
-				inc(func() { result.Skipped++ })
-			} else {
-				detail := "cache_without_data"
-				if res.SkipReason != "" {
-					detail = res.SkipReason
-				}
-				item.InfoStatus = "error"
-				item.Error = "info: " + detail
+			status, errMsg := classifyInfoCacheResult(res, company)
+			item.InfoStatus = status
+			if status == "error" {
+				item.Error = errMsg
 				inc(func() { result.Errors++ })
+			} else {
+				inc(func() { result.Skipped++ })
 			}
 		} else if company, err := s.repo.FindByID(item.CompanyID); err == nil && company != nil &&
 			companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
@@ -313,6 +306,25 @@ func (s *CompanyMissingBatchService) processItem(ctx context.Context, item *Miss
 			inc(func() { result.JobsOK++ })
 		}
 	}
+}
+
+// classifyInfoCacheResult は FetchAndSave の FromCache 結果をバッチ用ステータスへ変換する。
+// 予算超過は公開情報不足（empty）より先に判定し、警告経路を落とさない。
+func classifyInfoCacheResult(res *CompanyInfoResult, company *models.Company) (status, errMsg string) {
+	if res != nil && (res.BudgetExceeded || res.SkipReason == "budget") {
+		return "error", "info: budget"
+	}
+	if company != nil && companyfetch.HasBasicInfo(company.Description, company.WebsiteURL) {
+		return "skipped_cache", ""
+	}
+	if company != nil && companyfetch.HasBasicInfoFootprint(company.Description, company.WebsiteURL, company.Location) {
+		return "empty", ""
+	}
+	detail := "cache_without_data"
+	if res != nil && res.SkipReason != "" {
+		detail = res.SkipReason
+	}
+	return "error", "info: " + detail
 }
 
 // MissingNeedsFromCompany は不足判定ヘルパ（基本情報・技術・ビジネス関係・求人）。

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -145,6 +145,88 @@ func TestClampMissingBatchConcurrency(t *testing.T) {
 	}
 }
 
+func TestClassifyInfoCacheResult(t *testing.T) {
+	sparse := &models.Company{
+		Description: "",
+		WebsiteURL:  "https://example.com",
+		Location:    "東京都",
+	}
+	full := &models.Company{
+		Description: "概要",
+		WebsiteURL:  "https://example.com",
+	}
+	empty := &models.Company{}
+
+	tests := []struct {
+		name       string
+		res        *CompanyInfoResult
+		company    *models.Company
+		wantStatus string
+		wantErr    string
+	}{
+		{
+			name: "予算超過は footprint より先に error",
+			res: &CompanyInfoResult{
+				FromCache:      true,
+				BudgetExceeded: true,
+				SkipReason:     "budget",
+			},
+			company:    sparse,
+			wantStatus: "error",
+			wantErr:    "info: budget",
+		},
+		{
+			name: "SkipReason=budget のみでも error",
+			res: &CompanyInfoResult{
+				FromCache:  true,
+				SkipReason: "budget",
+			},
+			company:    sparse,
+			wantStatus: "error",
+			wantErr:    "info: budget",
+		},
+		{
+			name: "充足キャッシュは skipped_cache",
+			res: &CompanyInfoResult{
+				FromCache:  true,
+				SkipReason: "ttl",
+			},
+			company:    full,
+			wantStatus: "skipped_cache",
+		},
+		{
+			name: "疎データは empty",
+			res: &CompanyInfoResult{
+				FromCache:  true,
+				SkipReason: "ttl",
+			},
+			company:    sparse,
+			wantStatus: "empty",
+		},
+		{
+			name: "手がかりなしは error",
+			res: &CompanyInfoResult{
+				FromCache:  true,
+				SkipReason: "ttl",
+			},
+			company:    empty,
+			wantStatus: "error",
+			wantErr:    "info: ttl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, errMsg := classifyInfoCacheResult(tt.res, tt.company)
+			if status != tt.wantStatus {
+				t.Fatalf("status=%q want %q", status, tt.wantStatus)
+			}
+			if errMsg != tt.wantErr {
+				t.Fatalf("errMsg=%q want %q", errMsg, tt.wantErr)
+			}
+		})
+	}
+}
+
 type missingBatchRepoStub struct {
 	warmRepoStub
 	companies []models.Company

--- a/Backend/internal/services/company_missing_batch_service_test.go
+++ b/Backend/internal/services/company_missing_batch_service_test.go
@@ -86,8 +86,8 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 		RelationsFetchedAt: &now,
 	}
 	info, _, _, _ = MissingNeedsFromCompany(emptyInfoDespiteStamp)
-	if info {
-		t.Fatal("fresh InfoFetchedAt should not need info even without description (confirmed sparse)")
+	if !info {
+		t.Fatal("fresh InfoFetchedAt without description/website should still need info (FE missingAspects)")
 	}
 
 	sparseFootprintStamped := &models.Company{
@@ -102,8 +102,8 @@ func TestMissingNeedsFromCompany(t *testing.T) {
 		RelationsFetchedAt: &now,
 	}
 	info, _, _, _ = MissingNeedsFromCompany(sparseFootprintStamped)
-	if info {
-		t.Fatal("stamped sparse basic info should not need refetch until TTL")
+	if !info {
+		t.Fatal("stamped sparse basic info (no description) should need refetch to match FE")
 	}
 
 	// infra / 開発手法のみでは技術取得済みとみなさない

--- a/Backend/test/services/company_info_fetcher_test.go
+++ b/Backend/test/services/company_info_fetcher_test.go
@@ -67,7 +67,7 @@ func TestCompanyInfoFetcher_FetchAndSave_TTLCache(t *testing.T) {
 	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 
-func TestCompanyInfoFetcher_FetchAndSave_StampedSparseUsesTTL(t *testing.T) {
+func TestCompanyInfoFetcher_FetchAndSave_StampedSparseDoesNotSkipTTL(t *testing.T) {
 	now := time.Now()
 	repo := &mocks.CompanyRepositoryMock{}
 	repo.On("FindByID", uint(1)).Return(&models.Company{
@@ -76,14 +76,13 @@ func TestCompanyInfoFetcher_FetchAndSave_StampedSparseUsesTTL(t *testing.T) {
 		Description:   "",
 		WebsiteURL:    "https://example.com",
 		Location:      "東京都",
-		InfoFetchedAt: &now, // 公開情報限定でもスタンプ済みなら TTL スキップ
+		InfoFetchedAt: &now, // スタンプ済みでも概要が空なら TTL スキップしない
 	}, nil)
 
 	fetcher := services.NewCompanyInfoFetcher(repo, nil)
-	result, err := fetcher.FetchAndSave(context.Background(), 1, false)
-	require.NoError(t, err)
-	assert.True(t, result.FromCache)
-	assert.Equal(t, "ttl", result.SkipReason)
+	_, err := fetcher.FetchAndSave(context.Background(), 1, false)
+	// openai client なしで取得を試みるためエラーになる＝TTL だけで短絡していないことの証明
+	require.Error(t, err)
 	repo.AssertNotCalled(t, "Update", mock.Anything)
 }
 


### PR DESCRIPTION
## Summary
- FE の不足判定（`description` + `website_url`）と BE の再取得判定が食い違い、「情報を取得」しても不足が解消されない問題を修正
- `CompanyInfoFetcher.FetchAndSave`: TTL スキップは `HasBasicInfo` が揃っているときのみ
- `runPrimaryAspectFetches` / `MissingNeedsFromCompany`: 中身不足なら `needInfo=true`

## Test plan
- [x] `go test ./internal/services/... ./test/services/...`
- [x] `go test ./internal/controllers/... ./test/controllers/...`
- [ ] 管理画面で概要空・`info_fetched_at` 付き企業に「情報を取得」→ 再取得が走ることを確認

closes #743

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 企業の概要や公式URLなどの基本情報が不足している場合、キャッシュが有効期間内でも最新情報の取得を試みるようになりました。
  * 基本情報が揃っている場合のみ、キャッシュによる取得スキップが適用されます。
  * 基本情報の不足判定に関する動作を見直し、より正確に情報を補完できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->