### PR TITLE
Resolve #745: score-validation画面のデータ未表示を修正

### DIFF
--- a/Backend/internal/controllers/admin_score_validation_controller.go
+++ b/Backend/internal/controllers/admin_score_validation_controller.go
@@ -78,12 +78,13 @@ func (c *AdminScoreValidationController) GetCalibrationHistory(ctx echo.Context)
 }
 
 // ListVariants GET /api/admin/score-validation/variants
+// 全実験・全バリアントの詳細一覧を返す（管理画面のテーブル表示用）。
 func (c *AdminScoreValidationController) ListVariants(ctx echo.Context) error {
-	experiments, err := c.svc.ListExperiments()
+	variants, err := c.svc.ListAllVariants()
 	if err != nil {
 		return echoInternalError(err)
 	}
-	return ctx.JSON(http.StatusOK, map[string]any{"experiments": experiments})
+	return ctx.JSON(http.StatusOK, map[string]any{"experiments": variants})
 }
 
 // CreateVariant POST /api/admin/score-validation/variants

--- a/Backend/internal/repositories/score_validation_repository.go
+++ b/Backend/internal/repositories/score_validation_repository.go
@@ -21,12 +21,12 @@ func NewScoreValidationRepository(db *gorm.DB) *ScoreValidationRepository {
 
 // CategoryCorrelationRow カテゴリ別スコア vs 通過率の相関行データ
 type CategoryCorrelationRow struct {
-	Category    string
-	ScoreBand   string // "0-20", "21-40", "41-60", "61-80", "81-100"
-	TotalCount  int
-	PassCount   int    // document_passed / interview / offered / accepted のいずれか
-	PassRate    float64
-	AvgScore    float64
+	Category   string  `json:"category"`
+	ScoreBand  string  `json:"score_band"` // "0-20", "21-40", "41-60", "61-80", "81-100"
+	TotalCount int     `json:"total_count"`
+	PassCount  int     `json:"pass_count"` // document_passed / interview / offered / accepted のいずれか
+	PassRate   float64 `json:"pass_rate"`  // 0-100 のパーセント値
+	AvgScore   float64 `json:"avg_score"`
 }
 
 // GetCategoryPassRateCorrelation カテゴリ別スコア帯と選考通過率の相関を集計する
@@ -88,11 +88,11 @@ func (r *ScoreValidationRepository) GetCategoryPassRateCorrelation() ([]Category
 
 // PhasePrecisionRow フェーズ別精度メトリクス行
 type PhasePrecisionRow struct {
-	PhaseName      string
-	SessionCount   int
-	AvgCompletion  float64
-	PassCount      int
-	PassRate       float64
+	PhaseName     string  `json:"phase_name"`
+	SessionCount  int     `json:"session_count"`
+	AvgCompletion float64 `json:"avg_completion"` // 0-100
+	PassCount     int     `json:"pass_count"`
+	PassRate      float64 `json:"pass_rate"` // 0-100 のパーセント値
 }
 
 // GetPhasePrecisionMetrics フェーズ別の完了率・通過率相関を集計する
@@ -155,34 +155,43 @@ func (r *ScoreValidationRepository) FindAssignment(userID uint, sessionID string
 
 // VariantResultRow A/Bテスト結果比較行
 type VariantResultRow struct {
-	ExperimentName  string
-	VariantName     string
-	SessionCount    int
-	PassCount       int
-	PassRate        float64
-	AvgScoreSum     float64
+	ExperimentName string  `json:"experiment_name"`
+	VariantName    string  `json:"variant_name"`
+	SampleCount    int     `json:"sample_count"`
+	PassCount      int     `json:"pass_count"`
+	PassRate       float64 `json:"pass_rate"` // 0-100 のパーセント値
+	AvgScore       float64 `json:"avg_score"` // 割り当てセッションの平均完了スコア（0-100）
 }
 
-// GetVariantResults 実験バリアント別の通過率を集計する
+// GetVariantResults 実験バリアント別の通過率・平均完了スコアを集計する
 func (r *ScoreValidationRepository) GetVariantResults(experimentName string) ([]VariantResultRow, error) {
 	rows := []VariantResultRow{}
 	err := r.db.Raw(`
 		SELECT
 			va.experiment_name,
 			va.assigned_variant AS variant_name,
-			COUNT(DISTINCT va.session_id) AS session_count,
+			COUNT(DISTINCT va.session_id) AS sample_count,
 			COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS pass_count,
 			CASE
 				WHEN COUNT(DISTINCT va.user_id) = 0 THEN 0
 				ELSE CAST(COUNT(DISTINCT CASE WHEN uas.status IN ('document_passed','interview','offered','accepted') THEN uas.user_id END) AS FLOAT) /
 					COUNT(DISTINCT va.user_id) * 100
-			END AS pass_rate
+			END AS pass_rate,
+			COALESCE(AVG(uap.completion_score), 0) AS avg_score
 		FROM variant_assignments va
 		LEFT JOIN user_application_statuses uas ON uas.user_id = va.user_id
+		LEFT JOIN user_analysis_progress uap ON uap.session_id = va.session_id
 		WHERE va.experiment_name = ?
 		GROUP BY va.experiment_name, va.assigned_variant
 	`, experimentName).Scan(&rows).Error
 	return rows, err
+}
+
+// ListAllVariants 全実験・全バリアントの詳細一覧を返す（管理画面の一覧表示用）。
+func (r *ScoreValidationRepository) ListAllVariants() ([]models.QuestionVariant, error) {
+	var variants []models.QuestionVariant
+	err := r.db.Order("experiment_name ASC, created_at ASC").Find(&variants).Error
+	return variants, err
 }
 
 // ── キャリブレーション ────────────────────────────────────────────────────────

--- a/Backend/internal/services/interfaces/score_validation_service.go
+++ b/Backend/internal/services/interfaces/score_validation_service.go
@@ -14,6 +14,7 @@ type ScoreValidationService interface {
 	GetCalibrationHistory(limit int) ([]models.ScoreCalibrationWeight, error)
 	RunCalibration() (*services.CalibrationResult, error)
 	ListExperiments() ([]string, error)
+	ListAllVariants() ([]models.QuestionVariant, error)
 	CreateVariant(experimentName, variantName, description string, trafficRatio float64) (*models.QuestionVariant, error)
 	GetVariantResults(experimentName string) ([]repositories.VariantResultRow, error)
 }

--- a/Backend/internal/services/score_validation_service.go
+++ b/Backend/internal/services/score_validation_service.go
@@ -194,6 +194,11 @@ func (s *ScoreValidationService) ListExperiments() ([]string, error) {
 	return s.repo.ListAllExperiments()
 }
 
+// ListAllVariants 全実験・全バリアントの詳細一覧を返す（管理画面の一覧表示用）
+func (s *ScoreValidationService) ListAllVariants() ([]models.QuestionVariant, error) {
+	return s.repo.ListAllVariants()
+}
+
 // ── スコアキャリブレーション ──────────────────────────────────────────────────
 
 // CalibrationResult キャリブレーション実行結果

--- a/Backend/test/controllers/admin_lightweight_controllers_test.go
+++ b/Backend/test/controllers/admin_lightweight_controllers_test.go
@@ -195,7 +195,10 @@ func TestAdminScoreValidationController_RunCalibration_Success(t *testing.T) {
 
 func TestAdminScoreValidationController_ListVariants_Success(t *testing.T) {
 	svc := &mocks.ScoreValidationServiceMock{}
-	svc.On("ListExperiments").Return([]string{"exp-a", "exp-b"}, nil)
+	svc.On("ListAllVariants").Return([]models.QuestionVariant{
+		{ExperimentName: "exp-a", VariantName: "control"},
+		{ExperimentName: "exp-b", VariantName: "treatment"},
+	}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/admin/score-validation/variants", nil)
 	rec := httptest.NewRecorder()

--- a/Backend/test/controllers/mocks/score_validation_service_mock.go
+++ b/Backend/test/controllers/mocks/score_validation_service_mock.go
@@ -61,6 +61,14 @@ func (m *ScoreValidationServiceMock) ListExperiments() ([]string, error) {
 	return nil, args.Error(1)
 }
 
+func (m *ScoreValidationServiceMock) ListAllVariants() ([]models.QuestionVariant, error) {
+	args := m.Called()
+	if v := args.Get(0); v != nil {
+		return v.([]models.QuestionVariant), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *ScoreValidationServiceMock) CreateVariant(experimentName, variantName, description string, trafficRatio float64) (*models.QuestionVariant, error) {
 	args := m.Called(experimentName, variantName, description, trafficRatio)
 	if v := args.Get(0); v != nil {

--- a/frontend/app/admin/score-validation/page.tsx
+++ b/frontend/app/admin/score-validation/page.tsx
@@ -27,41 +27,47 @@ import {
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import AddIcon from '@mui/icons-material/Add'
 import { authService } from '@/lib/auth'
-import { correlationLabel, correlationColor, formatPercent } from '@/lib/score-validation-utils'
+import { correlationLabel, correlationColor, formatPercent, formatRate } from '@/lib/score-validation-utils'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import { PageContainer, ADMIN_PAGE_WIDTH } from '@/components/admin/PageContainer'
 
 // ── 型定義 ──────────────────────────────────────────────────────────────────
+// バックエンド (Backend/internal/services/score_validation_service.go ほか) の
+// 実際のレスポンス形式に合わせている。
 
 type CorrelationReport = {
-  generated_at: string
-  total_candidates: number
-  categories: Array<{
+  rows: Array<{
     category: string
-    correlation: number
-    p_value: number
-    sample_count: number
+    score_band: string
+    total_count: number
+    pass_count: number
+    pass_rate: number // 0-100
     avg_score: number
-    pass_rate: number
   }>
+  top_correlated: string[]
+  low_correlated: string[]
+  total_samples: number
 }
 
 type PhaseMetrics = {
-  generated_at: string
   phases: Array<{
-    phase: string
-    precision: number
-    recall: number
-    f1_score: number
-    sample_count: number
+    phase_name: string
+    session_count: number
+    avg_completion: number // 0-100
+    pass_count: number
+    pass_rate: number // 0-100
   }>
+  overall_pass_rate: number
 }
 
-type CalibrationResult = {
+type CalibrationWeightRow = {
   id: number
-  triggered_by: string
+  category: string
+  version: number
+  weight: number
   sample_count: number
-  weights: Record<string, number>
+  pass_rate: number // 0-100
+  correlation: number
   is_active: boolean
   created_at: string
 }
@@ -103,11 +109,14 @@ function CorrelationTab({ headers }: { headers: Record<string, string> }) {
   if (error) return <Alert severity="error">{error}</Alert>
   if (!data) return null
 
+  const isTop = (category: string) => data.top_correlated.includes(category)
+  const isLow = (category: string) => data.low_correlated.includes(category)
+
   return (
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
         <Typography variant="subtitle2" color="text.secondary">
-          対象候補者: {data.total_candidates}名 / 生成日時: {new Date(data.generated_at).toLocaleString('ja-JP')}
+          総サンプル数: {data.total_samples}件
         </Typography>
       </Stack>
       <TableContainer component={Paper} elevation={0} variant="outlined">
@@ -115,38 +124,37 @@ function CorrelationTab({ headers }: { headers: Record<string, string> }) {
           <TableHead>
             <TableRow sx={{ bgcolor: '#f5f5f5' }}>
               <TableCell>カテゴリ</TableCell>
-              <TableCell align="right">相関係数</TableCell>
+              <TableCell>スコア帯</TableCell>
               <TableCell>強度</TableCell>
-              <TableCell align="right">p値</TableCell>
-              <TableCell align="right">サンプル数</TableCell>
-              <TableCell align="right">平均スコア</TableCell>
+              <TableCell align="right">件数</TableCell>
+              <TableCell align="right">通過数</TableCell>
               <TableCell align="right">通過率</TableCell>
+              <TableCell align="right">平均スコア</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {data.categories.map(cat => (
-              <TableRow key={cat.category} hover>
-                <TableCell><Typography fontWeight={500}>{cat.category}</Typography></TableCell>
-                <TableCell align="right">
-                  <Typography fontWeight={700} color={correlationColor(cat.correlation)}>
-                    {cat.correlation.toFixed(3)}
-                  </Typography>
+            {data.rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                  相関を計算できるデータがまだありません（選考結果とスコアの両方が記録されたユーザーが必要です）
                 </TableCell>
+              </TableRow>
+            ) : data.rows.map((row, idx) => (
+              <TableRow key={`${row.category}-${row.score_band}-${idx}`} hover>
+                <TableCell><Typography fontWeight={500}>{row.category}</Typography></TableCell>
+                <TableCell>{row.score_band}</TableCell>
                 <TableCell>
-                  <Chip
-                    label={correlationLabel(cat.correlation)}
-                    size="small"
-                    sx={{ bgcolor: correlationColor(cat.correlation) + '20', color: correlationColor(cat.correlation) }}
-                  />
+                  {isTop(row.category) && (
+                    <Chip label={correlationLabel(0.7)} size="small" sx={{ bgcolor: correlationColor(0.7) + '20', color: correlationColor(0.7) }} />
+                  )}
+                  {isLow(row.category) && (
+                    <Chip label={correlationLabel(0)} size="small" sx={{ bgcolor: correlationColor(0) + '20', color: correlationColor(0) }} />
+                  )}
                 </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2" color={cat.p_value < 0.05 ? 'success.main' : 'text.secondary'}>
-                    {cat.p_value.toFixed(4)}
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">{cat.sample_count}</TableCell>
-                <TableCell align="right">{cat.avg_score.toFixed(2)}</TableCell>
-                <TableCell align="right">{formatPercent(cat.pass_rate)}</TableCell>
+                <TableCell align="right">{row.total_count}</TableCell>
+                <TableCell align="right">{row.pass_count}</TableCell>
+                <TableCell align="right">{formatRate(row.pass_rate)}</TableCell>
+                <TableCell align="right">{row.avg_score.toFixed(2)}</TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -177,31 +185,37 @@ function PhaseMetricsTab({ headers }: { headers: Record<string, string> }) {
   return (
     <Box>
       <Typography variant="subtitle2" color="text.secondary" mb={2}>
-        生成日時: {new Date(data.generated_at).toLocaleString('ja-JP')}
+        全体通過率: {formatRate(data.overall_pass_rate)}
       </Typography>
       <TableContainer component={Paper} elevation={0} variant="outlined">
         <Table size="small">
           <TableHead>
             <TableRow sx={{ bgcolor: '#f5f5f5' }}>
               <TableCell>フェーズ</TableCell>
-              <TableCell align="right">適合率 (Precision)</TableCell>
-              <TableCell align="right">再現率 (Recall)</TableCell>
-              <TableCell align="right">F1スコア</TableCell>
-              <TableCell align="right">サンプル数</TableCell>
+              <TableCell align="right">セッション数</TableCell>
+              <TableCell align="right">平均完了度</TableCell>
+              <TableCell align="right">通過数</TableCell>
+              <TableCell align="right">通過率</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {data.phases.map(ph => (
-              <TableRow key={ph.phase} hover>
-                <TableCell><Typography fontWeight={500}>{ph.phase}</Typography></TableCell>
-                <TableCell align="right">{formatPercent(ph.precision)}</TableCell>
-                <TableCell align="right">{formatPercent(ph.recall)}</TableCell>
+            {data.phases.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                  データがありません
+                </TableCell>
+              </TableRow>
+            ) : data.phases.map(ph => (
+              <TableRow key={ph.phase_name} hover>
+                <TableCell><Typography fontWeight={500}>{ph.phase_name}</Typography></TableCell>
+                <TableCell align="right">{ph.session_count}</TableCell>
+                <TableCell align="right">{formatRate(ph.avg_completion)}</TableCell>
+                <TableCell align="right">{ph.pass_count}</TableCell>
                 <TableCell align="right">
-                  <Typography fontWeight={700} color={ph.f1_score >= 0.7 ? 'success.main' : ph.f1_score >= 0.5 ? 'warning.main' : 'error.main'}>
-                    {ph.f1_score.toFixed(3)}
+                  <Typography fontWeight={700} color={ph.pass_rate >= 70 ? 'success.main' : ph.pass_rate >= 40 ? 'warning.main' : 'error.main'}>
+                    {formatRate(ph.pass_rate)}
                   </Typography>
                 </TableCell>
-                <TableCell align="right">{ph.sample_count}</TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -346,7 +360,7 @@ function ABTestTab({ headers }: { headers: Record<string, string> }) {
                     <TableCell><Typography fontWeight={500}>{r.variant_name}</Typography></TableCell>
                     <TableCell align="right">{r.sample_count}</TableCell>
                     <TableCell align="right">{r.avg_score.toFixed(2)}</TableCell>
-                    <TableCell align="right">{formatPercent(r.pass_rate)}</TableCell>
+                    <TableCell align="right">{formatRate(r.pass_rate)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -407,7 +421,7 @@ function ABTestTab({ headers }: { headers: Record<string, string> }) {
 }
 
 function CalibrationTab({ headers }: { headers: Record<string, string> }) {
-  const [history, setHistory] = useState<CalibrationResult[]>([])
+  const [history, setHistory] = useState<CalibrationWeightRow[]>([])
   const [loading, setLoading] = useState(false)
   const [running, setRunning] = useState(false)
   const [error, setError] = useState('')
@@ -435,7 +449,7 @@ function CalibrationTab({ headers }: { headers: Record<string, string> }) {
       })
       if (!res.ok) {
         const d = await res.json()
-        throw new Error(d?.message ?? 'キャリブレーションの実行に失敗しました')
+        throw new Error(d?.error ?? d?.message ?? 'キャリブレーションの実行に失敗しました')
       }
       setSuccess('キャリブレーションを実行しました')
       fetchHistory()
@@ -445,6 +459,15 @@ function CalibrationTab({ headers }: { headers: Record<string, string> }) {
       setRunning(false)
     }
   }
+
+  // バックエンドはカテゴリ単位の行を返すため、バージョンごとにまとめて表示する
+  const byVersion = new Map<number, CalibrationWeightRow[]>()
+  for (const row of history) {
+    const list = byVersion.get(row.version) ?? []
+    list.push(row)
+    byVersion.set(row.version, list)
+  }
+  const versions = [...byVersion.entries()].sort((a, b) => b[0] - a[0])
 
   return (
     <Box>
@@ -465,46 +488,54 @@ function CalibrationTab({ headers }: { headers: Record<string, string> }) {
 
       {loading ? (
         <Box textAlign="center" py={6}><CircularProgress /></Box>
+      ) : versions.length === 0 ? (
+        <Paper elevation={0} variant="outlined" sx={{ py: 4, textAlign: 'center', color: 'text.secondary' }}>
+          実行履歴がありません
+        </Paper>
       ) : (
-        <TableContainer component={Paper} elevation={0} variant="outlined">
-          <Table size="small">
-            <TableHead>
-              <TableRow sx={{ bgcolor: '#f5f5f5' }}>
-                <TableCell>実行日時</TableCell>
-                <TableCell>実行者</TableCell>
-                <TableCell align="right">サンプル数</TableCell>
-                <TableCell>ステータス</TableCell>
-                <TableCell>重みの概要</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {history.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={5} align="center" sx={{ py: 4, color: 'text.secondary' }}>
-                    実行履歴がありません
-                  </TableCell>
-                </TableRow>
-              ) : history.map(h => (
-                <TableRow key={h.id} hover>
-                  <TableCell>
-                    <Typography variant="body2">{new Date(h.created_at).toLocaleString('ja-JP')}</Typography>
-                  </TableCell>
-                  <TableCell>{h.triggered_by}</TableCell>
-                  <TableCell align="right">{h.sample_count}</TableCell>
-                  <TableCell>
-                    <Chip label={h.is_active ? '適用中' : '旧バージョン'} size="small" color={h.is_active ? 'primary' : 'default'} />
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace', fontSize: '0.78rem' }}>
-                      {Object.entries(h.weights).slice(0, 3).map(([k, v]) => `${k}: ${v.toFixed(2)}`).join(', ')}
-                      {Object.keys(h.weights).length > 3 && ' …'}
+        <Stack spacing={3}>
+          {versions.map(([version, rows]) => {
+            const isActive = rows.some(r => r.is_active)
+            const createdAt = rows[0]?.created_at
+            return (
+              <Box key={version}>
+                <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+                  <Typography variant="subtitle2" fontWeight={700}>バージョン {version}</Typography>
+                  <Chip label={isActive ? '適用中' : '旧バージョン'} size="small" color={isActive ? 'primary' : 'default'} />
+                  {createdAt && (
+                    <Typography variant="body2" color="text.secondary">
+                      {new Date(createdAt).toLocaleString('ja-JP')}
                     </Typography>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                  )}
+                </Stack>
+                <TableContainer component={Paper} elevation={0} variant="outlined">
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow sx={{ bgcolor: '#f5f5f5' }}>
+                        <TableCell>カテゴリ</TableCell>
+                        <TableCell align="right">重み</TableCell>
+                        <TableCell align="right">通過率</TableCell>
+                        <TableCell align="right">相関係数</TableCell>
+                        <TableCell align="right">サンプル数</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map(r => (
+                        <TableRow key={r.id} hover>
+                          <TableCell><Typography fontWeight={500}>{r.category}</Typography></TableCell>
+                          <TableCell align="right">{r.weight.toFixed(2)}</TableCell>
+                          <TableCell align="right">{formatRate(r.pass_rate)}</TableCell>
+                          <TableCell align="right">{r.correlation.toFixed(3)}</TableCell>
+                          <TableCell align="right">{r.sample_count}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            )
+          })}
+        </Stack>
       )}
     </Box>
   )
@@ -514,7 +545,9 @@ function CalibrationTab({ headers }: { headers: Record<string, string> }) {
 
 export default function ScoreValidationPage() {
   const [tab, setTab] = useState(0)
-  const [headers, setHeaders] = useState<Record<string, string>>({})
+  // null = 認証ヘッダー未初期化。空オブジェクトのまま子タブへ渡すと
+  // ヘッダー確定前にfetchが走り401になるため、確定するまでタブ本体を描画しない。
+  const [headers, setHeaders] = useState<Record<string, string> | null>(null)
 
   useEffect(() => {
     const user = authService.getStoredUser()
@@ -543,10 +576,16 @@ export default function ScoreValidationPage() {
           <Tab label="キャリブレーション" />
         </Tabs>
         <Box p={3}>
-          {tab === 0 && <CorrelationTab headers={headers} />}
-          {tab === 1 && <PhaseMetricsTab headers={headers} />}
-          {tab === 2 && <ABTestTab headers={headers} />}
-          {tab === 3 && <CalibrationTab headers={headers} />}
+          {headers === null ? (
+            <Box textAlign="center" py={6}><CircularProgress /></Box>
+          ) : (
+            <>
+              {tab === 0 && <CorrelationTab headers={headers} />}
+              {tab === 1 && <PhaseMetricsTab headers={headers} />}
+              {tab === 2 && <ABTestTab headers={headers} />}
+              {tab === 3 && <CalibrationTab headers={headers} />}
+            </>
+          )}
         </Box>
       </Paper>
     </PageContainer>

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -68,13 +68,13 @@ test.describe('管理者ダッシュボードフロー', () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ generated_at: new Date().toISOString(), total_candidates: 0, categories: [] }),
+          body: JSON.stringify({ rows: [], top_correlated: [], low_correlated: [], total_samples: 0 }),
         })
       } else if (url.includes('/phase-metrics')) {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ generated_at: new Date().toISOString(), phases: [] }),
+          body: JSON.stringify({ phases: [], overall_pass_rate: 0 }),
         })
       } else {
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })

--- a/frontend/lib/score-validation-utils.ts
+++ b/frontend/lib/score-validation-utils.ts
@@ -17,3 +17,9 @@ export function correlationColor(r: number): string {
 export function formatPercent(v: number): string {
   return `${(v * 100).toFixed(1)}%`
 }
+
+// バックエンドが 0-100 のパーセント値として返すフィールド（pass_rate, avg_completion 等）用。
+// formatPercent は 0-1 の比率（traffic_ratio 等）専用なので使い分けること。
+export function formatRate(v: number): string {
+  return `${v.toFixed(1)}%`
+}


### PR DESCRIPTION
Closes #745

## 変更内容

### 原因
1. **フロント/バックエンドのレスポンス形式の不一致**: 相関分析(`correlation`)・フェーズ別メトリクス(`phase-metrics`)で、フロントが期待するフィールド名(`categories`, `f1_score` 等)とバックエンドの実際のレスポンス(`rows`, `PhaseName` 等の無タグPascalCase)が一致しておらず、`undefined` へのアクセスで実質クラッシュしていた。
2. **A/Bテストのバリアント一覧APIが実験名の文字列配列のみ返却**: フロントが期待する詳細情報(id/説明/比率/日付など)を返せていなかった。
3. **レースコンディション**: ページ側で管理者認証ヘッダー(`X-Admin-Email`/`X-Admin-Token`)が非同期でセットされる前に各タブの初回fetchが発火し、初回表示時に401で必ず失敗していた。

### 対応
- `Backend/internal/repositories/score_validation_repository.go`: `CategoryCorrelationRow` / `PhasePrecisionRow` / `VariantResultRow` にJSONタグを追加してsnake_caseに統一し、`VariantResultRow` に実際の平均完了スコア(`avg_score`)集計を追加。全バリアント詳細を返す `ListAllVariants` を新設
- `Backend/internal/services/score_validation_service.go` / `interfaces/score_validation_service.go`: `ListAllVariants` サービスメソッドを追加
- `Backend/internal/controllers/admin_score_validation_controller.go`: `ListVariants` エンドポイントが全バリアント詳細を返すよう変更
- `Backend/test/controllers/mocks/score_validation_service_mock.go` / `admin_lightweight_controllers_test.go`: 上記に合わせてモック・テストを更新
- `frontend/app/admin/score-validation/page.tsx`: 4タブ(相関分析・フェーズ別メトリクス・A/Bテスト管理・キャリブレーション)の型定義・表示ロジックを実際のバックエンド形式に合わせて修正。キャリブレーション履歴はバージョン単位でグルーピングして表示するよう再設計。認証ヘッダー確定前はタブを描画しないよう修正(レースコンディション解消)。キャリブレーション実行エラーメッセージのキー不一致(`error`/`message`)を修正
- `frontend/lib/score-validation-utils.ts`: 0-100のパーセント値用フォーマッタ `formatRate` を追加

## 動作確認
- `go build ./...` / `go test ./internal/services/... ./internal/controllers/... ./test/controllers/...` すべて成功
- `tsc --noEmit` / `eslint` エラーなし
- Playwrightで実際にブラウザから4タブ全て・キャリブレーション実行のエラー表示まで動作確認(スクリーンショット確認済み)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin-only score validation and calibration display; JSON contract changes could break any other consumers of these endpoints, but scope is limited to internal admin tooling.
> 
> **Overview**
> Fixes **admin score-validation** tabs that showed no data by aligning frontend types and rendering with the backend, and by fixing a first-load **401** race on admin auth headers.
> 
> **Backend:** Adds JSON tags on correlation/phase/variant result rows, extends variant results with **`avg_score`** (via `user_analysis_progress`), and switches **`ListVariants`** from experiment name strings to full **`QuestionVariant`** records via **`ListAllVariants`**.
> 
> **Frontend:** Rewires all four tabs (correlation, phase metrics, A/B variants, calibration) to the real shapes (`rows`, `phase_name`, per-category calibration weights grouped by version). Adds **`formatRate`** for 0–100 percent fields vs **`formatPercent`** for 0–1 ratios. Blocks tab fetches until admin headers are set; calibration errors read **`error`** as well as **`message`**.
> 
> Tests and e2e mocks updated for the new payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c2208df923bf6b81a97f8cffd27d297baf92da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 管理画面で全実験・全バリアントの一覧を確認できるようになりました。
  - スコア精度検証の相関分析・フェーズ別メトリクス表示を刷新しました。
  - キャリブレーション履歴をバージョン単位で確認できるようになりました。

- **改善**
  - 通過率や平均スコアの表示を正確な形式に統一しました。
  - 管理画面の認証情報が準備されるまでローディング表示するよう改善しました。
  - エラー発生時のメッセージ表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->