### PR TITLE
feat: #748 DB高速化第1弾（マッチングN+1・INDEX・一覧Select）

### DIFF
--- a/Backend/domain/repository/analysis.go
+++ b/Backend/domain/repository/analysis.go
@@ -32,6 +32,8 @@ type UserAnalysisProgressRepository interface {
 // UserCompanyMatchRepository はユーザーと企業のマッチング結果の永続化インターフェース。
 type UserCompanyMatchRepository interface {
 	CreateOrUpdate(match *entity.UserCompanyMatch) error
+	// CreateOrUpdateBatch は同一 user/session のマッチ結果を一括 upsert する（既存のお気に入り等フラグは保持）。
+	CreateOrUpdateBatch(matches []*entity.UserCompanyMatch) (int, error)
 	FindTopMatchesByUserAndSession(userID uint, sessionID string, limit int) ([]*entity.UserCompanyMatch, error)
 	FindByID(id uint) (*entity.UserCompanyMatch, error)
 	MarkAsViewed(matchID uint) error

--- a/Backend/domain/repository/company.go
+++ b/Backend/domain/repository/company.go
@@ -35,6 +35,8 @@ type CompanyRepository interface {
 	FindByName(name string) (*models.Company, error)
 	FindByCorporateNumber(corporateNumber string) (*models.Company, error)
 	GetWeightProfile(companyID uint, jobPositionID *uint) (*models.CompanyWeightProfile, error)
+	// GetWeightProfilesByCompanyIDs は企業ID群の会社単位プロファイル（job_position_id IS NULL）を一括取得する。
+	GetWeightProfilesByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyWeightProfile, error)
 	Create(company *models.Company) error
 	Update(company *models.Company) error
 	FindJobPositionByCompanyAndTitle(companyID uint, title string) (*models.CompanyJobPosition, error)

--- a/Backend/internal/models/company.go
+++ b/Backend/internal/models/company.go
@@ -12,7 +12,7 @@ type Company struct {
 	Name             string     `gorm:"type:varchar(255);not null" json:"name"`
 	NameReading      string     `gorm:"type:varchar(255)" json:"name_reading"` // 企業名の読み仮名（ふりがな）
 	Description      string     `gorm:"type:text" json:"description"`
-	Industry         string     `gorm:"type:varchar(100)" json:"industry"`
+	Industry         string     `gorm:"type:varchar(100);index:idx_companies_active_status_industry,priority:3" json:"industry"`
 	EmployeeCount    int        `gorm:"default:0" json:"employee_count"`
 	FoundedYear      int        `json:"founded_year"`
 	Location         string     `gorm:"type:varchar(255)" json:"location"`
@@ -23,7 +23,7 @@ type Company struct {
 	SourceURL        string     `gorm:"type:varchar(500)" json:"source_url"`
 	SourceFetchedAt  *time.Time `json:"source_fetched_at,omitempty"`
 	IsProvisional    bool       `gorm:"default:true" json:"is_provisional"`
-	DataStatus       string     `gorm:"type:varchar(20);default:'draft'" json:"data_status"` // draft, published
+	DataStatus       string     `gorm:"type:varchar(20);default:'draft';index:idx_companies_active_status_industry,priority:2;index:idx_companies_active_status_id,priority:2" json:"data_status"` // draft, published
 	GBizLastSyncedAt *time.Time `json:"gbiz_last_synced_at,omitempty"`
 	GBizSyncStatus   string     `gorm:"type:varchar(20)" json:"gbiz_sync_status"` // success, failed
 	GBizSyncMessage  string     `gorm:"type:text" json:"gbiz_sync_message"`
@@ -53,7 +53,7 @@ type Company struct {
 	FemaleRatio  float64 `json:"female_ratio"`                   // 女性比率（%）
 
 	// 評価・ステータス
-	IsActive   bool `gorm:"default:true" json:"is_active"`
+	IsActive   bool `gorm:"default:true;index:idx_companies_active_status_industry,priority:1;index:idx_companies_active_status_id,priority:1" json:"is_active"`
 	IsVerified bool `gorm:"default:false" json:"is_verified"` // 認証済み企業フラグ
 
 	CreatedAt time.Time  `json:"created_at"`
@@ -87,8 +87,8 @@ type CompanyJobPosition struct {
 	PreferredSkills string `gorm:"type:text" json:"preferred_skills"` // JSON形式
 
 	// 募集ステータス
-	IsActive   bool   `gorm:"default:true" json:"is_active"`
-	DataStatus string `gorm:"type:varchar(20);default:'draft'" json:"data_status"` // draft, published, rejected
+	IsActive   bool   `gorm:"default:true;index:idx_company_job_positions_active_status,priority:1" json:"is_active"`
+	DataStatus string `gorm:"type:varchar(20);default:'draft';index:idx_company_job_positions_active_status,priority:2" json:"data_status"` // draft, published, rejected
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/Backend/internal/repositories/company_repository.go
+++ b/Backend/internal/repositories/company_repository.go
@@ -41,6 +41,12 @@ func (r *CompanyRepository) CountActive() (int64, error) {
 	return count, err
 }
 
+// companyListSelectColumns は管理画面一覧向けの軽量カラム（text 過取得を避ける）。
+// description / tech_stack は不足判定に必要なため残す。
+const companyListSelectColumns = "id, name, industry, location, source_type, is_provisional, data_status, " +
+	"info_fetched_at, jobs_fetched_at, tech_fetched_at, relations_fetched_at, " +
+	"website_url, description, tech_stack, created_at, updated_at"
+
 // ListActiveFiltered は名前・公開ステータス・業界・情報充足で絞り込んだアクティブ企業を返す。
 // status は "draft" / "published" / ""（指定なし=すべて）。
 // industry が "__unset__" のときは業界未設定のみ。
@@ -89,7 +95,8 @@ func (r *CompanyRepository) ListActiveFiltered(limit, offset int, name, status, 
 	}
 
 	var companies []models.Company
-	err := q.Session(&gorm.Session{}).Order(order).Limit(limit).Offset(offset).Find(&companies).Error
+	err := q.Session(&gorm.Session{}).Select(companyListSelectColumns).
+		Order(order).Limit(limit).Offset(offset).Find(&companies).Error
 	return companies, total, err
 }
 
@@ -190,6 +197,23 @@ func (r *CompanyRepository) GetWeightProfile(companyID uint, jobPositionID *uint
 		return nil, err
 	}
 	return &profile, nil
+}
+
+// GetWeightProfilesByCompanyIDs は会社単位プロファイル（job_position_id IS NULL）を一括取得する。
+func (r *CompanyRepository) GetWeightProfilesByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyWeightProfile, error) {
+	out := make(map[uint]*models.CompanyWeightProfile, len(companyIDs))
+	if len(companyIDs) == 0 {
+		return out, nil
+	}
+	var profiles []models.CompanyWeightProfile
+	err := r.db.Where("company_id IN ? AND job_position_id IS NULL", companyIDs).Find(&profiles).Error
+	if err != nil {
+		return nil, err
+	}
+	for i := range profiles {
+		out[profiles[i].CompanyID] = &profiles[i]
+	}
+	return out, nil
 }
 
 // Create 企業を作成

--- a/Backend/internal/repositories/user_company_match_repository.go
+++ b/Backend/internal/repositories/user_company_match_repository.go
@@ -42,6 +42,61 @@ func (r *UserCompanyMatchRepository) CreateOrUpdate(match *entity.UserCompanyMat
 	return r.db.Save(m).Error
 }
 
+// CreateOrUpdateBatch は同一 user/session のマッチを一括 upsert する。
+// 既存レコードは1クエリで読み、新規は CreateInBatches、更新は Save（お気に入り等フラグ保持）。
+func (r *UserCompanyMatchRepository) CreateOrUpdateBatch(matches []*entity.UserCompanyMatch) (int, error) {
+	if len(matches) == 0 {
+		return 0, nil
+	}
+	userID := matches[0].UserID
+	sessionID := matches[0].SessionID
+
+	var existing []models.UserCompanyMatch
+	if err := r.db.Where("user_id = ? AND session_id = ?", userID, sessionID).Find(&existing).Error; err != nil {
+		return 0, err
+	}
+	byCompany := make(map[uint]models.UserCompanyMatch, len(existing))
+	for _, e := range existing {
+		byCompany[e.CompanyID] = e
+	}
+
+	now := time.Now()
+	toCreate := make([]*models.UserCompanyMatch, 0)
+	toUpdate := make([]*models.UserCompanyMatch, 0)
+	for _, match := range matches {
+		if match == nil || match.UserID != userID || match.SessionID != sessionID {
+			continue
+		}
+		m := mapper.UserCompanyMatchFromEntity(match)
+		if ex, ok := byCompany[match.CompanyID]; ok {
+			m.ID = ex.ID
+			m.CreatedAt = ex.CreatedAt
+			m.UpdatedAt = now
+			m.IsViewed = ex.IsViewed
+			m.IsFavorited = ex.IsFavorited
+			m.IsApplied = ex.IsApplied
+			toUpdate = append(toUpdate, m)
+		} else {
+			toCreate = append(toCreate, m)
+		}
+	}
+
+	saved := 0
+	if len(toCreate) > 0 {
+		if err := r.db.CreateInBatches(toCreate, 100).Error; err != nil {
+			return saved, err
+		}
+		saved += len(toCreate)
+	}
+	for _, m := range toUpdate {
+		if err := r.db.Save(m).Error; err != nil {
+			continue
+		}
+		saved++
+	}
+	return saved, nil
+}
+
 // FindTopMatchesByUserAndSession マッチング度の高い順に企業を取得
 func (r *UserCompanyMatchRepository) FindTopMatchesByUserAndSession(
 	userID uint, sessionID string, limit int,

--- a/Backend/internal/services/catalog_warm_service_test.go
+++ b/Backend/internal/services/catalog_warm_service_test.go
@@ -42,6 +42,9 @@ func (s *warmRepoStub) FindByCorporateNumber(string) (*models.Company, error)   
 func (s *warmRepoStub) GetWeightProfile(uint, *uint) (*models.CompanyWeightProfile, error) {
 	return nil, nil
 }
+func (s *warmRepoStub) GetWeightProfilesByCompanyIDs([]uint) (map[uint]*models.CompanyWeightProfile, error) {
+	return map[uint]*models.CompanyWeightProfile{}, nil
+}
 func (s *warmRepoStub) Create(*models.Company) error { return nil }
 func (s *warmRepoStub) Update(*models.Company) error { return nil }
 func (s *warmRepoStub) FindJobPositionByCompanyAndTitle(uint, string) (*models.CompanyJobPosition, error) {

--- a/Backend/internal/services/matching_batch_test.go
+++ b/Backend/internal/services/matching_batch_test.go
@@ -1,0 +1,145 @@
+package services
+
+import (
+	"Backend/domain/entity"
+	"Backend/internal/models"
+	"context"
+	"testing"
+	"time"
+)
+
+// matchingCompanyRepo は CalculateMatching 用の最小スタブ。
+type matchingCompanyRepo struct {
+	companies []models.Company
+	profiles  map[uint]*models.CompanyWeightProfile
+}
+
+func (s *matchingCompanyRepo) FindAllPublished(int, int) ([]models.Company, error) {
+	return s.companies, nil
+}
+func (s *matchingCompanyRepo) GetWeightProfilesByCompanyIDs([]uint) (map[uint]*models.CompanyWeightProfile, error) {
+	return s.profiles, nil
+}
+func (s *matchingCompanyRepo) FindAllActive(int, int) ([]models.Company, error) { return nil, nil }
+func (s *matchingCompanyRepo) FindAllActiveNames(string) ([]models.CompanyName, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) CountActive() (int64, error) { return 0, nil }
+func (s *matchingCompanyRepo) ListActiveFiltered(int, int, string, string, string, string, string) ([]models.Company, int64, error) {
+	return nil, 0, nil
+}
+func (s *matchingCompanyRepo) ListActiveIndustries() ([]string, error) { return nil, nil }
+func (s *matchingCompanyRepo) CountPublished() (int64, error)          { return int64(len(s.companies)), nil }
+func (s *matchingCompanyRepo) FindByID(uint) (*models.Company, error)  { return nil, nil }
+func (s *matchingCompanyRepo) FindByIDs([]uint) ([]models.Company, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) FindByName(string) (*models.Company, error)            { return nil, nil }
+func (s *matchingCompanyRepo) FindByCorporateNumber(string) (*models.Company, error) { return nil, nil }
+func (s *matchingCompanyRepo) GetWeightProfile(uint, *uint) (*models.CompanyWeightProfile, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) Create(*models.Company) error { return nil }
+func (s *matchingCompanyRepo) Update(*models.Company) error { return nil }
+func (s *matchingCompanyRepo) FindJobPositionByCompanyAndTitle(uint, string) (*models.CompanyJobPosition, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) FindJobPositionByID(uint) (*models.CompanyJobPosition, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) CreateJobPosition(*models.CompanyJobPosition) error { return nil }
+func (s *matchingCompanyRepo) UpdateJobPosition(*models.CompanyJobPosition) error { return nil }
+func (s *matchingCompanyRepo) FindJobPositionsByCompany(uint) ([]models.CompanyJobPosition, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) ListJobPositions(*uint, int) ([]models.CompanyJobPosition, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) CreateOrUpdateWeightProfile(*models.CompanyWeightProfile) error {
+	return nil
+}
+func (s *matchingCompanyRepo) CountWeightProfiles() (int64, error) { return int64(len(s.profiles)), nil }
+func (s *matchingCompanyRepo) ListPublishedL1WarmCandidates(int, time.Duration) ([]models.CompanyL1WarmRow, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) CountL1Coverage(time.Duration) (*models.L1CoverageStats, error) {
+	return nil, nil
+}
+func (s *matchingCompanyRepo) ListActiveMissingFetchCandidates(int, bool) ([]models.Company, error) {
+	return nil, nil
+}
+
+type matchingScoreRepo struct {
+	scores []entity.UserWeightScore
+}
+
+func (s *matchingScoreRepo) SetScore(uint, string, string, int) error  { return nil }
+func (s *matchingScoreRepo) AddScore(uint, string, string, int) error  { return nil }
+func (s *matchingScoreRepo) FindByUserAndSession(uint, string) ([]entity.UserWeightScore, error) {
+	return s.scores, nil
+}
+func (s *matchingScoreRepo) FindTopCategories(uint, string, int) ([]entity.UserWeightScore, error) {
+	return nil, nil
+}
+func (s *matchingScoreRepo) FindByUserSessionAndCategory(uint, string, string) (*entity.UserWeightScore, error) {
+	return nil, nil
+}
+func (s *matchingScoreRepo) CountByUserAndSession(uint, string) (int64, error) {
+	return int64(len(s.scores)), nil
+}
+
+type matchingMatchRepo struct {
+	batchCalls int
+	saved      int
+}
+
+func (s *matchingMatchRepo) CreateOrUpdate(*entity.UserCompanyMatch) error { return nil }
+func (s *matchingMatchRepo) CreateOrUpdateBatch(matches []*entity.UserCompanyMatch) (int, error) {
+	s.batchCalls++
+	s.saved = len(matches)
+	return len(matches), nil
+}
+func (s *matchingMatchRepo) FindTopMatchesByUserAndSession(uint, string, int) ([]*entity.UserCompanyMatch, error) {
+	return nil, nil
+}
+func (s *matchingMatchRepo) FindByID(uint) (*entity.UserCompanyMatch, error) { return nil, nil }
+func (s *matchingMatchRepo) MarkAsViewed(uint) error                        { return nil }
+func (s *matchingMatchRepo) ToggleFavorite(uint) error                      { return nil }
+func (s *matchingMatchRepo) MarkAsApplied(uint) error                       { return nil }
+func (s *matchingMatchRepo) FindFavoritesByUser(uint, string) ([]*entity.UserCompanyMatch, error) {
+	return nil, nil
+}
+func (s *matchingMatchRepo) GetMatchStatistics(uint, string) (map[string]any, error) {
+	return nil, nil
+}
+
+func TestCalculateMatching_UsesBatchProfileAndUpsert(t *testing.T) {
+	companyRepo := &matchingCompanyRepo{
+		companies: []models.Company{
+			{ID: 1, Name: "A社", Industry: "IT"},
+			{ID: 2, Name: "B社", Industry: "製造"},
+			{ID: 3, Name: "C社", Industry: "IT"}, // プロファイルなし → スキップ
+		},
+		profiles: map[uint]*models.CompanyWeightProfile{
+			1: {CompanyID: 1, TechnicalOrientation: 80},
+			2: {CompanyID: 2, TechnicalOrientation: 40},
+		},
+	}
+	scoreRepo := &matchingScoreRepo{
+		scores: []entity.UserWeightScore{
+			{WeightCategory: "技術志向", Score: 70},
+		},
+	}
+	matchRepo := &matchingMatchRepo{}
+
+	svc := NewMatchingService(scoreRepo, companyRepo, matchRepo, nil)
+	if err := svc.CalculateMatching(context.Background(), 10, "sess-1"); err != nil {
+		t.Fatalf("CalculateMatching: %v", err)
+	}
+	if matchRepo.batchCalls != 1 {
+		t.Fatalf("CreateOrUpdateBatch calls=%d want 1", matchRepo.batchCalls)
+	}
+	if matchRepo.saved != 2 {
+		t.Fatalf("saved matches=%d want 2 (skip company without profile)", matchRepo.saved)
+	}
+}

--- a/Backend/internal/services/matching_service.go
+++ b/Backend/internal/services/matching_service.go
@@ -68,22 +68,31 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 
 	log.Printf("[CalculateMatching] Found %d published companies\n", len(companies))
 
-	// 3. 各企業とのマッチングを計算
-	matchCount := 0
-	for _, company := range companies {
-		// 企業のweightプロファイルを取得
-		profile, err := s.companyRepo.GetWeightProfile(company.ID, nil)
-		if err != nil {
-			log.Printf("[CalculateMatching] Warning: No profile for company %d: %v\n", company.ID, err)
+	companyIDs := make([]uint, len(companies))
+	for i := range companies {
+		companyIDs[i] = companies[i].ID
+	}
+	profiles, err := s.companyRepo.GetWeightProfilesByCompanyIDs(companyIDs)
+	if err != nil {
+		return fmt.Errorf("failed to get weight profiles: %w", err)
+	}
+	log.Printf("[CalculateMatching] Loaded %d weight profiles\n", len(profiles))
+
+	// 3. 各企業とのマッチングを計算（プロファイルはメモリ上で参照）
+	pending := make([]*entity.UserCompanyMatch, 0, len(companies))
+	for i := range companies {
+		company := &companies[i]
+		profile, ok := profiles[company.ID]
+		if !ok || profile == nil {
+			log.Printf("[CalculateMatching] Warning: No profile for company %d\n", company.ID)
 			continue
 		}
 
-		// マッチングスコアを計算
 		match := s.calculateMatchScore(scoreMap, profile)
 		match.UserID = userID
 		match.SessionID = sessionID
 		match.CompanyID = company.ID
-		match.Company = mapper.CompanyToEntity(&company)
+		match.Company = mapper.CompanyToEntity(company)
 
 		reason, err := s.GenerateMatchReason(ctx, match, userScores)
 		if err != nil {
@@ -91,13 +100,12 @@ func (s *MatchingService) CalculateMatching(ctx context.Context, userID uint, se
 			reason = BuildMatchReason(match, userScores)
 		}
 		match.MatchReason = reason
+		pending = append(pending, match)
+	}
 
-		// マッチング結果を保存
-		if err := s.matchRepo.CreateOrUpdate(match); err != nil {
-			log.Printf("[CalculateMatching] Warning: Failed to save match for company %d: %v\n", company.ID, err)
-			continue
-		}
-		matchCount++
+	matchCount, err := s.matchRepo.CreateOrUpdateBatch(pending)
+	if err != nil {
+		return fmt.Errorf("failed to save matches: %w", err)
 	}
 
 	log.Printf("[CalculateMatching] Completed: %d matches created for user %d, session %s\n", matchCount, userID, sessionID)

--- a/Backend/migrations/000007_add_company_filter_indexes.down.sql
+++ b/Backend/migrations/000007_add_company_filter_indexes.down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `company_relations`
+  DROP INDEX `idx_company_relations_active_to`,
+  DROP INDEX `idx_company_relations_active_from`,
+  DROP INDEX `idx_company_relations_active_child`,
+  DROP INDEX `idx_company_relations_active_parent`;
+
+ALTER TABLE `company_job_positions`
+  DROP INDEX `idx_company_job_positions_active_status`;
+
+ALTER TABLE `companies`
+  DROP INDEX `idx_companies_active_status_id`,
+  DROP INDEX `idx_companies_active_status_industry`;

--- a/Backend/migrations/000007_add_company_filter_indexes.up.sql
+++ b/Backend/migrations/000007_add_company_filter_indexes.up.sql
@@ -1,0 +1,13 @@
+-- companies / job_positions / relations のフィルタ・参照用インデックス (#748)
+ALTER TABLE `companies`
+  ADD INDEX `idx_companies_active_status_industry` (`is_active`, `data_status`, `industry`),
+  ADD INDEX `idx_companies_active_status_id` (`is_active`, `data_status`, `id`);
+
+ALTER TABLE `company_job_positions`
+  ADD INDEX `idx_company_job_positions_active_status` (`is_active`, `data_status`);
+
+ALTER TABLE `company_relations`
+  ADD INDEX `idx_company_relations_active_parent` (`is_active`, `parent_id`),
+  ADD INDEX `idx_company_relations_active_child` (`is_active`, `child_id`),
+  ADD INDEX `idx_company_relations_active_from` (`is_active`, `from_id`),
+  ADD INDEX `idx_company_relations_active_to` (`is_active`, `to_id`);

--- a/Backend/test/controllers/mocks/company_repository_mock.go
+++ b/Backend/test/controllers/mocks/company_repository_mock.go
@@ -102,6 +102,14 @@ func (m *CompanyRepositoryMock) GetWeightProfile(companyID uint, jobPositionID *
 	return nil, args.Error(1)
 }
 
+func (m *CompanyRepositoryMock) GetWeightProfilesByCompanyIDs(companyIDs []uint) (map[uint]*models.CompanyWeightProfile, error) {
+	args := m.Called(companyIDs)
+	if v := args.Get(0); v != nil {
+		return v.(map[uint]*models.CompanyWeightProfile), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *CompanyRepositoryMock) Create(company *models.Company) error {
 	args := m.Called(company)
 	return args.Error(0)

--- a/Backend/test/repositories/company_list_filtered_test.go
+++ b/Backend/test/repositories/company_list_filtered_test.go
@@ -36,7 +36,7 @@ func TestListActiveFiltered_ByNameAndStatus(t *testing.T) {
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND name LIKE \\?").
 		WithArgs(true, "%ソニー%").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND name LIKE \\? ORDER BY id desc LIMIT \\?").
+	mock.ExpectQuery("SELECT id, name, industry, location, source_type, is_provisional, data_status, info_fetched_at, jobs_fetched_at, tech_fetched_at, relations_fetched_at, website_url, description, tech_stack, created_at, updated_at FROM `companies` WHERE is_active = \\? AND name LIKE \\?").
 		WithArgs(true, "%ソニー%", 50).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "data_status", "is_active"}).
 			AddRow(2, "ソニー損保", "draft", true).
@@ -53,7 +53,7 @@ func TestListActiveFiltered_ByNameAndStatus(t *testing.T) {
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND name LIKE \\? AND data_status = \\?").
 		WithArgs(true, "%ソニー%", "published").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND name LIKE \\? AND data_status = \\? ORDER BY id desc LIMIT \\?").
+	mock.ExpectQuery("SELECT id, name, industry, location, source_type, is_provisional, data_status, info_fetched_at, jobs_fetched_at, tech_fetched_at, relations_fetched_at, website_url, description, tech_stack, created_at, updated_at FROM `companies` WHERE is_active = \\? AND name LIKE \\? AND data_status = \\?").
 		WithArgs(true, "%ソニー%", "published", 50).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "data_status", "is_active"}).
 			AddRow(1, "ソニー株式会社", "published", true))
@@ -77,7 +77,7 @@ func TestListActiveFiltered_ByIndustryAndReadiness(t *testing.T) {
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND industry = \\?").
 		WithArgs(true, "IT・ソフトウェア").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND industry = \\? ORDER BY id desc LIMIT \\?").
+	mock.ExpectQuery("SELECT id, name, industry, location, source_type, is_provisional, data_status, info_fetched_at, jobs_fetched_at, tech_fetched_at, relations_fetched_at, website_url, description, tech_stack, created_at, updated_at FROM `companies` WHERE is_active = \\? AND industry = \\?").
 		WithArgs(true, "IT・ソフトウェア", 50).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "industry", "is_active"}).
 			AddRow(1, "サンプルIT", "IT・ソフトウェア", true))
@@ -93,7 +93,7 @@ func TestListActiveFiltered_ByIndustryAndReadiness(t *testing.T) {
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `companies` WHERE is_active = \\? AND \\(\\(industry IS NULL OR industry = ''\\)\\)").
 		WithArgs(true).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery("SELECT \\* FROM `companies` WHERE is_active = \\? AND \\(\\(industry IS NULL OR industry = ''\\)\\) ORDER BY id desc LIMIT \\?").
+	mock.ExpectQuery("SELECT id, name, industry, location, source_type, is_provisional, data_status, info_fetched_at, jobs_fetched_at, tech_fetched_at, relations_fetched_at, website_url, description, tech_stack, created_at, updated_at FROM `companies` WHERE is_active = \\? AND \\(\\(industry IS NULL OR industry = ''\\)\\)").
 		WithArgs(true, 50).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
 

--- a/Backend/test/repositories/matching_batch_repo_test.go
+++ b/Backend/test/repositories/matching_batch_repo_test.go
@@ -1,0 +1,98 @@
+package repositories_test
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"Backend/domain/entity"
+	"Backend/internal/repositories"
+)
+
+func TestGetWeightProfilesByCompanyIDs(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB, SkipInitializeWithVersion: true}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := repositories.NewCompanyRepository(db)
+
+	mock.ExpectQuery("SELECT \\* FROM `company_weight_profiles` WHERE company_id IN \\(\\?,\\?\\) AND job_position_id IS NULL").
+		WithArgs(1, 2).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "company_id", "technical_orientation"}).
+			AddRow(10, 1, 80).
+			AddRow(11, 2, 40))
+
+	got, err := repo.GetWeightProfilesByCompanyIDs([]uint{1, 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[1] == nil || got[1].TechnicalOrientation != 80 {
+		t.Fatalf("unexpected profiles: %+v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetWeightProfilesByCompanyIDs_Empty(t *testing.T) {
+	repo := repositories.NewCompanyRepository(nil)
+	got, err := repo.GetWeightProfilesByCompanyIDs(nil)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("empty ids should return empty map, got %v err %v", got, err)
+	}
+}
+
+func TestCreateOrUpdateBatch_CreatesAndUpdates(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB, SkipInitializeWithVersion: true}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := repositories.NewUserCompanyMatchRepository(db)
+
+	mock.ExpectQuery("SELECT \\* FROM `user_company_matches` WHERE user_id = \\? AND session_id = \\?").
+		WithArgs(uint(1), "s1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "session_id", "company_id", "match_score", "is_favorited", "is_viewed", "is_applied",
+		}).AddRow(99, 1, "s1", 2, 50.0, true, false, false))
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `user_company_matches`").
+		WillReturnResult(sqlmock.NewResult(100, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `user_company_matches`").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	saved, err := repo.CreateOrUpdateBatch([]*entity.UserCompanyMatch{
+		{UserID: 1, SessionID: "s1", CompanyID: 1, MatchScore: 80},
+		{UserID: 1, SessionID: "s1", CompanyID: 2, MatchScore: 90},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved != 2 {
+		t.Fatalf("saved=%d want 2", saved)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
Issue #748 の P0〜P1 一部を実装した第1弾です。

- **indexes**: `companies` / `company_job_positions` / `company_relations` の複合 INDEX（migration 000007）
- **matching-batch**: `GetWeightProfilesByCompanyIDs` + `CreateOrUpdateBatch` で N+1 を削減
- **list-select**: `ListActiveFiltered` を一覧用カラムのみ Select

## Query 改善（マッチング）
| Before | After |
|--------|-------|
| 1 + N(profile) + ~2N(upsert) | 1(companies) + 1(profiles) + 1(existing matches) + batches |

## 続く予定（#748 残）
- 相関・市場 API の limit
- InterviewSession soft-delete
- Dashboard CSV / Trend の残 N+1

## Test plan
- [x] `go test ./internal/services/ -run TestCalculateMatching_UsesBatch`
- [x] `go test ./test/repositories/ -run "TestListActiveFiltered|TestGetWeightProfiles|TestCreateOrUpdateBatch"`
- [x] `go test ./migrations/`
- [ ] CI 通過
- [ ] ローカルで `go run ./cmd/migrate` 適用確認

Related to #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * マッチング結果の一括保存に対応し、処理効率と安定性を向上しました。
  * 複数企業の重み付け情報をまとめて取得できるようになり、マッチング処理を高速化しました。
  * 重み付け情報がない企業を適切に除外するよう改善しました。
  * 企業一覧の検索・絞り込み性能を向上しました。
  * マッチング結果の既存ステータスを保持したまま更新できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->