### PR TITLE
fix: 面接ロビーのリロード・カメラ再試行を修正 (#750)

### DIFF
--- a/frontend/app/interview/components/LobbyScreen.tsx
+++ b/frontend/app/interview/components/LobbyScreen.tsx
@@ -87,10 +87,22 @@ export default function LobbyScreen({
           {/* Camera preview */}
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
             <Box sx={{ position: 'relative', width: '100%', aspectRatio: '16/9', bgcolor: '#202124', borderRadius: 2, overflow: 'hidden', boxShadow: '0 4px 20px rgba(0,0,0,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <video
+                ref={lobbyVideoRef}
+                muted
+                playsInline
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                  transform: 'scaleX(-1)',
+                  display: lobbyPermissionError || !cameraEnabled ? 'none' : 'block',
+                }}
+              />
               {lobbyPermissionError ? (
-                <Box sx={{ textAlign: 'center', p: 3 }}>
+                <Box sx={{ textAlign: 'center', p: 3, position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
                   <Typography sx={{ color: '#f28b82', mb: 1.5, fontSize: 14 }}>{lobbyPermissionError}</Typography>
-                  <Box sx={{ mb: 2, textAlign: 'left', bgcolor: 'rgba(0,0,0,0.4)', borderRadius: 1, p: 1.5 }}>
+                  <Box sx={{ mb: 2, textAlign: 'left', bgcolor: 'rgba(0,0,0,0.4)', borderRadius: 1, p: 1.5, width: '100%', maxWidth: 360 }}>
                     <Typography sx={{ color: '#e8eaed', fontSize: 12, mb: 0.5 }}>【ブラウザの許可】</Typography>
                     <Typography sx={{ color: '#9aa0a6', fontSize: 12, lineHeight: 1.8, mb: 1 }}>
                       アドレスバー左端の 🔒 → カメラ・マイクを「許可」
@@ -105,14 +117,7 @@ export default function LobbyScreen({
                     再試行
                   </Button>
                 </Box>
-              ) : (
-                <video
-                  ref={lobbyVideoRef}
-                  muted
-                  playsInline
-                  style={{ width: '100%', height: '100%', objectFit: 'cover', transform: 'scaleX(-1)', display: cameraEnabled ? 'block' : 'none' }}
-                />
-              )}
+              ) : null}
               {!lobbyPermissionError && !cameraEnabled && (
                 <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                   <VideocamOffIcon sx={{ color: '#9aa0a6', fontSize: 48 }} />

--- a/frontend/app/interview/hooks/useInterviewMedia.ts
+++ b/frontend/app/interview/hooks/useInterviewMedia.ts
@@ -43,33 +43,55 @@ export function useInterviewMedia({ loading, status }: UseInterviewMediaArgs) {
   // Lobby camera preview — 選択画面では getUserMedia しない（遷移直後の遅延を避ける）
   useEffect(() => {
     if (!shouldStartInterviewMediaPreview({ loading, status })) return
-    let stream: MediaStream | null = null
+    let cancelled = false
     const startPreview = async () => {
       try {
-        stream = await navigator.mediaDevices.getUserMedia(MEDIA_CONSTRAINTS)
-        streamRef.current = stream
-        if (lobbyVideoRef.current) {
+        let stream = streamRef.current
+        const needsNew =
+          !stream || stream.getTracks().length === 0 || stream.getTracks().every((t) => t.readyState === 'ended')
+        if (needsNew) {
+          stream = await navigator.mediaDevices.getUserMedia(MEDIA_CONSTRAINTS)
+          if (cancelled) {
+            stream.getTracks().forEach((t) => t.stop())
+            return
+          }
+          streamRef.current = stream
+        }
+        if (lobbyVideoRef.current && stream) {
           lobbyVideoRef.current.srcObject = stream
           lobbyVideoRef.current.play().catch(() => undefined)
         }
-      } catch (err: any) {
-        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
-          // カメラとマイクを個別に試してどちらがブロックされているか特定する
+        setLobbyPermissionError(null)
+      } catch (err: unknown) {
+        if (cancelled) return
+        const name = err instanceof DOMException ? err.name : err instanceof Error ? err.name : ''
+        if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
           const blocked: string[] = []
-          await navigator.mediaDevices.getUserMedia({ video: true }).then(s => s.getTracks().forEach(t => t.stop())).catch(() => { blocked.push('カメラ') })
-          await navigator.mediaDevices.getUserMedia({ audio: true }).then(s => s.getTracks().forEach(t => t.stop())).catch(() => { blocked.push('マイク') })
+          await navigator.mediaDevices
+            .getUserMedia({ video: true })
+            .then((s) => s.getTracks().forEach((t) => t.stop()))
+            .catch(() => {
+              blocked.push('カメラ')
+            })
+          await navigator.mediaDevices
+            .getUserMedia({ audio: true })
+            .then((s) => s.getTracks().forEach((t) => t.stop()))
+            .catch(() => {
+              blocked.push('マイク')
+            })
           const target = blocked.length > 0 ? blocked.join('と') : 'マイクとカメラ'
           setLobbyPermissionError(`${target}へのアクセスが拒否されました。`)
-        } else if (err.name === 'NotFoundError') {
+        } else if (name === 'NotFoundError') {
           setLobbyPermissionError('マイクまたはカメラが見つかりません。デバイスを確認してください。')
         } else {
           setLobbyPermissionError('カメラの起動に失敗しました。')
         }
       }
     }
-    startPreview()
+    void startPreview()
     return () => {
-      // stream is kept in streamRef for reuse during interview
+      cancelled = true
+      // stream は面接中再利用のため streamRef に残す
     }
   }, [loading, status])
 
@@ -81,14 +103,63 @@ export function useInterviewMedia({ loading, status }: UseInterviewMediaArgs) {
     }
   }, [status])
 
+  const classifyMediaError = async (err: unknown): Promise<string> => {
+    const name = err instanceof DOMException ? err.name : err instanceof Error ? err.name : ''
+    if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
+      const blocked: string[] = []
+      await navigator.mediaDevices
+        .getUserMedia({ video: true })
+        .then((s) => s.getTracks().forEach((t) => t.stop()))
+        .catch(() => {
+          blocked.push('カメラ')
+        })
+      await navigator.mediaDevices
+        .getUserMedia({ audio: true })
+        .then((s) => s.getTracks().forEach((t) => t.stop()))
+        .catch(() => {
+          blocked.push('マイク')
+        })
+      const target = blocked.length > 0 ? blocked.join('と') : 'マイクとカメラ'
+      return `${target}へのアクセスが拒否されました。`
+    }
+    if (name === 'NotFoundError') {
+      return 'マイクまたはカメラが見つかりません。デバイスを確認してください。'
+    }
+    return 'カメラの起動に失敗しました。'
+  }
+
+  /** ページリロードせず getUserMedia を再実行する（会社選択状態を維持）。 */
+  const retryLobbyPreview = async () => {
+    setLobbyPermissionError(null)
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop())
+      streamRef.current = null
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(MEDIA_CONSTRAINTS)
+      streamRef.current = stream
+      // エラー UI 解除後に video がマウントされるのを待つ
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+      if (lobbyVideoRef.current) {
+        lobbyVideoRef.current.srcObject = stream
+        await lobbyVideoRef.current.play().catch(() => undefined)
+      }
+    } catch (err: unknown) {
+      setLobbyPermissionError(await classifyMediaError(err))
+    }
+  }
+
   const ensureStream = async (): Promise<MediaStream> => {
     let stream = streamRef.current
-    if (!stream) {
+    if (!stream || stream.getTracks().every((t) => t.readyState === 'ended')) {
       try {
         stream = await navigator.mediaDevices.getUserMedia(MEDIA_CONSTRAINTS)
-      } catch (err: any) {
-        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') throw new Error('NotAllowedError')
-        if (err.name === 'NotFoundError') throw new Error('NotFoundError')
+      } catch (err: unknown) {
+        const name = err instanceof DOMException ? err.name : err instanceof Error ? err.name : ''
+        if (name === 'NotAllowedError' || name === 'PermissionDeniedError') throw new Error('NotAllowedError')
+        if (name === 'NotFoundError') throw new Error('NotFoundError')
         throw err
       }
       streamRef.current = stream
@@ -168,6 +239,7 @@ export function useInterviewMedia({ loading, status }: UseInterviewMediaArgs) {
     stopStream,
     startVideoRecording,
     stopAndCollectVideoBlob,
+    retryLobbyPreview,
   }
 }
 

--- a/frontend/app/interview/lobbyDraft.ts
+++ b/frontend/app/interview/lobbyDraft.ts
@@ -1,0 +1,96 @@
+/**
+ * 面接ロビーの下書き（企業・職種）を sessionStorage に保持する。
+ * リロード後も会社選択に戻さずロビーを復元するため。
+ */
+
+import type { InterviewCompany, Position } from './types'
+import { POSITIONS } from './constants'
+
+export const INTERVIEW_LOBBY_DRAFT_KEY = 'interview_lobby_draft_v1'
+
+export type InterviewLobbyDraft = {
+  company: InterviewCompany
+  positionId: string
+  positionCategory: 'general' | 'sier'
+  savedAt: number
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+export function parseInterviewLobbyDraft(raw: string | null): InterviewLobbyDraft | null {
+  if (!raw) return null
+  try {
+    const data: unknown = JSON.parse(raw)
+    if (!isRecord(data)) return null
+    const company = data.company
+    if (!isRecord(company) || typeof company.name !== 'string' || !company.name.trim()) {
+      return null
+    }
+    const id = typeof company.id === 'number' && Number.isFinite(company.id) ? company.id : 0
+    const positionId = typeof data.positionId === 'string' ? data.positionId : POSITIONS[0].id
+    const positionCategory =
+      data.positionCategory === 'sier' || data.positionCategory === 'general'
+        ? data.positionCategory
+        : 'general'
+    return {
+      company: {
+        id,
+        name: company.name.trim(),
+        industry: typeof company.industry === 'string' ? company.industry : undefined,
+        description: typeof company.description === 'string' ? company.description : undefined,
+        location: typeof company.location === 'string' ? company.location : undefined,
+      },
+      positionId,
+      positionCategory,
+      savedAt: typeof data.savedAt === 'number' ? data.savedAt : Date.now(),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function loadInterviewLobbyDraft(
+  storage: Pick<Storage, 'getItem'> | null | undefined = typeof sessionStorage !== 'undefined' ? sessionStorage : null,
+): InterviewLobbyDraft | null {
+  if (!storage) return null
+  try {
+    return parseInterviewLobbyDraft(storage.getItem(INTERVIEW_LOBBY_DRAFT_KEY))
+  } catch {
+    return null
+  }
+}
+
+export function saveInterviewLobbyDraft(
+  draft: Omit<InterviewLobbyDraft, 'savedAt'>,
+  storage: Pick<Storage, 'setItem'> | null | undefined = typeof sessionStorage !== 'undefined' ? sessionStorage : null,
+): void {
+  if (!storage) return
+  try {
+    const payload: InterviewLobbyDraft = { ...draft, savedAt: Date.now() }
+    storage.setItem(INTERVIEW_LOBBY_DRAFT_KEY, JSON.stringify(payload))
+  } catch {
+    // private mode 等では無視
+  }
+}
+
+export function clearInterviewLobbyDraft(
+  storage: Pick<Storage, 'removeItem'> | null | undefined = typeof sessionStorage !== 'undefined' ? sessionStorage : null,
+): void {
+  if (!storage) return
+  try {
+    storage.removeItem(INTERVIEW_LOBBY_DRAFT_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+export function resolvePositionFromDraft(
+  positionId: string,
+  category: 'general' | 'sier',
+): Position {
+  const found = POSITIONS.find((p) => p.id === positionId)
+  if (found) return found
+  return POSITIONS.find((p) => p.category === category) ?? POSITIONS[0]
+}

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -14,6 +14,12 @@ import { GUEST_REGISTER_PATH } from '@/lib/guest-limits'
 import { POSITIONS } from './constants'
 import type { InterviewCompany, Position, InterviewStatus } from './types'
 import { resolveCompanyByName } from './utils'
+import {
+  clearInterviewLobbyDraft,
+  loadInterviewLobbyDraft,
+  resolvePositionFromDraft,
+  saveInterviewLobbyDraft,
+} from './lobbyDraft'
 import { useInterviewMedia } from './hooks/useInterviewMedia'
 import { useInterviewSession } from './hooks/useInterviewSession'
 
@@ -83,6 +89,34 @@ function InterviewContent() {
       })
     }
   }, [loading, searchParams])
+
+  // リロード時: sessionStorage の下書きからロビー（企業・職種）を復元する
+  useEffect(() => {
+    if (loading) return
+    if (searchParams.get('company_name')) return
+    const draft = loadInterviewLobbyDraft()
+    if (!draft) return
+    setInterviewCompany(draft.company)
+    setSelectedPosition(resolvePositionFromDraft(draft.positionId, draft.positionCategory))
+    setPositionCategory(draft.positionCategory)
+    setStatus('lobby')
+  }, [loading, searchParams])
+
+  // ロビー以降は下書きを保持（リロードで会社選択へ戻らないようにする）
+  useEffect(() => {
+    if (status !== 'lobby' && status !== 'connecting' && status !== 'connected') return
+    if (!interviewCompany?.name) return
+    saveInterviewLobbyDraft({
+      company: interviewCompany,
+      positionId: selectedPosition.id,
+      positionCategory,
+    })
+  }, [status, interviewCompany, selectedPosition.id, positionCategory])
+
+  // 面接完了後は下書きを破棄（次回は選択画面から）
+  useEffect(() => {
+    if (status === 'finished') clearInterviewLobbyDraft()
+  }, [status])
 
   // Load company list for selection screen (initial fetch + debounced search)
   useEffect(() => {
@@ -191,7 +225,16 @@ function InterviewContent() {
         companyHints={companyHints}
         hintsLoading={hintsLoading}
         questionDurationSeconds={questionDurationSeconds}
-        onStartInterview={() => setStatus('lobby')}
+        onStartInterview={() => {
+          if (interviewCompany?.name) {
+            saveInterviewLobbyDraft({
+              company: interviewCompany,
+              positionId: selectedPosition.id,
+              positionCategory,
+            })
+          }
+          setStatus('lobby')
+        }}
       />
     )
   }
@@ -220,7 +263,7 @@ function InterviewContent() {
         interviewCompany={interviewCompany}
         fromMatchingResults={Boolean(searchParams.get('company_name'))}
         lobbyPermissionError={media.lobbyPermissionError}
-        onRetryPermissions={() => { media.setLobbyPermissionError(null); window.location.reload() }}
+        onRetryPermissions={() => { void media.retryLobbyPreview() }}
         micEnabled={media.micEnabled}
         cameraEnabled={media.cameraEnabled}
         onToggleMic={media.toggleMic}

--- a/frontend/tests/app/interview/LobbyScreen.test.tsx
+++ b/frontend/tests/app/interview/LobbyScreen.test.tsx
@@ -37,4 +37,29 @@ describe('LobbyScreen', () => {
     expect(screen.getByText('準備はできましたか？')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '面接に参加' })).toBeInTheDocument()
   })
+
+  it('許可エラー時も video 要素を残し再試行ボタンを表示する', () => {
+    const { container } = render(
+      <LobbyScreen
+        userName="テストユーザー"
+        companyName="テスト株式会社"
+        interviewCompany={{ id: 1, name: 'テスト株式会社' }}
+        fromMatchingResults={false}
+        lobbyPermissionError="カメラへのアクセスが拒否されました。"
+        onRetryPermissions={noop}
+        micEnabled={true}
+        cameraEnabled={true}
+        onToggleMic={noop}
+        onToggleCamera={noop}
+        lobbyVideoRef={{ current: null }}
+        onBack={noop}
+        onJoinWithConsent={noop}
+        consentDialog={null}
+      />,
+    )
+
+    expect(screen.getByText(/カメラへのアクセスが拒否されました/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /再試行/ })).toBeInTheDocument()
+    expect(container.querySelector('video')).not.toBeNull()
+  })
 })

--- a/frontend/tests/app/interview/lobbyDraft.test.ts
+++ b/frontend/tests/app/interview/lobbyDraft.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  INTERVIEW_LOBBY_DRAFT_KEY,
+  clearInterviewLobbyDraft,
+  loadInterviewLobbyDraft,
+  parseInterviewLobbyDraft,
+  resolvePositionFromDraft,
+  saveInterviewLobbyDraft,
+} from '@/app/interview/lobbyDraft'
+import { POSITIONS } from '@/app/interview/constants'
+
+describe('lobbyDraft', () => {
+  it('有効な JSON をパースする', () => {
+    const draft = parseInterviewLobbyDraft(
+      JSON.stringify({
+        company: { id: 3, name: '株式会社テスト', industry: 'IT' },
+        positionId: POSITIONS[0].id,
+        positionCategory: 'general',
+        savedAt: 1,
+      }),
+    )
+    expect(draft?.company.name).toBe('株式会社テスト')
+    expect(draft?.company.id).toBe(3)
+    expect(draft?.positionId).toBe(POSITIONS[0].id)
+  })
+
+  it('会社名がない JSON は null', () => {
+    expect(parseInterviewLobbyDraft(JSON.stringify({ company: { id: 1 } }))).toBeNull()
+    expect(parseInterviewLobbyDraft(null)).toBeNull()
+    expect(parseInterviewLobbyDraft('not-json')).toBeNull()
+  })
+
+  it('sessionStorage への保存・読込・削除ができる', () => {
+    const store = new Map<string, string>()
+    const storage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v)
+      },
+      removeItem: (k: string) => {
+        store.delete(k)
+      },
+    }
+
+    saveInterviewLobbyDraft(
+      {
+        company: { id: 1, name: '復元テスト社' },
+        positionId: POSITIONS[0].id,
+        positionCategory: 'sier',
+      },
+      storage,
+    )
+    expect(store.has(INTERVIEW_LOBBY_DRAFT_KEY)).toBe(true)
+
+    const loaded = loadInterviewLobbyDraft(storage)
+    expect(loaded?.company.name).toBe('復元テスト社')
+    expect(loaded?.positionCategory).toBe('sier')
+
+    clearInterviewLobbyDraft(storage)
+    expect(loadInterviewLobbyDraft(storage)).toBeNull()
+  })
+
+  it('未知の positionId はカテゴリからフォールバックする', () => {
+    const pos = resolvePositionFromDraft('unknown-id', 'general')
+    expect(pos.category).toBe('general')
+    expect(POSITIONS.some((p) => p.id === pos.id)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes https://github.com/ISCProduct/soc-ai-agent/issues/750
- ロビーの企業・職種を `sessionStorage` に保存し、リロード後も会社選択ではなくロビーへ復元する
- カメラ/マイク許可の「再試行」を `window.location.reload()` から `getUserMedia` 再取得に変更し、エラー時も `<video>` をマウントしたまま再アタッチ可能にする

## Test plan
- [ ] `/interview` で会社・職種を選んでロビーへ進み、ブラウザをリロードしても会社選択に戻らず同一ロビーが復元されること
- [ ] マッチング結果からの `?company_name=` 遷移は従来どおりロビーへ入ること
- [ ] カメラ/マイク拒否時にエラー案内と「再試行」が出ること
- [ ] ブラウザで許可した後に「再試行」するとページ全体がリロードされずプレビューが復帰すること
- [ ] 面接完了（レポート画面）後に `/interview` を開き直すと選択画面から始まること
- [ ] `cd frontend && npm test -- --testPathPatterns='interview/(lobbyDraft|LobbyScreen|hooks|mediaPreviewGate)'`


Made with [Cursor](https://cursor.com)