### PR TITLE
fix: 面接官TTS音声がCSPで再生されない問題を修正 (#752)

### DIFF
--- a/frontend/app/interview/hooks/useInterviewSession.ts
+++ b/frontend/app/interview/hooks/useInterviewSession.ts
@@ -162,7 +162,23 @@ export function useInterviewSession({
     setAiSpeaking(true)
 
     let rafId: number | null = null
-    let routedThroughCtx = false
+
+    const cleanup = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      if (aiLevelRafRef.current !== null) {
+        cancelAnimationFrame(aiLevelRafRef.current)
+        aiLevelRafRef.current = null
+      }
+      setAiLevel(0)
+      setAiSpeaking(false)
+      URL.revokeObjectURL(url)
+      if (aiAudioRef.current === el) aiAudioRef.current = null
+      el.removeAttribute('src')
+      el.load()
+    }
 
     try {
       if (!aiAudioCtxRef.current || aiAudioCtxRef.current.state === 'closed') {
@@ -172,8 +188,7 @@ export function useInterviewSession({
       // resume を await して running 状態を確実に待つ（suspended のまま再生すると無音になる）
       await ctx.resume()
 
-      const source   = ctx.createMediaElementSource(el)
-      routedThroughCtx = true
+      const source = ctx.createMediaElementSource(el)
       const analyser = ctx.createAnalyser()
       analyser.fftSize = 512
       analyser.smoothingTimeConstant = 0.6
@@ -184,31 +199,36 @@ export function useInterviewSession({
       const trackLevel = () => {
         analyser.getByteTimeDomainData(timeData)
         let sum = 0
-        for (const v of timeData) { const n = (v - 128) / 128; sum += n * n }
+        for (const v of timeData) {
+          const n = (v - 128) / 128
+          sum += n * n
+        }
         const rms = Math.sqrt(sum / timeData.length)
         setAiLevel(Math.min(1, rms * 6))
         rafId = requestAnimationFrame(trackLevel)
       }
       rafId = requestAnimationFrame(trackLevel)
       aiLevelRafRef.current = rafId
-    } catch {
-      // AudioContext 未対応またはセキュリティポリシーで拒否された場合はリップシンク無効で続行
-      if (!routedThroughCtx) {
-        // AudioContext を経由していないので Audio 要素がデフォルト出力に直接流れる
-      }
-    }
-
-    const cleanup = () => {
-      if (rafId !== null) cancelAnimationFrame(rafId)
-      if (aiLevelRafRef.current !== null) cancelAnimationFrame(aiLevelRafRef.current)
-      aiLevelRafRef.current = null
-      setAiLevel(0)
+    } catch (err) {
+      // AudioContext 未対応時は Audio 要素のデフォルト出力にフォールバック（リップシンクなし）
+      console.warn('[Interview] AudioContext routing unavailable; playing via element output', err)
     }
 
     return new Promise<void>((resolve) => {
-      el.onended = () => { cleanup(); setAiSpeaking(false); URL.revokeObjectURL(url); resolve() }
-      el.onerror = () => { cleanup(); setAiSpeaking(false); URL.revokeObjectURL(url); resolve() }
-      el.play().catch(() => { cleanup(); setAiSpeaking(false); resolve() })
+      el.onended = () => {
+        cleanup()
+        resolve()
+      }
+      el.onerror = () => {
+        console.error('[Interview] AI audio element error', el.error)
+        cleanup()
+        resolve()
+      }
+      el.play().catch((err) => {
+        console.error('[Interview] AI audio play() failed (check CSP media-src / autoplay)', err)
+        cleanup()
+        resolve()
+      })
     })
   }
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,6 +14,8 @@ const securityHeaders = [
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' https://fonts.gstatic.com",
       "img-src 'self' data: https:",
+      // blob: URL の音声/動画再生を許可（AI面接の TTS は blob: 経由で再生。connect-src の blob: では不足）
+      "media-src 'self' blob:",
       // 開発モードでは webpack HMR の WebSocket 接続を許可
       isDev
         ? "connect-src 'self' blob: http://localhost:* https://api.openai.com ws://localhost:* wss://localhost:*"


### PR DESCRIPTION
## Summary
- Fixes https://github.com/ISCProduct/soc-ai-agent/issues/752
- CSP に `media-src 'self' blob:` を追加（面接官 TTS の `blob:` URL 再生を許可）
- `playAudioBlob` の再生失敗を console に出し、cleanup 時の `revokeObjectURL` 漏れを解消

## Test plan
- [ ] `/interview` で面接に参加し、面接官の最初の質問がスピーカーから聞こえること
- [ ] DevTools → Network/Console で `media-src` / blob 関連の CSP 違反が出ないこと
- [ ] 応答後の次の質問音声も同様に再生されること
- [ ] `curl -sI http://localhost:3000/interview` の CSP に `media-src 'self' blob:` が含まれること


Made with [Cursor](https://cursor.com)