### PR TITLE
ci: デプロイフローをdevelop→release→mainの3段階に変更

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,11 +1,17 @@
-name: Deploy Frontend & Backend to ECS (disabled)
+name: Deploy Frontend & Backend to ECS
 
 on:
+  push:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # develop -> staging (ECS on EC2) / main -> production (ECS on Fargate, 展示会時起動)
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     branches:
+      - develop
+      - release
       - main
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 - FE: `NEXT_PUBLIC_BACKEND_URL=http://localhost:8080`
 
 ## CI/CD
-- PR時: Go/FEのLint & Test。Main push時: ECR/EC2へ自動デプロイ。
+- ブランチフロー: `feature/* → develop → release → main`（各ブランチPRレビュー必須）
+- PR時(develop/release/main宛): Go/FEのLint & Test
+- push時: develop→staging(ECS on EC2)へ自動デプロイ / main→本番(ECS on Fargate)へ自動デプロイ。releaseは中間ゲート（自動デプロイなし）
 
 ## コード規約
 - **共通**: 日本語(コメント/コミット), UTF-8/LF, camelCase(Go/TS), snake_case(Py)


### PR DESCRIPTION
## Summary
- develop→release→mainの3段階デプロイフローに変更
- develop push → staging(ECS on EC2)自動デプロイ / main push → 本番(ECS on Fargate)自動デプロイ
- test.ymlのPRトリガーにdevelop/releaseを追加
- CLAUDE.mdのCI/CD記述を更新

## Note
- staging Environmentのシークレット(AWS認証情報・ECRリポジトリ名等)は未登録のため、staging Terraform適用後に設定が必要

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-deploy to staging and production is now active on push; incorrect secrets, environment protection, or branch mistakes could deploy the wrong build until staging GitHub Environment secrets are configured.
> 
> **Overview**
> **Re-enables automatic ECS deployment** and wires it to the new branch model: pushes to `develop` deploy to **staging** (GitHub `staging` environment / ECS on EC2), and pushes to `main` deploy to **production** (Fargate). The deploy workflow name no longer marks it disabled, and the deploy job picks `environment` from the ref (`main` → production, otherwise staging).
> 
> **Test CI** now runs on pull requests targeting `develop` and `release` in addition to `main`, matching the documented `feature/* → develop → release → main` gate where `release` does not auto-deploy.
> 
> `CLAUDE.md` is updated to describe this flow and when staging vs production deploys run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36391dab14a7fdcbccdf947194ecf2b9bbd0510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->