### PR TITLE
ci: developの変更をreleaseへ反映

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,11 +1,17 @@
-name: Deploy Frontend & Backend to ECS (disabled)
+name: Deploy Frontend & Backend to ECS
 
 on:
+  push:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # develop -> staging (ECS on EC2) / main -> production (ECS on Fargate, 展示会時起動)
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     branches:
+      - develop
+      - release
       - main
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 - FE: `NEXT_PUBLIC_BACKEND_URL=http://localhost:8080`
 
 ## CI/CD
-- PR時: Go/FEのLint & Test。Main push時: ECR/EC2へ自動デプロイ。
+- ブランチフロー: `feature/* → develop → release → main`（各ブランチPRレビュー必須）
+- PR時(develop/release/main宛): Go/FEのLint & Test
+- push時: develop→staging(ECS on EC2)へ自動デプロイ / main→本番(ECS on Fargate)へ自動デプロイ。releaseは中間ゲート（自動デプロイなし）
 
 ## コード規約
 - **共通**: 日本語(コメント/コミット), UTF-8/LF, camelCase(Go/TS), snake_case(Py)


### PR DESCRIPTION
デプロイフロー変更(#782)をreleaseへ反映

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enabling branch-triggered deploys to staging and production increases operational impact if workflows or secrets are misconfigured; changes are limited to GitHub Actions and docs, not application code.
> 
> **Overview**
> **Re-enables automatic ECS deployment** that was previously disabled, and wires it to the `develop` / `main` branch model from the deploy-flow change (#782).
> 
> The **Deploy** workflow now runs on pushes to `develop` and `main` (still supports manual `workflow_dispatch`). The deploy job selects the GitHub **environment** from the branch: `main` → `production`, anything else on that trigger → `staging`, with comments documenting staging on ECS/EC2 and production on ECS/Fargate.
> 
> The **Test** workflow now runs on pull requests targeting **`develop`** and **`release`** in addition to `main`, so the gate branches match the documented flow.
> 
> **`CLAUDE.md`** is updated to describe `feature/* → develop → release → main`, PR testing on develop/release/main, and that only `develop` and `main` pushes auto-deploy (release stays a gate with no deploy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7b4a4616c318085fb89600eee4d30fb8ac2ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->