### PR TITLE
ci: releaseの変更をmainへ反映

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,11 +1,17 @@
-name: Deploy Frontend & Backend to ECS (disabled)
+name: Deploy Frontend & Backend to ECS
 
 on:
+  push:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # develop -> staging (ECS on EC2) / main -> production (ECS on Fargate, 展示会時起動)
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     branches:
+      - develop
+      - release
       - main
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ SOC AI Agent: 採用支援SaaS (Go + Next.js + Python RAG)
 - FE: `NEXT_PUBLIC_BACKEND_URL=http://localhost:8080`
 
 ## CI/CD
-- PR時: Go/FEのLint & Test。Main push時: ECR/EC2へ自動デプロイ。
+- ブランチフロー: `feature/* → develop → release → main`（各ブランチPRレビュー必須）
+- PR時(develop/release/main宛): Go/FEのLint & Test
+- push時: develop→staging(ECS on EC2)へ自動デプロイ / main→本番(ECS on Fargate)へ自動デプロイ。releaseは中間ゲート（自動デプロイなし）
 
 ## コード規約
 - **共通**: 日本語(コメント/コミット), UTF-8/LF, camelCase(Go/TS), snake_case(Py)


### PR DESCRIPTION
デプロイフロー変更(#782)をmainへ反映。以降のリリースはdevelop→release→mainを経由します。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> `main` への push で本番 ECS への自動デプロイが有効になるため、誤マージや設定ミスが即本番反映されるリスクがあります。
> 
> **Overview**
> **ECS デプロイを再有効化**し、`develop` / `main` への **push で自動実行**するように変更します。ジョブの GitHub **environment** は `main` → `production`、それ以外（`develop`）→ `staging` に切り替え、コメント上は staging は ECS on EC2、本番は ECS on Fargate 向けです。
> 
> **Test ワークフロー**の PR 対象ブランチに **`develop` と `release` を追加**し、`feature/* → develop → release → main` のゲートに合わせます。`release` にはデプロイは付かず、PR 時の Lint/Test のみが走る想定です。
> 
> **`CLAUDE.md`** の CI/CD 節を、上記ブランチフロー・PR/push 時の挙動と一致するよう更新しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5fd3f25b67032f372b079feea9fceccce8b83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * `develop` および `main` ブランチへの変更時に、環境に応じたデプロイが自動実行されるようになりました。
  * 必要に応じて手動でデプロイを開始できる機能を維持しています。
  * `develop` と `release` 向けのプルリクエストで、品質チェックが実行されるようになりました。

* **ドキュメント**
  * ブランチ運用、テスト、ステージング環境・本番環境へのデプロイ方針を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->