### PR TITLE
ci: mainへのpushでもTestを実行する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
## Summary
- test.ymlのpushトリガーから branches-ignore: main を削除
- 理由: 管理者権限でブランチ保護をバイパスしてmainへ直接push(cherry-pick)した際、PRを経由しないためTestが一度も走らないことが判明した
- push時は全ブランチでTestが走るようにし、バイパス経路でも安全網を確保する

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only trigger change that adds test runs on `main` pushes; no application or security logic is modified.
> 
> **Overview**
> **Removes `branches-ignore: main` from the `push` trigger** in `.github/workflows/test.yml`, so the Test workflow runs on **every branch push**, including `main`.
> 
> This closes a gap where **direct pushes to `main`** (e.g. admin cherry-picks that bypass branch protection and skip opening a PR) never triggered the suite. **Pull request triggers are unchanged** (`develop`, `release`, `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f925fe67224a9a083f36277eeb3a6f8066e238f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->