### PR TITLE
chore: .backlog.env をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.local
 .env.production
 .env.*.local
+.backlog.env
 
 # Terraform（シークレットを含む可能性があるため管理外）
 *.tfvars


### PR DESCRIPTION
## Summary
- Backlog連携用の秘匿情報ファイル `.backlog.env` が誤ってコミットされないよう `.gitignore` に追加

## Test plan
- N/A (gitignoreのみ)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` entry with no runtime or security logic changes.
> 
> **Overview**
> Adds **`.backlog.env`** to the **Environment files** block in `.gitignore`, alongside existing `.env` patterns, so Backlog integration secrets are not tracked or committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc457bd2fad964fba93004ef66ec28db9e71e9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->