### PR TITLE
refactor: ログインページのLoginContent分離とSpeedInsights導入

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { MuiProvider } from '@/components/mui-provider'
 import { Analytics } from '@vercel/analytics/react'
+// Vercelでホスティングされるまで実データは収集されない(AWS ECSデプロイのため現状は未計測)
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 export const metadata: Metadata = {
   title: 'IT企業エージェント',
@@ -23,6 +25,7 @@ export default function RootLayout({
           {children}
         </MuiProvider>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   )

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,36 +1,6 @@
-'use client'
-
-import { Suspense, useEffect } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { LoginPage } from '@/components/login-page'
-import { authService, AuthResponse } from '@/lib/auth'
-import { isLoginRegisterTab } from '@/lib/guest-limits'
+import { Suspense } from 'react'
+import { LoginContent } from '@/components/login-content'
 import { PageLoading } from '@/components/common/PageLoading'
-
-function LoginContent() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const wantRegister = isLoginRegisterTab(searchParams.get('tab'))
-
-  useEffect(() => {
-    const storedUser = authService.getStoredUser()
-    if (!storedUser) return
-
-    // ゲストが登録CTAから来た場合はセッションをクリアして登録画面を表示する
-    if (wantRegister && storedUser.is_guest) {
-      authService.logout()
-      return
-    }
-
-    router.replace('/')
-  }, [router, wantRegister])
-
-  const handleAuthSuccess = (_authResponse: AuthResponse) => {
-    router.push('/')
-  }
-
-  return <LoginPage onAuthSuccess={handleAuthSuccess} initialTab={wantRegister ? 1 : 0} />
-}
 
 export default function Login() {
   return (

--- a/frontend/components/login-content.tsx
+++ b/frontend/components/login-content.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { LoginPage } from '@/components/login-page'
+import { authService, AuthResponse } from '@/lib/auth'
+import { isLoginRegisterTab } from '@/lib/guest-limits'
+
+export function LoginContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const wantRegister = isLoginRegisterTab(searchParams.get('tab'))
+
+  useEffect(() => {
+    const storedUser = authService.getStoredUser()
+    if (!storedUser) return
+
+    // ゲストが登録CTAから来た場合はセッションをクリアして登録画面を表示する
+    if (wantRegister && storedUser.is_guest) {
+      authService.logout()
+      return
+    }
+
+    router.replace('/')
+  }, [router, wantRegister])
+
+  const handleAuthSuccess = (_authResponse: AuthResponse) => {
+    router.push('/')
+  }
+
+  return <LoginPage onAuthSuccess={handleAuthSuccess} initialTab={wantRegister ? 1 : 0} />
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-slot": "^1.1.0",
         "@vercel/analytics": "^1.3.1",
+        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.0",
         "lucide-react": "^0.454.0",
         "next": "^16.0.4",
@@ -4570,6 +4571,44 @@
           "optional": true
         },
         "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
           "optional": true
         },
         "react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.1.0",
     "@vercel/analytics": "^1.3.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.0",
     "lucide-react": "^0.454.0",
     "next": "^16.0.4",


### PR DESCRIPTION
## Summary
- `frontend/app/login/page.tsx` の `LoginContent` を `frontend/components/login-content.tsx` に分離
- `@vercel/speed-insights` を導入(Vercelホスティング移行後の計測用。現状のAWS ECS配信では未計測)

## Test plan
- [ ] `npm run lint`
- [ ] ログイン画面が従来通り表示・動作すること

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves login/auth flows; Speed Insights is additive telemetry with no auth or data-path changes.
> 
> **Overview**
> **Login route structure:** Client-side login behavior (`useRouter`, `useSearchParams`, guest logout on register tab, redirect when already logged in) moves from `app/login/page.tsx` into a new `components/login-content.tsx` client module. The login page file becomes a thin server component that only wraps `LoginContent` in `Suspense` with the existing loading fallback—behavior is unchanged, but the App Router client boundary is clearer.
> 
> **Performance telemetry:** Adds `@vercel/speed-insights` and renders `<SpeedInsights />` in the root layout next to existing Vercel Analytics, with a note that real data only applies once hosted on Vercel (not on current AWS ECS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be870d49a833c62f348d6517faac0abb0c52b260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->