### PR TITLE
feat: #809 反映後Playwrightスモーク（プラン1: staging基盤）

### DIFF
--- a/.github/workflows/deploy-smoke.yml
+++ b/.github/workflows/deploy-smoke.yml
@@ -1,0 +1,56 @@
+name: Deploy Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '対象環境'
+        required: true
+        type: choice
+        options:
+          - staging
+        default: staging
+
+concurrency:
+  group: deploy-smoke-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Playwright Smoke (${{ github.event.inputs.environment }})
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ./frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: ./frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npx playwright test --config=playwright.smoke.config.ts
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: ${{ vars.STAGING_BASE_URL || 'https://stg.shukatsu-ai.jp' }}
+          PLAYWRIGHT_API_BASE_URL: ${{ vars.STAGING_API_BASE_URL || 'https://api-stg.shukatsu-ai.jp' }}
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.event.inputs.environment }}
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/automation/deploy-smoke/README.md
+++ b/automation/deploy-smoke/README.md
@@ -1,0 +1,49 @@
+# deploy-smoke（反映後スモークテスト）
+
+反映後に人手で「動作チェックお願いします」と依頼する代わりに、Playwrightで実環境向けの非破壊スモークを自動実行する。親Issue: #808 / プラン分割: #809
+
+現在実装済みなのは **プラン1（staging スモーク基盤）** のみ。Discord通知（プラン2）、デプロイ連携・production対応（プラン3）は未実装。
+
+## 実行方法
+
+GitHub Actions の `Deploy Smoke Test`（`.github/workflows/deploy-smoke.yml`）を `workflow_dispatch` で手動起動する。`environment` に `staging` を選択する（現状はこれのみ）。
+
+```
+gh workflow run deploy-smoke.yml -f environment=staging
+```
+
+## 対象URL
+
+| 環境 | フロントエンド | バックエンドAPI |
+|------|----------------|------------------|
+| staging | `https://stg.shukatsu-ai.jp` | `https://api-stg.shukatsu-ai.jp` |
+
+`vars.STAGING_BASE_URL` / `vars.STAGING_API_BASE_URL`（リポジトリ Variables）で上書き可能。未設定時は上表のデフォルト値を使う。
+
+## チェック内容（非破壊のみ）
+
+`frontend/e2e/smoke/staging.spec.ts` 参照。
+
+- トップページへの到達
+- ログイン画面の表示
+- バックエンド `/healthz` の疎通
+- フロントエンド `/api/healthz` の疎通
+
+データの作成・削除を伴う操作は行わない（Out of scope: #808）。
+
+## ローカルでの実行
+
+```bash
+cd frontend
+PLAYWRIGHT_BASE_URL=https://stg.shukatsu-ai.jp \
+PLAYWRIGHT_API_BASE_URL=https://api-stg.shukatsu-ai.jp \
+npx playwright test --config=playwright.smoke.config.ts
+```
+
+## 既存E2Eとの違い
+
+`frontend/playwright.config.ts`（`.github/workflows/test.yml` の `e2e-frontend`）はlocalhostで `webServer` を起動し、APIをモックする単体〜結合レベルのE2E。今回の `playwright.smoke.config.ts` は実際に反映された環境（実バックエンド）に対して疎通確認するためのもので、完全に別設定・別ディレクトリ（`e2e/smoke/`）に分離している。既存E2Eには影響しない。
+
+## 失敗時
+
+`playwright-report` がArtifactとして保存される（保持7日）。Discordへの結果通知は未実装（プラン2で対応予定）。

--- a/frontend/e2e/smoke/staging.spec.ts
+++ b/frontend/e2e/smoke/staging.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+
+// 反映後スモーク（#809 プラン1）。実バックエンドに対して実行するため、
+// データ作成・削除を伴う操作は行わない（Out of scope: #808）。
+const apiBaseURL = process.env.PLAYWRIGHT_API_BASE_URL
+if (!apiBaseURL) {
+  throw new Error('PLAYWRIGHT_API_BASE_URL is required for smoke tests')
+}
+
+test.describe('反映後スモーク', () => {
+  test('トップページに到達できる', async ({ page }) => {
+    const response = await page.goto('/')
+    expect(response?.ok()).toBeTruthy()
+  })
+
+  test('ログイン画面が表示される', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.getByRole('tab', { name: 'ログイン' })).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+  })
+
+  test('バックエンドAPIのヘルスチェックが疎通する', async ({ request }) => {
+    const response = await request.get(`${apiBaseURL}/healthz`)
+    expect(response.ok()).toBeTruthy()
+  })
+
+  test('フロントエンドのヘルスチェックが疎通する', async ({ request, baseURL }) => {
+    const response = await request.get(`${baseURL}/api/healthz`)
+    expect(response.ok()).toBeTruthy()
+  })
+})

--- a/frontend/playwright.smoke.config.ts
+++ b/frontend/playwright.smoke.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// 反映後の実環境（staging/production）に対する非破壊スモークテスト用設定。
+// playwright.config.ts（localhost向け・webServer起動）とは完全に分離する。
+const baseURL = process.env.PLAYWRIGHT_BASE_URL
+if (!baseURL) {
+  throw new Error('PLAYWRIGHT_BASE_URL is required for smoke tests')
+}
+
+export default defineConfig({
+  testDir: './e2e/smoke',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 15000,
+    navigationTimeout: 20000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary
- #809 プラン1（staging スモーク基盤）を実装
- `frontend/playwright.smoke.config.ts` を新設し、実環境（staging）向けの非破壊スモークを既存E2E（localhost向け）と完全分離
- `frontend/e2e/smoke/staging.spec.ts`: トップ到達・ログイン画面表示・backend/frontend healthz疎通
- `.github/workflows/deploy-smoke.yml`: `workflow_dispatch`でstaging向けに実行、失敗時`playwright-report`をartifact保存
- `automation/deploy-smoke/README.md`: 実行手順・Secrets/Variables方針

プラン2（Discord通知）・プラン3（デプロイ連携/production対応）は本PRのスコープ外（#809で後続対応）。

Closes #809 (プラン1のみ)

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx playwright test --config=playwright.smoke.config.ts --list` — 4件のスモークテストを正しく認識
- [x] `npx playwright test --list`（既存config）— 21件のまま変化なし（新規スモークが混入しないことを確認）
- [x] `npm run lint` — 新規ファイルに起因するエラー/警告なし
- [ ] Actionsから`workflow_dispatch`でstaging向けに実際に実行して疎通確認（マージ後）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only additions with non-destructive health/UI checks; no changes to app runtime or auth logic.
> 
> **Overview**
> Adds a **post-deploy smoke path** for staging so teams can verify a live deployment without manual “please smoke test” requests.
> 
> A dedicated **`playwright.smoke.config.ts`** and **`e2e/smoke/`** suite run **read-only** checks against real staging URLs (top page, login UI, backend `/healthz`, frontend `/api/healthz`), kept separate from localhost E2E with mocked APIs.
> 
> A new **`Deploy Smoke Test`** GitHub Action runs on **`workflow_dispatch`** (staging only for now), sets `PLAYWRIGHT_BASE_URL` / `PLAYWRIGHT_API_BASE_URL` from repo variables with staging defaults, and uploads **`playwright-report`** on failure. **`automation/deploy-smoke/README.md`** documents how to run it locally and in Actions.
> 
> Discord notifications and deploy-hook / production support are explicitly out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5ee600ebba3e7a4c106d5d2923a7d9b23dacb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->