### PR TITLE
fix/feat: Backlog↔GitHub課題ステータス同期を修正・拡張

### DIFF
--- a/.github/workflows/backlog-to-github-issue.yml
+++ b/.github/workflows/backlog-to-github-issue.yml
@@ -116,7 +116,19 @@ jobs:
               bl_status_id = issue["status"]["id"]
 
               if "GitHub Issue:" in bl_desc:
-                  print(f"  スキップ（GitHub 起源）: {bl_key}", flush=True)
+                  # GitHub起源の課題はタイトル/本文を書き換えるとループするためスキップするが、
+                  # Backlog側で直接ステータス変更された場合に状態(open/closed)だけは反映する。
+                  existing_gh = gh_search_issue(bl_key)
+                  if existing_gh is None:
+                      print(f"  スキップ（GitHub 起源、対応Issue未検出）: {bl_key}", flush=True)
+                      continue
+                  gh_num = existing_gh["number"]
+                  new_state = "closed" if bl_status_id in CLOSED_STATUS_IDS else "open"
+                  if existing_gh["state"] != new_state:
+                      gh_request("PATCH", f"/repos/{GH_REPO}/issues/{gh_num}", {"state": new_state})
+                      print(f"  GitHub Issue の状態を同期しました（GitHub 起源）: #{gh_num} ← {bl_key} (state: {new_state})", flush=True)
+                  else:
+                      print(f"  スキップ（GitHub 起源、状態変更なし）: {bl_key}", flush=True)
                   continue
 
               gh_title = f"[{bl_key}] {bl_summary}"


### PR DESCRIPTION
## Summary
### 1. Backlog→GitHub状態同期の抜け漏れ修正
- `backlog-to-github-issue.yml` は、GitHub起源のBacklog課題（`GitHub Issue:` マーカーを含む説明文）を無条件にスキップしており、Backlog側で直接ステータスを完了にしてもGitHub Issueが永久にcloseされなかった
- タイトル/本文の書き換え（ループの原因）はスキップしたまま、状態（open/closed）のみBacklogのステータスに追従させるよう修正
- 直近の全スケジュール実行ログで、SOCAIAGENT-161 / 124 / 62 / 150（GitHub Issue #819 / #747 / #617 / #792）が毎回「GitHub起源のためスキップ」となっていることを確認済み
- ループ再発なし: 本修正でcloseされたGitHub Issueは `github-issue-to-backlog.yml` 側で冪等なBacklogステータス更新（既にstatusId=4）が走るだけで、次回実行では状態一致のため何もPATCHされず収束する

### 2. PRマージ先ブランチに応じたBacklogステータス切替
- `pr-to-backlog.yml` は、マージされたPRのBacklog課題を常に固定で「完了」にしていたが、`feature/* → develop → release → main` のブランチフローに合わせて分岐させた
  - develop へマージ: 「ステージング環境反映」
  - release へマージ: 「リリース待ち」
  - main    へマージ: 「完了」
- 「ステージング環境反映」「リリース待ち」は名前からBacklogのステータスIDを動的解決する（スペースごとにIDが異なるカスタムステータスのため）。**Backlog側でこの2つを事前にカスタムステータスとして作成しておく必要がある**（未作成の場合はワークフローがエラーで停止し、既存ステータス一覧をログに出力する）
- release/main へのプロモーションPR（実際の運用を確認したところ、develop→release→mainは複数feature PRを束ねた「Release」PRでマージされる形）は、PR本体のBacklogキーだけでなく各コミットが参照する元PR番号からもBacklogキーを解決し、含まれる全課題のステータスをまとめて更新する

## 前提条件（マージ前に確認）
- [ ] Backlogプロジェクトの管理画面で、カスタムステータス「ステージング環境反映」「リリース待ち」を作成済みであること（名称は完全一致が必要）

## Test plan
- [ ] マージ後、次回スケジュール実行（15分毎）のログで対象4件が `GitHub Issue の状態を同期しました` と出力されることを確認
- [ ] 該当するGitHub Issue（#819, #747, #617, #792）がBacklog側のステータスに応じて実際にcloseされることを確認
- [ ] developへの通常PRマージで、対応するBacklog課題が「ステージング環境反映」になることを確認
- [ ] release→mainのプロモーションPRマージで、束ねられた複数のBacklog課題がすべて「完了」になることを確認