### PR TITLE
fix: staging EC2のディスク枯渇によるデプロイ後障害を防止する

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -198,9 +198,14 @@ jobs:
               chmod +x /tmp/edge-sync/ensure-edge-compose.sh
               /tmp/edge-sync/ensure-edge-compose.sh /opt/app/docker-compose.yml
               cd /opt/app
-              docker image prune -af
+              df -h /
+              # image prune だけでは未使用ビルドキャッシュ・停止コンテナ等が残り続け
+              # ディスク枯渇(no space left on device)を招くため system prune に強化。
+              # named volume(chroma_data)は --volumes を付けない限り対象外で消えない。
+              docker system prune -af
               docker compose pull
               docker compose up -d
+              df -h /
             '
 
       - name: Revoke runner IP for SSH

--- a/infra/staging/ensure-edge-compose.sh
+++ b/infra/staging/ensure-edge-compose.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# /opt/app/docker-compose.yml に edge nginx を idempotent に追加する。
-# ponytail: user_data 再実行なしで既存 staging EC2 を edge 構成へ寄せる。
+# /opt/app/docker-compose.yml に edge nginx とログサイズ上限を idempotent に追加する。
+# ponytail: user_data 再実行なしで既存 staging EC2 を最新構成へ寄せる。
 set -euo pipefail
 
 COMPOSE="${1:-/opt/app/docker-compose.yml}"
@@ -11,30 +11,21 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text()
+changed = False
 
-if "edge:" in text:
-    print("edge service already present")
-    sys.exit(0)
-
-text = text.replace(
-    """  frontend:
-    image:""",
-    """  frontend:
-    image:""",
-)
-
-# host 公開 3000 を internal expose に差し替え
-text = text.replace(
-    """    ports:
+if "edge:" not in text:
+    # host 公開 3000 を internal expose に差し替え
+    text = text.replace(
+        """    ports:
       - "3000:3000"
 """,
-    """    expose:
+        """    expose:
       - "3000"
 """,
-    1,
-)
+        1,
+    )
 
-edge_block = """
+    edge_block = """
   edge:
     image: nginx:1.27-alpine
     restart: always
@@ -47,10 +38,36 @@ edge_block = """
       - frontend
 """
 
-marker = "  rag-review:"
-if marker not in text:
-    sys.exit("unexpected docker-compose.yml shape")
-text = text.replace(marker, edge_block + marker, 1)
-path.write_text(text)
-print("patched edge nginx into docker-compose.yml")
+    marker = "  rag-review:"
+    if marker not in text:
+        sys.exit("unexpected docker-compose.yml shape")
+    text = text.replace(marker, edge_block + marker, 1)
+    print("patched edge nginx into docker-compose.yml")
+    changed = True
+else:
+    print("edge service already present")
+
+# ログドライバのデフォルト(json-file/無制限)によるディスク逼迫(#no space left on device)防止。
+# 各サービス直下の "restart: always" 行の直後に logging 参照を差し込む。
+if "x-logging:" not in text:
+    text = (
+        "x-logging: &default-logging\n"
+        "  driver: json-file\n"
+        "  options:\n"
+        '    max-size: "10m"\n'
+        '    max-file: "3"\n\n'
+    ) + text
+    text = text.replace(
+        "    restart: always\n",
+        "    restart: always\n    logging: *default-logging\n",
+    )
+    print("patched log size limits into docker-compose.yml")
+    changed = True
+else:
+    print("log size limits already present")
+
+if changed:
+    path.write_text(text)
+else:
+    print("no changes needed")
 PY

--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -70,11 +70,18 @@ EOF
 chmod 600 /opt/app/.env
 
 cat > /opt/app/docker-compose.yml <<EOF
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   backend:
     image: ${backend_image}
     restart: always
     env_file: .env
+    logging: *default-logging
     ports:
       - "8080:8080"
     depends_on:
@@ -83,11 +90,13 @@ services:
     image: ${frontend_image}
     restart: always
     env_file: .env
+    logging: *default-logging
     expose:
       - "3000"
   edge:
     image: nginx:1.27-alpine
     restart: always
+    logging: *default-logging
     ports:
       - "3000:80"
     volumes:
@@ -99,11 +108,13 @@ services:
     image: ${rag_image}
     restart: always
     env_file: .env
+    logging: *default-logging
     depends_on:
       - chroma
   chroma:
     image: chromadb/chroma:0.6.3
     restart: always
+    logging: *default-logging
     volumes:
       - chroma_data:/chroma/chroma
     environment:


### PR DESCRIPTION
## Summary
直近2回のstagingデプロイ（PR #820, #821）で、SSHデプロイステップのログに以下のエラーが出ていた:

```
failed to extract layer ... write ... no space left on device
```

イメージ層の展開がディスク枯渇で失敗した状態のまま `docker compose up -d` が実行され、ジョブ自体は成功扱いになるが、実際のアプリは壊れた状態で起動し、後続の Playwright スモークテスト（トップページ／ログイン画面／バックエンド・フロントエンド両ヘルスチェック）が全滅していた（デプロイ完了後、数分経過してもフロントエンド503・バックエンド502のまま復旧せず）。

## 原因
- コンテナのログドライバがデフォルト(json-file、サイズ上限なし)で、`restart: always` の常駐コンテナが出すログでディスクが際限なく肥大化しうる
- デプロイ時のクリーンアップが `docker image prune -af` のみで、未使用ビルドキャッシュ等のディスク消費源が残り続ける

## 対応
- `docker-compose.yml` を生成する2箇所（新規EC2起動時の `app_user_data.sh.tftpl`、既存EC2への idempotent パッチである `ensure-edge-compose.sh`）に、全サービス共通のログサイズ上限（`max-size: "10m"`, `max-file: "3"`）を追加
- デプロイスクリプトの prune を `docker image prune -af` → `docker system prune -af` に強化（named volume の `chroma_data` は `--volumes` を付けないため対象外、データは保持される）
- デプロイ前後に `df -h /` を出力し、次回以降のディスク逼迫の切り分けを容易にする

`ensure-edge-compose.sh` は稼働中インスタンスへ再デプロイのたびに idempotent 適用されるため、次回のstagingデプロイで既存インスタンスにもログ上限が反映される想定（ローカルでダミーcompose fileに対して新規/edge済み/両方適用済みの3パターンを実行し、冪等性とYAML妥当性を確認済み）。

## 既知の制約（このPRでは対応しない）
- **現在既にディスクが逼迫している稼働中インスタンスの復旧は別途手動対応が必要**（このPRは再発防止のみ。ログ上限もsystem pruneも、既に埋まっているディスクを即座には空けない）
- EBSボリューム拡張（現状20GB）はスコープ外（ユーザー判断によりworkflow/user_data改善のみに限定）

## Test plan
- [ ] マージ後の次回staging再デプロイで、`Deploy via SSH` ステップのログに `df -h /` の出力が2回（system prune前後で空き容量の変化）表示されることを確認
- [ ] 上記デプロイ後、Playwrightスモーク（4件）が復旧することを確認
- [ ] `docker compose config` 等でnamed volume `chroma_data` のデータが system prune 後も保持されていることを確認