### PR TITLE
fix: マッチング結果ページの部分データ取得失敗をユーザーに通知する

### DIFF
--- a/frontend/app/results/components/ResultsListView.tsx
+++ b/frontend/app/results/components/ResultsListView.tsx
@@ -39,6 +39,8 @@ export interface ResultsListViewProps {
   isProvisional: boolean
   analysisScores: AnalysisScores | null
   scoreComment: string
+  analysisError: string | null
+  onRetryAnalysis: () => void
   jobSuitabilityComment: string
   suggestedRoles: SuggestedRole[]
   emailSending: boolean
@@ -64,6 +66,8 @@ export default function ResultsListView({
   isProvisional,
   analysisScores,
   scoreComment,
+  analysisError,
+  onRetryAnalysis,
   jobSuitabilityComment,
   suggestedRoles,
   emailSending,
@@ -149,6 +153,21 @@ export default function ResultsListView({
         backgroundColor: '#fafafa',
       }}>
         <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
+          {/* 分析データの部分取得失敗（サイレント失敗させず明示する） */}
+          {analysisError && (
+            <Alert
+              severity="warning"
+              sx={{ mb: 3 }}
+              action={
+                <Button color="inherit" size="small" startIcon={<Refresh />} onClick={onRetryAnalysis}>
+                  再読み込み
+                </Button>
+              }
+            >
+              {analysisError}（4分析スコア・向いている職種は表示されません）
+            </Alert>
+          )}
+
           {/* 4分析スコアと総合コメント */}
           {(scoreComment || analysisScores) && (
             <Card elevation={2} sx={{ mb: 3, border: '2px solid', borderColor: 'primary.light', backgroundColor: '#f0f4ff' }}>

--- a/frontend/app/results/hooks/useResultsData.ts
+++ b/frontend/app/results/hooks/useResultsData.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, type MouseEvent } from 'react'
+import { useState, useEffect, useCallback, type MouseEvent } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { sendAnalysisReport } from '@/lib/api'
 import { fetchWithTimeout } from '@/lib/fetch-timeout'
@@ -43,6 +43,7 @@ export function useResultsData() {
   const [suggestedRoles, setSuggestedRoles] = useState<SuggestedRole[]>([])
   const [scoreComment, setScoreComment] = useState('')
   const [analysisScores, setAnalysisScores] = useState<AnalysisScores | null>(null)
+  const [analysisError, setAnalysisError] = useState<string | null>(null)
   const [selectedCompany, setSelectedCompany] = useState<Company | null>(null)
   const [detailTab, setDetailTab] = useState(0)
   const [relations, setRelations] = useState<CapitalRelation[]>([])
@@ -80,6 +81,32 @@ export function useResultsData() {
     router.replace('/')
   }, [mounted, userId, sessionId, router])
 
+  const fetchAnalysis = useCallback(async () => {
+    if (!sessionId) return
+    setAnalysisError(null)
+    try {
+      const res = await fetch(`/api/chat/analysis?session_id=${sessionId}`, {
+        headers: authService.getUserFetchHeaders(),
+      })
+      if (!res.ok) throw new Error('分析データの取得に失敗しました')
+      const data = await res.json()
+      if (data?.job_suitability_comment) {
+        setJobSuitabilityComment(data.job_suitability_comment)
+      }
+      if (data?.suggested_roles) {
+        setSuggestedRoles(data.suggested_roles)
+      }
+      if (data?.score_comment) {
+        setScoreComment(data.score_comment)
+      }
+      if (data?.scores) {
+        setAnalysisScores(mapAnalysisScores(data.scores))
+      }
+    } catch {
+      setAnalysisError('分析データの取得に失敗しました')
+    }
+  }, [sessionId])
+
   useEffect(() => {
     if (!mounted || !userId || !sessionId) {
       return
@@ -90,24 +117,7 @@ export function useResultsData() {
         setLoading(true)
         // 再フェッチ時に前回の error が残ると一覧が描画されない（Bugbot）
         setError(null)
-        // 職種適性コメントを取得
-        fetch(`/api/chat/analysis?session_id=${sessionId}`, { headers: authService.getUserFetchHeaders() })
-          .then((r) => (r.ok ? r.json() : null))
-          .then((data) => {
-            if (data?.job_suitability_comment) {
-              setJobSuitabilityComment(data.job_suitability_comment)
-            }
-            if (data?.suggested_roles) {
-              setSuggestedRoles(data.suggested_roles)
-            }
-            if (data?.score_comment) {
-              setScoreComment(data.score_comment)
-            }
-            if (data?.scores) {
-              setAnalysisScores(mapAnalysisScores(data.scores))
-            }
-          })
-          .catch(() => { /* サイレント失敗 */ })
+        void fetchAnalysis()
 
         const response = await fetchWithTimeout(`/api/chat/recommendations?session_id=${sessionId}&limit=10`, {
           headers: authService.getUserFetchHeaders(),
@@ -148,7 +158,7 @@ export function useResultsData() {
     }
 
     fetchCompanies()
-  }, [mounted, userId, sessionId])
+  }, [mounted, userId, sessionId, fetchAnalysis])
 
   // 企業詳細を開いたときに関係図データを取得
   useEffect(() => {
@@ -299,6 +309,8 @@ export function useResultsData() {
     suggestedRoles,
     scoreComment,
     analysisScores,
+    analysisError,
+    handleRetryAnalysis: fetchAnalysis,
     selectedCompany,
     setSelectedCompany,
     detailTab,

--- a/frontend/app/results/page.tsx
+++ b/frontend/app/results/page.tsx
@@ -39,6 +39,8 @@ function ResultsContent() {
     suggestedRoles,
     scoreComment,
     analysisScores,
+    analysisError,
+    handleRetryAnalysis,
     selectedCompany,
     setSelectedCompany,
     detailTab,
@@ -105,6 +107,8 @@ function ResultsContent() {
       isProvisional={isProvisional}
       analysisScores={analysisScores}
       scoreComment={scoreComment}
+      analysisError={analysisError}
+      onRetryAnalysis={handleRetryAnalysis}
       jobSuitabilityComment={jobSuitabilityComment}
       suggestedRoles={suggestedRoles}
       emailSending={emailSending}

--- a/frontend/tests/app/results/ResultsListView.test.tsx
+++ b/frontend/tests/app/results/ResultsListView.test.tsx
@@ -30,6 +30,8 @@ describe('ResultsListView', () => {
         isProvisional={false}
         analysisScores={null}
         scoreComment=""
+        analysisError={null}
+        onRetryAnalysis={noop}
         jobSuitabilityComment=""
         suggestedRoles={[]}
         emailSending={false}
@@ -70,5 +72,19 @@ describe('ResultsListView', () => {
   it('暫定評価チップを表示する', () => {
     renderList({ isProvisional: true })
     expect(screen.getByText('暫定評価')).toBeInTheDocument()
+  })
+
+  it('分析データ取得失敗時に警告と再読み込みボタンを表示する', () => {
+    const onRetryAnalysis = jest.fn()
+    renderList({ analysisError: '分析データの取得に失敗しました', onRetryAnalysis })
+
+    expect(screen.getByText(/分析データの取得に失敗しました/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '再読み込み' }))
+    expect(onRetryAnalysis).toHaveBeenCalledTimes(1)
+  })
+
+  it('分析エラーがない場合は警告を表示しない', () => {
+    renderList()
+    expect(screen.queryByRole('button', { name: '再読み込み' })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
SOCAIAGENT-36 / #565 対応。

`/results` の職種適性コメント・4分析スコア取得（`/api/chat/analysis`）が失敗すると `.catch(() => {})` で握りつぶされ、該当セクション（4分析スコア・向いている職種）が理由もなく非表示になっていた。企業一覧自体は表示されるため、ユーザーからは「分析完了」に見えるが説明・スコアだけ欠落する状態だった。

なお、Issue にあったもう1つの症状（お気に入り操作の失敗が無通知）は `useResultsData.ts` の `handleToggleFavorite` で既に Snackbar 表示済みだったため対象外（別PRで対応済みと思われる）。

## 変更内容
- `analysisError` 状態を追加し、分析データ取得（`fetch('/api/chat/analysis', ...)`）を `fetchAnalysis` として切り出し
- 失敗時は `analysisError` をセットし、`ResultsListView` に警告Alert（再読み込みボタン付き）を表示
- 成功時は従来通りスコア・コメントを表示（回帰なし）
- 再読み込みボタンから `fetchAnalysis` を再実行可能に

## Test plan
- [x] `npx jest tests/app/results` — 25件全て通過（新規2件含む）
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint app/results/...` — エラーなし
- [ ] 実環境で `/api/chat/analysis` を意図的に失敗させ、警告表示と再読み込みボタンの動作を確認