### PR TITLE
fix: stagingのディスク不足とbackendポート不一致を防ぐ

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -183,6 +183,7 @@ jobs:
           host: ${{ steps.instance.outputs.ip }}
           username: ubuntu
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          script_stop: true
           script: |
             set -e
             sudo bash -c '
@@ -199,13 +200,20 @@ jobs:
               /tmp/edge-sync/ensure-edge-compose.sh /opt/app/docker-compose.yml
               cd /opt/app
               df -h /
-              # image prune だけでは未使用ビルドキャッシュ・停止コンテナ等が残り続け
-              # ディスク枯渇(no space left on device)を招くため system prune に強化。
-              # named volume(chroma_data)は --volumes を付けない限り対象外で消えない。
+              # 稼働中イメージは prune できない。先に down してから空ける。
+              # named volume(chroma_data)は --volumes を付けない限り残る。
+              docker compose down --remove-orphans || true
               docker system prune -af
               docker compose pull
               docker compose up -d
               df -h /
+              for s in frontend backend edge; do
+                docker compose ps --status running --services | grep -qx "$s" || {
+                  echo "service $s is not running" >&2
+                  docker compose ps -a
+                  exit 1
+                }
+              done
             '
 
       - name: Revoke runner IP for SSH

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -414,10 +414,6 @@ func main() {
 
 	// サーバー起動
 	port := cfg.ServerPort
-	if port == "" {
-		port = "80"
-	}
-
 	slog.Info("Starting server", "port", port)
 	if err := e.Start(":" + port); err != nil {
 		log.Fatalf("Server failed: %v", err)

--- a/Backend/internal/config/config.go
+++ b/Backend/internal/config/config.go
@@ -72,7 +72,7 @@ func LoadConfig() (*Config, error) {
 		DBHost:           os.Getenv("DB_HOST"),
 		DBPort:           os.Getenv("DB_PORT"),
 		DBName:           os.Getenv("DB_NAME"),
-		ServerPort:       get("SERVER_PORT", "80"),
+		ServerPort:       get("SERVER_PORT", "8080"),
 		GBizInfoBaseURL:  get("GBIZINFO_BASE_URL", ""),
 		GBizInfoToken:    getFirst("GBIZINFO_API_KEY", "GBIZINFO_API_TOKEN"),
 		AdminSecret:      adminSecret,

--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -66,6 +66,7 @@ BACKEND_URL=https://${backend_domain}
 RAG_REVIEW_URL=http://rag-review:9000
 CHROMA_HOST=chroma
 CHROMA_PORT=8000
+SERVER_PORT=8080
 EOF
 chmod 600 /opt/app/.env
 

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -196,9 +196,9 @@ resource "aws_launch_template" "app" {
   block_device_mappings {
     device_name = "/dev/sda1"
     ebs {
-      # backend/frontend/rag-review(chromadb・onnxruntime等)の3イメージ分で
-      # 20GBは逼迫しdocker pullが「no space left on device」で失敗したため増量
-      volume_size = 30
+      # backend/frontend/rag-review の同時 pull で 20GB は不足。
+      # 30GB でも旧イメージ稼働中の pull で逼迫するため 40GB。
+      volume_size = 40
       volume_type = "gp3"
     }
   }


### PR DESCRIPTION
## Summary
- staging EC2 のルートを 40GB にし、デプロイ時は `compose down` → prune → pull → up する（稼働中イメージは prune できない）
- backend の `SERVER_PORT` 既定を 8080 にし、user_data にも明示する（ALB/compose は 8080 なのに既定 80 で health check が落ちていた）
- appleboy の `script_stop` とサービス running チェックで、pull/up 失敗を success にしない

## すでに実施済み（この PR 外）
- 現行インスタンスの EBS を 40GB に拡張し、filesystem を resize
- `SERVER_PORT=8080` を `.env` に追加して backend を recreate
- `https://stg.shukatsu-ai.jp/` と `/healthz` は 200

## Test plan
- [ ] Terraform の `volume_size = 40` が次の apply で launch template に載る
- [ ] develop マージ後の staging deploy がディスク不足で落ちない
- [ ] backend `/healthz` が 8080 で通る
- [ ] compose 失敗時に Deploy job が failure になる