### PR TITLE
feat: #853 学生画面をカード基調と高コントラスト切替にする

### DIFF
--- a/frontend/app/error/opengraph-image.tsx
+++ b/frontend/app/error/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { BRAND_LOGO_COLOR } from '@/lib/brand'
 
 export const alt = '接続できません'
 export const size = { width: 1200, height: 630 }
@@ -19,7 +20,7 @@ export default function OpenGraphImage() {
           color: '#0f172a',
         }}
       >
-        <div style={{ fontSize: 28, fontWeight: 700, color: '#ec5b13' }}>就活AI</div>
+        <div style={{ fontSize: 28, fontWeight: 700, color: BRAND_LOGO_COLOR }}>就活AI</div>
         <div style={{ fontSize: 64, fontWeight: 800, marginTop: 24 }}>接続できません</div>
         <div style={{ fontSize: 32, color: '#475569', marginTop: 16 }}>
           しばらくしてから再試行してください

--- a/frontend/app/es-rewrite/page.tsx
+++ b/frontend/app/es-rewrite/page.tsx
@@ -23,7 +23,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import EditNoteIcon from '@mui/icons-material/EditNote'
 import RateReviewIcon from '@mui/icons-material/RateReview'
-const PRIMARY = '#ec5b13'
+import { PRIMARY } from '@/app/interview/constants'
 
 const QUESTION_TYPES = ['志望動機', '自己PR', '学チカ', 'ガクチカ', 'その他']
 

--- a/frontend/app/interview/components/InterviewSummary.tsx
+++ b/frontend/app/interview/components/InterviewSummary.tsx
@@ -18,8 +18,7 @@ import CheckIcon from '@mui/icons-material/Check'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import { InterviewReport, PhraseSuggestion, interviewApi } from '@/lib/interview'
 import { parseJsonSafe } from '@/lib/interview-utils'
-
-const PRIMARY = '#ec5b13'
+import { PRIMARY } from '../constants'
 
 const SCORE_LABELS: Record<string, string> = {
   logic: '論理性',

--- a/frontend/app/interview/constants.ts
+++ b/frontend/app/interview/constants.ts
@@ -2,8 +2,9 @@
  * Shared constants for the interview feature.
  */
 import type { Position } from './types'
+import { COMFORTABLE_PRIMARY } from '@/lib/student-theme'
 
-export const PRIMARY = '#ec5b13'
+export const PRIMARY = COMFORTABLE_PRIMARY
 export const BG_LIGHT = '#f8f6f6'
 export const BG_DARK = '#221610'
 

--- a/frontend/app/interview/history/InterviewTrendChart.tsx
+++ b/frontend/app/interview/history/InterviewTrendChart.tsx
@@ -11,8 +11,7 @@ import {
   YAxis,
 } from 'recharts'
 import type { InterviewTrendPoint } from '@/lib/interview'
-
-const PRIMARY = '#ec5b13'
+import { PRIMARY } from '../constants'
 
 type InterviewTrendChartProps = {
   points: InterviewTrendPoint[]

--- a/frontend/app/interview/history/page.tsx
+++ b/frontend/app/interview/history/page.tsx
@@ -22,8 +22,7 @@ import { authService, User } from '@/lib/auth'
 import { interviewApi, InterviewDetail, InterviewSession, InterviewTrendPoint, TeacherReport } from '@/lib/interview'
 import InterviewSummary from '../components/InterviewSummary'
 import { parseJsonSafe } from '@/lib/interview-utils'
-
-const PRIMARY = '#ec5b13'
+import { PRIMARY } from '../constants'
 
 const InterviewTrendChart = dynamic(() => import('./InterviewTrendChart'), {
   ssr: false,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { MuiProvider } from '@/components/mui-provider'
+import { StudentBottomNav } from '@/components/student-bottom-nav'
 import { Analytics } from '@vercel/analytics/react'
 // Vercelでホスティングされるまで実データは収集されない(AWS ECSデプロイのため現状は未計測)
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -39,6 +40,7 @@ export default function RootLayout({
       <body style={{ margin: 0, padding: 0 }}>
         <MuiProvider>
           {children}
+          <StudentBottomNav />
         </MuiProvider>
         <Analytics />
         <SpeedInsights />

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -26,7 +26,7 @@ import { getResultsPathOrChat } from '@/lib/results-navigation'
 
 const STEPS = [
   {
-    icon: <ChatIcon sx={{ fontSize: 32, color: '#ec5b13' }} />,
+    icon: <ChatIcon sx={{ fontSize: 32, color: 'primary.main' }} />,
     title: '自己分析チャット',
     description: 'AIとの会話を通じて、あなたの強み・志向・経験を整理します。まずここから始めましょう。',
     action: 'チャットを始める',
@@ -122,7 +122,8 @@ export default function OnboardingPage() {
                 key={step.title}
                 variant="outlined"
                 sx={{
-                  border: isDone ? '2px solid #388e3c' : isActive ? '2px solid #ec5b13' : '1px solid #e0e0e0',
+                  border: '2px solid',
+                  borderColor: isDone ? 'success.main' : isActive ? 'primary.main' : 'divider',
                   bgcolor: isDone ? '#f1f8f1' : isActive ? '#fff8f5' : '#fff',
                 }}
               >
@@ -149,7 +150,7 @@ export default function OnboardingPage() {
                       flexShrink: 0,
                       width: { xs: '100%', sm: 'auto' },
                       ...(isActive && !isDone
-                        ? { bgcolor: '#ec5b13', '&:hover': { bgcolor: '#c44d0e' }, color: '#fff' }
+                        ? { bgcolor: 'primary.main', '&:hover': { bgcolor: 'primary.dark' }, color: 'primary.contrastText' }
                         : {}),
                       textTransform: 'none',
                       borderRadius: 9999,

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { BRAND_LOGO_COLOR } from '@/lib/brand'
 
 export const alt = '就活AI — IT企業エージェント'
 export const size = { width: 1200, height: 630 }
@@ -19,7 +20,7 @@ export default function OpenGraphImage() {
           color: '#0f172a',
         }}
       >
-        <div style={{ fontSize: 28, fontWeight: 700, color: '#ec5b13' }}>就活AI</div>
+        <div style={{ fontSize: 28, fontWeight: 700, color: BRAND_LOGO_COLOR }}>就活AI</div>
         <div style={{ fontSize: 64, fontWeight: 800, marginTop: 24 }}>IT企業エージェント</div>
         <div style={{ fontSize: 32, color: '#475569', marginTop: 16 }}>
           適性診断から企業マッチングまで

--- a/frontend/app/page.module.css
+++ b/frontend/app/page.module.css
@@ -19,6 +19,13 @@
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+    padding-bottom: 56px;
+}
+
+@media (min-width: 900px) {
+    .mainContent {
+        padding-bottom: 0;
+    }
 }
 
 .chatWrapper {

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -32,6 +32,7 @@ import { BACKEND_URL } from '@/lib/backend-url'
 import { CERTIFICATION_OPTIONS, joinCertifications, splitCertifications } from '@/lib/profile'
 import GitHubSkills from '@/components/github-skills'
 import { PageLoading } from '@/components/common/PageLoading'
+import { StudentThemeToggle } from '@/components/student-theme-toggle'
 
 export default function ProfilePage() {
   return (
@@ -251,7 +252,12 @@ function ProfilePageContent() {
         </Container>
       </Box>
 
-      <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Container maxWidth="lg" sx={{ py: 4, pb: { xs: 12, md: 4 } }}>
+        <Card sx={{ mb: 3, borderRadius: 2 }}>
+          <CardContent sx={{ p: 3 }}>
+            <StudentThemeToggle />
+          </CardContent>
+        </Card>
         {/* ユーザーヘッダーカード */}
         <Card sx={{ mb: 3, borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>

--- a/frontend/app/results/components/ResultsListView.tsx
+++ b/frontend/app/results/components/ResultsListView.tsx
@@ -92,7 +92,8 @@ export default function ResultsListView({
       display: 'flex',
       flexDirection: 'column',
       overflow: 'hidden',
-      backgroundColor: '#fff',
+      backgroundColor: 'background.default',
+      pb: { xs: 7, md: 0 },
     }}>
       {/* ヘッダー部分 */}
       <Box sx={{
@@ -149,8 +150,8 @@ export default function ResultsListView({
       <Box sx={{
         flexGrow: 1,
         overflowY: 'auto',
-        p: { xs: 2, sm: 3 },
-        backgroundColor: '#fafafa',
+        p: { xs: 2, sm: 4 },
+        backgroundColor: 'background.default',
       }}>
         <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
           {/* 分析データの部分取得失敗（サイレント失敗させず明示する） */}
@@ -259,20 +260,24 @@ export default function ResultsListView({
             </Card>
           )}
 
-          <Stack spacing={3}>
+          <Stack spacing={4}>
             {companies.map((company, index) => (
               <Card
                 key={`${company.id}-${index}`}
-                elevation={3}
+                elevation={0}
                 sx={{
                   border: '2px solid',
-                  borderColor: 'primary.light',
+                  borderColor: 'divider',
+                  borderRadius: 3,
                   cursor: 'pointer',
-                  transition: 'all 0.3s ease',
+                  p: { xs: 0.5, sm: 1 },
                   '&:hover': {
                     borderColor: 'primary.main',
-                    transform: 'translateY(-4px)',
-                    boxShadow: 6,
+                    boxShadow: 3,
+                  },
+                  '&:focus-visible': {
+                    outline: '3px solid',
+                    outlineColor: 'primary.main',
                   },
                 }}
                 onClick={() => onSelectCompany(company)}
@@ -280,7 +285,7 @@ export default function ResultsListView({
                 <CardContent>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                      <Avatar sx={{ bgcolor: 'primary.main', width: 40, height: 40, fontWeight: 'bold' }}>
+                      <Avatar sx={{ bgcolor: 'primary.main', width: 56, height: 56, fontWeight: 'bold' }}>
                         {index + 1}
                       </Avatar>
                       <Box>

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -266,11 +266,11 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
 
                 {/* 今日やること（推奨フロー） */}
                 {progress.overall < 100 && (
-                    <Box sx={{ mb: 2, p: 1.5, bgcolor: '#fff8f5', borderRadius: 1, border: '1px solid #ffcc99' }}>
-                        <Typography variant="caption" sx={{ fontWeight: 700, color: '#ec5b13', display: 'block', mb: 0.5 }}>
+                    <Box sx={{ mb: 2, p: 1.5, bgcolor: 'action.hover', borderRadius: 1, border: '2px solid', borderColor: 'primary.main' }}>
+                        <Typography variant="caption" sx={{ fontWeight: 700, color: 'primary.main', display: 'block', mb: 0.5 }}>
                             今日やること
                         </Typography>
-                        <Typography variant="body2" sx={{ fontSize: '0.8rem', color: '#555', mb: shouldShowResultsCta(progress.overall) ? 1 : 0 }}>
+                        <Typography variant="body2" sx={{ fontSize: '0.8rem', color: 'text.secondary', mb: shouldShowResultsCta(progress.overall) ? 1 : 0 }}>
                             {getTodayActionLabel(progress.overall)}
                         </Typography>
                         {shouldShowResultsCta(progress.overall) && (
@@ -281,13 +281,13 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                                 }}
                                 sx={{
                                     borderRadius: 1,
-                                    bgcolor: '#ec5b13',
-                                    color: '#fff',
+                                    bgcolor: 'primary.main',
+                                    color: 'primary.contrastText',
                                     py: 0.75,
-                                    '&:hover': { bgcolor: '#c44d0e' },
+                                    '&:hover': { bgcolor: 'primary.dark' },
                                 }}
                             >
-                                <ListItemIcon sx={{ minWidth: 32, color: '#fff' }}>
+                                <ListItemIcon sx={{ minWidth: 32, color: 'inherit' }}>
                                     <Business fontSize="small" />
                                 </ListItemIcon>
                                 <ListItemText
@@ -321,16 +321,17 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                             >
                                 <ListItemIcon sx={{minWidth: 36}}>
                                     {step.completed ? (
-                                        <CheckCircle color="success"/>
+                                        <CheckCircle color="success" aria-label="完了" />
                                     ) : (
-                                        <RadioButtonUnchecked color="action"/>
+                                        <RadioButtonUnchecked color="action" aria-label="未完了" />
                                     )}
                                 </ListItemIcon>
                                 <ListItemText
                                     primary={step.label}
+                                    secondary={step.completed ? '完了' : '未完了'}
                                     primaryTypographyProps={{
-                                        fontSize: '0.875rem',
-                                        fontWeight: step.completed ? 500 : 400,
+                                        fontSize: '0.95rem',
+                                        fontWeight: step.completed ? 700 : 500,
                                     }}
                                 />
                             </ListItem>
@@ -339,7 +340,15 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                                     <LinearProgress
                                         variant="determinate"
                                         value={step.progress}
-                                        sx={{height: 6, borderRadius: 3}}
+                                        aria-label={`${step.label} ${step.progress}%`}
+                                        sx={{
+                                          height: 10,
+                                          borderRadius: 1,
+                                          bgcolor: 'action.selected',
+                                          '& .MuiLinearProgress-bar': {
+                                            backgroundImage: 'repeating-linear-gradient(90deg, transparent, transparent 4px, rgba(255,255,255,0.35) 4px, rgba(255,255,255,0.35) 8px)',
+                                          },
+                                        }}
                                     />
                                     <Typography
                                         variant="caption"

--- a/frontend/components/common/PageLoading.tsx
+++ b/frontend/components/common/PageLoading.tsx
@@ -27,11 +27,11 @@ export function PageLoading({
       }}
     >
       {showBrand && (
-        <Typography variant="h6" sx={{ fontWeight: 700, color: '#ec5b13' }}>
+        <Typography variant="h6" sx={{ fontWeight: 700, color: 'primary.main' }}>
           IT業界キャリアエージェント
         </Typography>
       )}
-      <CircularProgress sx={{ color: '#ec5b13' }} />
+      <CircularProgress color="primary" />
       <Typography variant="body2" color="text.secondary">
         {message}
       </Typography>

--- a/frontend/components/login-page.tsx
+++ b/frontend/components/login-page.tsx
@@ -19,7 +19,7 @@ import Link from 'next/link'
 import { authService, AuthResponse } from '@/lib/auth'
 import { BACKEND_URL } from '@/lib/backend-url'
 import { GUEST_LIMITATIONS } from '@/lib/guest-limits'
-import { extractTenantSlug } from '@/lib/tenant'
+import { StudentThemeToggle } from '@/components/student-theme-toggle'
 
 interface LoginPageProps {
   onAuthSuccess: (authResponse: AuthResponse) => void
@@ -106,11 +106,11 @@ export function LoginPage({ onAuthSuccess, initialTab = 0 }: LoginPageProps) {
         justifyContent: 'center',
         minHeight: '100vh',
         bgcolor: 'background.default',
-        p: 2,
+        p: { xs: 2, sm: 3 },
       }}
     >
-      <Card sx={{ maxWidth: 450, width: '100%' }}>
-        <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
+      <Card sx={{ maxWidth: 520, width: '100%' }}>
+        <CardContent sx={{ p: { xs: 3, sm: 5 } }}>
           <Typography variant="h4" align="center" gutterBottom fontWeight="bold">
             IT業界キャリアエージェント
           </Typography>
@@ -150,7 +150,7 @@ export function LoginPage({ onAuthSuccess, initialTab = 0 }: LoginPageProps) {
                 sx={{ mb: 1 }}
               />
               <Box sx={{ textAlign: 'right', mt: -1, mb: 2 }}>
-                <Link href="/forgot-password" style={{ fontSize: '0.875rem', color: '#1976D2' }}>
+                <Link href="/forgot-password" style={{ fontSize: '0.875rem' }}>
                   パスワードをお忘れですか？
                 </Link>
               </Box>
@@ -229,6 +229,9 @@ export function LoginPage({ onAuthSuccess, initialTab = 0 }: LoginPageProps) {
               あとからアカウント登録すると解放されます。
             </Typography>
           </Box>
+
+          <Divider sx={{ my: 3 }} />
+          <StudentThemeToggle />
         </CardContent>
       </Card>
     </Box>

--- a/frontend/components/login-page.tsx
+++ b/frontend/components/login-page.tsx
@@ -20,6 +20,7 @@ import { authService, AuthResponse } from '@/lib/auth'
 import { BACKEND_URL } from '@/lib/backend-url'
 import { GUEST_LIMITATIONS } from '@/lib/guest-limits'
 import { StudentThemeToggle } from '@/components/student-theme-toggle'
+import { extractTenantSlug } from '@/lib/tenant'
 
 interface LoginPageProps {
   onAuthSuccess: (authResponse: AuthResponse) => void

--- a/frontend/components/mui-provider.tsx
+++ b/frontend/components/mui-provider.tsx
@@ -1,28 +1,71 @@
 'use client'
 
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter'
+import {
+  createStudentMuiTheme,
+  readStudentThemeMode,
+  writeStudentThemeMode,
+  type StudentThemeMode,
+} from '@/lib/student-theme'
 
-const theme = createTheme({
-  palette: {
-    mode: 'light',
-    primary: {
-      main: '#1976d2',
-    },
-    secondary: {
-      main: '#dc004e',
-    },
-  },
+const ADMIN_THEME = createTheme({
+  palette: { mode: 'light', primary: { main: '#1976d2' } },
 })
 
-export function MuiProvider({ children }: { children: React.ReactNode }) {
+type StudentThemeContextValue = {
+  mode: StudentThemeMode
+  setMode: (mode: StudentThemeMode) => void
+}
+
+const StudentThemeContext = createContext<StudentThemeContextValue | null>(null)
+
+export function useStudentTheme(): StudentThemeContextValue {
+  const ctx = useContext(StudentThemeContext)
+  if (!ctx) {
+    return {
+      mode: 'comfortable',
+      setMode: () => {},
+    }
+  }
+  return ctx
+}
+
+function storage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  return window.localStorage
+}
+
+export function MuiProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname() || ''
+  const isAdmin = pathname.startsWith('/admin')
+  const [mode, setModeState] = useState<StudentThemeMode>('comfortable')
+
+  useEffect(() => {
+    setModeState(readStudentThemeMode(storage()))
+  }, [])
+
+  const setMode = useCallback((next: StudentThemeMode) => {
+    setModeState(next)
+    writeStudentThemeMode(next, storage())
+  }, [])
+
+  const theme = useMemo(
+    () => (isAdmin ? ADMIN_THEME : createStudentMuiTheme(mode)),
+    [isAdmin, mode],
+  )
+
   return (
     <AppRouterCacheProvider>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        {children}
-      </ThemeProvider>
+      <StudentThemeContext.Provider value={{ mode, setMode }}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {children}
+        </ThemeProvider>
+      </StudentThemeContext.Provider>
     </AppRouterCacheProvider>
   )
 }

--- a/frontend/components/service-error-view.tsx
+++ b/frontend/components/service-error-view.tsx
@@ -3,8 +3,6 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
 import { useRouter } from 'next/navigation'
 
-const PRIMARY = '#ec5b13'
-
 type Props = {
   code?: string | number
   onRetry?: () => void
@@ -21,12 +19,12 @@ export function ServiceErrorView({ code, onRetry }: Props) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        bgcolor: '#f8f6f6',
+        bgcolor: 'background.default',
         px: 2,
       }}
     >
       <Stack spacing={2} alignItems="center" sx={{ maxWidth: 420, textAlign: 'center' }}>
-        <Typography sx={{ fontSize: 13, fontWeight: 700, color: PRIMARY }}>{label}</Typography>
+        <Typography sx={{ fontSize: 13, fontWeight: 700, color: 'error.main' }}>{label}</Typography>
         <Typography variant="h5" fontWeight={700}>
           接続できません
         </Typography>

--- a/frontend/components/student-bottom-nav.tsx
+++ b/frontend/components/student-bottom-nav.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { BottomNavigation, BottomNavigationAction, Paper } from '@mui/material'
+import ChatIcon from '@mui/icons-material/Chat'
+import BusinessIcon from '@mui/icons-material/Business'
+import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver'
+import DescriptionIcon from '@mui/icons-material/Description'
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
+import { STUDENT_BOTTOM_NAV_ITEMS, shouldShowStudentBottomNav } from '@/lib/sidebar-nav'
+import { getResultsPathOrChat } from '@/lib/results-navigation'
+
+const ICONS = {
+  '/': <ChatIcon />,
+  '/results': <BusinessIcon />,
+  '/interview': <RecordVoiceOverIcon />,
+  '/resume': <DescriptionIcon />,
+  '/profile': <ManageAccountsIcon />,
+} as const
+
+export function StudentBottomNav() {
+  const pathname = usePathname() || ''
+  const router = useRouter()
+  if (!shouldShowStudentBottomNav(pathname)) return null
+
+  const current =
+    STUDENT_BOTTOM_NAV_ITEMS.find((i) =>
+      i.href === '/' ? pathname === '/' : pathname === i.href || pathname.startsWith(`${i.href}/`),
+    )?.href ?? false
+
+  return (
+    <Paper
+      elevation={8}
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: (t) => t.zIndex.appBar,
+        display: { xs: 'block', md: 'none' },
+        pb: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      <BottomNavigation
+        showLabels
+        value={current}
+        onChange={(_, href: string) => {
+          router.push(href === '/results' ? getResultsPathOrChat() : href)
+        }}
+      >
+        {STUDENT_BOTTOM_NAV_ITEMS.map((item) => (
+          <BottomNavigationAction
+            key={item.href}
+            value={item.href}
+            label={item.label}
+            icon={ICONS[item.href]}
+          />
+        ))}
+      </BottomNavigation>
+    </Paper>
+  )
+}

--- a/frontend/components/student-theme-toggle.tsx
+++ b/frontend/components/student-theme-toggle.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material'
+import { useStudentTheme } from '@/components/mui-provider'
+import { STUDENT_THEME_LABELS, type StudentThemeMode } from '@/lib/student-theme'
+
+export function StudentThemeToggle() {
+  const { mode, setMode } = useStudentTheme()
+  return (
+    <FormControl component="fieldset" variant="standard">
+      <FormLabel component="legend">画面の見え方</FormLabel>
+      <RadioGroup
+        value={mode}
+        onChange={(e) => setMode(e.target.value as StudentThemeMode)}
+      >
+        {(Object.keys(STUDENT_THEME_LABELS) as StudentThemeMode[]).map((key) => (
+          <FormControlLabel
+            key={key}
+            value={key}
+            control={<Radio />}
+            label={STUDENT_THEME_LABELS[key]}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  )
+}

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -1,0 +1,2 @@
+/** ロゴ・OGP専用。画面の primary には使わない（#853） */
+export const BRAND_LOGO_COLOR = '#ec5b13'

--- a/frontend/lib/sidebar-nav.ts
+++ b/frontend/lib/sidebar-nav.ts
@@ -16,3 +16,29 @@ export const SIDEBAR_ADMIN_NAV = {
   href: '/admin',
   label: '管理者機能',
 } as const
+
+export const STUDENT_BOTTOM_NAV_ITEMS = [
+  { href: '/', label: '診断' },
+  { href: '/results', label: '結果' },
+  { href: '/interview', label: '面接' },
+  { href: '/resume', label: '履歴書' },
+  { href: '/profile', label: '設定' },
+] as const
+
+const HIDE_BOTTOM_NAV = [
+  '/login',
+  '/forgot-password',
+  '/reset-password',
+  '/register',
+  '/verify-email',
+  '/verify-registration',
+  '/auth',
+  '/error',
+  '/company-entry',
+  '/admin',
+  '/onboarding',
+]
+
+export function shouldShowStudentBottomNav(pathname: string): boolean {
+  return !HIDE_BOTTOM_NAV.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+}

--- a/frontend/lib/student-theme.ts
+++ b/frontend/lib/student-theme.ts
@@ -1,0 +1,94 @@
+import { createTheme } from '@mui/material/styles'
+
+export const STUDENT_THEME_STORAGE_KEY = 'student-theme-mode'
+
+export type StudentThemeMode = 'comfortable' | 'high-contrast'
+
+export const STUDENT_THEME_LABELS: Record<StudentThemeMode, string> = {
+  comfortable: '見やすい表示（推奨）',
+  'high-contrast': '高コントラスト（色弱・弱視向け）',
+}
+
+const FONT_FAMILY =
+  "'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+
+/** パターン3 既定: Wong に近い色覚セーフ青 */
+export const COMFORTABLE_PRIMARY = '#0072B2'
+
+const COMFORTABLE = {
+  primary: COMFORTABLE_PRIMARY,
+  success: '#009E73',
+  warning: '#E69F00',
+  error: '#000000',
+  background: '#f4f7fb',
+  paper: '#ffffff',
+}
+
+/** パターン5: 高コントラスト */
+const HIGH_CONTRAST = {
+  primary: '#0B3D91',
+  success: '#006400',
+  warning: '#B36B00',
+  error: '#8B0000',
+  background: '#ffffff',
+  paper: '#ffffff',
+}
+
+export function isStudentThemeMode(value: string | null | undefined): value is StudentThemeMode {
+  return value === 'comfortable' || value === 'high-contrast'
+}
+
+export function readStudentThemeMode(storage?: Pick<Storage, 'getItem'> | null): StudentThemeMode {
+  const raw = storage?.getItem(STUDENT_THEME_STORAGE_KEY)
+  return isStudentThemeMode(raw) ? raw : 'comfortable'
+}
+
+export function writeStudentThemeMode(
+  mode: StudentThemeMode,
+  storage?: Pick<Storage, 'setItem'> | null,
+): void {
+  storage?.setItem(STUDENT_THEME_STORAGE_KEY, mode)
+}
+
+export function createStudentMuiTheme(mode: StudentThemeMode) {
+  const p = mode === 'high-contrast' ? HIGH_CONTRAST : COMFORTABLE
+  const focusWidth = mode === 'high-contrast' ? 3 : 2
+
+  return createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: p.primary },
+      secondary: { main: p.warning },
+      success: { main: p.success },
+      warning: { main: p.warning },
+      error: { main: p.error },
+      background: { default: p.background, paper: p.paper },
+      text: { primary: '#111111', secondary: '#333333' },
+    },
+    typography: { fontFamily: FONT_FAMILY },
+    shape: { borderRadius: mode === 'high-contrast' ? 4 : 12 },
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: { fontFamily: FONT_FAMILY },
+          '*:focus-visible': {
+            outline: `${focusWidth}px solid ${p.primary}`,
+            outlineOffset: 2,
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: { textTransform: 'none', fontWeight: 700, minHeight: 44 },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            border: mode === 'high-contrast' ? `2px solid ${p.primary}` : '1px solid #d0d7de',
+          },
+        },
+      },
+    },
+  })
+}

--- a/frontend/tests/lib/sidebar-nav.test.ts
+++ b/frontend/tests/lib/sidebar-nav.test.ts
@@ -1,4 +1,4 @@
-import { SIDEBAR_ADMIN_NAV, SIDEBAR_NAV_ITEMS } from '@/lib/sidebar-nav'
+import { SIDEBAR_ADMIN_NAV, SIDEBAR_NAV_ITEMS, shouldShowStudentBottomNav, STUDENT_BOTTOM_NAV_ITEMS } from '@/lib/sidebar-nav'
 
 describe('sidebar-nav', () => {
   it('主要ナビは絶対パスで定義されている', () => {
@@ -18,5 +18,13 @@ describe('sidebar-nav', () => {
 
   it('管理者ナビは /admin', () => {
     expect(SIDEBAR_ADMIN_NAV.href).toBe('/admin')
+  })
+
+  it('モバイル下ナビは5件でログインでは出さない', () => {
+    expect(STUDENT_BOTTOM_NAV_ITEMS).toHaveLength(5)
+    expect(shouldShowStudentBottomNav('/login')).toBe(false)
+    expect(shouldShowStudentBottomNav('/admin/costs')).toBe(false)
+    expect(shouldShowStudentBottomNav('/')).toBe(true)
+    expect(shouldShowStudentBottomNav('/interview/history')).toBe(true)
   })
 })

--- a/frontend/tests/lib/student-theme.test.ts
+++ b/frontend/tests/lib/student-theme.test.ts
@@ -1,0 +1,54 @@
+import {
+  createStudentMuiTheme,
+  isStudentThemeMode,
+  readStudentThemeMode,
+  STUDENT_THEME_STORAGE_KEY,
+  writeStudentThemeMode,
+} from '@/lib/student-theme'
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const data = { ...initial }
+  return {
+    getItem: (k: string) => (k in data ? data[k] : null),
+    setItem: (k: string, v: string) => {
+      data[k] = v
+    },
+    snapshot: () => data,
+  }
+}
+
+describe('student-theme', () => {
+  it('未知の値は comfortable に倒す', () => {
+    expect(isStudentThemeMode('dark')).toBe(false)
+    expect(readStudentThemeMode(memoryStorage())).toBe('comfortable')
+    expect(readStudentThemeMode(memoryStorage({ [STUDENT_THEME_STORAGE_KEY]: 'nope' }))).toBe(
+      'comfortable',
+    )
+  })
+
+  it('保存したモードを読み戻す', () => {
+    const s = memoryStorage()
+    writeStudentThemeMode('high-contrast', s)
+    expect(s.snapshot()[STUDENT_THEME_STORAGE_KEY]).toBe('high-contrast')
+    expect(readStudentThemeMode(s)).toBe('high-contrast')
+  })
+
+  it('comfortable の primary は色覚セーフ青', () => {
+    const theme = createStudentMuiTheme('comfortable')
+    expect(theme.palette.primary.main.toUpperCase()).toBe('#0072B2')
+    expect(theme.palette.mode).toBe('light')
+  })
+
+  it('high-contrast はより濃い primary と太いフォーカス', () => {
+    const theme = createStudentMuiTheme('high-contrast')
+    expect(theme.palette.primary.main.toUpperCase()).toBe('#0B3D91')
+    expect(theme.palette.background.default).toBe('#ffffff')
+    expect(JSON.stringify(theme.components?.MuiCssBaseline)).toContain('3px solid')
+  })
+
+  it('画面 primary にブランド橙を使わない', () => {
+    for (const mode of ['comfortable', 'high-contrast'] as const) {
+      expect(createStudentMuiTheme(mode).palette.primary.main.toLowerCase()).not.toBe('#ec5b13')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- #853 の採用案（パターン3既定 / パターン5切替）をテーマとして実装
- 学生画面の primary を色覚セーフ青 `#0072B2` にし、橙はロゴ・OGPのみ
- ログイン・プロフィールで見え方を切替。モバイルは下ナビ

## Test plan
- [ ] ログイン画面で「見やすい表示」「高コントラスト」を切り替える
- [ ] 診断チャットの進捗が primary 色になり、完了/未完了ラベルがある
- [ ] 結果一覧の企業カードが大きく、モバイルで下ナビが見える
- [ ] `/admin` は従来の青テーマのまま
- [ ] `cd frontend && npx jest tests/lib/student-theme.test.ts tests/lib/sidebar-nav.test.ts`