### PR TITLE
hotfix: CIのgovulncheckとnpm auditを通す

### DIFF
--- a/Backend/go.mod
+++ b/Backend/go.mod
@@ -1,6 +1,6 @@
 module Backend
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7869,9 +7869,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "sharp": "^0.35.3",
     "postcss": "^8.5.10",
     "brace-expansion": "^5.0.8",
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "nanoid": "^3.3.18"
   }
 }


### PR DESCRIPTION
## Summary
- Go 標準ライブラリ脆弱性（govulncheck）を解消するため `go.mod` を 1.25.12 → **1.25.13**
- `nanoid` の high（GHSA-2v37-7h3g-55p8）を解消するため **3.3.18** 以上に固定
- 履歴書 SSE 修正（#856）は含まない

## Test plan
- [ ] GitHub Actions の Go Unit Tests（govulncheck）が通る
- [ ] GitHub Actions の Frontend Security Audit が通る