### PR TITLE
hotfix: 履歴書レビューSSEのFlush panicを避ける (#855)

### DIFF
--- a/Backend/internal/services/resume_review.go
+++ b/Backend/internal/services/resume_review.go
@@ -231,15 +231,10 @@ func (s *ResumeService) fetchRAGReportStream(ctx context.Context, resumeText, co
 // ReviewDocumentStream はドキュメントを前処理した後、SSEでRAGレポートをストリーミングし、
 // 最後にスコア・指摘事項を complete イベントとして送信する。
 func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uint, requestingUserID uint, companyName, jobTitle, candidateType string, w http.ResponseWriter) error {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		return fmt.Errorf("streaming not supported")
-	}
-
 	sendEvent := func(v map[string]any) {
 		data, _ := json.Marshal(v)
 		fmt.Fprintf(w, "data: %s\n\n", data)
-		flusher.Flush()
+		flushSSE(w)
 	}
 
 	doc, err := s.repo.FindDocumentByID(documentID)
@@ -314,7 +309,7 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	if strings.TrimSpace(companyName) != "" {
 		ragBody, ragErr := s.fetchRAGReportStream(ctx, text, companyName, jobTitle)
 		if ragErr == nil {
-			ragReport, _ = relaySSEChunks(ragBody, w, flusher)
+			ragReport, _ = relaySSEChunks(ragBody, w)
 			ragBody.Close()
 		} else {
 			log.Printf("resume_review_stream: rag stream failed: %v", ragErr)
@@ -359,9 +354,28 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	return nil
 }
 
+// flushSSE はバッファを送出する。Echo の Response.Flush は WrapMiddleware 配下で
+// panic するため使わず、Unwrap して実体の Flusher を探す (#855)。
+func flushSSE(w http.ResponseWriter) {
+	rw := w
+	for range 8 {
+		u, unwraps := rw.(interface{ Unwrap() http.ResponseWriter })
+		if unwraps {
+			if next := u.Unwrap(); next != nil && next != rw {
+				rw = next
+				continue
+			}
+		}
+		if f, ok := rw.(http.Flusher); ok {
+			f.Flush()
+		}
+		return
+	}
+}
+
 // relaySSEChunks はFastAPIからのSSEストリームを読み取り、chunk イベントをそのまま
 // クライアントに転送しつつ、全テキストを返す。
-func relaySSEChunks(body io.Reader, w io.Writer, flusher http.Flusher) (string, error) {
+func relaySSEChunks(body io.Reader, w http.ResponseWriter) (string, error) {
 	var accum strings.Builder
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024)
@@ -386,7 +400,7 @@ func relaySSEChunks(body io.Reader, w io.Writer, flusher http.Flusher) (string, 
 		case "chunk":
 			accum.WriteString(event.Text)
 			fmt.Fprintf(w, "data: %s\n\n", payload)
-			flusher.Flush()
+			flushSSE(w)
 		case "done":
 			return accum.String(), nil
 		case "error":

--- a/Backend/internal/services/resume_service_test.go
+++ b/Backend/internal/services/resume_service_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/http"
 	"net/http/httptest"
 	"net/textproto"
 	"os"
@@ -248,5 +249,33 @@ func TestResumeService_ReviewDocumentStreamRejectsOtherUser(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "forbidden") {
 		t.Fatalf("SSE エラーに forbidden が含まれるべき: got %q", rr.Body.String())
+	}
+}
+
+// echo 相当: Flush は panic、Unwrap で実体の writer に届く (#855)
+type panicFlushWriter struct {
+	http.ResponseWriter
+}
+
+func (w panicFlushWriter) Flush() {
+	panic("echo: response writer does not support flushing")
+}
+
+func (w panicFlushWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func TestRelaySSEChunks_DoesNotPanicWhenFlushPanics(t *testing.T) {
+	body := strings.NewReader("data: {\"type\":\"chunk\",\"text\":\"hello\"}\n\ndata: {\"type\":\"done\"}\n\n")
+	rr := httptest.NewRecorder()
+	got, err := relaySSEChunks(body, panicFlushWriter{ResponseWriter: rr})
+	if err != nil {
+		t.Fatalf("relaySSEChunks: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("accum: got %q", got)
+	}
+	if !strings.Contains(rr.Body.String(), "hello") {
+		t.Fatalf("body: %q", rr.Body.String())
 	}
 }


### PR DESCRIPTION
Closes #855

## Summary
- ステージングには [PR #856](https://github.com/ISCProduct/soc-ai-agent/pull/856) を develop へマージ済み
- 本番向けに SSE Flush panic 修正のみを main へ取り込む（develop 全体は載せない）

## Test plan
- [x] ローカル Playwright でレビュー完了を確認済み
- [ ] 本 PR の CI