### PR TITLE
fix: ステージングの履歴書レビュー document processing failed

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -199,6 +199,10 @@ jobs:
               chmod +x /tmp/edge-sync/ensure-edge-compose.sh
               /tmp/edge-sync/ensure-edge-compose.sh /opt/app/docker-compose.yml
               cd /opt/app
+              # 既存インスタンスの .env は S3_BUCKET のみ。アプリは AWS_S3_BUCKET を読む。
+              if [ -f .env ] && grep -q '^S3_BUCKET=' .env && ! grep -q '^AWS_S3_BUCKET=' .env; then
+                echo "AWS_S3_BUCKET=$(grep '^S3_BUCKET=' .env | cut -d= -f2-)" >> .env
+              fi
               df -h /
               # 稼働中イメージは prune できない。先に down してから空ける。
               # named volume(chroma_data)は --volumes を付けない限り残る。

--- a/Backend/internal/services/resume_review.go
+++ b/Backend/internal/services/resume_review.go
@@ -280,6 +280,7 @@ func (s *ResumeService) ReviewDocumentStream(ctx context.Context, documentID uin
 	_ = s.repo.UpdateDocument(doc)
 
 	if err := validatePathInDir(pdfPath, workDir); err != nil {
+		log.Printf("resume_review_stream: pdf path outside workDir pdf=%q workDir=%q err=%v", pdfPath, workDir, err)
 		sendEvent(map[string]any{"type": "error", "message": "document processing failed"})
 		return fmt.Errorf("invalid pdf path: %w", err)
 	}

--- a/Backend/internal/services/resume_service_test.go
+++ b/Backend/internal/services/resume_service_test.go
@@ -279,3 +279,25 @@ func TestRelaySSEChunks_DoesNotPanicWhenFlushPanics(t *testing.T) {
 		t.Fatalf("body: %q", rr.Body.String())
 	}
 }
+
+func TestResolveLocalPathCopiesStoredFileIntoWorkDir(t *testing.T) {
+	storage := t.TempDir()
+	work := t.TempDir()
+	src := filepath.Join(storage, "resume.pdf")
+	if err := os.WriteFile(src, []byte("%PDF-1.4\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := (&ResumeService{}).resolveLocalPath(&models.ResumeDocument{
+		StoredPath:       src,
+		OriginalFilename: "resume.pdf",
+	}, work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == src {
+		t.Fatal("永続パスをそのまま返してはいけない")
+	}
+	if err := validatePathInDir(got, work); err != nil {
+		t.Fatalf("workDir 配下であるべき: %v", err)
+	}
+}

--- a/Backend/internal/services/resume_storage.go
+++ b/Backend/internal/services/resume_storage.go
@@ -38,7 +38,19 @@ func (s *ResumeService) resolveLocalPath(doc *models.ResumeDocument, workDir str
 			}
 			return downloaded, nil
 		}
-		return doc.StoredPath, nil
+		// 永続パスは workDir 配下ではない。検証・OCR用にコピーする。
+		ext := strings.ToLower(filepath.Ext(doc.OriginalFilename))
+		if ext == "" {
+			ext = strings.ToLower(filepath.Ext(doc.StoredPath))
+		}
+		if ext == "" {
+			ext = ".pdf"
+		}
+		dest := filepath.Join(workDir, "original"+ext)
+		if err := copyFile(doc.StoredPath, dest); err != nil {
+			return "", fmt.Errorf("failed to load stored resume: %w", err)
+		}
+		return dest, nil
 	}
 	if err := s.ensureS3Available(); err != nil {
 		return "", err

--- a/Backend/internal/services/s3_bucket_env_test.go
+++ b/Backend/internal/services/s3_bucket_env_test.go
@@ -1,0 +1,16 @@
+package services
+
+import "testing"
+
+func TestS3BucketFromEnvPrefersAWSThenLegacy(t *testing.T) {
+	t.Setenv("AWS_S3_BUCKET", "")
+	t.Setenv("S3_BUCKET", "legacy-bucket")
+	if got := s3BucketFromEnv(); got != "legacy-bucket" {
+		t.Fatalf("legacy S3_BUCKET: got %q", got)
+	}
+
+	t.Setenv("AWS_S3_BUCKET", "canonical-bucket")
+	if got := s3BucketFromEnv(); got != "canonical-bucket" {
+		t.Fatalf("AWS_S3_BUCKET should win: got %q", got)
+	}
+}

--- a/Backend/internal/services/s3_storage.go
+++ b/Backend/internal/services/s3_storage.go
@@ -21,8 +21,17 @@ type s3Storage struct {
 	prefix      string
 }
 
+func s3BucketFromEnv() string {
+	b := strings.TrimSpace(os.Getenv("AWS_S3_BUCKET"))
+	if b == "" {
+		// staging user_data は歴史的に S3_BUCKET のみ渡していた
+		b = strings.TrimSpace(os.Getenv("S3_BUCKET"))
+	}
+	return b
+}
+
 func newS3StorageFromEnv(ctx context.Context) (*s3Storage, error) {
-	bucket := strings.TrimSpace(os.Getenv("AWS_S3_BUCKET"))
+	bucket := s3BucketFromEnv()
 	if bucket == "" {
 		return nil, nil
 	}

--- a/Backend/internal/services/s3_upload_service.go
+++ b/Backend/internal/services/s3_upload_service.go
@@ -25,7 +25,7 @@ type S3UploadService struct {
 // NewS3UploadService initialises the service from environment variables
 // (AWS_REGION, AWS_S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
 func NewS3UploadService() (*S3UploadService, error) {
-	bucket := os.Getenv("AWS_S3_BUCKET")
+	bucket := s3BucketFromEnv()
 	region := os.Getenv("AWS_REGION")
 	if bucket == "" {
 		return nil, fmt.Errorf("AWS_S3_BUCKET is not set")

--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -48,6 +48,7 @@ DB_PASSWORD=${db_password}
 AWS_REGION=${aws_region}
 AWS_ACCESS_KEY_ID=${aws_access_key_id}
 AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
+AWS_S3_BUCKET=${s3_bucket}
 S3_BUCKET=${s3_bucket}
 OPENAI_API_KEY=${openai_api_key}
 GOOGLE_CLIENT_ID=${google_client_id}


### PR DESCRIPTION
## Summary
- ステージングの履歴書レビューが \`document processing failed\` になる
- S3 バケット自体は Terraform で既存。アプリは \`AWS_S3_BUCKET\` を見るが、staging の \`.env\` は \`S3_BUCKET\` だけだった
- レビュー前に作業ディレクトリへコピー（S3 未使用時の保険）
- \`AWS_S3_BUCKET\` を user_data / デプロイ SSH で渡す。Go は \`S3_BUCKET\` もフォールバック

## Test plan
- [x] \`go test ./internal/services/ -run TestResolveLocalPathCopiesStoredFileIntoWorkDir\`
- [x] \`go test ./internal/services/ -run TestS3BucketFromEnvPrefersAWSThenLegacy\`
- [ ] develop マージ後、ステージングで PDF アップロード → レビュー完了
- [ ] バックエンドログに \`resume_upload: stored locally\` が出ないこと（S3 利用時）