### PR TITLE
Resolve #861: 更新情報（リリースノート）ページを追加

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -372,3 +372,30 @@ jobs:
           service: frontend
           cluster: ${{ env.PROJECT_NAME }}
           wait-for-service-stability: true
+
+  # 更新情報(#861): mainへの直近マージPRをAI要約してDBへ取り込む。
+  # 本番(Fargate)は展示会時のみ起動(desired_countは変更しない)のため、
+  # デプロイ直後に到達できない場合がある。pr_numberでべき等なので、
+  # 失敗しても後続の実行(展示会起動時など)で取りこぼしなく再取り込みされる。
+  sync-whats-new:
+    needs: deploy-production
+    if: github.ref_name == 'main' && always() && needs.deploy-production.result == 'success'
+    name: Sync whats-new from merged PRs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Fetch recently merged PRs and ingest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ADMIN_SECRET: ${{ secrets.ADMIN_SECRET }}
+          API_BASE: https://${{ vars.PROD_API_DOMAIN || 'api.shukatsu-ai.jp' }}
+        run: |
+          set -e
+          sources=$(gh pr list --repo "${{ github.repository }}" --state merged --base main --limit 20 \
+            --json number,title,body,mergedAt \
+            --jq '[.[] | {pr_number: .number, title: .title, body: .body, merged_at: .mergedAt}]')
+          curl -sf -X POST "$API_BASE/api/admin/whats-new/ingest" \
+            -H "Content-Type: application/json" \
+            -H "X-Admin-Secret: $ADMIN_SECRET" \
+            -d "{\"sources\": $sources}" \
+            --max-time 60

--- a/Backend/cmd/server/main.go
+++ b/Backend/cmd/server/main.go
@@ -323,6 +323,8 @@ func main() {
 	companyEntryService := services.NewCompanyEntryService(db, userRepo, pendingRegistrationRepo, emailService)
 	authService.SetCompanyOwnershipClaimer(companyEntryService)
 	companyEntryController := controllers.NewCompanyEntryController(companyEntryService)
+	releaseNoteService := services.NewReleaseNoteService(db, aiClient)
+	releaseNoteController := controllers.NewReleaseNoteController(releaseNoteService)
 	githubController := controllers.NewGitHubController(githubService, skillScoreService)
 	esRewriteController := controllers.NewESRewriteController(aiClient)
 	scheduleRepo := repositories.NewScheduleRepository(db)
@@ -387,8 +389,12 @@ func main() {
 	routes.SetupUserRoutes(api, integratedProfileController)
 	routes.SetupCollectiveInsightRoutes(api, collectiveInsightController, cfg.UserSecret, userDeletionService, organizationService)
 	api.POST("/company-entry", companyEntryController.Submit, echoCompanyEntryRateLimit())
+	api.GET("/whats-new", releaseNoteController.List)
 	adminEntry := api.Group("/admin", routes.EchoAdminAuth(userRepo, cfg.AdminSecret))
 	adminEntry.POST("/company-entry-submissions/:id/resend-email", companyEntryController.ResendEmail)
+	// CI(GitHub Actions)からのマシン間呼び出しのため、ログインユーザー前提のEchoAdminAuthではなく
+	// 共有シークレットのみで認証する(#861)
+	api.POST("/admin/whats-new/ingest", releaseNoteController.Ingest, routes.EchoStaticSecretAuth(cfg.AdminSecret))
 
 	go crawlService.StartScheduler()
 

--- a/Backend/internal/controllers/release_note_controller.go
+++ b/Backend/internal/controllers/release_note_controller.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	"Backend/internal/services"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+type ReleaseNoteController struct {
+	service *services.ReleaseNoteService
+}
+
+func NewReleaseNoteController(service *services.ReleaseNoteService) *ReleaseNoteController {
+	return &ReleaseNoteController{service: service}
+}
+
+type releaseNoteResponse struct {
+	Title    string    `json:"title"`
+	Summary  string    `json:"summary"`
+	MergedAt time.Time `json:"merged_at"`
+}
+
+// List GET /api/whats-new
+func (c *ReleaseNoteController) List(ctx echo.Context) error {
+	notes, err := c.service.List(ctx.Request().Context(), 20)
+	if err != nil {
+		return echoInternalError(err)
+	}
+	res := make([]releaseNoteResponse, 0, len(notes))
+	for _, n := range notes {
+		res = append(res, releaseNoteResponse{Title: n.Title, Summary: n.Summary, MergedAt: n.MergedAt})
+	}
+	return ctx.JSON(http.StatusOK, res)
+}
+
+type ingestSourceRequest struct {
+	PRNumber uint      `json:"pr_number"`
+	Title    string    `json:"title"`
+	Body     string    `json:"body"`
+	MergedAt time.Time `json:"merged_at"`
+}
+
+type ingestRequest struct {
+	Sources []ingestSourceRequest `json:"sources"`
+}
+
+// Ingest POST /api/admin/whats-new/ingest
+// CIから直近マージされたPR一覧を受け取り、未取り込み分のみAI要約してDBへ保存する。
+func (c *ReleaseNoteController) Ingest(ctx echo.Context) error {
+	var req ingestRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid payload")
+	}
+
+	sources := make([]services.ReleaseNoteSource, 0, len(req.Sources))
+	for _, s := range req.Sources {
+		sources = append(sources, services.ReleaseNoteSource{
+			PRNumber: s.PRNumber,
+			Title:    s.Title,
+			Body:     s.Body,
+			MergedAt: s.MergedAt,
+		})
+	}
+
+	saved, err := c.service.IngestMergedPRs(ctx.Request().Context(), sources)
+	if err != nil {
+		return echoInternalError(err)
+	}
+	return ctx.JSON(http.StatusOK, map[string]int{"saved": saved})
+}

--- a/Backend/internal/controllers/release_note_controller_test.go
+++ b/Backend/internal/controllers/release_note_controller_test.go
@@ -1,0 +1,112 @@
+package controllers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"Backend/internal/controllers"
+	"Backend/internal/services"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/labstack/echo/v4"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newReleaseNoteControllerTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("gorm: %v", err)
+	}
+	return db, mock
+}
+
+func TestReleaseNoteController_List_ReturnsNotesNewestFirst(t *testing.T) {
+	db, mock := newReleaseNoteControllerTestDB(t)
+	svc := services.NewReleaseNoteService(db, nil)
+	ctrl := controllers.NewReleaseNoteController(svc)
+	e := echo.New()
+
+	rows := sqlmock.NewRows([]string{"id", "pr_number", "title", "summary", "merged_at", "created_at"}).
+		AddRow(1, 100, "更新情報ページを追加", "更新情報を確認できるようになりました。", time.Now(), time.Now())
+	mock.ExpectQuery("SELECT \\* FROM `release_notes` ORDER BY merged_at DESC LIMIT \\?").
+		WithArgs(20).
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/whats-new", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	if err := ctrl.List(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if len(body) != 1 || body[0]["title"] != "更新情報ページを追加" {
+		t.Fatalf("unexpected body: %v", body)
+	}
+}
+
+func TestReleaseNoteController_Ingest_InvalidPayload(t *testing.T) {
+	db, _ := newReleaseNoteControllerTestDB(t)
+	svc := services.NewReleaseNoteService(db, nil)
+	ctrl := controllers.NewReleaseNoteController(svc)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/whats-new/ingest", bytes.NewReader([]byte("not-json")))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := ctrl.Ingest(ctx)
+	if err == nil {
+		t.Fatal("expected error for invalid payload")
+	}
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 HTTPError, got %v", err)
+	}
+}
+
+func TestReleaseNoteController_Ingest_NilLLMClientReturnsInternalError(t *testing.T) {
+	db, _ := newReleaseNoteControllerTestDB(t)
+	svc := services.NewReleaseNoteService(db, nil)
+	ctrl := controllers.NewReleaseNoteController(svc)
+	e := echo.New()
+
+	payload := map[string]any{
+		"sources": []map[string]any{
+			{"pr_number": 1, "title": "t", "body": "b", "merged_at": time.Now()},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/whats-new/ingest", bytes.NewReader(b))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := ctrl.Ingest(ctx)
+	if err == nil {
+		t.Fatal("expected error when llm client is nil")
+	}
+}

--- a/Backend/internal/models/release_note.go
+++ b/Backend/internal/models/release_note.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// ReleaseNote GitHub PRからAI要約して生成する更新情報（#861）
+type ReleaseNote struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	PRNumber  uint      `gorm:"not null;uniqueIndex:uq_release_notes_pr_number" json:"pr_number"`
+	Title     string    `gorm:"type:varchar(255);not null" json:"title"`
+	Summary   string    `gorm:"type:text;not null" json:"summary"`
+	MergedAt  time.Time `gorm:"not null;index" json:"merged_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (ReleaseNote) TableName() string { return "release_notes" }

--- a/Backend/internal/routes/echo_adapter.go
+++ b/Backend/internal/routes/echo_adapter.go
@@ -5,6 +5,7 @@ import (
 	"Backend/internal/repositories"
 	"Backend/internal/services"
 	"context"
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"strconv"
@@ -93,6 +94,23 @@ func EchoTenantResolver(orgs *services.OrganizationService) echo.MiddlewareFunc 
 
 // EchoAdminAuth はX-Admin-Email / X-Admin-Tokenヘッダーを検証するEcho nativeミドルウェアを返す。
 // 検証済み管理者のユーザーIDを AdminUserIDContextKey へ格納する(後続のEchoAdminSchoolScope等が利用する)。
+// EchoStaticSecretAuth はログインユーザーを介さないサービス間呼び出し（CI等）向けの
+// 単純な共有シークレット認証。X-Admin-Secretヘッダーの値をadminSecretと定数時間比較する。
+func EchoStaticSecretAuth(adminSecret string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if adminSecret == "" {
+				return echo.NewHTTPError(http.StatusServiceUnavailable, "Service Unavailable: admin authentication not configured")
+			}
+			token := c.Request().Header.Get("X-Admin-Secret")
+			if token == "" || subtle.ConstantTimeCompare([]byte(token), []byte(adminSecret)) != 1 {
+				return echo.NewHTTPError(http.StatusForbidden, "Forbidden")
+			}
+			return next(c)
+		}
+	}
+}
+
 func EchoAdminAuth(userRepo *repositories.UserRepository, adminSecret string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/Backend/internal/services/release_note_service.go
+++ b/Backend/internal/services/release_note_service.go
@@ -1,0 +1,110 @@
+package services
+
+import (
+	"Backend/internal/models"
+	"Backend/internal/openai"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+var ErrReleaseNoteLLMClientNil = errors.New("openai client is nil")
+
+const releaseNoteSummarySystemPrompt = `あなたはtoC向けSaaSのリリースノート編集者です。開発者向けのPRタイトル・本文から、エンドユーザー（就活中の学生）向けにやさしい日本語で1〜2文の更新内容を要約してください。技術用語（API名・関数名・内部実装の詳細）は避け、ユーザーにとって何が変わったか・何が嬉しいかを書いてください。ユーザーに関係のない内部改修（リファクタリング・CI設定・依存関係更新など）の場合は summary を空文字にしてください。JSON形式のみで出力し、他のテキストは含めないでください。`
+
+const releaseNoteSummarySchema = `{"title": "ユーザー向けの短いタイトル(20字以内)", "summary": "ユーザー向けの説明文(1〜2文)。ユーザーに関係ない変更なら空文字"}`
+
+// ReleaseNoteSource は取り込み対象のマージ済みPR情報。
+type ReleaseNoteSource struct {
+	PRNumber uint
+	Title    string
+	Body     string
+	MergedAt time.Time
+}
+
+type releaseNoteSummaryResult struct {
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+}
+
+type ReleaseNoteService struct {
+	db  *gorm.DB
+	llm *openai.Client
+}
+
+func NewReleaseNoteService(db *gorm.DB, llm *openai.Client) *ReleaseNoteService {
+	return &ReleaseNoteService{db: db, llm: llm}
+}
+
+// IngestMergedPRs は未取り込みのPRのみAIで要約しDBへ保存する（pr_numberでべき等）。
+// 戻り値は新規に保存された件数。
+func (s *ReleaseNoteService) IngestMergedPRs(ctx context.Context, sources []ReleaseNoteSource) (int, error) {
+	if s.llm == nil {
+		return 0, ErrReleaseNoteLLMClientNil
+	}
+
+	saved := 0
+	for _, src := range sources {
+		var count int64
+		if err := s.db.Model(&models.ReleaseNote{}).Where("pr_number = ?", src.PRNumber).Count(&count).Error; err != nil {
+			return saved, fmt.Errorf("check existing release note: %w", err)
+		}
+		if count > 0 {
+			continue
+		}
+
+		result, err := s.summarize(ctx, src)
+		if err != nil {
+			return saved, fmt.Errorf("summarize PR #%d: %w", src.PRNumber, err)
+		}
+		if strings.TrimSpace(result.Summary) == "" {
+			// ユーザーに関係ない変更として要約対象外
+			continue
+		}
+
+		note := models.ReleaseNote{
+			PRNumber: src.PRNumber,
+			Title:    result.Title,
+			Summary:  result.Summary,
+			MergedAt: src.MergedAt,
+		}
+		if err := s.db.Create(&note).Error; err != nil {
+			return saved, fmt.Errorf("save release note for PR #%d: %w", src.PRNumber, err)
+		}
+		saved++
+	}
+	return saved, nil
+}
+
+func (s *ReleaseNoteService) summarize(ctx context.Context, src ReleaseNoteSource) (*releaseNoteSummaryResult, error) {
+	userPrompt := fmt.Sprintf(
+		"以下のPR内容を次のJSON形式で要約してください。\n%s\n\n---\nPRタイトル: %s\nPR本文:\n%s",
+		releaseNoteSummarySchema, src.Title, src.Body,
+	)
+	raw, err := s.llm.ChatCompletionJSON(ctx, releaseNoteSummarySystemPrompt, userPrompt, 0.3, 300)
+	if err != nil {
+		return nil, err
+	}
+	var result releaseNoteSummaryResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return nil, fmt.Errorf("parse summary JSON: %w", err)
+	}
+	return &result, nil
+}
+
+// List は更新情報を新しい順に返す。
+func (s *ReleaseNoteService) List(ctx context.Context, limit int) ([]models.ReleaseNote, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	var notes []models.ReleaseNote
+	if err := s.db.WithContext(ctx).Order("merged_at DESC").Limit(limit).Find(&notes).Error; err != nil {
+		return nil, fmt.Errorf("list release notes: %w", err)
+	}
+	return notes, nil
+}

--- a/Backend/internal/services/release_note_service_test.go
+++ b/Backend/internal/services/release_note_service_test.go
@@ -1,0 +1,165 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"Backend/internal/openai"
+	"Backend/internal/services"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newReleaseNoteTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("gorm: %v", err)
+	}
+	return db, mock
+}
+
+// newSummaryStubServer は ChatCompletionJSON の呼び出しに対して固定の summary を返すスタブ。
+func newSummaryStubServer(t *testing.T, summary string) (*httptest.Server, *openai.Client) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/chat/completions") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body := map[string]any{
+			"title":   "テストタイトル",
+			"summary": summary,
+		}
+		raw, _ := json.Marshal(body)
+		resp := map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]string{"content": string(raw)},
+			}},
+			"usage": map[string]any{"prompt_tokens": 10, "completion_tokens": 10},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	client := openai.NewWithBaseURL(server.URL, "gpt-4o-mini")
+	return server, client
+}
+
+func TestReleaseNoteService_IngestMergedPRs_SkipsExisting(t *testing.T) {
+	db, mock := newReleaseNoteTestDB(t)
+	server, client := newSummaryStubServer(t, "")
+	defer server.Close()
+	svc := services.NewReleaseNoteService(db, client)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `release_notes` WHERE pr_number = \\?").
+		WithArgs(uint(100)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	saved, err := svc.IngestMergedPRs(context.Background(), []services.ReleaseNoteSource{
+		{PRNumber: 100, Title: "既存PR", Body: "本文", MergedAt: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved != 0 {
+		t.Fatalf("expected 0 saved, got %d", saved)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestReleaseNoteService_IngestMergedPRs_SkipsEmptySummary(t *testing.T) {
+	db, mock := newReleaseNoteTestDB(t)
+	server, client := newSummaryStubServer(t, "")
+	defer server.Close()
+	svc := services.NewReleaseNoteService(db, client)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `release_notes` WHERE pr_number = \\?").
+		WithArgs(uint(200)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	saved, err := svc.IngestMergedPRs(context.Background(), []services.ReleaseNoteSource{
+		{PRNumber: 200, Title: "内部リファクタリング", Body: "ユーザーに影響なし", MergedAt: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved != 0 {
+		t.Fatalf("expected 0 saved (empty summary), got %d", saved)
+	}
+}
+
+func TestReleaseNoteService_IngestMergedPRs_SavesNewEntry(t *testing.T) {
+	db, mock := newReleaseNoteTestDB(t)
+	server, client := newSummaryStubServer(t, "新機能を追加しました。")
+	defer server.Close()
+	svc := services.NewReleaseNoteService(db, client)
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM `release_notes` WHERE pr_number = \\?").
+		WithArgs(uint(300)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `release_notes`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	saved, err := svc.IngestMergedPRs(context.Background(), []services.ReleaseNoteSource{
+		{PRNumber: 300, Title: "新機能", Body: "ユーザー向けの本文", MergedAt: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved != 1 {
+		t.Fatalf("expected 1 saved, got %d", saved)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestReleaseNoteService_IngestMergedPRs_NilClientErrors(t *testing.T) {
+	db, _ := newReleaseNoteTestDB(t)
+	svc := services.NewReleaseNoteService(db, nil)
+
+	_, err := svc.IngestMergedPRs(context.Background(), []services.ReleaseNoteSource{{PRNumber: 1}})
+	if err != services.ErrReleaseNoteLLMClientNil {
+		t.Fatalf("expected ErrReleaseNoteLLMClientNil, got %v", err)
+	}
+}
+
+func TestReleaseNoteService_List_OrdersByMergedAtDesc(t *testing.T) {
+	db, mock := newReleaseNoteTestDB(t)
+	svc := services.NewReleaseNoteService(db, nil)
+
+	rows := sqlmock.NewRows([]string{"id", "pr_number", "title", "summary", "merged_at", "created_at"}).
+		AddRow(2, 200, "新しい方", "説明2", time.Now(), time.Now()).
+		AddRow(1, 100, "古い方", "説明1", time.Now().Add(-24*time.Hour), time.Now())
+	mock.ExpectQuery("SELECT \\* FROM `release_notes` ORDER BY merged_at DESC LIMIT \\?").
+		WithArgs(20).
+		WillReturnRows(rows)
+
+	notes, err := svc.List(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 2 || notes[0].Title != "新しい方" {
+		t.Fatalf("unexpected result: %+v", notes)
+	}
+}

--- a/Backend/migrations/000010_release_notes.down.sql
+++ b/Backend/migrations/000010_release_notes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS release_notes;

--- a/Backend/migrations/000010_release_notes.up.sql
+++ b/Backend/migrations/000010_release_notes.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE release_notes (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    pr_number INT UNSIGNED NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    summary TEXT NOT NULL,
+    merged_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_release_notes_pr_number (pr_number),
+    KEY idx_release_notes_merged_at (merged_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frontend/app/api/whats-new/route.ts
+++ b/frontend/app/api/whats-new/route.ts
@@ -1,0 +1,14 @@
+import { buildProxyJsonResponse, buildProxyNetworkErrorResponse } from '@/lib/api-proxy'
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://app:8080'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/whats-new`, { cache: 'no-store' })
+    return buildProxyJsonResponse(response)
+  } catch (error) {
+    return buildProxyNetworkErrorResponse(error, 'Failed to connect to backend')
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Box, IconButton, AppBar, Toolbar, Typography } from '@mui/material'
+import { Box, IconButton, AppBar, Toolbar, Typography, Alert } from '@mui/material'
 import { Menu as MenuIcon } from '@mui/icons-material'
 import { AnalysisSidebar } from '@/components/analysis-sidebar'
 import { MuiChat } from '@/components/mui-chat'
 import { PageLoading } from '@/components/common/PageLoading'
 import { authService, User } from '@/lib/auth'
+import { WhatsNewEntry, fetchWhatsNewEntries, hasUnreadWhatsNew, markWhatsNewAsSeen } from '@/lib/whats-new-data'
 import styles from './page.module.css'
 
 export default function Home() {
@@ -15,6 +16,8 @@ export default function Home() {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [whatsNewEntries, setWhatsNewEntries] = useState<WhatsNewEntry[]>([])
+  const [showWhatsNewBanner, setShowWhatsNewBanner] = useState(false)
 
   useEffect(() => {
     const storedUser = authService.getStoredUser()
@@ -24,7 +27,20 @@ export default function Home() {
     }
     setUser(storedUser)
     setLoading(false)
+    fetchWhatsNewEntries()
+      .then((entries) => {
+        setWhatsNewEntries(entries)
+        setShowWhatsNewBanner(hasUnreadWhatsNew(entries))
+      })
+      .catch(() => {
+        // 更新情報の取得失敗はチャット画面の利用を妨げない
+      })
   }, [router])
+
+  const dismissWhatsNewBanner = () => {
+    markWhatsNewAsSeen(whatsNewEntries)
+    setShowWhatsNewBanner(false)
+  }
 
   const handleLogout = () => {
     authService.logout()
@@ -66,6 +82,24 @@ export default function Home() {
             </Typography>
           </Toolbar>
         </AppBar>
+        {showWhatsNewBanner && whatsNewEntries.length > 0 && (
+          <Alert
+            severity="info"
+            onClose={dismissWhatsNewBanner}
+            sx={{ borderRadius: 0 }}
+            action={
+              <Box
+                component="a"
+                href="/whats-new"
+                sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'inherit', textDecoration: 'underline', mr: 1, alignSelf: 'center' }}
+              >
+                詳しく見る
+              </Box>
+            }
+          >
+            新着情報: {whatsNewEntries[0].title}
+          </Alert>
+        )}
         <div className={styles.chatWrapper}>
           <MuiChat />
         </div>

--- a/frontend/app/whats-new/page.tsx
+++ b/frontend/app/whats-new/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Box, Container, Typography, Divider, Button } from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { useRouter } from 'next/navigation'
+import { WhatsNewEntry, fetchWhatsNewEntries, markWhatsNewAsSeen } from '@/lib/whats-new-data'
+import { PageLoading } from '@/components/common/PageLoading'
+
+export default function WhatsNewPage() {
+  const router = useRouter()
+  const [entries, setEntries] = useState<WhatsNewEntry[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    fetchWhatsNewEntries()
+      .then((data) => {
+        setEntries(data)
+        markWhatsNewAsSeen(data)
+      })
+      .catch(() => setError(true))
+  }, [])
+
+  return (
+    <Container maxWidth="md" sx={{ py: 6 }}>
+      <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()} sx={{ mb: 3 }}>
+        戻る
+      </Button>
+
+      <Typography variant="h4" fontWeight="bold" gutterBottom>
+        更新情報
+      </Typography>
+      <Divider sx={{ my: 3 }} />
+
+      {error ? (
+        <Typography variant="body1" color="text.secondary">
+          更新情報の取得に失敗しました。時間をおいて再度お試しください。
+        </Typography>
+      ) : entries === null ? (
+        <PageLoading message="更新情報を取得しています..." />
+      ) : entries.length === 0 ? (
+        <Typography variant="body1" color="text.secondary">
+          更新情報はまだありません。
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {entries.map((entry) => (
+            <Box key={entry.merged_at + entry.title}>
+              <Typography variant="caption" color="text.secondary">
+                {new Date(entry.merged_at).toLocaleDateString('ja-JP')}
+              </Typography>
+              <Typography variant="h6" fontWeight="bold">
+                {entry.title}
+              </Typography>
+              <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5 }}>
+                {entry.summary}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Container>
+  )
+}

--- a/frontend/components/analysis-sidebar.tsx
+++ b/frontend/components/analysis-sidebar.tsx
@@ -41,6 +41,7 @@ import {
     CalendarMonth,
     Business,
     Assignment,
+    NewReleases,
 } from '@mui/icons-material'
 import {authService, User} from '@/lib/auth'
 import {useRouter} from 'next/navigation'
@@ -567,6 +568,29 @@ export function AnalysisSidebar({user, onLogout, mobileOpen = false, onMobileClo
                         </ListItemIcon>
                         <ListItemText
                             primary="プロフィール設定"
+                            primaryTypographyProps={{
+                                fontSize: '0.875rem',
+                                fontWeight: 500,
+                            }}
+                        />
+                    </ListItemButton>
+                </ListItem>
+
+                <ListItem disablePadding>
+                    <ListItemButton
+                        onClick={() => {
+                            router.push('/whats-new')
+                            onMobileClose?.()
+                        }}
+                        sx={{
+                            borderRadius: 1,
+                        }}
+                    >
+                        <ListItemIcon sx={{minWidth: 36}}>
+                            <NewReleases color="primary"/>
+                        </ListItemIcon>
+                        <ListItemText
+                            primary="更新情報"
                             primaryTypographyProps={{
                                 fontSize: '0.875rem',
                                 fontWeight: 500,

--- a/frontend/lib/whats-new-data.ts
+++ b/frontend/lib/whats-new-data.ts
@@ -1,0 +1,24 @@
+export interface WhatsNewEntry {
+  title: string
+  summary: string
+  merged_at: string
+}
+
+export async function fetchWhatsNewEntries(): Promise<WhatsNewEntry[]> {
+  const res = await fetch('/api/whats-new', { cache: 'no-store' })
+  if (!res.ok) throw new Error('whats-new')
+  return res.json() as Promise<WhatsNewEntry[]>
+}
+
+const LAST_SEEN_KEY = 'whatsNewLastSeenMergedAt'
+
+export function hasUnreadWhatsNew(entries: WhatsNewEntry[]): boolean {
+  if (typeof window === 'undefined' || entries.length === 0) return false
+  const latest = entries[0].merged_at
+  return window.localStorage.getItem(LAST_SEEN_KEY) !== latest
+}
+
+export function markWhatsNewAsSeen(entries: WhatsNewEntry[]): void {
+  if (typeof window === 'undefined' || entries.length === 0) return
+  window.localStorage.setItem(LAST_SEEN_KEY, entries[0].merged_at)
+}

--- a/frontend/tests/app/whats-new/page.test.tsx
+++ b/frontend/tests/app/whats-new/page.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import WhatsNewPage from '@/app/whats-new/page'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+}))
+
+describe('WhatsNewPage', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('取得した更新情報を新しい順に表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { title: '新機能A', summary: '説明A', merged_at: '2026-08-15T00:00:00Z' },
+        { title: '過去の更新', summary: '説明B', merged_at: '2026-08-01T00:00:00Z' },
+      ],
+    })
+
+    render(<WhatsNewPage />)
+
+    expect(await screen.findByText('新機能A')).toBeInTheDocument()
+    expect(screen.getByText('過去の更新')).toBeInTheDocument()
+  })
+
+  it('取得失敗時はエラーメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: false })
+
+    render(<WhatsNewPage />)
+
+    expect(await screen.findByText(/取得に失敗しました/)).toBeInTheDocument()
+  })
+
+  it('更新情報が0件の場合はその旨を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => [] })
+
+    render(<WhatsNewPage />)
+
+    expect(await screen.findByText('更新情報はまだありません。')).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/lib/whats-new-data.test.ts
+++ b/frontend/tests/lib/whats-new-data.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import { hasUnreadWhatsNew, markWhatsNewAsSeen, type WhatsNewEntry } from '@/lib/whats-new-data'
+
+describe('whats-new-data', () => {
+  const entries: WhatsNewEntry[] = [
+    { title: '新機能A', summary: '説明A', merged_at: '2026-08-15T00:00:00Z' },
+    { title: '過去の更新', summary: '説明B', merged_at: '2026-08-01T00:00:00Z' },
+  ]
+
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('未読なし(空配列)ではバナーを出さない', () => {
+    expect(hasUnreadWhatsNew([])).toBe(false)
+  })
+
+  it('既読情報がなければ未読扱いにする', () => {
+    expect(hasUnreadWhatsNew(entries)).toBe(true)
+  })
+
+  it('最新エントリを既読にすると未読ではなくなる', () => {
+    markWhatsNewAsSeen(entries)
+    expect(hasUnreadWhatsNew(entries)).toBe(false)
+  })
+
+  it('さらに新しいエントリが追加されると再び未読になる', () => {
+    markWhatsNewAsSeen(entries)
+    const withNew: WhatsNewEntry[] = [
+      { title: '新機能B', summary: '説明C', merged_at: '2026-08-20T00:00:00Z' },
+      ...entries,
+    ]
+    expect(hasUnreadWhatsNew(withNew)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #861

## 変更内容
更新情報の入力方式は「開発者が静的ファイルを編集」から「GitHub PRをAIが要約してDB/APIで配信」する方式に変更（Issue内で経緯を記録）。

### Backend
- `release_notes`テーブルのマイグレーション追加（`pr_number`一意制約でべき等）
- `ReleaseNoteService`: 未取り込みPRのみOpenAI(`ChatCompletionJSON`)でユーザー向けタイトル・要約を生成しDBへ保存。ユーザーに無関係な変更は要約を空文字にして保存しない
- `GET /api/whats-new`（公開、新しい順で一覧取得）
- `POST /api/admin/whats-new/ingest`（CI等サービス間呼び出し向け。ログインユーザー前提の`EchoAdminAuth`とは別に、`X-Admin-Secret`ヘッダーによる共有シークレット認証`EchoStaticSecretAuth`を新設）
- テーブル駆動テスト（sqlmock + httptestでDB/OpenAIをモック）

### CI
- `.github/workflows/deployment.yml`に`sync-whats-new`ジョブを追加。`main`への本番デプロイ成功後、直近マージPRを取得しingest APIへ送信。`continue-on-error: true`で非ブロッキング、`pr_number`べき等のため本番(ECS Fargate、展示会時のみ起動)が停止中でも次回起動時に取りこぼしなく再取り込みされる

### Frontend
- `/whats-new`: 更新履歴一覧ページ（API取得、新しい順表示）
- `frontend/app/api/whats-new/route.ts`: バックエンドへのプロキシ
- `frontend/lib/whats-new-data.ts`: 取得・未読判定（localStorageで既読管理）
- サイドバー下部に「更新情報」リンクを追加
- トップ画面に未読時のみ表示するバナーを追加

### 要確認事項
- GitHub Actions側に`ADMIN_SECRET`シークレットの登録が必要です（既存BackendのECS環境変数と同じ値）。リポジトリ設定からの登録をお願いします。

## テスト
- `go build ./...` / `go test ./internal/services/... ./internal/controllers/... ./internal/routes/...` すべて成功
- `npx tsc --noEmit` / `npm test`（既存267件+新規7件）すべて成功
- `npm run lint`: 新規エラーなし（既存warningのみ）