### PR TITLE
fix: #863 ステージングのEMAIL_FROMを検証済みドメインにする

### DIFF
--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -53,6 +53,7 @@ S3_BUCKET=${s3_bucket}
 OPENAI_API_KEY=${openai_api_key}
 RESEND_API_KEY=${resend_api_key}
 EMAIL_PROVIDER=resend
+EMAIL_FROM=noreply@shukatsu-ai.jp
 GOOGLE_CLIENT_ID=${google_client_id}
 GOOGLE_CLIENT_SECRET=${google_client_secret}
 GITHUB_CLIENT_ID=${github_client_id}


### PR DESCRIPTION
## 変更内容
PR #865のマージ後、実際にステージングを起動して動作確認したところ、`EMAIL_FROM`未設定により`noreply@example.com`にフォールバックしていることが判明。Resend未検証ドメインのため実送信に失敗する可能性が高い。本番(`infra/terraform/environments/prod/main.tf:218`)と同じ`noreply@shukatsu-ai.jp`をステージングにも設定する。

## 動作確認
ステージングEC2を一時起動しSSHで確認:
- 修正前: `[EmailService] provider=resend from=noreply@example.com`
- 修正後: `[EmailService] provider=resend from=noreply@shukatsu-ai.jp`（本番と同じ検証済みドメイン）

確認後、`aws_launch_template.app`のみterraform apply済み。ステージングEC2は動作確認後に停止済み（ASG desired=0に戻した）。