### PR TITLE
Release: 2026-08-16 更新情報の同期をstagingにも拡張・ADMIN_SECRET固定値化

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -381,6 +381,7 @@ jobs:
   # 本番(Fargate)は展示会時のみ起動(desired_countは変更しない)のため、
   # デプロイ直後に到達できない場合がある。pr_numberでべき等なので、
   # 失敗しても後続の実行(展示会起動時など)で取りこぼしなく再取り込みされる。
+  # stagingにも同じmain由来の内容を反映し、本番が停止中でもstagingで確認できるようにする。
   sync-whats-new:
     needs: deploy-production
     if: github.ref_name == 'main' && always() && needs.deploy-production.result == 'success'
@@ -392,14 +393,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ADMIN_SECRET: ${{ secrets.ADMIN_SECRET }}
-          API_BASE: https://${{ vars.PROD_API_DOMAIN || 'api.shukatsu-ai.jp' }}
+          PROD_API_BASE: https://${{ vars.PROD_API_DOMAIN || 'api.shukatsu-ai.jp' }}
+          STAGING_API_BASE: https://${{ vars.STAGING_API_DOMAIN || 'api-stg.shukatsu-ai.jp' }}
         run: |
-          set -e
           sources=$(gh pr list --repo "${{ github.repository }}" --state merged --base main --limit 20 \
             --json number,title,body,mergedAt \
             --jq '[.[] | {pr_number: .number, title: .title, body: .body, merged_at: .mergedAt}]')
-          curl -sf -X POST "$API_BASE/api/admin/whats-new/ingest" \
+
+          curl -sf -X POST "$PROD_API_BASE/api/admin/whats-new/ingest" \
             -H "Content-Type: application/json" \
             -H "X-Admin-Secret: $ADMIN_SECRET" \
             -d "{\"sources\": $sources}" \
-            --max-time 60
+            --max-time 60 \
+            || echo "本番への取り込みに失敗しました(停止中の可能性)。スキップします。"
+
+          curl -sf -X POST "$STAGING_API_BASE/api/admin/whats-new/ingest" \
+            -H "Content-Type: application/json" \
+            -H "X-Admin-Secret: $ADMIN_SECRET" \
+            -d "{\"sources\": $sources}" \
+            --max-time 60 \
+            || echo "stagingへの取り込みに失敗しました(停止中の可能性)。スキップします。"

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -8,7 +8,7 @@ locals {
   backend_domain  = "api.${var.domain_name}"
 
   backend_secret_arns = compact(concat(
-    [module.secrets.db_secret_arn, aws_secretsmanager_secret.oauth.arn, aws_secretsmanager_secret.email.arn],
+    [module.secrets.db_secret_arn, aws_secretsmanager_secret.oauth.arn, aws_secretsmanager_secret.email.arn, aws_secretsmanager_secret.admin.arn],
     var.openai_secret_arn != "" ? [var.openai_secret_arn] : [],
     var.additional_secret_arns
   ))
@@ -65,6 +65,12 @@ locals {
         name      = "RESEND_API_KEY"
         valueFrom = "${aws_secretsmanager_secret.email.arn}:resend_api_key::"
       }
+    ],
+    [
+      {
+        name      = "ADMIN_SECRET"
+        valueFrom = "${aws_secretsmanager_secret.admin.arn}:admin_secret::"
+      }
     ]
   )
 }
@@ -95,6 +101,19 @@ resource "aws_secretsmanager_secret_version" "email" {
   secret_id = aws_secretsmanager_secret.email.id
   secret_string = jsonencode({
     resend_api_key = var.resend_api_key
+  })
+}
+
+# 管理者認証シークレット(sync-whats-newジョブ等、CIからのサービス間呼び出しに使用)
+resource "aws_secretsmanager_secret" "admin" {
+  name = "${var.project_name}/admin"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "admin" {
+  secret_id = aws_secretsmanager_secret.admin.id
+  secret_string = jsonencode({
+    admin_secret = var.admin_secret
   })
 }
 

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -135,6 +135,13 @@ variable "resend_api_key" {
   default     = ""
 }
 
+variable "admin_secret" {
+  type        = string
+  description = "管理者認証シークレット。CI(sync-whats-newジョブ等)から既知の値で呼び出すため、stagingのadmin_secret_plainと同じ値を設定すること"
+  sensitive   = true
+  default     = ""
+}
+
 variable "additional_secret_arns" {
   type        = list(string)
   description = "Extra secret ARNs the backend execution role may read"

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -157,11 +157,6 @@ resource "random_password" "user_secret" {
   special = false
 }
 
-resource "random_password" "admin_secret" {
-  length  = 48
-  special = false
-}
-
 resource "random_password" "oauth_state_secret" {
   length  = 32
   special = false
@@ -225,7 +220,7 @@ resource "aws_launch_template" "app" {
     backend_domain           = local.backend_domain
     frontend_domain          = local.frontend_domain
     user_secret              = random_password.user_secret.result
-    admin_secret             = random_password.admin_secret.result
+    admin_secret             = var.admin_secret_plain
     oauth_state_secret       = random_password.oauth_state_secret.result
     token_encryption_key     = random_id.token_encryption_key.hex
     edge_nginx_conf          = file("${path.module}/../../../nginx/staging-edge.conf")

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -180,6 +180,13 @@ variable "resend_api_key_plain" {
   default     = ""
 }
 
+variable "admin_secret_plain" {
+  type        = string
+  description = "管理者認証シークレット(平文)。CI(sync-whats-newジョブ等)から既知の値で呼び出せるよう、random_passwordではなく固定値にする"
+  sensitive   = true
+  default     = ""
+}
+
 variable "google_client_id" {
   type        = string
   description = "Google OAuthクライアントID。コールバックURL https://<api_domain>/api/auth/google/callback をGoogle Cloud Console側で許可しておくこと"


### PR DESCRIPTION
## 変更内容
- whats-new(更新情報)の同期を本番に加えstagingにも拡張
- staging/prodのADMIN_SECRETをrandom_password/未設定から固定値方式に変更
- GitHub Actions Secretsに`ADMIN_SECRET`を新規登録

詳細は #870 を参照。