### PR TITLE
Resolve #864 AI面接練習の発音誤り・企業デフォルト選択・文字起こし精度を改善する

### DIFF
--- a/Backend/internal/openai/tts.go
+++ b/Backend/internal/openai/tts.go
@@ -22,7 +22,7 @@ func (cli *Client) Transcribe(ctx context.Context, audio []byte, filename string
 
 	model := os.Getenv("OPENAI_WHISPER_MODEL")
 	if model == "" {
-		model = "whisper-1"
+		model = "gpt-4o-transcribe"
 	}
 
 	var buf bytes.Buffer

--- a/Backend/internal/openai/tts_test.go
+++ b/Backend/internal/openai/tts_test.go
@@ -9,56 +9,46 @@ import (
 	"testing"
 )
 
-func TestTranscribe_DefaultModelIsGPT4oTranscribe(t *testing.T) {
-	var gotModel string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		if err != nil {
-			t.Fatalf("failed to parse content type: %v", err)
-		}
-		mr := multipart.NewReader(r.Body, params["boundary"])
-		form, err := mr.ReadForm(10 << 20)
-		if err != nil {
-			t.Fatalf("failed to read multipart form: %v", err)
-		}
-		if v := form.Value["model"]; len(v) > 0 {
-			gotModel = v[0]
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"text":"テスト"}`))
-	}))
-	defer server.Close()
-
-	t.Setenv("OPENAI_WHISPER_MODEL", "")
-	cli := NewWithBaseURL(server.URL, "gpt-4o-mini")
-	if _, err := cli.Transcribe(context.Background(), []byte("dummy"), "audio.webm"); err != nil {
-		t.Fatalf("Transcribe returned error: %v", err)
+func TestTranscribe_Model(t *testing.T) {
+	tests := []struct {
+		name      string
+		envModel  string
+		wantModel string
+	}{
+		{name: "default is gpt-4o-transcribe", envModel: "", wantModel: "gpt-4o-transcribe"},
+		{name: "respects env override", envModel: "whisper-1", wantModel: "whisper-1"},
 	}
-	if gotModel != "gpt-4o-transcribe" {
-		t.Fatalf("Transcribe model = %q, want %q", gotModel, "gpt-4o-transcribe")
-	}
-}
 
-func TestTranscribe_RespectsEnvOverride(t *testing.T) {
-	var gotModel string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		mr := multipart.NewReader(r.Body, params["boundary"])
-		form, _ := mr.ReadForm(10 << 20)
-		if v := form.Value["model"]; len(v) > 0 {
-			gotModel = v[0]
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"text":"テスト"}`))
-	}))
-	defer server.Close()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var gotModel string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+				if err != nil {
+					t.Fatalf("failed to parse content type: %v", err)
+				}
+				mr := multipart.NewReader(r.Body, params["boundary"])
+				form, err := mr.ReadForm(10 << 20)
+				if err != nil {
+					t.Fatalf("failed to read multipart form: %v", err)
+				}
+				if v := form.Value["model"]; len(v) > 0 {
+					gotModel = v[0]
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"text":"テスト"}`))
+			}))
+			defer server.Close()
 
-	t.Setenv("OPENAI_WHISPER_MODEL", "whisper-1")
-	cli := NewWithBaseURL(server.URL, "gpt-4o-mini")
-	if _, err := cli.Transcribe(context.Background(), []byte("dummy"), "audio.webm"); err != nil {
-		t.Fatalf("Transcribe returned error: %v", err)
-	}
-	if gotModel != "whisper-1" {
-		t.Fatalf("Transcribe model = %q, want %q", gotModel, "whisper-1")
+			t.Setenv("OPENAI_WHISPER_MODEL", tt.envModel)
+			cli := NewWithBaseURL(server.URL, "gpt-4o-mini")
+			if _, err := cli.Transcribe(context.Background(), []byte("dummy"), "audio.webm"); err != nil {
+				t.Fatalf("Transcribe returned error: %v", err)
+			}
+			if gotModel != tt.wantModel {
+				t.Fatalf("Transcribe model = %q, want %q", gotModel, tt.wantModel)
+			}
+		})
 	}
 }

--- a/Backend/internal/openai/tts_test.go
+++ b/Backend/internal/openai/tts_test.go
@@ -1,0 +1,64 @@
+package openai
+
+import (
+	"context"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTranscribe_DefaultModelIsGPT4oTranscribe(t *testing.T) {
+	var gotModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("failed to parse content type: %v", err)
+		}
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		form, err := mr.ReadForm(10 << 20)
+		if err != nil {
+			t.Fatalf("failed to read multipart form: %v", err)
+		}
+		if v := form.Value["model"]; len(v) > 0 {
+			gotModel = v[0]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"テスト"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_WHISPER_MODEL", "")
+	cli := NewWithBaseURL(server.URL, "gpt-4o-mini")
+	if _, err := cli.Transcribe(context.Background(), []byte("dummy"), "audio.webm"); err != nil {
+		t.Fatalf("Transcribe returned error: %v", err)
+	}
+	if gotModel != "gpt-4o-transcribe" {
+		t.Fatalf("Transcribe model = %q, want %q", gotModel, "gpt-4o-transcribe")
+	}
+}
+
+func TestTranscribe_RespectsEnvOverride(t *testing.T) {
+	var gotModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		form, _ := mr.ReadForm(10 << 20)
+		if v := form.Value["model"]; len(v) > 0 {
+			gotModel = v[0]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"テスト"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_WHISPER_MODEL", "whisper-1")
+	cli := NewWithBaseURL(server.URL, "gpt-4o-mini")
+	if _, err := cli.Transcribe(context.Background(), []byte("dummy"), "audio.webm"); err != nil {
+		t.Fatalf("Transcribe returned error: %v", err)
+	}
+	if gotModel != "whisper-1" {
+		t.Fatalf("Transcribe model = %q, want %q", gotModel, "whisper-1")
+	}
+}

--- a/Backend/internal/services/interview/interview_turn.go
+++ b/Backend/internal/services/interview/interview_turn.go
@@ -94,9 +94,9 @@ func (s *InterviewService) Turn(
 		return nil, fmt.Errorf("chat error: %w", err)
 	}
 
-	// TTS: AI返答を音声化
+	// TTS: AI返答を音声化（企業名は読み仮名に置換して誤読を防ぐ。表示用のaiTextはそのまま保持）
 	voice := ttsVoiceForGenderAndLang(session.InterviewerGender, session.Language)
-	audio, err := s.openaiClient.TTS(ctx, aiText, voice)
+	audio, err := s.openaiClient.TTS(ctx, applyCompanyReadingForTTS(aiText, companyName, companyReading), voice)
 	if err != nil {
 		return nil, fmt.Errorf("tts error: %w", err)
 	}
@@ -187,8 +187,9 @@ func (s *InterviewService) StartTurn(
 		return nil, fmt.Errorf("chat error: %w", err)
 	}
 
+	// TTS: 企業名は読み仮名に置換して誤読を防ぐ（表示用のaiTextはそのまま保持）
 	voice := ttsVoiceForGenderAndLang(session.InterviewerGender, session.Language)
-	audio, err := s.openaiClient.TTS(ctx, aiText, voice)
+	audio, err := s.openaiClient.TTS(ctx, applyCompanyReadingForTTS(aiText, companyName, companyReading), voice)
 	if err != nil {
 		return nil, fmt.Errorf("tts error: %w", err)
 	}
@@ -205,4 +206,16 @@ func (s *InterviewService) StartTurn(
 		result.IsDeepening = directive.IsDeepening
 	}
 	return result, nil
+}
+
+// applyCompanyReadingForTTS はTTS読み上げ用に、AI発話中の企業名（漢字等の表記）を
+// 読み仮名に置換する。Chatモデルが読み仮名を無視して漢字表記のまま出力しても、
+// TTSには常に正しい読みが渡るようにするための対策（表示用テキストは変更しない）。
+func applyCompanyReadingForTTS(text, companyName, companyReading string) string {
+	companyName = strings.TrimSpace(companyName)
+	companyReading = strings.TrimSpace(companyReading)
+	if companyName == "" || companyReading == "" || companyName == companyReading {
+		return text
+	}
+	return strings.ReplaceAll(text, companyName, companyReading)
 }

--- a/Backend/internal/services/interview/interview_turn_test.go
+++ b/Backend/internal/services/interview/interview_turn_test.go
@@ -1,0 +1,62 @@
+package interview
+
+import "testing"
+
+func TestApplyCompanyReadingForTTS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		text           string
+		companyName    string
+		companyReading string
+		want           string
+	}{
+		{
+			name:           "replaces company name with reading",
+			text:           "味の素株式会社様の面接を始めます。味の素株式会社での経験を教えてください。",
+			companyName:    "味の素株式会社",
+			companyReading: "アジノモト",
+			want:           "アジノモト様の面接を始めます。アジノモトでの経験を教えてください。",
+		},
+		{
+			name:           "no reading leaves text unchanged",
+			text:           "味の素株式会社様の面接を始めます。",
+			companyName:    "味の素株式会社",
+			companyReading: "",
+			want:           "味の素株式会社様の面接を始めます。",
+		},
+		{
+			name:           "no company name leaves text unchanged",
+			text:           "本日はよろしくお願いします。",
+			companyName:    "",
+			companyReading: "アジノモト",
+			want:           "本日はよろしくお願いします。",
+		},
+		{
+			name:           "reading equal to name leaves text unchanged",
+			text:           "ABC株式会社の面接です。",
+			companyName:    "ABC株式会社",
+			companyReading: "ABC株式会社",
+			want:           "ABC株式会社の面接です。",
+		},
+		{
+			name:           "company name not present in text leaves text unchanged",
+			text:           "本日はよろしくお願いします。",
+			companyName:    "味の素株式会社",
+			companyReading: "アジノモト",
+			want:           "本日はよろしくお願いします。",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := applyCompanyReadingForTTS(tt.text, tt.companyName, tt.companyReading)
+			if got != tt.want {
+				t.Fatalf("applyCompanyReadingForTTS(%q, %q, %q) = %q, want %q", tt.text, tt.companyName, tt.companyReading, got, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/app/interview/hooks/useInterviewSession.ts
+++ b/frontend/app/interview/hooks/useInterviewSession.ts
@@ -452,7 +452,7 @@ export function useInterviewSession({
     if (audioTracks.length === 0) return
     const micStream = new MediaStream(audioTracks)
     audioChunksRef.current = []
-    const mr = new MediaRecorder(micStream, { mimeType: 'audio/webm' })
+    const mr = new MediaRecorder(micStream, { mimeType: 'audio/webm', audioBitsPerSecond: 128000 })
     mr.ondataavailable = (e) => { if (e.data.size > 0) audioChunksRef.current.push(e.data) }
     mr.onstop = () => { void sendTurn() }
     mediaRecorderRef.current = mr

--- a/frontend/app/interview/page.tsx
+++ b/frontend/app/interview/page.tsx
@@ -141,7 +141,6 @@ function InterviewContent() {
         const data = await r.json()
         const list: InterviewCompany[] = Array.isArray(data?.companies) ? data.companies : []
         setAllCompanies(list)
-        if (list.length > 0 && !interviewCompany) setInterviewCompany(list[0])
       } catch (e) {
         if (cancelled) return
         setCompaniesLoadError(


### PR DESCRIPTION
Closes #864

## 変更内容

### 1. AI面接官の発音誤りを修正
- `Backend/internal/services/interview/interview_turn.go` に `applyCompanyReadingForTTS` を追加。TTS呼び出し直前に、AI発話テキスト中の企業名（漢字表記）を読み仮名（`companyReading`）へ置換してから音声合成する。
- Chatモデルの出力が漢字表記のままでも、TTSには常に正しい読みが渡るようにすることで誤読を防止。表示用の`aiText`自体は変更しないため、画面表示は従来通り。
- `Turn`（通常ターン）・`StartTurn`（面接開始時）の両方に適用。

### 2. 企業一覧の先頭企業（味の素株式会社）が誤ってデフォルト選択される不具合を修正
- `frontend/app/interview/page.tsx` の企業一覧取得後に先頭企業を自動選択していた処理（`if (list.length > 0 && !interviewCompany) setInterviewCompany(list[0])`）を削除。
- 企業を明示的に選択するまで「未選択」状態を維持する。

### 3. 文字起こし精度の改善
- `Backend/internal/openai/tts.go`: Whisperのデフォルトモデルを `whisper-1` から `gpt-4o-transcribe` に変更（`OPENAI_WHISPER_MODEL` 環境変数での上書きは引き続き可能）。
- `frontend/app/interview/hooks/useInterviewSession.ts`: `MediaRecorder` に `audioBitsPerSecond: 128000` を明示指定し、録音品質のブレを抑制。

## テスト
- `applyCompanyReadingForTTS` のテーブル駆動テストを追加（置換あり/読み未設定/対象企業名なし等のパターン）
- Whisperモデルのデフォルト値・環境変数上書きをhttptestで検証するテストを追加
- `go test ./internal/services/interview/... ./internal/openai/...` 全通過
- `tsc --noEmit` / `eslint`（変更ファイル）ともに新規エラーなし
- Docker環境（実OpenAI API）でPlaywrightヘッドレスブラウザを用いてE2E動作確認済み
  - 企業未選択画面の表示、TTS直前の企業名→読み仮名置換（一時デバッグログで実測）、録音〜STT(gpt-4o-transcribe)〜Chat〜TTSのフルパイプラインが正常完了することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 音声文字起こしの標準モデルを更新し、認識精度の向上を図りました。
  - 面接中の音声読み上げで、企業名を適切な読み方に変換するよう改善しました。
  - 録音時の音質設定を見直し、より安定した音声データを送信できるようにしました。
  - 企業一覧を読み込んだ際、企業が自動選択されないよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->