### PR TITLE
Resolve #832 stagingにREDIS_URLを設定しインメモリ制限フォールバックを外す

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - soc-ai-network
     logging:
@@ -32,6 +34,7 @@ services:
       - NODE_ENV=${NODE_ENV:-development}
       - ANNOTATION_FONT_PATH=${ANNOTATION_FONT_PATH:-/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc}
       - RAG_REVIEW_URL=${RAG_REVIEW_URL:-http://rag-review:9000}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
 
   # 明示的な migrate ワンショット（app 起動前にも実行可能: docker compose run --rm migrate）
   migrate:
@@ -80,6 +83,24 @@ services:
       --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "${LOG_MAX_SIZE:-10m}"
+        max-file: "${LOG_MAX_FILE:-3}"
+
+  # レート制限(#617)・asynqキューのバックエンド。未起動でもBackendはインメモリにフォールバックする
+  redis:
+    image: redis:7-alpine
+    container_name: soc-ai-redis
+    restart: unless-stopped
+    networks:
+      - soc-ai-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -64,6 +64,7 @@ RAG_REVIEW_URL=http://rag-review:9000
 CHROMA_HOST=chroma
 CHROMA_PORT=8000
 SERVER_PORT=8080
+REDIS_URL=redis://redis:6379/0
 EOF
 chmod 600 /opt/app/.env
 
@@ -84,6 +85,7 @@ services:
       - "8080:8080"
     depends_on:
       - rag-review
+      - redis
   frontend:
     image: ${frontend_image}
     restart: always
@@ -118,6 +120,10 @@ services:
     environment:
       IS_PERSISTENT: "TRUE"
       ANONYMIZED_TELEMETRY: "FALSE"
+  redis:
+    image: redis:7-alpine
+    restart: always
+    logging: *default-logging
 
 volumes:
   chroma_data:


### PR DESCRIPTION
Closes #832

**注意**: このブランチは #829（`fix/issue-829-staging-iam-role` / PR #878）を土台にしているため、baseをそちらに向けています。#878がdevelopにマージされた後、本PRのbaseもdevelopへ自動追従します。

## 変更内容
- `compose.yml`にローカル用`redis`サービス(redis:7-alpine)を追加。`app`サービスに`REDIS_URL=redis://redis:6379/0`と`depends_on(redis: service_healthy)`を追加
- `app_user_data.sh.tftpl`のdocker-composeに`redis`コンテナを追加（`chroma`と同じEC2内コンテナ方式）。`.env`へ`REDIS_URL`を追加、`backend`の`depends_on`に`redis`を追加

Backend側は`Backend/internal/infrastructure/redisx/client.go`が`REDIS_URL`環境変数を見て自動接続し、未設定時はインメモリへフォールバックする実装が既に存在するため、コード変更は不要です（レート制限 #617 / asynqキューとも同じ接続を共有）。

## 構成の選択（ElastiCacheではなくEC2内コンテナ）
staging単体構成（1台構成・デプロイ後1時間アイドルで自動停止）を踏まえ、レート制限・キューという性質上EC2再起動時のデータ消失を許容し、追加コスト・VPC設定が不要なEC2内コンテナ方式を採用（#829で導入したIAMロール方式と同じ「必要最小限のstaging構成」の方針に合わせています）。将来的な可用性強化が必要になればElastiCacheへの切替を検討します。

## 動作確認
- ローカルで`docker compose up -d redis app`後、backendログで `[redis] connected (redis://redis:6379/0)` を確認済み
- staging環境へ`terraform apply`実施済み（Launch Template更新のみ、無関係なドリフトは含まない）。apply時点で`desired_capacity=0`のため、実インスタンスでの動作確認（レート制限がRedis経由で共有される・asynqワーカー起動）は次回デプロイ時に実施

## 受け入れ条件
- [x] staging の Backend ログで Redis / asynq worker 起動が分かる（コード側は実装済み。次回デプロイ後にログ確認予定）
- [ ] 次回デプロイ後、2インスタンス相当でレート制限が共有されることを確認（現状1台構成のため、次回複数台化時に確認）