### PR TITLE
Resolve #522 チャット回答判定ロジックの精度改善（シグナル検出・isTooPerfect・LLMフォールバック）

### DIFF
--- a/Backend/internal/services/chat/answer_evaluator_human.go
+++ b/Backend/internal/services/chat/answer_evaluator_human.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"context"
 	"math"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -51,7 +53,7 @@ func (e *AnswerEvaluator) EvaluateHumanScoring(question, answer string, isChoice
 	category := e.categorizeQuestion(question)
 	rubric := rubricForCategory(category)
 	signals := extractSignals(answer, category)
-	dimensionScores := scoreDimensions(rubric, signals, answer)
+	dimensionScores := scoreDimensions(rubric, category, signals, answer)
 	rawScore := scoreFromDimensions(rubric, dimensionScores)
 	score, penalties, boosts := applyPenaltiesAndBoosts(rawScore, signals, len([]rune(strings.TrimSpace(answer))))
 
@@ -101,6 +103,7 @@ func (e *AnswerEvaluator) EvaluateHumanScoringWithContext(
 	if n > 0 && n <= 30 {
 		ruleWeight = 0.35 // 短文は LLM（内容品質）比重を上げる
 	}
+	ruleWeight = configuredRuleWeight(ruleWeight)
 	blended := int(math.Round(ruleWeight*float64(rule.Score) + (1-ruleWeight)*float64(llmResult.Score)))
 	if blended < 0 {
 		blended = 0
@@ -114,6 +117,20 @@ func (e *AnswerEvaluator) EvaluateHumanScoringWithContext(
 		rule.Reason = llmResult.Explanation
 	}
 	return rule
+}
+
+// configuredRuleWeight は CHAT_EVAL_RULE_WEIGHT 環境変数（0.0〜1.0）で
+// ハイブリッド評価のルールベース比重を上書きする（#522）。未設定・不正値なら fallback を返す。
+func configuredRuleWeight(fallback float64) float64 {
+	raw := strings.TrimSpace(os.Getenv("CHAT_EVAL_RULE_WEIGHT"))
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v < 0 || v > 1 {
+		return fallback
+	}
+	return v
 }
 
 // floorEngagedShortScore は関与のある短文が Score=0 で進捗から落ちないよう下限を設ける (#561)。

--- a/Backend/internal/services/chat/answer_evaluator_human.go
+++ b/Backend/internal/services/chat/answer_evaluator_human.go
@@ -127,7 +127,9 @@ func configuredRuleWeight(fallback float64) float64 {
 		return fallback
 	}
 	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil || v < 0 || v > 1 {
+	// ParseFloat は "NaN" をエラーなしで返し、NaN との比較は常に false になるため
+	// v<0/v>1 の範囲チェックをすり抜けてしまう。NaN/Inf は明示的に弾く。
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > 1 {
 		return fallback
 	}
 	return v

--- a/Backend/internal/services/chat/answer_evaluator_scoring.go
+++ b/Backend/internal/services/chat/answer_evaluator_scoring.go
@@ -72,13 +72,15 @@ func extractSignals(answer string, category string) signalSet {
 		hasAction: shared.ContainsAny(lower, []string{
 			"取り組", "実施", "作成", "作った", "実装", "改善", "対応", "開発", "設計", "検証",
 			"分担", "役割", "リリース", "出した", "進め", "仕上げ", "完了", "提出", "納品", "デプロイ",
-			"まとめた", "進めた", "対応した", "リリースした",
+			"まとめた", "進めた", "対応した", "リリースした", "推進", "展開", // #522: 同義表現拡充
 		}),
 		hasResult: shared.ContainsAny(lower, []string{
 			"結果", "成果", "達成", "改善された", "向上", "成功", "失敗",
-			"リリース", "出した", "出荷", "納品",
+			"リリース", "出した", "出荷", "納品", "実現", "改善でき", // #522: 同義表現拡充
 		}),
-		hasReason: shared.ContainsAny(lower, []string{"理由", "なぜ", "ので", "ため", "から", "だから"}),
+		hasReason: shared.ContainsAny(lower, []string{
+			"理由", "なぜ", "ので", "ため", "から", "だから", "背景", "きっかけ", // #522: 同義表現拡充
+		}),
 		hasNumbersOrTime: regexp.MustCompile(`[0-9]`).MatchString(lower) || shared.ContainsAny(lower, []string{
 			"ヶ月", "年", "週間", "日間", "日で", "%", "人", "回",
 		}),
@@ -98,7 +100,15 @@ func extractSignals(answer string, category string) signalSet {
 	}
 }
 
-func scoreDimensions(rubric string, signals signalSet, answer string) map[string]int {
+// isTooPerfectRelaxedCategories は数値・時間表現を使わない回答が自然な職種カテゴリ。
+// これらのカテゴリでは isTooPerfect（定型文疑い）を適用しない（#522: 誤検知対策）。
+var isTooPerfectRelaxedCategories = map[string]bool{
+	"motivation":           true,
+	"communication_non_it": true,
+	"ui_ux":                true,
+}
+
+func scoreDimensions(rubric string, category string, signals signalSet, answer string) map[string]int {
 	length := len([]rune(strings.TrimSpace(answer)))
 	scores := map[string]int{
 		"relevance":   1,
@@ -107,8 +117,11 @@ func scoreDimensions(rubric string, signals signalSet, answer string) map[string
 		"credibility": 1,
 	}
 
-	// 理想的・定型的な回答に対するペナルティ
-	isTooPerfect := !signals.hasReason && !signals.hasNumbersOrTime && length > 50 && signals.hasAction && signals.hasResult
+	// 理想的・定型的な回答に対するペナルティ。
+	// motivation・communication_non_it・ui_ux は数値表現を使わない回答が自然なため、
+	// この判定自体を適用しない（#522）。
+	isTooPerfect := !isTooPerfectRelaxedCategories[category] &&
+		!signals.hasReason && !signals.hasNumbersOrTime && length > 50 && signals.hasAction && signals.hasResult
 
 	if rubric == "collaboration_rubric" && !signals.hasCollaborationTerm {
 		scores["relevance"] = 1
@@ -143,7 +156,7 @@ func scoreDimensions(rubric string, signals signalSet, answer string) map[string
 	if signals.contradiction {
 		scores["credibility"] = 0 // 矛盾あり: 最低評価
 	} else if isTooPerfect {
-		scores["credibility"] = 1 // 理由・数値のない定型回答: 信頼度を落とす
+		scores["credibility"] = 2 // 理由・数値のない定型回答: 減点はするが完全ゼロ評価は避ける（#522）
 	} else if signals.hasNumbersOrTime {
 		scores["credibility"] = 3
 	} else if signals.hasConcreteExample || (signals.hasEmotion && signals.hasReason) {

--- a/Backend/internal/services/chat/answer_evaluator_test.go
+++ b/Backend/internal/services/chat/answer_evaluator_test.go
@@ -542,6 +542,11 @@ func TestConfiguredRuleWeight(t *testing.T) {
 		{"範囲外(負)は fallback を返す", "-0.1", 0.55, 0.55},
 		{"範囲外(1超)は fallback を返す", "1.5", 0.55, 0.55},
 		{"パース不能な値は fallback を返す", "abc", 0.55, 0.55},
+		// ParseFloatは"NaN"/"Inf"をエラーなしで返し、NaNとの比較は常にfalseになるため
+		// 範囲チェックをすり抜けないことを確認する
+		{"NaNは fallback を返す", "NaN", 0.55, 0.55},
+		{"+Infは fallback を返す", "+Inf", 0.55, 0.55},
+		{"-Infは fallback を返す", "-Inf", 0.55, 0.55},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/Backend/internal/services/chat/answer_evaluator_test.go
+++ b/Backend/internal/services/chat/answer_evaluator_test.go
@@ -57,14 +57,15 @@ func TestExtractSignals_noSignals(t *testing.T) {
 // ──────────────────────────────────────────────
 
 // isTooPerfect の条件:
-//   !hasReason && !hasNumbersOrTime && length > 50 && hasAction && hasResult
+//   !isTooPerfectRelaxedCategories[category] && !hasReason && !hasNumbersOrTime && length > 50 && hasAction && hasResult
+// （#522: motivation/communication_non_it/ui_ux カテゴリでは適用しない）
 
-// 定型的・優等生的な回答（理由・数値なし、行動+結果あり、50文字超） → credibility = 1
+// 定型的・優等生的な回答（理由・数値なし、行動+結果あり、50文字超） → credibility = 2
 func TestScoreDimensions_isTooPerfect_appliesPenalty(t *testing.T) {
 	// 理由・数値なし、行動（取り組み）・結果（成果）あり、50文字超
 	answer := "チームで積極的に取り組み、プロジェクトを成功させ素晴らしい成果と達成を収めることができました。大変良い経験でした。"
 	signals := extractSignals(answer, "")
-	scores := scoreDimensions("generic_rubric", signals, answer)
+	scores := scoreDimensions("generic_rubric", "", signals, answer)
 
 	// hasAction と hasResult が検出されていることを前提確認
 	if !signals.hasAction || !signals.hasResult {
@@ -75,9 +76,9 @@ func TestScoreDimensions_isTooPerfect_appliesPenalty(t *testing.T) {
 		t.Skip("テスト用回答に理由・数値が含まれているためスキップ")
 	}
 
-	// credibility は 1（ペナルティ適用）であること
-	if scores["credibility"] != 1 {
-		t.Errorf("isTooPerfect 判定で credibility=1 を期待したが %d が返った", scores["credibility"])
+	// credibility は 2（ペナルティ適用、完全ゼロ評価は避ける #522）であること
+	if scores["credibility"] != 2 {
+		t.Errorf("isTooPerfect 判定で credibility=2 を期待したが %d が返った", scores["credibility"])
 	}
 }
 
@@ -85,7 +86,7 @@ func TestScoreDimensions_isTooPerfect_appliesPenalty(t *testing.T) {
 func TestScoreDimensions_hasReason_notTooPerfect(t *testing.T) {
 	answer := "効率化のために積極的に取り組み、プロジェクトを成功させ素晴らしい成果と達成を収めることができました。大変良い経験でした。"
 	signals := extractSignals(answer, "")
-	scores := scoreDimensions("generic_rubric", signals, answer)
+	scores := scoreDimensions("generic_rubric", "", signals, answer)
 
 	if !signals.hasReason {
 		t.Skip("テスト用回答に「ため」が含まれていない")
@@ -100,7 +101,7 @@ func TestScoreDimensions_hasReason_notTooPerfect(t *testing.T) {
 func TestScoreDimensions_hasNumbersOrTime_notTooPerfect(t *testing.T) {
 	answer := "3ヶ月かけて積極的に取り組み、プロジェクトを成功させ素晴らしい成果と達成を収めることができました。大変良い経験でした。"
 	signals := extractSignals(answer, "")
-	scores := scoreDimensions("generic_rubric", signals, answer)
+	scores := scoreDimensions("generic_rubric", "", signals, answer)
 
 	if !signals.hasNumbersOrTime {
 		t.Skip("テスト用回答に数値・時間が含まれていない")
@@ -115,7 +116,7 @@ func TestScoreDimensions_hasNumbersOrTime_notTooPerfect(t *testing.T) {
 func TestScoreDimensions_shortAnswer_notTooPerfect(t *testing.T) {
 	answer := "取り組み、成果が出ました。" // 50文字未満
 	signals := extractSignals(answer, "")
-	scores := scoreDimensions("generic_rubric", signals, answer)
+	scores := scoreDimensions("generic_rubric", "", signals, answer)
 
 	// 50文字以下なら isTooPerfect は false のはず → credibility が 1 でも別の理由（初期値）
 	// ただし contradiction もないので 0 にはならないことを確認
@@ -134,10 +135,67 @@ func TestScoreDimensions_contradiction_credibilityZero(t *testing.T) {
 		contradiction:    true,
 	}
 	answer := "取り組み、成果と達成と向上を収めました。チームで実施しました。成功しました。大変良い経験でした。"
-	scores := scoreDimensions("generic_rubric", signals, answer)
+	scores := scoreDimensions("generic_rubric", "", signals, answer)
 
 	if scores["credibility"] != 0 {
 		t.Errorf("contradiction ありの場合は credibility=0 を期待したが %d が返った", scores["credibility"])
+	}
+}
+
+// isTooPerfect のカテゴリ別緩和テスト（#522）:
+// motivation・communication_non_it・ui_ux では理由・数値が無い定型回答でも
+// isTooPerfect ペナルティ（credibility=2）を適用せず、デフォルト値(1)のままとする。
+// experience・collaboration・generic では従来どおり厳格適用する。
+func TestScoreDimensions_isTooPerfect_categoryRelaxation(t *testing.T) {
+	// 理由・数値・具体例なし、行動+結果あり、50文字超（isTooPerfect の前提を満たす回答）
+	answer := "チームで施策を推進し、業務プロセスを改善して大きな成果を出すことができました。皆で協力して乗り越えました。"
+	signals := extractSignals(answer, "")
+	if signals.hasReason || signals.hasNumbersOrTime || signals.hasConcreteExample || !signals.hasAction || !signals.hasResult {
+		t.Fatal("テスト用回答の前提シグナルが崩れている")
+	}
+
+	tests := []struct {
+		name     string
+		category string
+		want     int
+	}{
+		{"motivation is relaxed", "motivation", 1},
+		{"communication_non_it is relaxed", "communication_non_it", 1},
+		{"ui_ux is relaxed", "ui_ux", 1},
+		{"experience stays strict", "experience", 2},
+		{"collaboration stays strict", "collaboration", 2},
+		{"generic stays strict", "generic", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scores := scoreDimensions(rubricForCategory(tt.category), tt.category, signals, answer)
+			if scores["credibility"] != tt.want {
+				t.Errorf("category=%s: credibility=%d を期待したが %d が返った", tt.category, tt.want, scores["credibility"])
+			}
+		})
+	}
+}
+
+// #522: extractSignals の同義表現拡充テスト
+func TestExtractSignals_synonymExpansion(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+		check  func(signalSet) bool
+	}{
+		{"hasAction: 推進した", "新しい施策を推進した", func(s signalSet) bool { return s.hasAction }},
+		{"hasAction: 展開した", "全社に展開した", func(s signalSet) bool { return s.hasAction }},
+		{"hasResult: 実現した", "業務効率化を実現した", func(s signalSet) bool { return s.hasResult }},
+		{"hasResult: 改善できた", "顧客対応を改善できた", func(s signalSet) bool { return s.hasResult }},
+		{"hasReason: 背景として", "背景として人手不足がありました", func(s signalSet) bool { return s.hasReason }},
+		{"hasReason: きっかけは", "きっかけは先輩の一言でした", func(s signalSet) bool { return s.hasReason }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.check(extractSignals(tt.answer, "")) {
+				t.Fatalf("signal not detected for %q", tt.answer)
+			}
+		})
 	}
 }
 
@@ -162,9 +220,9 @@ func TestEvaluateHumanScoring_tooPerfectAnswer_lowScore(t *testing.T) {
 	if !ok {
 		t.Error("DimensionScores に credibility が含まれていない")
 	}
-	// isTooPerfect が適用されれば credibility <= 1
-	if credibility > 1 {
-		t.Errorf("優等生的回答で credibility=%d（期待: <=1）", credibility)
+	// isTooPerfect が適用されれば credibility <= 2（#522: 1→2に緩和し完全ゼロ評価を避ける）
+	if credibility > 2 {
+		t.Errorf("優等生的回答で credibility=%d（期待: <=2）", credibility)
 	}
 }
 
@@ -468,5 +526,30 @@ func TestGetConfidenceLevel(t *testing.T) {
 		if got != tc.want {
 			t.Fatalf("score=%d kw=%d got=%q want %q", tc.score, tc.keywords, got, tc.want)
 		}
+	}
+}
+
+// #522: CHAT_EVAL_RULE_WEIGHT によるハイブリッド評価の ruleWeight 上書きテスト
+func TestConfiguredRuleWeight(t *testing.T) {
+	cases := []struct {
+		name     string
+		envValue string
+		fallback float64
+		want     float64
+	}{
+		{"未設定なら fallback を返す", "", 0.55, 0.55},
+		{"有効な値で上書きされる", "0.7", 0.55, 0.7},
+		{"範囲外(負)は fallback を返す", "-0.1", 0.55, 0.55},
+		{"範囲外(1超)は fallback を返す", "1.5", 0.55, 0.55},
+		{"パース不能な値は fallback を返す", "abc", 0.55, 0.55},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CHAT_EVAL_RULE_WEIGHT", tc.envValue)
+			got := configuredRuleWeight(tc.fallback)
+			if got != tc.want {
+				t.Errorf("got=%v want=%v", got, tc.want)
+			}
+		})
 	}
 }

--- a/Backend/internal/services/chat/chat_answer_validator.go
+++ b/Backend/internal/services/chat/chat_answer_validator.go
@@ -87,7 +87,7 @@ func (s *ChatService) checkAnswerValidity(ctx context.Context, history []models.
 		if err := s.sessionValidationRepo.TerminateSession(sessionID); err != nil {
 			log.Printf("Warning: failed to terminate session: %v\n", err)
 		}
-		assistantText = "申し訳ございませんが、質問と関係のない内容が3回続いたため、チャットを終了させていただきます。新しいセッションで最初からやり直してください。"
+		assistantText = "申し訳ございませんが、質問と関係のない内容が3回続いたため、チャットを終了させていただきます。「最初からやり直す」から新しいセッションを開始するか、この質問をスキップして別の話題からお試しください。"
 	} else {
 		// 1-2回目の無効回答 -> 警告メッセージ
 		assistantText = fmt.Sprintf("書かれた内容にはお答えできません。質問に回答してください。（%d/3回目の警告）", validation.InvalidAnswerCount)

--- a/Backend/internal/services/chat/chat_process_flow.go
+++ b/Backend/internal/services/chat/chat_process_flow.go
@@ -35,9 +35,10 @@ func (s *ChatService) handleInvalidAnswerFlow(ctx context.Context, req ChatReque
 		chatResponse.InvalidAnswerCount = validation.InvalidAnswerCount
 		chatResponse.IsTerminated = validation.IsTerminated
 
-		// 3回目の無効回答の場合は完了フラグを立てる
+		// 3回目の無効回答の場合は完了フラグを立て、やり直し/スキップを提案する（#522）
 		if validation.IsTerminated {
 			chatResponse.IsComplete = true
+			chatResponse.SuggestRestart = true
 		}
 	}
 

--- a/Backend/internal/services/chat/chat_service.go
+++ b/Backend/internal/services/chat/chat_service.go
@@ -83,6 +83,7 @@ type ChatResponse struct {
 	AllPhases           []PhaseProgress          `json:"all_phases,omitempty"`
 	IsComplete          bool                     `json:"is_complete"`
 	IsTerminated        bool                     `json:"is_terminated,omitempty"`
+	SuggestRestart      bool                     `json:"suggest_restart,omitempty"`
 	InvalidAnswerCount  int                      `json:"invalid_answer_count,omitempty"`
 	TotalQuestions      int                      `json:"total_questions"`
 	AnsweredQuestions   int                      `json:"answered_questions"`


### PR DESCRIPTION
Closes #522

## 実装内容（Issue記載の課題①②③④すべて対応）

### ①isTooPerfect誤検知対策
`Backend/internal/services/chat/answer_evaluator_scoring.go`
- `scoreDimensions`にcategoryパラメータを追加
- motivation・communication_non_it・ui_uxカテゴリでは、数値・時間表現の欠如を根拠にした定型文判定(`isTooPerfect`)を適用しないよう変更（`isTooPerfectRelaxedCategories`）
- experience・collaboration・genericは従来どおり厳格適用
- ペナルティ時のcredibilityを1→2に緩和し、完全ゼロ評価を回避

### ②シグナル検出のキーワード拡充
`extractSignals`に同義表現を追加:
- hasAction: 「推進」「展開」
- hasResult: 「実現」「改善でき」
- hasReason: 「背景」「きっかけ」

### ③LLMフォールバック拡張
`Backend/internal/services/chat/answer_evaluator_human.go`
- ハイブリッド評価の`ruleWeight`を`CHAT_EVAL_RULE_WEIGHT`環境変数で上書き可能に（`configuredRuleWeight`関数）。未設定・不正値時は既存の短文/長文別デフォルト値（0.35/0.55）を維持

### ④強制終了UX（軽微・Low優先度）
- `ChatResponse`に`SuggestRestart bool`を追加
- 3回目の無効回答メッセージに「最初からやり直す」「この質問をスキップ」の案内を明記

## 補足
Issueの「実装ファイル」記載は`answer_evaluator.go`でしたが、実際にチャットスコアリングで使われているのは`answer_evaluator_human.go`/`answer_evaluator_scoring.go`（`EvaluateHumanScoring`系）でした。`answer_evaluator.go`の`EvaluateWithLLMFallback`/`EvaluateHybrid`は本番コードから未使用のため対象外としています。

## テスト
- カテゴリ別isTooPerfect緩和のテーブル駆動テスト追加
- 新規シグナルキーワードのテスト追加
- `CHAT_EVAL_RULE_WEIGHT`設定のテスト追加
- 既存テストの期待値をcredibility=2に合わせて更新
- `go build ./...` / `go test ./...`（全パッケージ）通過、`gofmt`/`go vet`クリーン