### PR TITLE
chore: 汎用デフォルトモデルへの意図しない高コスト化を防ぐ

### DIFF
--- a/Backend/internal/controllers/admin_company_graph_controller.go
+++ b/Backend/internal/controllers/admin_company_graph_controller.go
@@ -518,7 +518,7 @@ func (c *AdminCompanyGraphController) fetchRelationsWithLLM(ctx context.Context,
 	ctxTimeout, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	text, err := c.openaiClient.ChatCompletionJSON(ctxTimeout, systemPrompt, userPrompt, 0.2, 800)
+	text, err := c.openaiClient.ChatCompletionJSON(ctxTimeout, systemPrompt, userPrompt, 0.2, 800, companyfetch.ExtractModel())
 	if err != nil {
 		return nil, fmt.Errorf("企業関係情報の取得失敗: %w", err)
 	}

--- a/Backend/internal/controllers/company_relation_controller.go
+++ b/Backend/internal/controllers/company_relation_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"Backend/domain/repository"
+	"Backend/internal/companyfetch"
 	"Backend/internal/openai"
 	"Backend/internal/services/company"
 	"Backend/internal/services/shared"
@@ -273,7 +274,7 @@ func (ctrl *CompanyRelationController) searchCompaniesWithOpenAI(ctx context.Con
 	ctxTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	text, err := ctrl.openaiClient.ChatCompletionJSON(ctxTimeout, systemPrompt, userPrompt, 0.2, 500)
+	text, err := ctrl.openaiClient.ChatCompletionJSON(ctxTimeout, systemPrompt, userPrompt, 0.2, 500, companyfetch.ExtractModel())
 	if err != nil {
 		return []map[string]string{}
 	}

--- a/Backend/internal/services/interview/interview_turn_fetch.go
+++ b/Backend/internal/services/interview/interview_turn_fetch.go
@@ -1,6 +1,7 @@
 package interview
 
 import (
+	"Backend/internal/companyfetch"
 	"Backend/internal/models"
 	"context"
 	"fmt"
@@ -42,7 +43,7 @@ func (s *InterviewService) lookupCompanyReading(ctx context.Context, companyName
 	query := fmt.Sprintf("「%s」の正しい日本語読み（ふりがな）をカタカナで1行だけ答えてください。", companyName)
 	ctxTimeout, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	result, err := s.openaiClient.ResponsesWithTemperature(ctxTimeout, systemPrompt, query, 0.0)
+	result, err := s.openaiClient.ResponsesWithTemperature(ctxTimeout, systemPrompt, query, 0.0, companyfetch.ExtractModel())
 	if err != nil {
 		return ""
 	}

--- a/infra/terraform/environments/staging/app_user_data.sh.tftpl
+++ b/infra/terraform/environments/staging/app_user_data.sh.tftpl
@@ -51,6 +51,7 @@ AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
 AWS_S3_BUCKET=${s3_bucket}
 S3_BUCKET=${s3_bucket}
 OPENAI_API_KEY=${openai_api_key}
+OPENAI_MODEL=${openai_model}
 RESEND_API_KEY=${resend_api_key}
 EMAIL_PROVIDER=resend
 EMAIL_FROM=noreply@shukatsu-ai.jp

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -212,6 +212,7 @@ resource "aws_launch_template" "app" {
     db_password              = module.rds.master_password
     s3_bucket                = module.s3.bucket_id
     openai_api_key           = var.openai_api_key_plain
+    openai_model             = var.openai_model
     resend_api_key           = var.resend_api_key_plain
     google_client_id         = var.google_client_id
     google_client_secret     = var.google_client_secret

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -173,6 +173,12 @@ variable "openai_api_key_plain" {
   default     = ""
 }
 
+variable "openai_model" {
+  type        = string
+  description = "チャット採点・要約・面接進行など汎用タスクのデフォルトモデル。未設定時はコード側でgpt-4o-miniにフォールバックするが、環境変数の設定漏れ・実験用設定の残留による意図しない高コストモデル化を防ぐため明示的に固定する"
+  default     = "gpt-4o-mini"
+}
+
 variable "resend_api_key_plain" {
   type        = string
   description = "Resend APIキー(平文、Secrets Manager未使用のためuser_dataに直接埋め込む)。未設定時はEMAIL_PROVIDERがlogにフォールバックする"
@@ -194,9 +200,9 @@ variable "google_client_id" {
 }
 
 variable "google_client_secret" {
-  type        = string
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 variable "github_client_id" {
@@ -206,9 +212,9 @@ variable "github_client_id" {
 }
 
 variable "github_client_secret" {
-  type        = string
-  sensitive   = true
-  default     = ""
+  type      = string
+  sensitive = true
+  default   = ""
 }
 
 variable "domain_name" {


### PR DESCRIPTION
## 背景
コスト試算の議論の中で、`internal/companyfetch`（企業情報の事実確認系）は既に`gpt-4o-mini-search-preview`等を明示指定しているのに対し、それ以外の15箇所以上（チャット採点・要約・面接進行・企業名読み仮名検索など）はモデル指定なしでクライアントの`DefaultModel`（`OPENAI_MODEL`環境変数、未設定時`gpt-4o-mini`）に暗黙で乗っていることが判明した。開発環境でこの`OPENAI_MODEL`に実験用の高コストモデル(`gpt-5.2`)が設定されたまま残っていたため、実際にコストログ上で最大の支出項目になっていた。

## 変更内容
1. 企業事実確認系で個別指定が漏れていた3箇所に`companyfetch.ExtractModel()`（既定`gpt-4o-mini`）を明示指定
   - `admin_company_graph_controller.go`（企業関係情報のAI知識ベース取得）
   - `company_relation_controller.go`（企業名検索のAI知識ベースフォールバック）
   - `interview_turn_fetch.go`（面接官の企業名読み仮名検索、#864関連）
2. staging terraformに`OPENAI_MODEL`変数を追加し`gpt-4o-mini`を明示固定（コード側の暗黙フォールバックに依存しない）

## 検証
ローカルで`OPENAI_MODEL=gpt-5.2`が設定された状態のまま`lookupCompanyReading`を実行し、`/api/admin/costs/summary`のモデル別内訳で**`gpt-5.2`の呼び出し数・トークン数が完全に変化せず、`gpt-4o-mini`の呼び出しのみ+1件増加**することを実機確認。グローバル設定のドリフトから該当フローが正しく隔離されていることを確認済み。

`go build`/`go test ./...`（全パッケージ）/ `gofmt`/`go vet`/`terraform validate` すべてクリーン。