### PR TITLE
fix: prod terraformのS3バックエンド設定が無効化されたままだった問題を修正

### DIFF
--- a/infra/terraform/environments/prod/versions.tf
+++ b/infra/terraform/environments/prod/versions.tf
@@ -12,12 +12,7 @@ terraform {
     }
   }
 
-  # bootstrap apply 後に有効化:
-  #   cp backend.hcl.example backend.hcl  # bucket/table を記入
-  #   terraform init -backend-config=backend.hcl
-  #
-  # 初回検証でローカル state のまま使う場合は、下の backend "s3" ブロックをコメントアウトしたまま init。
-  # backend "s3" {
-  #   # configured via -backend-config=backend.hcl
-  # }
+  backend "s3" {
+    # configured via -backend-config=backend.hcl
+  }
 }


### PR DESCRIPTION
## 背景
`infra/terraform/environments/prod/versions.tf`の`backend "s3" {}`ブロックがコメントアウトされたままで、`terraform init`してもS3バックエンドに接続されず、prod環境が一度も`terraform apply`されていなかった。これが原因で、mainへのpushごとにCI（`sync-whats-new`/`deploy-production`）が「ECS task definitionが存在しない」エラーで継続的に失敗していた（実害は本番未構築のためなし）。

## 変更内容
- `backend "s3" {}`ブロックのコメントアウトを解除

## 検証
- `terraform init -backend-config=backend.hcl`でS3バックエンド（`soc-tfstate-508897596159-7332` / `prod/terraform.tfstate`）への接続を確認
- `terraform plan`で56リソースの新規作成プランを確認（ECS Fargate desired_count=0のため起動はしない設計のまま）

## 今後の対応（別途実施）
実際の`terraform apply`は本PRでは実施していない。Secrets ManagerのARNが未確定な状態でIAMポリシーの`count`条件を評価できない初回apply特有の制約があるため、基盤（network/s3/rds/secrets）→全体という2段階applyが必要。コスト影響（RDS/ALB常時課金）もあるため、apply自体は別途ユーザー確認の上で実施予定。