### PR TITLE
fix: PR #896のCodeRabbit指摘を修正(Discord本番稼働日管理)

### DIFF
--- a/.github/workflows/prod-uptime-scheduler.yml
+++ b/.github/workflows/prod-uptime-scheduler.yml
@@ -14,6 +14,8 @@ on:
     - cron: "5 * * * *" # 毎時5分(UTC)
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   sync-prod-uptime:
     runs-on: ubuntu-latest
@@ -34,8 +36,17 @@ jobs:
 
           TODAY_JST=$(TZ=Asia/Tokyo date +%F)
 
-          DATES=$(aws ssm get-parameter --name "/${PROJECT_NAME}/prod-uptime-dates" \
-            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          # パラメータ未作成(初回)のみ空扱いにし、それ以外のAWSエラー(権限/スロットリング/
+          # ネットワーク等)は握りつぶさずジョブを失敗させる(誤って両サービスを0にしないため)。
+          if DATES=$(aws ssm get-parameter --name "/${PROJECT_NAME}/prod-uptime-dates" \
+            --query 'Parameter.Value' --output text 2>/tmp/ssm_get_parameter_err); then
+            :
+          elif grep -q "ParameterNotFound" /tmp/ssm_get_parameter_err; then
+            DATES=""
+          else
+            cat /tmp/ssm_get_parameter_err >&2
+            exit 1
+          fi
 
           DESIRED=0
           if echo ",$DATES," | grep -q ",$TODAY_JST,"; then

--- a/Backend/internal/controllers/discord_interaction_controller.go
+++ b/Backend/internal/controllers/discord_interaction_controller.go
@@ -2,11 +2,13 @@ package controllers
 
 import (
 	"Backend/internal/services/discord"
+	"context"
 	"encoding/json"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -29,11 +31,17 @@ func NewDiscordInteractionController(uptimeService *discord.UptimeService) *Disc
 	}
 }
 
+// maxInteractionBodyBytes はDiscord Interactionペイロードの許容上限。
+// 実際のペイロード(モーダル1入力分)は数百バイト程度なので十分な余裕を持たせつつ、
+// 署名検証前の無制限読み取りによるDoSを防ぐ。
+const maxInteractionBodyBytes = 1 << 20 // 1MiB
+
 // Interactions POST /api/discord/interactions
 func (c *DiscordInteractionController) Interactions(ctx echo.Context) error {
+	ctx.Request().Body = http.MaxBytesReader(ctx.Response(), ctx.Request().Body, maxInteractionBodyBytes)
 	body, err := io.ReadAll(ctx.Request().Body)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "failed to read body")
+		return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "request body too large")
 	}
 
 	signature := ctx.Request().Header.Get("X-Signature-Ed25519")
@@ -135,22 +143,31 @@ func (c *DiscordInteractionController) handleModalSubmit(ctx echo.Context, inter
 		})
 	}
 
-	dates, err := c.uptimeService.AddDate(ctx.Request().Context(), date)
-	if err != nil {
-		log.Printf("[Discord] prod-uptime add error: %v", err)
-		return ctx.JSON(http.StatusOK, discord.InteractionResponse{
-			Type: discord.ResponseTypeChannelMessageWithSource,
-			Data: &discord.InteractionResponseData{Content: err.Error(), Flags: discord.EphemeralFlag},
-		})
-	}
+	// SSMへの読み書きがDiscordの3秒応答制限を超える可能性があるため、
+	// 先にdeferred応答(type=5)を返し、実処理は非同期でフォローアップメッセージとして送る。
+	applicationID, token := interaction.ApplicationID, interaction.Token
+	go c.addDateAndFollowUp(applicationID, token, date)
 
 	return ctx.JSON(http.StatusOK, discord.InteractionResponse{
-		Type: discord.ResponseTypeChannelMessageWithSource,
-		Data: &discord.InteractionResponseData{
-			Content: "✅ " + date + " を本番終日起動の対象日に追加しました。\n登録済みの日付: " + joinDates(dates),
-			Flags:   discord.EphemeralFlag,
-		},
+		Type: discord.ResponseTypeDeferredChannelMessageWithSource,
+		Data: &discord.InteractionResponseData{Flags: discord.EphemeralFlag},
 	})
+}
+
+func (c *DiscordInteractionController) addDateAndFollowUp(applicationID, token, date string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dates, err := c.uptimeService.AddDate(ctx, date)
+	content := "✅ " + date + " を本番終日起動の対象日に追加しました。\n登録済みの日付: " + joinDates(dates)
+	if err != nil {
+		log.Printf("[Discord] prod-uptime add error: %v", err)
+		content = err.Error()
+	}
+
+	if err := discord.EditOriginalResponse(applicationID, token, content); err != nil {
+		log.Printf("[Discord] prod-uptime followup error: %v", err)
+	}
 }
 
 func (c *DiscordInteractionController) hasAllowedRole(interaction *discord.Interaction) bool {

--- a/Backend/internal/services/discord/followup.go
+++ b/Backend/internal/services/discord/followup.go
@@ -1,0 +1,40 @@
+package discord
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const discordAPIBase = "https://discord.com/api/v10"
+
+var followupHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// EditOriginalResponse はtype=5(deferred)で即時応答した後、確定した内容で
+// オリジナルメッセージを更新する。interaction token自体が認可情報を兼ねるため
+// 追加の認証ヘッダは不要(Botトークンをバックエンドに持たせずに済む)。
+func EditOriginalResponse(applicationID, token, content string) error {
+	body, err := json.Marshal(map[string]any{"content": content})
+	if err != nil {
+		return fmt.Errorf("marshal followup body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/webhooks/%s/%s/messages/@original", discordAPIBase, applicationID, token)
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build followup request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := followupHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send followup request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord followup returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/Backend/internal/services/discord/types.go
+++ b/Backend/internal/services/discord/types.go
@@ -14,9 +14,10 @@ const (
 type ResponseType int
 
 const (
-	ResponseTypePong                     ResponseType = 1
-	ResponseTypeChannelMessageWithSource ResponseType = 4
-	ResponseTypeModal                    ResponseType = 9
+	ResponseTypePong                             ResponseType = 1
+	ResponseTypeChannelMessageWithSource         ResponseType = 4
+	ResponseTypeDeferredChannelMessageWithSource ResponseType = 5
+	ResponseTypeModal                            ResponseType = 9
 )
 
 type ComponentType int
@@ -33,10 +34,14 @@ const (
 )
 
 // Interaction はDiscordから届くリクエストボディ。
+// ApplicationID/Token は、type=5(deferred)で即時応答した後にフォローアップメッセージを
+// 送る(PATCH /webhooks/{application_id}/{token}/messages/@original)際に必要。
 type Interaction struct {
-	Type   InteractionType  `json:"type"`
-	Member *Member          `json:"member"`
-	Data   *InteractionData `json:"data"`
+	Type          InteractionType  `json:"type"`
+	ApplicationID string           `json:"application_id"`
+	Token         string           `json:"token"`
+	Member        *Member          `json:"member"`
+	Data          *InteractionData `json:"data"`
 }
 
 type Member struct {

--- a/Backend/internal/services/discord/uptime_service.go
+++ b/Backend/internal/services/discord/uptime_service.go
@@ -2,11 +2,13 @@ package discord
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,6 +27,10 @@ var dateOnlyPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 type UptimeService struct {
 	client        *ssm.Client
 	parameterName string
+	// ponytail: read-modify-writeの排他はプロセス内mutexのみ。
+	// staging EC2は単一インスタンス運用(#829)のため実害はないが、複数インスタンス化する場合は
+	// SSM単体にCAS機構が無いため、DynamoDB等を使った分散ロックへの置き換えが必要。
+	mu sync.Mutex
 }
 
 // NewUptimeServiceFromEnv はAWSデフォルトクレデンシャルチェーン(IAMロール等)でクライアントを構築する。
@@ -63,6 +69,9 @@ func (s *UptimeService) AddDate(ctx context.Context, date string) ([]string, err
 		return nil, fmt.Errorf("過去の日付は指定できません（今日: %s）", today)
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	dates, err := s.listDates(ctx)
 	if err != nil {
 		return nil, err
@@ -91,7 +100,8 @@ func (s *UptimeService) AddDate(ctx context.Context, date string) ([]string, err
 func (s *UptimeService) listDates(ctx context.Context) ([]string, error) {
 	out, err := s.client.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String(s.parameterName)})
 	if err != nil {
-		if strings.Contains(err.Error(), "ParameterNotFound") {
+		var notFound *ssmtypes.ParameterNotFound
+		if errors.As(err, &notFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("SSM parameter取得に失敗しました: %w", err)


### PR DESCRIPTION
## 概要
https://github.com/ISCProduct/soc-ai-agent/pull/896 (develop→release) でCodeRabbitが指摘した
コード修正項目のみ対応。ドキュメントのlint/正確性指摘(MD040の言語識別子、既存EC2への反映手順)は
コード修正ではないためスコープ外。

## 修正内容
- `.github/workflows/prod-uptime-scheduler.yml`
  - SSM `get-parameter` のエラーを `ParameterNotFound` 以外は握りつぶさずジョブを失敗させる
    (権限/スロットリング/ネットワークエラー時に誤って本番desired_countを0にしてしまう問題を防止)
  - `permissions: {}` を追加(GITHUB_TOKENの既定権限を無効化)
- `Backend/internal/controllers/discord_interaction_controller.go`
  - 署名検証前のボディ読み取りに`http.MaxBytesReader`で1MiB上限を設定、超過時は413を返す
  - モーダル送信をdeferred応答(type=5)にし、SSMへの登録処理を非同期化してDiscordの3秒応答
    制限を回避(完了後にフォローアップメッセージで結果を通知)
- `Backend/internal/services/discord/uptime_service.go`
  - `ParameterNotFound`判定を文字列一致から`errors.As`ベースに変更
  - `AddDate`のread-modify-writeをmutexで排他化(staging EC2は単一インスタンス運用が前提。
    複数インスタンス化する場合は分散ロックへの置き換えが必要な点をponytailコメントで明記)
- `Backend/internal/services/discord/followup.go` (新規)
  - deferred応答後のフォローアップメッセージ送信(`PATCH /webhooks/{app_id}/{token}/messages/@original`)

## テスト
- `go build ./...` / `go vet ./...`: クリーン
- `go test ./...`: 全パス
- YAML構文チェック: クリーン