### PR TITLE
feat: 本番終日起動の登録済み日付を誰でも閲覧できる/prod-uptime-listを追加

### DIFF
--- a/Backend/internal/controllers/discord_interaction_controller.go
+++ b/Backend/internal/controllers/discord_interaction_controller.go
@@ -74,7 +74,18 @@ func (c *DiscordInteractionController) Interactions(ctx echo.Context) error {
 }
 
 func (c *DiscordInteractionController) handleCommand(ctx echo.Context, interaction *discord.Interaction) error {
-	if interaction.Data == nil || interaction.Data.Name != discord.CommandNameProdUptime {
+	if interaction.Data == nil {
+		return ctx.JSON(http.StatusOK, discord.InteractionResponse{
+			Type: discord.ResponseTypeChannelMessageWithSource,
+			Data: &discord.InteractionResponseData{Content: "不明なコマンドです。", Flags: discord.EphemeralFlag},
+		})
+	}
+
+	if interaction.Data.Name == discord.CommandNameProdUptimeList {
+		return c.handleListCommand(ctx)
+	}
+
+	if interaction.Data.Name != discord.CommandNameProdUptime {
 		return ctx.JSON(http.StatusOK, discord.InteractionResponse{
 			Type: discord.ResponseTypeChannelMessageWithSource,
 			Data: &discord.InteractionResponseData{Content: "不明なコマンドです。", Flags: discord.EphemeralFlag},
@@ -107,6 +118,33 @@ func (c *DiscordInteractionController) handleCommand(ctx echo.Context, interacti
 					},
 				},
 			},
+		},
+	})
+}
+
+// handleListCommand は登録済み日付一覧を返す(閲覧専用、ロール制限なし)。
+func (c *DiscordInteractionController) handleListCommand(ctx echo.Context) error {
+	if c.uptimeService == nil {
+		return ctx.JSON(http.StatusOK, discord.InteractionResponse{
+			Type: discord.ResponseTypeChannelMessageWithSource,
+			Data: &discord.InteractionResponseData{Content: "現在この機能は利用できません(未設定)。", Flags: discord.EphemeralFlag},
+		})
+	}
+
+	dates, err := c.uptimeService.ListDates(ctx.Request().Context())
+	if err != nil {
+		log.Printf("[Discord] prod-uptime list error: %v", err)
+		return ctx.JSON(http.StatusOK, discord.InteractionResponse{
+			Type: discord.ResponseTypeChannelMessageWithSource,
+			Data: &discord.InteractionResponseData{Content: err.Error(), Flags: discord.EphemeralFlag},
+		})
+	}
+
+	return ctx.JSON(http.StatusOK, discord.InteractionResponse{
+		Type: discord.ResponseTypeChannelMessageWithSource,
+		Data: &discord.InteractionResponseData{
+			Content: "本番終日起動の登録済み日付: " + joinDates(dates),
+			Flags:   discord.EphemeralFlag,
 		},
 	})
 }

--- a/Backend/internal/services/discord/types.go
+++ b/Backend/internal/services/discord/types.go
@@ -85,9 +85,10 @@ const EphemeralFlag = 1 << 6
 
 // ModalCustomIDProdUptime / TextInputCustomIDDate はコマンド・モーダル間の識別子。
 const (
-	CommandNameProdUptime   = "prod-uptime"
-	ModalCustomIDProdUptime = "prod_uptime_modal"
-	TextInputCustomIDDate   = "prod_uptime_date"
+	CommandNameProdUptime     = "prod-uptime"
+	CommandNameProdUptimeList = "prod-uptime-list"
+	ModalCustomIDProdUptime   = "prod_uptime_modal"
+	TextInputCustomIDDate     = "prod_uptime_date"
 )
 
 // FindComponentValue はモーダル送信データのネストしたComponentsから指定custom_idの入力値を探す。

--- a/Backend/internal/services/discord/uptime_service.go
+++ b/Backend/internal/services/discord/uptime_service.go
@@ -97,6 +97,11 @@ func (s *UptimeService) AddDate(ctx context.Context, date string) ([]string, err
 	return dates, nil
 }
 
+// ListDates は登録済みの日付一覧を返す(閲覧専用、ロール制限なしのコマンドから利用)。
+func (s *UptimeService) ListDates(ctx context.Context) ([]string, error) {
+	return s.listDates(ctx)
+}
+
 func (s *UptimeService) listDates(ctx context.Context) ([]string, error) {
 	out, err := s.client.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String(s.parameterName)})
 	if err != nil {

--- a/automation/discord/register-commands.sh
+++ b/automation/discord/register-commands.sh
@@ -25,6 +25,11 @@ curl -sf -X PUT \
       "name": "prod-uptime",
       "description": "本番を終日起動する日付を追加します",
       "type": 1
+    },
+    {
+      "name": "prod-uptime-list",
+      "description": "本番終日起動の登録済み日付を表示します(誰でも閲覧可)",
+      "type": 1
     }
   ]'
 

--- a/docs/architecture/discord-prod-uptime-setup.md
+++ b/docs/architecture/discord-prod-uptime-setup.md
@@ -5,6 +5,9 @@
 `infra-decision-oci-stg-aws-prod.md` の本番起動ポリシー「(B) 指定日は終日起動」を、
 Discordのスラッシュコマンド `/prod-uptime` から操作できるようにする機能のセットアップ手順。
 
+- `/prod-uptime`: 日付の追加(モーダル入力)。`DISCORD_ALLOWED_ROLE_ID`のロール保有者のみ実行可
+- `/prod-uptime-list`: 登録済み日付一覧の表示。ロール制限なし(サーバー参加者なら誰でも閲覧可)
+
 ## 仕組み
 
 ```


### PR DESCRIPTION
## 概要
`/prod-uptime`(日付登録)は引き続き`DISCORD_ALLOWED_ROLE_ID`保有者のみに制限しつつ、
登録済み日付一覧を誰でも見られる閲覧専用コマンド`/prod-uptime-list`を追加する。

## 変更内容
- `Backend/internal/services/discord/uptime_service.go`: 既存の非公開`listDates`を呼ぶ公開メソッド`ListDates`を追加
- `Backend/internal/services/discord/types.go`: `CommandNameProdUptimeList`定数を追加
- `Backend/internal/controllers/discord_interaction_controller.go`: `handleListCommand`を追加し、ロールチェックなしで日付一覧をephemeralメッセージで返す
- `automation/discord/register-commands.sh`: `/prod-uptime-list`をコマンド登録対象に追加
- `docs/architecture/discord-prod-uptime-setup.md`: 2コマンドの役割分担を追記

## テスト
- `go build ./...` / `go vet ./...`: クリーン
- `go test ./internal/services/discord/... ./internal/controllers/...`: 全パス

## 反映後の作業
マージ後、stagingへのデプロイに加えて `automation/discord/register-commands.sh` の再実行が必要
(新しいコマンドをDiscordに登録するため)。