### PR TITLE
fix: prod-uptime-schedulerがproduction環境のAWS認証情報を使うよう修正

### DIFF
--- a/.github/workflows/prod-uptime-scheduler.yml
+++ b/.github/workflows/prod-uptime-scheduler.yml
@@ -19,6 +19,10 @@ permissions: {}
 jobs:
   sync-prod-uptime:
     runs-on: ubuntu-latest
+    # ECS(本番)へのアクセスにはproduction環境のAWS認証情報が必要。
+    # 未指定だとリポジトリ既定のAWS_ACCESS_KEY_ID(旧・ECSクラスタ作成前の認証情報)が使われ、
+    # ClusterNotFoundExceptionになる(実際に発生した障害)。
+    environment: production
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
       PROJECT_NAME: ${{ vars.PROJECT_NAME || 'soc-app' }}


### PR DESCRIPTION
## 概要
初回のスケジュール実行(#1)が `ClusterNotFoundException` で失敗した。

```
aws: [ERROR]: An error occurred (ClusterNotFoundException) when calling the UpdateService operation: Cluster not found.
```

## 原因
`prod-uptime-scheduler.yml` に `environment:` を指定していなかったため、リポジトリ既定の
`AWS_ACCESS_KEY_ID`(2025-12-10発行、ECSクラスタ作成前の古い認証情報)が使われていた。
本番ECSクラスタへのアクセスに必要な新しい認証情報は `production` environment secretsに
分離されている(`deployment.yml` の `deploy-production` ジョブと同じ構成)。

## 修正
`environment: production` を追加し、正しい認証情報を使うようにした。

## 確認
- YAML構文チェック: クリーン
- マージ後、次回の定期実行(毎時5分)または `workflow_dispatch` で正常動作を確認する