### PR TITLE
Release: 2026-08-18 本番未起動バグ修正+Discord本番稼働日連携

### DIFF
--- a/.github/workflows/prod-uptime-scheduler.yml
+++ b/.github/workflows/prod-uptime-scheduler.yml
@@ -19,6 +19,10 @@ permissions: {}
 jobs:
   sync-prod-uptime:
     runs-on: ubuntu-latest
+    # ECS(本番)へのアクセスにはproduction環境のAWS認証情報が必要。
+    # 未指定だとリポジトリ既定のAWS_ACCESS_KEY_ID(旧・ECSクラスタ作成前の認証情報)が使われ、
+    # ClusterNotFoundExceptionになる(実際に発生した障害)。
+    environment: production
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
       PROJECT_NAME: ${{ vars.PROJECT_NAME || 'soc-app' }}


### PR DESCRIPTION
## 変更内容

### 修正
- prod-uptime-schedulerがproduction環境のAWS認証情報を使うよう修正(#900)
  - environment未指定でリポジトリ既定の古い認証情報が使われ、毎時cronがClusterNotFoundExceptionで失敗し続けていた

このリリースをmainまで反映することで、毎時の本番起動/停止スケジューラが正しいAWS認証情報で
動作するようになります(現状はdevelopにのみ反映されており、cron実行は main のワークフロー定義を
参照するため未反映のままでした)。