### PR TITLE
Release: 2026-08-18 本番稼働スケジューラのAWS認証情報修正

### DIFF
--- a/.github/workflows/prod-uptime-scheduler.yml
+++ b/.github/workflows/prod-uptime-scheduler.yml
@@ -19,6 +19,10 @@ permissions: {}
 jobs:
   sync-prod-uptime:
     runs-on: ubuntu-latest
+    # ECS(本番)へのアクセスにはproduction環境のAWS認証情報が必要。
+    # 未指定だとリポジトリ既定のAWS_ACCESS_KEY_ID(旧・ECSクラスタ作成前の認証情報)が使われ、
+    # ClusterNotFoundExceptionになる(実際に発生した障害)。
+    environment: production
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
       PROJECT_NAME: ${{ vars.PROJECT_NAME || 'soc-app' }}


### PR DESCRIPTION
## 変更内容
- prod-uptime-schedulerがproduction環境のAWS認証情報を使うよう修正(#900)

毎時cronの本番起動/停止スケジューラは main ブランチのワークフロー定義を参照するため、
このマージで初めて実際のcron実行に修正が反映されます。